### PR TITLE
refactor: extract PasswordField to shared widget

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../services/client_manager.dart';
 import '../services/matrix_service.dart';
 import '../widgets/login_controller.dart';
+import '../widgets/password_field.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({
@@ -23,8 +24,6 @@ class _LoginScreenState extends State<LoginScreen>
     with SingleTickerProviderStateMixin {
   final _usernameCtrl = TextEditingController();
   final _passwordCtrl = TextEditingController();
-  bool _obscurePassword = true;
-
   late final AnimationController _fadeCtrl;
   late final Animation<double> _fadeAnim;
 
@@ -144,25 +143,9 @@ class _LoginScreenState extends State<LoginScreen>
                       textInputAction: TextInputAction.next,
                     ),
                     const SizedBox(height: 14),
-                    TextField(
+                    PasswordField(
                       controller: _passwordCtrl,
                       enabled: formEnabled,
-                      obscureText: _obscurePassword,
-                      decoration: InputDecoration(
-                        prefixIcon: Icon(Icons.lock_outline,
-                            color: cs.onSurfaceVariant),
-                        hintText: 'Password',
-                        suffixIcon: IconButton(
-                          icon: Icon(
-                            _obscurePassword
-                                ? Icons.visibility_off_outlined
-                                : Icons.visibility_outlined,
-                            color: cs.onSurfaceVariant,
-                          ),
-                          onPressed: () => setState(
-                              () => _obscurePassword = !_obscurePassword),
-                        ),
-                      ),
                       textInputAction: TextInputAction.done,
                       onSubmitted: formEnabled ? (_) => _login() : null,
                     ),

--- a/lib/screens/registration_screen.dart
+++ b/lib/screens/registration_screen.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 
 import '../services/matrix_service.dart';
 import '../widgets/app_logo_header.dart';
+import '../widgets/password_field.dart';
 import '../widgets/registration_controller.dart';
 import '../widgets/registration_views.dart';
 
@@ -25,8 +26,6 @@ class _RegistrationScreenState extends State<RegistrationScreen>
   final _confirmPasswordCtrl = TextEditingController();
   final _tokenCtrl = TextEditingController();
 
-  bool _obscurePassword = true;
-  bool _obscureConfirmPassword = true;
   String? _confirmPasswordError;
 
   late final AnimationController _fadeCtrl;
@@ -209,51 +208,20 @@ class _RegistrationScreenState extends State<RegistrationScreen>
                   const SizedBox(height: 14),
 
                   // ── Password ──
-                  TextField(
+                  PasswordField(
                     controller: _passwordCtrl,
                     enabled: formEnabled,
-                    obscureText: _obscurePassword,
-                    decoration: InputDecoration(
-                      prefixIcon:
-                          Icon(Icons.lock_outline, color: cs.onSurfaceVariant),
-                      hintText: 'Password',
-                      errorText: _controller.passwordError,
-                      suffixIcon: IconButton(
-                        icon: Icon(
-                          _obscurePassword
-                              ? Icons.visibility_off_outlined
-                              : Icons.visibility_outlined,
-                          color: cs.onSurfaceVariant,
-                        ),
-                        onPressed: () => setState(
-                            () => _obscurePassword = !_obscurePassword),
-                      ),
-                    ),
+                    errorText: _controller.passwordError,
                     textInputAction: TextInputAction.next,
                   ),
                   const SizedBox(height: 14),
 
                   // ── Confirm Password ──
-                  TextField(
+                  PasswordField(
                     controller: _confirmPasswordCtrl,
+                    hintText: 'Confirm password',
                     enabled: formEnabled,
-                    obscureText: _obscureConfirmPassword,
-                    decoration: InputDecoration(
-                      prefixIcon:
-                          Icon(Icons.lock_outline, color: cs.onSurfaceVariant),
-                      hintText: 'Confirm password',
-                      errorText: _confirmPasswordError,
-                      suffixIcon: IconButton(
-                        icon: Icon(
-                          _obscureConfirmPassword
-                              ? Icons.visibility_off_outlined
-                              : Icons.visibility_outlined,
-                          color: cs.onSurfaceVariant,
-                        ),
-                        onPressed: () => setState(() =>
-                            _obscureConfirmPassword = !_obscureConfirmPassword),
-                      ),
-                    ),
+                    errorText: _confirmPasswordError,
                     textInputAction: TextInputAction.done,
                     onSubmitted: formEnabled ? (_) => _submit() : null,
                   ),

--- a/lib/widgets/password_field.dart
+++ b/lib/widgets/password_field.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+class PasswordField extends StatefulWidget {
+  const PasswordField({
+    super.key,
+    required this.controller,
+    this.hintText = 'Password',
+    this.errorText,
+    this.enabled = true,
+    this.textInputAction,
+    this.onSubmitted,
+  });
+
+  final TextEditingController controller;
+  final String hintText;
+  final String? errorText;
+  final bool enabled;
+  final TextInputAction? textInputAction;
+  final ValueChanged<String>? onSubmitted;
+
+  @override
+  State<PasswordField> createState() => _PasswordFieldState();
+}
+
+class _PasswordFieldState extends State<PasswordField> {
+  bool _obscure = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return TextField(
+      controller: widget.controller,
+      enabled: widget.enabled,
+      obscureText: _obscure,
+      decoration: InputDecoration(
+        prefixIcon: Icon(Icons.lock_outline, color: cs.onSurfaceVariant),
+        hintText: widget.hintText,
+        errorText: widget.errorText,
+        suffixIcon: IconButton(
+          icon: Icon(
+            _obscure
+                ? Icons.visibility_off_outlined
+                : Icons.visibility_outlined,
+            color: cs.onSurfaceVariant,
+          ),
+          onPressed: () => setState(() => _obscure = !_obscure),
+        ),
+      ),
+      textInputAction: widget.textInputAction,
+      onSubmitted: widget.onSubmitted,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Extract duplicated password TextField with visibility toggle into `lib/widgets/password_field.dart`
- Update `login_screen.dart` and `registration_screen.dart` to use the shared `PasswordField` widget
- Each screen drops its `_obscure*` boolean state — `PasswordField` manages toggle internally
- No visual changes

Closes #50