### PR TITLE
Extract SectionHeader widget to reusable component

### DIFF
--- a/lib/screens/devices_screen.dart
+++ b/lib/screens/devices_screen.dart
@@ -8,6 +8,7 @@ import '../extensions/device_extension.dart';
 import '../services/matrix_service.dart';
 import '../widgets/device_list_item.dart';
 import '../widgets/key_verification_dialog.dart';
+import '../widgets/section_header.dart';
 
 class DevicesScreen extends StatefulWidget {
   const DevicesScreen({super.key});
@@ -379,7 +380,7 @@ class _DevicesScreenState extends State<DevicesScreen> {
 
           // ── This Device ──
           if (thisDevice.isNotEmpty) ...[
-            const _SectionHeader(label: 'THIS DEVICE'),
+            const SectionHeader(label: 'THIS DEVICE'),
             Card(
               child: DeviceListItem(
                 device: thisDevice.first,
@@ -392,7 +393,7 @@ class _DevicesScreenState extends State<DevicesScreen> {
           ],
 
           // ── Other Devices ──
-          const _SectionHeader(label: 'OTHER DEVICES'),
+          const SectionHeader(label: 'OTHER DEVICES'),
           if (otherDevices.isEmpty)
             Card(
               child: Padding(
@@ -466,25 +467,3 @@ class _DevicesScreenState extends State<DevicesScreen> {
   }
 }
 
-// ── Private Section Header ───────────────────────────────────
-
-class _SectionHeader extends StatelessWidget {
-  const _SectionHeader({required this.label});
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-    return Padding(
-      padding: const EdgeInsets.only(left: 4, bottom: 8),
-      child: Text(
-        label,
-        style: tt.labelSmall?.copyWith(
-          color: cs.primary,
-          letterSpacing: 1.5,
-        ),
-      ),
-    );
-  }
-}

--- a/lib/screens/notification_settings_screen.dart
+++ b/lib/screens/notification_settings_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../services/preferences_service.dart';
+import '../widgets/section_header.dart';
 
 class NotificationSettingsScreen extends StatefulWidget {
   const NotificationSettingsScreen({super.key});
@@ -48,7 +49,7 @@ class _NotificationSettingsScreenState
         padding: const EdgeInsets.all(16),
         children: [
           // ── Notification level ──────────────────────────────
-          const _SectionHeader(label: 'NOTIFICATION LEVEL'),
+          const SectionHeader(label: 'NOTIFICATION LEVEL'),
           Card(
             child: RadioGroup<NotificationLevel>(
               groupValue: prefs.notificationLevel,
@@ -81,7 +82,7 @@ class _NotificationSettingsScreenState
           ),
 
           // ── Custom keywords ─────────────────────────────────
-          const _SectionHeader(label: 'CUSTOM KEYWORDS'),
+          const SectionHeader(label: 'CUSTOM KEYWORDS'),
           Card(
             child: Padding(
               padding: const EdgeInsets.all(16),
@@ -142,7 +143,7 @@ class _NotificationSettingsScreenState
           const SizedBox(height: 24),
 
           // ── OS notifications ─────────────────────────────────
-          const _SectionHeader(label: 'OS NOTIFICATIONS'),
+          const SectionHeader(label: 'OS NOTIFICATIONS'),
           Card(
             child: Column(
               children: [
@@ -187,25 +188,3 @@ class _NotificationSettingsScreenState
   }
 }
 
-// ── Section header ──────────────────────────────────────────────
-
-class _SectionHeader extends StatelessWidget {
-  const _SectionHeader({required this.label});
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-    return Padding(
-      padding: const EdgeInsets.only(left: 4, bottom: 8),
-      child: Text(
-        label,
-        style: tt.labelSmall?.copyWith(
-          color: cs.primary,
-          letterSpacing: 1.5,
-        ),
-      ),
-    );
-  }
-}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -8,6 +8,7 @@ import '../services/client_manager.dart';
 import '../services/matrix_service.dart';
 import '../services/preferences_service.dart';
 import '../widgets/bootstrap_dialog.dart';
+import '../widgets/section_header.dart';
 import '../widgets/user_avatar.dart';
 import 'devices_screen.dart';
 import 'notification_settings_screen.dart';
@@ -272,7 +273,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           // ── Account Switcher ──
           if (manager.hasMultipleAccounts) ...[
             const SizedBox(height: 16),
-            const _SectionHeader(label: 'ACCOUNTS'),
+            const SectionHeader(label: 'ACCOUNTS'),
             Card(
               child: Column(
                 children: [
@@ -323,7 +324,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           const SizedBox(height: 16),
 
           // ── Preferences ──
-          const _SectionHeader(label: 'PREFERENCES'),
+          const SectionHeader(label: 'PREFERENCES'),
           Card(
             child: Column(
               children: [
@@ -360,7 +361,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           const SizedBox(height: 16),
 
           // ── Security ──
-          const _SectionHeader(label: 'SECURITY'),
+          const SectionHeader(label: 'SECURITY'),
           Card(
             child: Column(
               children: [
@@ -400,7 +401,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           const SizedBox(height: 16),
 
           // ── About ──
-          const _SectionHeader(label: 'ABOUT'),
+          const SectionHeader(label: 'ABOUT'),
           Card(
             child: Column(
               children: [
@@ -653,27 +654,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
   }
 
-}
-
-class _SectionHeader extends StatelessWidget {
-  const _SectionHeader({required this.label});
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-    return Padding(
-      padding: const EdgeInsets.only(left: 4, bottom: 8),
-      child: Text(
-        label,
-        style: tt.labelSmall?.copyWith(
-          color: cs.primary,
-          letterSpacing: 1.5,
-        ),
-      ),
-    );
-  }
 }
 
 class _DisableBackupDialog extends StatefulWidget {

--- a/lib/widgets/section_header.dart
+++ b/lib/widgets/section_header.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class SectionHeader extends StatelessWidget {
+  const SectionHeader({super.key, required this.label});
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.only(left: 4, bottom: 8),
+      child: Text(
+        label,
+        style: tt.labelSmall?.copyWith(
+          color: cs.primary,
+          letterSpacing: 1.5,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Refactored the `_SectionHeader` widget from being duplicated across multiple screens into a single reusable `SectionHeader` component in the widgets directory.

## Key Changes
- Created new `lib/widgets/section_header.dart` with the `SectionHeader` widget
- Removed duplicate `_SectionHeader` private class implementations from:
  - `lib/screens/settings_screen.dart`
  - `lib/screens/notification_settings_screen.dart`
  - `lib/screens/devices_screen.dart`
- Updated all three screens to import and use the new shared `SectionHeader` widget
- Changed all usages from `_SectionHeader` (private) to `SectionHeader` (public)

## Implementation Details
The extracted `SectionHeader` widget maintains the same styling and functionality as the original implementations:
- Displays a label with primary color and letter spacing (1.5)
- Uses `labelSmall` text theme with custom styling
- Applies consistent padding (left: 4, bottom: 8)

This change eliminates code duplication and makes the component available for use in other screens if needed in the future.

https://claude.ai/code/session_018d4jaG1hdb8mmGUmkBekoU