### PR TITLE
feat: add DM device verification status and sender avatars

### DIFF
--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -7,8 +7,8 @@ import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import '../services/matrix_service.dart';
 import '../widgets/room_avatar.dart';
 import '../widgets/room_details_panel.dart';
-import '../utils/sender_color.dart';
 import '../widgets/message_bubble.dart';
+import '../widgets/user_avatar.dart';
 
 class ChatScreen extends StatefulWidget {
   const ChatScreen({
@@ -591,17 +591,11 @@ class _SearchResultTile extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // Sender avatar
-            CircleAvatar(
-              radius: 18,
-              backgroundColor: senderColor(event.senderId, cs),
-              child: Text(
-                senderName.isNotEmpty ? senderName[0].toUpperCase() : '?',
-                style: const TextStyle(
-                  fontSize: 13,
-                  fontWeight: FontWeight.w600,
-                  color: Colors.white,
-                ),
-              ),
+            UserAvatar(
+              client: event.room.client,
+              avatarUrl: event.senderFromMemoryOrFallback.avatarUrl,
+              userId: event.senderId,
+              size: 36,
             ),
             const SizedBox(width: 12),
 

--- a/lib/widgets/message_bubble.dart
+++ b/lib/widgets/message_bubble.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 import '../services/preferences_service.dart';
 import '../utils/media_auth.dart';
 import '../utils/sender_color.dart';
+import 'user_avatar.dart';
 
 class MessageBubble extends StatelessWidget {
   const MessageBubble({
@@ -55,19 +56,11 @@ class MessageBubble extends StatelessWidget {
           if (!isMe && isFirst)
             Padding(
               padding: const EdgeInsets.only(right: 8),
-              child: CircleAvatar(
-                radius: metrics.avatarRadius,
-                backgroundColor: senderColor(event.senderId, cs),
-                child: Text(
-                  _senderInitial(event),
-                  style: TextStyle(
-                    fontSize: metrics.avatarFontSize,
-                    fontWeight: FontWeight.w600,
-                    color: ThemeData.estimateBrightnessForColor(senderColor(event.senderId, cs)) == Brightness.dark
-                        ? Colors.white
-                        : Colors.black,
-                  ),
-                ),
+              child: UserAvatar(
+                client: event.room.client,
+                avatarUrl: event.senderFromMemoryOrFallback.avatarUrl,
+                userId: event.senderId,
+                size: metrics.avatarRadius * 2,
               ),
             )
           else if (!isMe)
@@ -169,12 +162,6 @@ class MessageBubble extends StatelessWidget {
         height: metrics.bodyLineHeight,
       ),
     );
-  }
-
-  String _senderInitial(Event event) {
-    final name =
-        event.senderFromMemoryOrFallback.displayName ?? event.senderId;
-    return name.isNotEmpty ? name[0].toUpperCase() : '?';
   }
 
   String _formatTime(DateTime ts) {


### PR DESCRIPTION
Show partner device verification summary in room details for encrypted DMs with expandable device list and inline verify action. Replace initial-only CircleAvatars with UserAvatar widget in message bubbles and search results to display actual Matrix profile images.

Closes #33