### PR TITLE
refactor: extract inline dialogs from settings_screen.dart

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -7,8 +7,11 @@ import 'package:url_launcher/url_launcher.dart';
 import '../services/client_manager.dart';
 import '../services/matrix_service.dart';
 import '../services/preferences_service.dart';
+import '../widgets/backup_info_dialog.dart';
 import '../widgets/bootstrap_dialog.dart';
+import '../widgets/density_picker_dialog.dart';
 import '../widgets/section_header.dart';
+import '../widgets/theme_picker_dialog.dart';
 import '../widgets/user_avatar.dart';
 import 'devices_screen.dart';
 import 'notification_settings_screen.dart';
@@ -332,7 +335,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   icon: Icons.dark_mode_outlined,
                   title: 'Theme',
                   subtitle: prefs.themeModeLabel,
-                  onTap: () => _showThemePicker(context),
+                  onTap: () => ThemePickerDialog.show(context),
                 ),
                 const Divider(height: 1, indent: 56),
                 _SettingsTile(
@@ -352,7 +355,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   icon: Icons.text_fields_rounded,
                   title: 'Message density',
                   subtitle: prefs.messageDensity.label,
-                  onTap: () => _showDensityPicker(context),
+                  onTap: () => DensityPickerDialog.show(context),
                 ),
               ],
             ),
@@ -378,7 +381,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   onTap: matrix.chatBackupLoading
                       ? () {}
                       : () => matrix.chatBackupEnabled
-                          ? _showBackupInfo(context)
+                          ? BackupInfoDialog.show(
+                              context,
+                              onDisableBackup: () =>
+                                  _confirmDisableBackup(context),
+                            )
                           : BootstrapDialog.show(context),
                 ),
                 const Divider(height: 1, indent: 56),
@@ -441,129 +448,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ),
 
           const SizedBox(height: 32),
-        ],
-      ),
-    );
-  }
-
-  void _showThemePicker(BuildContext context) {
-    final prefs = context.read<PreferencesService>();
-    final options = [
-      (ThemeMode.system, 'System default'),
-      (ThemeMode.light, 'Light'),
-      (ThemeMode.dark, 'Dark'),
-    ];
-    showDialog(
-      context: context,
-      builder: (ctx) {
-        return AlertDialog(
-          title: const Text('Theme'),
-          contentPadding: const EdgeInsets.only(top: 12, bottom: 8),
-          content: RadioGroup<ThemeMode>(
-            groupValue: prefs.themeMode,
-            onChanged: (ThemeMode? value) {
-              if (value != null) {
-                prefs.setThemeMode(value);
-                Navigator.pop(ctx);
-              }
-            },
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: options.map((option) {
-                final (mode, label) = option;
-                return RadioListTile<ThemeMode>(
-                  title: Text(label),
-                  value: mode,
-                  mouseCursor: SystemMouseCursors.click,
-                );
-              }).toList(),
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(ctx),
-              child: const Text('Cancel'),
-            ),
-          ],
-        );
-      },
-    );
-  }
-
-  void _showDensityPicker(BuildContext context) {
-    final prefs = context.read<PreferencesService>();
-    showDialog(
-      context: context,
-      builder: (ctx) {
-        return AlertDialog(
-          title: const Text('Message density'),
-          contentPadding: const EdgeInsets.only(top: 12, bottom: 8),
-          content: RadioGroup<MessageDensity>(
-            groupValue: prefs.messageDensity,
-            onChanged: (MessageDensity? value) {
-              if (value != null) {
-                prefs.setMessageDensity(value);
-                Navigator.pop(ctx);
-              }
-            },
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: MessageDensity.values.map((density) {
-                return RadioListTile<MessageDensity>(
-                  title: Text(density.label),
-                  value: density,
-                  mouseCursor: SystemMouseCursors.click,
-                );
-              }).toList(),
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(ctx),
-              child: const Text('Cancel'),
-            ),
-          ],
-        );
-      },
-    );
-  }
-
-  void _showBackupInfo(BuildContext context) {
-    showDialog(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Chat backup'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              Icons.check_circle,
-              color: Theme.of(ctx).colorScheme.primary,
-              size: 64,
-            ),
-            const SizedBox(height: 16),
-            const Text(
-              'Your keys are backed up. Your encrypted messages are '
-              'secure and accessible from any device.',
-              textAlign: TextAlign.center,
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(
-            onPressed: () {
-              Navigator.pop(ctx);
-              _confirmDisableBackup(context);
-            },
-            child: Text(
-              'Disable backup',
-              style: TextStyle(color: Theme.of(ctx).colorScheme.error),
-            ),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx),
-            child: const Text('OK'),
-          ),
         ],
       ),
     );

