### PR TITLE
refactor: extract AppLogoHeader to shared widget

### DIFF
--- a/lib/screens/homeserver_screen.dart
+++ b/lib/screens/homeserver_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../services/matrix_service.dart' show MatrixService;
+import '../widgets/app_logo_header.dart';
 import '../widgets/homeserver_controller.dart';
 import 'login_screen.dart';
 import 'registration_screen.dart';
@@ -81,7 +82,6 @@ class _HomeserverScreenState extends State<HomeserverScreen>
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
 
     final isChecking = _controller.state == HomeserverState.checking;
     final hasError = _controller.state == HomeserverState.error;
@@ -97,28 +97,9 @@ class _HomeserverScreenState extends State<HomeserverScreen>
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  // ── Logo ──
-                  Container(
-                    width: 72,
-                    height: 72,
-                    decoration: BoxDecoration(
-                      color: cs.primaryContainer,
-                      borderRadius: BorderRadius.circular(20),
-                    ),
-                    child: Icon(
-                      Icons.hub_rounded,
-                      size: 36,
-                      color: cs.onPrimaryContainer,
-                    ),
+                  const AppLogoHeader(
+                    subtitle: 'Connect to the Matrix network',
                   ),
-                  const SizedBox(height: 20),
-                  Text('Lattice', style: tt.displayLarge),
-                  const SizedBox(height: 4),
-                  Text(
-                    'Connect to the Matrix network',
-                    style: tt.bodyMedium,
-                  ),
-                  const SizedBox(height: 40),
 
                   // ── Homeserver ──
                   TextField(

--- a/lib/screens/registration_screen.dart
+++ b/lib/screens/registration_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../services/matrix_service.dart';
+import '../widgets/app_logo_header.dart';
 import '../widgets/registration_controller.dart';
 import '../widgets/registration_views.dart';
 
@@ -116,7 +117,6 @@ class _RegistrationScreenState extends State<RegistrationScreen>
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
 
     final isChecking = _controller.state == RegistrationState.checkingServer;
     final isRegistering = _controller.state == RegistrationState.registering;
@@ -148,28 +148,9 @@ class _RegistrationScreenState extends State<RegistrationScreen>
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  // ── Logo ──
-                  Container(
-                    width: 72,
-                    height: 72,
-                    decoration: BoxDecoration(
-                      color: cs.primaryContainer,
-                      borderRadius: BorderRadius.circular(20),
-                    ),
-                    child: Icon(
-                      Icons.hub_rounded,
-                      size: 36,
-                      color: cs.onPrimaryContainer,
-                    ),
+                  const AppLogoHeader(
+                    subtitle: 'Create an account on the Matrix network',
                   ),
-                  const SizedBox(height: 20),
-                  Text('Lattice', style: tt.displayLarge),
-                  const SizedBox(height: 4),
-                  Text(
-                    'Create an account on the Matrix network',
-                    style: tt.bodyMedium,
-                  ),
-                  const SizedBox(height: 40),
 
                   // ── Homeserver ──
                   TextField(

--- a/lib/widgets/app_logo_header.dart
+++ b/lib/widgets/app_logo_header.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+class AppLogoHeader extends StatelessWidget {
+  const AppLogoHeader({super.key, required this.subtitle});
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // ── Logo ──
+        Container(
+          width: 72,
+          height: 72,
+          decoration: BoxDecoration(
+            color: cs.primaryContainer,
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Icon(
+            Icons.hub_rounded,
+            size: 36,
+            color: cs.onPrimaryContainer,
+          ),
+        ),
+        const SizedBox(height: 20),
+        Text('Lattice', style: tt.displayLarge),
+        const SizedBox(height: 4),
+        Text(subtitle, style: tt.bodyMedium),
+        const SizedBox(height: 40),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Extract duplicated app logo + title header into `lib/widgets/app_logo_header.dart`
- Update `homeserver_screen.dart` and `registration_screen.dart` to use the shared widget
- No visual changes

Closes #49