### PR TITLE
feat: implement in-room message search

### DIFF
--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -30,6 +30,20 @@ class _ChatScreenState extends State<ChatScreen> {
   StreamSubscription? _timelineSub;
   bool _loadingHistory = false;
 
+  // ── Search state ──────────────────────────────────────────
+  bool _isSearching = false;
+  final _searchCtrl = TextEditingController();
+  final _searchFocusNode = FocusNode();
+  List<Event> _searchResults = [];
+  String? _searchNextBatch;
+  bool _isSearchLoading = false;
+  String? _searchError;
+  Timer? _debounceTimer;
+  String? _highlightedEventId;
+  static const _searchBatchLimit = 500;
+  static const _minQueryLength = 3;
+  static const _debounceDuration = Duration(milliseconds: 500);
+
   @override
   void initState() {
     super.initState();
@@ -82,10 +96,141 @@ class _ChatScreenState extends State<ChatScreen> {
     await room.sendTextEvent(text);
   }
 
+  // ── Search methods ────────────────────────────────────────
+
+  void _openSearch() {
+    setState(() {
+      _isSearching = true;
+      _searchResults = [];
+      _searchNextBatch = null;
+      _searchError = null;
+    });
+    // Delay focus request to after the frame builds.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _searchFocusNode.requestFocus();
+    });
+  }
+
+  void _closeSearch() {
+    _debounceTimer?.cancel();
+    _searchCtrl.clear();
+    setState(() {
+      _isSearching = false;
+      _searchResults = [];
+      _searchNextBatch = null;
+      _isSearchLoading = false;
+      _searchError = null;
+    });
+  }
+
+  void _onSearchChanged(String query) {
+    _debounceTimer?.cancel();
+    if (query.trim().length < _minQueryLength) {
+      setState(() {
+        _searchResults = [];
+        _searchNextBatch = null;
+        _searchError = null;
+      });
+      return;
+    }
+    // Rebuild to show/hide close button immediately.
+    setState(() {});
+    _debounceTimer = Timer(_debounceDuration, () {
+      _performSearch();
+    });
+  }
+
+  Future<void> _performSearch({bool loadMore = false}) async {
+    final query = _searchCtrl.text.trim();
+    if (query.length < _minQueryLength) return;
+
+    final matrix = context.read<MatrixService>();
+    final room = matrix.client.getRoomById(widget.roomId);
+    if (room == null) return;
+
+    setState(() {
+      _isSearchLoading = true;
+      _searchError = null;
+      if (!loadMore) {
+        _searchResults = [];
+        _searchNextBatch = null;
+      }
+    });
+
+    try {
+      debugPrint('[Lattice] Searching room for: $query');
+      final result = await room.searchEvents(
+        searchTerm: query,
+        limit: _searchBatchLimit,
+        nextBatch: loadMore ? _searchNextBatch : null,
+      );
+
+      if (!mounted) return;
+
+      setState(() {
+        if (loadMore) {
+          _searchResults.addAll(result.events);
+        } else {
+          _searchResults = result.events.toList();
+        }
+        _searchNextBatch = result.nextBatch;
+        _isSearchLoading = false;
+      });
+    } catch (e) {
+      debugPrint('[Lattice] Search error: $e');
+      if (!mounted) return;
+      setState(() {
+        _isSearchLoading = false;
+        _searchError = 'Search failed. Please try again.';
+      });
+    }
+  }
+
+  void _scrollToEvent(Event event) {
+    _closeSearch();
+
+    // Find the event in the current timeline.
+    final events = _timeline?.events
+            .where((e) =>
+                e.type == EventTypes.Message ||
+                e.type == EventTypes.Encrypted)
+            .toList() ??
+        [];
+
+    final index = events.indexWhere((e) => e.eventId == event.eventId);
+    if (index == -1) {
+      // Event not loaded in timeline yet — highlight briefly won't work,
+      // but we still clear search mode.
+      debugPrint('[Lattice] Event not in loaded timeline: ${event.eventId}');
+      return;
+    }
+
+    setState(() => _highlightedEventId = event.eventId);
+
+    // Scroll to the event. Since ListView is reversed, index 0 is at bottom.
+    // Estimate position: each message is roughly 70px tall.
+    final estimatedOffset = index * 70.0;
+    _scrollCtrl.animateTo(
+      estimatedOffset.clamp(0.0, _scrollCtrl.position.maxScrollExtent),
+      duration: const Duration(milliseconds: 400),
+      curve: Curves.easeInOut,
+    );
+
+    // Clear highlight after a delay.
+    Timer(const Duration(seconds: 2), () {
+      if (mounted) {
+        setState(() => _highlightedEventId = null);
+      }
+    });
+  }
+
   @override
   void dispose() {
     _msgCtrl.dispose();
     _scrollCtrl.dispose();
+    _searchCtrl.dispose();
+    _searchFocusNode.dispose();
+    _debounceTimer?.cancel();
     _timelineSub?.cancel();
     _timeline?.cancelSubscriptions();
     super.dispose();
@@ -112,102 +257,261 @@ class _ChatScreenState extends State<ChatScreen> {
         [];
 
     return Scaffold(
-      appBar: AppBar(
-        leading: widget.onBack != null
-            ? IconButton(
-                icon: const Icon(Icons.arrow_back_rounded),
-                onPressed: widget.onBack,
-              )
-            : null,
-        automaticallyImplyLeading: false,
-        titleSpacing: widget.onBack != null ? 0 : 16,
-        title: Row(
-          children: [
-            RoomAvatarWidget(room: room, size: 34),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    room.getLocalizedDisplayname(),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: tt.titleMedium,
-                  ),
-                  Text(
-                    _memberCountLabel(room),
-                    style: tt.bodyMedium?.copyWith(fontSize: 11),
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.search_rounded),
-            onPressed: () {
-              // TODO: in-room search
-            },
-          ),
-          IconButton(
-            icon: const Icon(Icons.more_vert_rounded),
-            onPressed: () {
-              // TODO: room details sheet
-            },
-          ),
-        ],
-      ),
-      body: Column(
+      appBar: _isSearching
+          ? _buildSearchAppBar(cs, tt)
+          : _buildDefaultAppBar(room, tt),
+      body: _isSearching
+          ? _buildSearchBody(cs, tt)
+          : _buildChatBody(events, matrix, cs, tt),
+    );
+  }
+
+  // ── Default app bar ───────────────────────────────────────
+
+  AppBar _buildDefaultAppBar(Room room, TextTheme tt) {
+    return AppBar(
+      leading: widget.onBack != null
+          ? IconButton(
+              icon: const Icon(Icons.arrow_back_rounded),
+              onPressed: widget.onBack,
+            )
+          : null,
+      automaticallyImplyLeading: false,
+      titleSpacing: widget.onBack != null ? 0 : 16,
+      title: Row(
         children: [
-          // ── Messages ──
+          RoomAvatarWidget(room: room, size: 34),
+          const SizedBox(width: 12),
           Expanded(
-            child: _timeline == null
-                ? const Center(child: CircularProgressIndicator())
-                : events.isEmpty
-                    ? Center(
-                        child: Text(
-                          'No messages yet.\nSay hello!',
-                          textAlign: TextAlign.center,
-                          style: tt.bodyMedium?.copyWith(
-                            color: cs.onSurfaceVariant.withValues(alpha: 0.5),
-                          ),
-                        ),
-                      )
-                    : ListView.builder(
-                        controller: _scrollCtrl,
-                        reverse: true,
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 12, vertical: 8),
-                        itemCount: events.length,
-                        itemBuilder: (context, i) {
-                          final event = events[i];
-                          final isMe =
-                              event.senderId == matrix.client.userID;
-
-                          // Group consecutive messages from same sender.
-                          final prevSender = i + 1 < events.length
-                              ? events[i + 1].senderId
-                              : null;
-                          final isFirst = event.senderId != prevSender;
-
-                          return MessageBubble(
-                            event: event,
-                            isMe: isMe,
-                            isFirst: isFirst,
-                          );
-                        },
-                      ),
-          ),
-
-          // ── Compose bar ──
-          _ComposeBar(
-            controller: _msgCtrl,
-            onSend: _send,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  room.getLocalizedDisplayname(),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: tt.titleMedium,
+                ),
+                Text(
+                  _memberCountLabel(room),
+                  style: tt.bodyMedium?.copyWith(fontSize: 11),
+                ),
+              ],
+            ),
           ),
         ],
       ),
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.search_rounded),
+          onPressed: _openSearch,
+        ),
+        IconButton(
+          icon: const Icon(Icons.more_vert_rounded),
+          onPressed: () {
+            // TODO: room details sheet
+          },
+        ),
+      ],
+    );
+  }
+
+  // ── Search app bar ────────────────────────────────────────
+
+  AppBar _buildSearchAppBar(ColorScheme cs, TextTheme tt) {
+    return AppBar(
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back_rounded),
+        onPressed: _closeSearch,
+      ),
+      titleSpacing: 0,
+      title: TextField(
+        controller: _searchCtrl,
+        focusNode: _searchFocusNode,
+        onChanged: _onSearchChanged,
+        style: tt.bodyLarge,
+        decoration: InputDecoration(
+          hintText: 'Search messages…',
+          border: InputBorder.none,
+          hintStyle: tt.bodyLarge?.copyWith(
+            color: cs.onSurfaceVariant.withValues(alpha: 0.5),
+          ),
+        ),
+      ),
+      actions: [
+        if (_searchCtrl.text.isNotEmpty)
+          IconButton(
+            icon: const Icon(Icons.close_rounded),
+            onPressed: () {
+              _searchCtrl.clear();
+              _onSearchChanged('');
+              _searchFocusNode.requestFocus();
+            },
+          ),
+      ],
+    );
+  }
+
+  // ── Chat body (messages + compose) ────────────────────────
+
+  Widget _buildChatBody(
+      List<Event> events, MatrixService matrix, ColorScheme cs, TextTheme tt) {
+    return Column(
+      children: [
+        // ── Messages ──
+        Expanded(
+          child: _timeline == null
+              ? const Center(child: CircularProgressIndicator())
+              : events.isEmpty
+                  ? Center(
+                      child: Text(
+                        'No messages yet.\nSay hello!',
+                        textAlign: TextAlign.center,
+                        style: tt.bodyMedium?.copyWith(
+                          color: cs.onSurfaceVariant.withValues(alpha: 0.5),
+                        ),
+                      ),
+                    )
+                  : ListView.builder(
+                      controller: _scrollCtrl,
+                      reverse: true,
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 12, vertical: 8),
+                      itemCount: events.length,
+                      itemBuilder: (context, i) {
+                        final event = events[i];
+                        final isMe =
+                            event.senderId == matrix.client.userID;
+
+                        // Group consecutive messages from same sender.
+                        final prevSender = i + 1 < events.length
+                            ? events[i + 1].senderId
+                            : null;
+                        final isFirst = event.senderId != prevSender;
+
+                        return MessageBubble(
+                          event: event,
+                          isMe: isMe,
+                          isFirst: isFirst,
+                          highlighted: event.eventId == _highlightedEventId,
+                        );
+                      },
+                    ),
+        ),
+
+        // ── Compose bar ──
+        _ComposeBar(
+          controller: _msgCtrl,
+          onSend: _send,
+        ),
+      ],
+    );
+  }
+
+  // ── Search body (results list) ────────────────────────────
+
+  Widget _buildSearchBody(ColorScheme cs, TextTheme tt) {
+    final query = _searchCtrl.text.trim();
+
+    // Not enough characters yet.
+    if (query.length < _minQueryLength) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Text(
+            'Type at least $_minQueryLength characters to search',
+            style: tt.bodyMedium?.copyWith(
+              color: cs.onSurfaceVariant.withValues(alpha: 0.5),
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+
+    // Error state.
+    if (_searchError != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.error_outline_rounded,
+                  size: 48, color: cs.error.withValues(alpha: 0.6)),
+              const SizedBox(height: 12),
+              Text(
+                _searchError!,
+                style: tt.bodyMedium?.copyWith(color: cs.error),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    // Loading first batch.
+    if (_isSearchLoading && _searchResults.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    // Empty results.
+    if (_searchResults.isEmpty && !_isSearchLoading) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.search_off_rounded,
+                  size: 48,
+                  color: cs.onSurfaceVariant.withValues(alpha: 0.4)),
+              const SizedBox(height: 12),
+              Text(
+                'No messages found for "$query"',
+                style: tt.bodyMedium?.copyWith(
+                  color: cs.onSurfaceVariant.withValues(alpha: 0.6),
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    // Results list.
+    return ListView.builder(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      itemCount: _searchResults.length + (_searchNextBatch != null ? 1 : 0),
+      itemBuilder: (context, i) {
+        // "Load more" button at the end.
+        if (i == _searchResults.length) {
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            child: Center(
+              child: _isSearchLoading
+                  ? const SizedBox(
+                      width: 24,
+                      height: 24,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : TextButton(
+                      onPressed: () => _performSearch(loadMore: true),
+                      child: const Text('Load more results'),
+                    ),
+            ),
+          );
+        }
+
+        final event = _searchResults[i];
+        return _SearchResultTile(
+          event: event,
+          query: query,
+          onTap: () => _scrollToEvent(event),
+        );
+      },
     );
   }
 
@@ -218,6 +522,179 @@ class _ChatScreenState extends State<ChatScreen> {
     return '$count members';
   }
 }
+
+// ── Search result tile ────────────────────────────────────────
+
+class _SearchResultTile extends StatelessWidget {
+  const _SearchResultTile({
+    required this.event,
+    required this.query,
+    required this.onTap,
+  });
+
+  final Event event;
+  final String query;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+    final senderName =
+        event.senderFromMemoryOrFallback.displayName ?? event.senderId;
+
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Sender avatar
+            CircleAvatar(
+              radius: 18,
+              backgroundColor: _senderColor(event.senderId, cs),
+              child: Text(
+                senderName.isNotEmpty ? senderName[0].toUpperCase() : '?',
+                style: const TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  color: Colors.white,
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+
+            // Content
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Sender name + timestamp
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          senderName,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: tt.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                      Text(
+                        _formatTimestamp(event.originServerTs),
+                        style: tt.bodySmall?.copyWith(
+                          color: cs.onSurfaceVariant.withValues(alpha: 0.5),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 2),
+
+                  // Message body with highlighted query
+                  _buildHighlightedBody(tt, cs),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHighlightedBody(TextTheme tt, ColorScheme cs) {
+    final body = event.body;
+    final spans = _highlightSpans(body, query);
+
+    return RichText(
+      maxLines: 2,
+      overflow: TextOverflow.ellipsis,
+      text: TextSpan(
+        style: tt.bodyMedium?.copyWith(
+          color: cs.onSurfaceVariant.withValues(alpha: 0.7),
+        ),
+        children: spans.map((span) {
+          if (span.isMatch) {
+            return TextSpan(
+              text: span.text,
+              style: TextStyle(
+                backgroundColor: cs.primaryContainer,
+                color: cs.onPrimaryContainer,
+                fontWeight: FontWeight.w600,
+              ),
+            );
+          }
+          return TextSpan(text: span.text);
+        }).toList(),
+      ),
+    );
+  }
+
+  Color _senderColor(String senderId, ColorScheme cs) {
+    final hash = senderId.codeUnits.fold<int>(0, (h, c) => h + c);
+    final palette = [
+      cs.primary,
+      cs.tertiary,
+      cs.secondary,
+      cs.error,
+      const Color(0xFF6750A4),
+      const Color(0xFFB4846C),
+      const Color(0xFF7C9A6E),
+      const Color(0xFFC17B5F),
+    ];
+    return palette[hash % palette.length];
+  }
+
+  String _formatTimestamp(DateTime ts) {
+    final now = DateTime.now();
+    final diff = now.difference(ts);
+    if (diff.inMinutes < 1) return 'now';
+    if (diff.inHours < 24) {
+      final h = ts.hour.toString().padLeft(2, '0');
+      final m = ts.minute.toString().padLeft(2, '0');
+      return '$h:$m';
+    }
+    if (diff.inDays < 7) return '${diff.inDays}d ago';
+    return '${ts.day.toString().padLeft(2, '0')}/${ts.month.toString().padLeft(2, '0')}';
+  }
+}
+
+// ── Highlighted text helpers ──────────────────────────────────
+
+class _HighlightSpan {
+  const _HighlightSpan(this.text, this.isMatch);
+  final String text;
+  final bool isMatch;
+}
+
+List<_HighlightSpan> _highlightSpans(String text, String query) {
+  if (query.isEmpty) return [_HighlightSpan(text, false)];
+
+  final lower = text.toLowerCase();
+  final queryLower = query.toLowerCase();
+  final spans = <_HighlightSpan>[];
+  var start = 0;
+
+  while (start < text.length) {
+    final index = lower.indexOf(queryLower, start);
+    if (index == -1) {
+      spans.add(_HighlightSpan(text.substring(start), false));
+      break;
+    }
+    if (index > start) {
+      spans.add(_HighlightSpan(text.substring(start, index), false));
+    }
+    spans.add(_HighlightSpan(
+        text.substring(index, index + query.length), true));
+    start = index + query.length;
+  }
+
+  return spans;
+}
+
+// ── Compose bar ───────────────────────────────────────────────
 
 class _ComposeBar extends StatelessWidget {
   const _ComposeBar({

--- a/lib/widgets/message_bubble.dart
+++ b/lib/widgets/message_bubble.dart
@@ -10,6 +10,7 @@ class MessageBubble extends StatelessWidget {
     required this.event,
     required this.isMe,
     required this.isFirst,
+    this.highlighted = false,
   });
 
   final Event event;
@@ -17,6 +18,9 @@ class MessageBubble extends StatelessWidget {
 
   /// Whether this is the first message in a group from the same sender.
   final bool isFirst;
+
+  /// Whether this message should be visually highlighted (e.g. from search).
+  final bool highlighted;
 
   @override
   Widget build(BuildContext context) {
@@ -26,10 +30,17 @@ class MessageBubble extends StatelessWidget {
     final density = context.watch<PreferencesService>().messageDensity;
     final metrics = _DensityMetrics.of(density);
 
-    return Padding(
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 500),
       padding: EdgeInsets.only(
         top: isFirst ? metrics.firstMessageTopPad : metrics.messageTopPad,
         bottom: metrics.messageBottomPad,
+      ),
+      decoration: BoxDecoration(
+        color: highlighted
+            ? cs.primaryContainer.withValues(alpha: 0.3)
+            : Colors.transparent,
+        borderRadius: BorderRadius.circular(8),
       ),
       child: Row(
         mainAxisAlignment:

--- a/test/screens/chat_search_test.dart
+++ b/test/screens/chat_search_test.dart
@@ -1,0 +1,204 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:matrix/matrix.dart';
+import 'package:provider/provider.dart';
+import 'package:lattice/services/matrix_service.dart';
+import 'package:lattice/services/preferences_service.dart';
+import 'package:lattice/screens/chat_screen.dart';
+
+@GenerateNiceMocks([
+  MockSpec<Client>(),
+  MockSpec<MatrixService>(),
+  MockSpec<Room>(),
+  MockSpec<Timeline>(),
+])
+import 'chat_search_test.mocks.dart';
+
+void main() {
+  late MockClient mockClient;
+  late MockMatrixService mockMatrix;
+  late MockRoom mockRoom;
+  late MockTimeline mockTimeline;
+  late PreferencesService prefsService;
+
+  setUp(() {
+    mockClient = MockClient();
+    mockMatrix = MockMatrixService();
+    mockRoom = MockRoom();
+    mockTimeline = MockTimeline();
+    prefsService = PreferencesService();
+
+    when(mockMatrix.client).thenReturn(mockClient);
+    when(mockClient.getRoomById('!room:example.com')).thenReturn(mockRoom);
+    when(mockClient.userID).thenReturn('@me:example.com');
+    when(mockRoom.getLocalizedDisplayname()).thenReturn('Test Room');
+    when(mockRoom.id).thenReturn('!room:example.com');
+    when(mockTimeline.events).thenReturn([]);
+    when(mockTimeline.canRequestHistory).thenReturn(false);
+    when(mockRoom.getTimeline(onUpdate: anyNamed('onUpdate')))
+        .thenAnswer((_) async => mockTimeline);
+  });
+
+  Widget buildTestWidget() {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider<MatrixService>.value(value: mockMatrix),
+        ChangeNotifierProvider<PreferencesService>.value(value: prefsService),
+      ],
+      child: const MaterialApp(
+        home: ChatScreen(roomId: '!room:example.com'),
+      ),
+    );
+  }
+
+  group('ChatScreen search', () {
+    testWidgets('shows search icon in app bar', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.search_rounded), findsOneWidget);
+    });
+
+    testWidgets('tapping search icon shows search app bar', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.search_rounded));
+      await tester.pumpAndSettle();
+
+      // Search text field should appear.
+      expect(find.widgetWithText(TextField, ''), findsWidgets);
+      // Back arrow should be present.
+      expect(find.byIcon(Icons.arrow_back_rounded), findsOneWidget);
+      // The original room title should be gone.
+      expect(find.text('Test Room'), findsNothing);
+      // Hint text should show.
+      expect(find.text('Search messages…'), findsOneWidget);
+    });
+
+    testWidgets('shows minimum character hint when query too short',
+        (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.search_rounded));
+      await tester.pumpAndSettle();
+
+      // Type less than 3 characters.
+      await tester.enterText(find.byType(TextField).last, 'ab');
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Type at least 3 characters to search'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('close button clears search and restores app bar',
+        (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      // Open search.
+      await tester.tap(find.byIcon(Icons.search_rounded));
+      await tester.pumpAndSettle();
+
+      // Tap back to close.
+      await tester.tap(find.byIcon(Icons.arrow_back_rounded));
+      await tester.pumpAndSettle();
+
+      // Room name should be back.
+      expect(find.text('Test Room'), findsOneWidget);
+      // Search hint should be gone.
+      expect(find.text('Search messages…'), findsNothing);
+    });
+
+    testWidgets('shows empty state when no results found', (tester) async {
+      when(mockRoom.searchEvents(
+        searchTerm: anyNamed('searchTerm'),
+        limit: anyNamed('limit'),
+        nextBatch: anyNamed('nextBatch'),
+      )).thenAnswer((_) async => (
+            events: <Event>[],
+            nextBatch: null,
+            searchedUntil: null,
+          ));
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      // Open search.
+      await tester.tap(find.byIcon(Icons.search_rounded));
+      await tester.pumpAndSettle();
+
+      // Type a query.
+      await tester.enterText(find.byType(TextField).last, 'xyz123');
+      await tester.pump(const Duration(milliseconds: 600)); // debounce
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('No messages found'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('shows error state when search fails', (tester) async {
+      when(mockRoom.searchEvents(
+        searchTerm: anyNamed('searchTerm'),
+        limit: anyNamed('limit'),
+        nextBatch: anyNamed('nextBatch'),
+      )).thenThrow(Exception('Server error'));
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      // Open search.
+      await tester.tap(find.byIcon(Icons.search_rounded));
+      await tester.pumpAndSettle();
+
+      // Type a query.
+      await tester.enterText(find.byType(TextField).last, 'hello world');
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Search failed. Please try again.'), findsOneWidget);
+      expect(find.byIcon(Icons.error_outline_rounded), findsOneWidget);
+    });
+
+    testWidgets('shows loading indicator while searching', (tester) async {
+      final completer = Completer<
+          ({List<Event> events, String? nextBatch, DateTime? searchedUntil})>();
+      when(mockRoom.searchEvents(
+        searchTerm: anyNamed('searchTerm'),
+        limit: anyNamed('limit'),
+        nextBatch: anyNamed('nextBatch'),
+      )).thenAnswer((_) => completer.future);
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      // Open search.
+      await tester.tap(find.byIcon(Icons.search_rounded));
+      await tester.pumpAndSettle();
+
+      // Type a query.
+      await tester.enterText(find.byType(TextField).last, 'hello');
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pump(); // Trigger the search.
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      // Complete the future to avoid pending timers.
+      completer.complete((
+        events: <Event>[],
+        nextBatch: null,
+        searchedUntil: null,
+      ));
+      await tester.pumpAndSettle();
+    });
+  });
+}


### PR DESCRIPTION
Add search functionality to the chat screen that allows users to find
messages within a specific room. Tapping the search icon replaces the
app bar with a text field that searches using Room.searchEvents() from
the Matrix SDK with 500ms debounce and 3-character minimum query.

Search results show sender avatar, name, message snippet with
highlighted matching text, and timestamp. Tapping a result closes
search and scrolls to the message with a brief highlight animation.
Pagination is supported via nextBatch tokens with a "Load more" button.

Includes empty state, loading indicator, and error handling UI.

Closes #8

https://claude.ai/code/session_01Q4MjKSuWPfhfE1EjPbcApn