--- a/lib/widgets/backup_info_dialog.dart
+++ b/lib/widgets/backup_info_dialog.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+// ── Backup info dialog ──────────────────────────────────────────
+
+class BackupInfoDialog extends StatelessWidget {
+  const BackupInfoDialog._({required this.onDisableBackup});
+
+  final VoidCallback onDisableBackup;
+
+  static Future<void> show(
+    BuildContext context, {
+    required VoidCallback onDisableBackup,
+  }) {
+    return showDialog(
+      context: context,
+      builder: (_) => BackupInfoDialog._(onDisableBackup: onDisableBackup),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return AlertDialog(
+      title: const Text('Chat backup'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.check_circle,
+            color: cs.primary,
+            size: 64,
+          ),
+          const SizedBox(height: 16),
+          const Text(
+            'Your keys are backed up. Your encrypted messages are '
+            'secure and accessible from any device.',
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.pop(context);
+            onDisableBackup();
+          },
+          child: Text(
+            'Disable backup',
+            style: TextStyle(color: cs.error),
+          ),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('OK'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/density_picker_dialog.dart
+++ b/lib/widgets/density_picker_dialog.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/preferences_service.dart';
+
+// ── Density picker dialog ───────────────────────────────────────
+
+class DensityPickerDialog extends StatelessWidget {
+  const DensityPickerDialog._();
+
+  static Future<void> show(BuildContext context) {
+    return showDialog(
+      context: context,
+      builder: (_) => const DensityPickerDialog._(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final prefs = context.read<PreferencesService>();
+    return AlertDialog(
+      title: const Text('Message density'),
+      contentPadding: const EdgeInsets.only(top: 12, bottom: 8),
+      content: RadioGroup<MessageDensity>(
+        groupValue: prefs.messageDensity,
+        onChanged: (MessageDensity? value) {
+          if (value != null) {
+            prefs.setMessageDensity(value);
+            Navigator.pop(context);
+          }
+        },
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: MessageDensity.values.map((density) {
+            return RadioListTile<MessageDensity>(
+              title: Text(density.label),
+              value: density,
+              mouseCursor: SystemMouseCursors.click,
+            );
+          }).toList(),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/theme_picker_dialog.dart
+++ b/lib/widgets/theme_picker_dialog.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/preferences_service.dart';
+
+// ── Theme picker dialog ─────────────────────────────────────────
+
+class ThemePickerDialog extends StatelessWidget {
+  const ThemePickerDialog._();
+
+  static Future<void> show(BuildContext context) {
+    return showDialog(
+      context: context,
+      builder: (_) => const ThemePickerDialog._(),
+    );
+  }
+
+  static const _options = [
+    (ThemeMode.system, 'System default'),
+    (ThemeMode.light, 'Light'),
+    (ThemeMode.dark, 'Dark'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final prefs = context.read<PreferencesService>();
+    return AlertDialog(
+      title: const Text('Theme'),
+      contentPadding: const EdgeInsets.only(top: 12, bottom: 8),
+      content: RadioGroup<ThemeMode>(
+        groupValue: prefs.themeMode,
+        onChanged: (ThemeMode? value) {
+          if (value != null) {
+            prefs.setThemeMode(value);
+            Navigator.pop(context);
+          }
+        },
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: _options.map((option) {
+            final (mode, label) = option;
+            return RadioListTile<ThemeMode>(
+              title: Text(label),
+              value: mode,
+              mouseCursor: SystemMouseCursors.click,
+            );
+          }).toList(),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Extract `ThemePickerDialog`, `DensityPickerDialog`, and `BackupInfoDialog` from inline builder methods in `settings_screen.dart` into standalone widget classes in `lib/widgets/`
- Each dialog follows the project's `static show()` + private constructor convention (matching `NewRoomDialog`, etc.)
- Reduces `settings_screen.dart` by ~125 lines with no visual changes

Closes #51

## Test plan
- [x] `flutter analyze` passes with no issues
- [x] All 389 existing tests pass
- [x] Open Settings → tap Theme picker → verify dialog appears and selection works
- [x] Open Settings → tap Message density → verify dialog appears and selection works
- [x] Open Settings → tap Chat backup (when enabled) → verify info dialog appears, "Disable backup" triggers confirmation