### PR TITLE
feat: add inline code and code block rendering with syntax highlighting

### DIFF
--- a/lib/widgets/chat/code_block.dart
+++ b/lib/widgets/chat/code_block.dart
@@ -1,0 +1,293 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:highlight/highlight_core.dart' as hi;
+import 'package:highlight/languages/bash.dart' as lang_bash;
+import 'package:highlight/languages/c.dart' as lang_c;
+import 'package:highlight/languages/cpp.dart' as lang_cpp;
+import 'package:highlight/languages/cs.dart' as lang_cs;
+import 'package:highlight/languages/css.dart' as lang_css;
+import 'package:highlight/languages/dart.dart' as lang_dart;
+import 'package:highlight/languages/go.dart' as lang_go;
+import 'package:highlight/languages/java.dart' as lang_java;
+import 'package:highlight/languages/javascript.dart' as lang_js;
+import 'package:highlight/languages/json.dart' as lang_json;
+import 'package:highlight/languages/kotlin.dart' as lang_kotlin;
+import 'package:highlight/languages/markdown.dart' as lang_md;
+import 'package:highlight/languages/php.dart' as lang_php;
+import 'package:highlight/languages/python.dart' as lang_python;
+import 'package:highlight/languages/ruby.dart' as lang_ruby;
+import 'package:highlight/languages/rust.dart' as lang_rust;
+import 'package:highlight/languages/sql.dart' as lang_sql;
+import 'package:highlight/languages/swift.dart' as lang_swift;
+import 'package:highlight/languages/typescript.dart' as lang_ts;
+import 'package:highlight/languages/xml.dart' as lang_xml;
+import 'package:highlight/languages/yaml.dart' as lang_yaml;
+
+/// Renders a fenced code block with syntax highlighting and a copy button.
+///
+/// Used by [HtmlMessageText] to render `<pre><code>` blocks from Matrix
+/// formatted messages.
+class CodeBlock extends StatelessWidget {
+  const CodeBlock({
+    super.key,
+    required this.code,
+    this.language,
+    required this.isMe,
+  });
+
+  final String code;
+  final String? language;
+  final bool isMe;
+
+  // ── Highlight.js engine (singleton) ──────────────────────────────
+
+  static final hi.Highlight _highlight = _initHighlight();
+
+  static hi.Highlight _initHighlight() {
+    final h = hi.Highlight();
+    h.registerLanguage('bash', lang_bash.bash);
+    h.registerLanguage('c', lang_c.c);
+    h.registerLanguage('cpp', lang_cpp.cpp);
+    h.registerLanguage('csharp', lang_cs.cs);
+    h.registerLanguage('css', lang_css.css);
+    h.registerLanguage('dart', lang_dart.dart);
+    h.registerLanguage('go', lang_go.go);
+    h.registerLanguage('java', lang_java.java);
+    h.registerLanguage('javascript', lang_js.javascript);
+    h.registerLanguage('json', lang_json.json);
+    h.registerLanguage('kotlin', lang_kotlin.kotlin);
+    h.registerLanguage('markdown', lang_md.markdown);
+    h.registerLanguage('php', lang_php.php);
+    h.registerLanguage('python', lang_python.python);
+    h.registerLanguage('ruby', lang_ruby.ruby);
+    h.registerLanguage('rust', lang_rust.rust);
+    h.registerLanguage('sql', lang_sql.sql);
+    h.registerLanguage('swift', lang_swift.swift);
+    h.registerLanguage('typescript', lang_ts.typescript);
+    h.registerLanguage('html', lang_xml.xml);
+    h.registerLanguage('xml', lang_xml.xml);
+    h.registerLanguage('yaml', lang_yaml.yaml);
+    // Common aliases.
+    h.registerLanguage('js', lang_js.javascript);
+    h.registerLanguage('ts', lang_ts.typescript);
+    h.registerLanguage('py', lang_python.python);
+    h.registerLanguage('rb', lang_ruby.ruby);
+    h.registerLanguage('sh', lang_bash.bash);
+    h.registerLanguage('shell', lang_bash.bash);
+    h.registerLanguage('cs', lang_cs.cs);
+    h.registerLanguage('md', lang_md.markdown);
+    h.registerLanguage('yml', lang_yaml.yaml);
+    return h;
+  }
+
+  // ── Build ────────────────────────────────────────────────────────
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final brightness = Theme.of(context).brightness;
+
+    final bgColor = isMe
+        ? cs.onPrimary.withValues(alpha: 0.12)
+        : cs.surfaceContainerHighest;
+
+    final textColor = isMe ? cs.onPrimary : cs.onSurface;
+
+    final codeSpans = _buildHighlightedSpans(cs, brightness, textColor);
+
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // ── Header bar ─────────────────────────────────────────
+          Padding(
+            padding: const EdgeInsets.only(left: 12, right: 4, top: 4),
+            child: Row(
+              children: [
+                if (language != null)
+                  Text(
+                    language!,
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: textColor.withValues(alpha: 0.6),
+                        ),
+                  ),
+                const Spacer(),
+                SizedBox(
+                  height: 32,
+                  width: 32,
+                  child: IconButton(
+                    icon: Icon(
+                      Icons.copy_rounded,
+                      size: 16,
+                      color: textColor.withValues(alpha: 0.6),
+                    ),
+                    padding: EdgeInsets.zero,
+                    tooltip: 'Copy code',
+                    onPressed: () {
+                      Clipboard.setData(ClipboardData(text: code));
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Copied to clipboard'),
+                          duration: Duration(seconds: 2),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          // ── Code area ──────────────────────────────────────────
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 400),
+            child: SingleChildScrollView(
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+                child: Text.rich(
+                  TextSpan(
+                    style: TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 13,
+                      height: 1.5,
+                      color: textColor,
+                    ),
+                    children: codeSpans,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── Syntax highlighting ──────────────────────────────────────────
+
+  List<TextSpan> _buildHighlightedSpans(
+    ColorScheme cs,
+    Brightness brightness,
+    Color defaultColor,
+  ) {
+    hi.Result result;
+    try {
+      if (language != null) {
+        result = _highlight.parse(code, language: language);
+      } else {
+        result = _highlight.parse(code, autoDetection: true);
+      }
+    } catch (_) {
+      return [TextSpan(text: code)];
+    }
+
+    if (result.nodes == null) {
+      return [TextSpan(text: code)];
+    }
+
+    final theme = _buildThemeMap(cs, brightness, defaultColor);
+    final spans = <TextSpan>[];
+    for (final node in result.nodes!) {
+      _walkNode(node, theme, defaultColor, spans);
+    }
+    return spans;
+  }
+
+  void _walkNode(
+    hi.Node node,
+    Map<String, TextStyle> theme,
+    Color defaultColor,
+    List<TextSpan> spans,
+  ) {
+    if (node.value != null) {
+      final style = node.className != null ? theme[node.className] : null;
+      spans.add(TextSpan(text: node.value, style: style));
+    } else if (node.children != null) {
+      for (final child in node.children!) {
+        // Nested nodes may refine the class name.
+        if (child.className == null && node.className != null) {
+          child.className = node.className;
+        }
+        _walkNode(child, theme, defaultColor, spans);
+      }
+    }
+  }
+
+  static Map<String, TextStyle> _buildThemeMap(
+    ColorScheme cs,
+    Brightness brightness,
+    Color defaultColor,
+  ) {
+    final isLight = brightness == Brightness.light;
+
+    final keyword = TextStyle(
+      color: cs.primary,
+      fontWeight: FontWeight.w600,
+    );
+    final string = TextStyle(
+      color: isLight ? const Color(0xFF2E7D32) : const Color(0xFF81C784),
+    );
+    final comment = TextStyle(
+      color: defaultColor.withValues(alpha: 0.5),
+      fontStyle: FontStyle.italic,
+    );
+    final number = TextStyle(color: cs.secondary);
+    final title = TextStyle(color: cs.tertiary);
+    final builtin = TextStyle(color: cs.secondary);
+
+    return {
+      'keyword': keyword,
+      'built_in': builtin,
+      'type': title,
+      'literal': number,
+      'number': number,
+      'regexp': string,
+      'string': string,
+      'subst': string,
+      'symbol': number,
+      'class': title,
+      'function': title,
+      'title': title,
+      'params': TextStyle(color: defaultColor),
+      'comment': comment,
+      'doctag': comment,
+      'meta': TextStyle(color: defaultColor.withValues(alpha: 0.7)),
+      'meta-keyword': keyword,
+      'meta-string': string,
+      'section': title,
+      'tag': keyword,
+      'name': keyword,
+      'attr': title,
+      'attribute': title,
+      'variable': number,
+      'bullet': number,
+      'code': TextStyle(color: defaultColor),
+      'emphasis': const TextStyle(fontStyle: FontStyle.italic),
+      'strong': const TextStyle(fontWeight: FontWeight.bold),
+      'formula': string,
+      'link': TextStyle(
+        color: cs.primary,
+        decoration: TextDecoration.underline,
+      ),
+      'quote': comment,
+      'selector-tag': keyword,
+      'selector-id': title,
+      'selector-class': title,
+      'selector-attr': keyword,
+      'selector-pseudo': keyword,
+      'template-tag': keyword,
+      'template-variable': number,
+      'addition': string,
+      'deletion': TextStyle(
+        color: isLight ? const Color(0xFFC62828) : const Color(0xFFEF9A9A),
+      ),
+    };
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   canonical_json: ^1.1.2
   vodozemac: ^0.5.0
   file_picker: ^8.1.3
+  highlight: ^0.7.0
   html: ^0.15.4
   scrollable_positioned_list: ^0.3.8
   flutter_local_notifications: ^18.0.1

--- a/test/widgets/chat/code_block_test.dart
+++ b/test/widgets/chat/code_block_test.dart
@@ -1,0 +1,238 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:lattice/widgets/chat/code_block.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    home: Scaffold(body: SingleChildScrollView(child: child)),
+  );
+}
+
+void main() {
+  group('CodeBlock', () {
+    testWidgets('renders code text', (tester) async {
+      await tester.pumpWidget(_wrap(
+        const CodeBlock(
+          code: 'print("hello")',
+          isMe: false,
+        ),
+      ));
+
+      // Code is rendered via Text.rich with TextSpan children.
+      // Find a RichText whose text tree contains 'print("hello")'.
+      final richTexts =
+          tester.widgetList<RichText>(find.byType(RichText)).toList();
+      final codeRichText = richTexts.where((rt) {
+        final span = rt.text as TextSpan;
+        return span.toPlainText().contains('print("hello")');
+      });
+      expect(codeRichText, isNotEmpty);
+    });
+
+    testWidgets('displays language label when provided', (tester) async {
+      await tester.pumpWidget(_wrap(
+        const CodeBlock(
+          code: 'void main() {}',
+          language: 'dart',
+          isMe: false,
+        ),
+      ));
+
+      // Language label is a plain Text widget with the language name.
+      final textWidgets = tester.widgetList<Text>(find.byType(Text));
+      final languageLabel = textWidgets.where(
+        (t) => t.data == 'dart',
+      );
+      expect(languageLabel, isNotEmpty);
+    });
+
+    testWidgets('hides language label when language is null', (tester) async {
+      await tester.pumpWidget(_wrap(
+        const CodeBlock(
+          code: 'some code',
+          isMe: false,
+        ),
+      ));
+
+      // There should be no Text widget for a language label.
+      // All Text widgets should either be empty or part of the code rendering.
+      final textWidgets = tester.widgetList<Text>(find.byType(Text));
+      final languageLabels = textWidgets.where((t) {
+        // Language labels are plain Text with string data, not Text.rich.
+        // The code is rendered via Text.rich, so data will be null for it.
+        return t.data != null && t.data!.isNotEmpty;
+      });
+      expect(languageLabels, isEmpty);
+    });
+
+    testWidgets('copy button is present', (tester) async {
+      await tester.pumpWidget(_wrap(
+        const CodeBlock(
+          code: 'const x = 42;',
+          language: 'dart',
+          isMe: false,
+        ),
+      ));
+
+      expect(find.byIcon(Icons.copy_rounded), findsOneWidget);
+      expect(find.byTooltip('Copy code'), findsOneWidget);
+    });
+
+    testWidgets('copy button copies code to clipboard', (tester) async {
+      // Set up clipboard mock.
+      String? clipboardContent;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (MethodCall call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboardContent =
+                (call.arguments as Map<String, dynamic>)['text'] as String;
+          }
+          return null;
+        },
+      );
+
+      await tester.pumpWidget(_wrap(
+        const CodeBlock(
+          code: 'const x = 42;',
+          language: 'dart',
+          isMe: false,
+        ),
+      ));
+
+      await tester.tap(find.byIcon(Icons.copy_rounded));
+      await tester.pumpAndSettle();
+
+      expect(clipboardContent, 'const x = 42;');
+      expect(find.text('Copied to clipboard'), findsOneWidget);
+
+      // Clean up mock.
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      );
+    });
+
+    testWidgets('horizontal scrolling is enabled', (tester) async {
+      await tester.pumpWidget(_wrap(
+        const CodeBlock(
+          code: 'a very long line of code that should scroll horizontally '
+              'when it exceeds the container width',
+          isMe: false,
+        ),
+      ));
+
+      final scrollViews = tester.widgetList<SingleChildScrollView>(
+        find.byType(SingleChildScrollView),
+      );
+      final horizontalScroll = scrollViews.where(
+        (sv) => sv.scrollDirection == Axis.horizontal,
+      );
+      expect(horizontalScroll, isNotEmpty);
+    });
+
+    testWidgets('renders with monospace font', (tester) async {
+      await tester.pumpWidget(_wrap(
+        const CodeBlock(
+          code: 'fn main() {}',
+          language: 'rust',
+          isMe: false,
+        ),
+      ));
+
+      // Find RichText widgets that have monospace font in their root span.
+      final richTexts =
+          tester.widgetList<RichText>(find.byType(RichText)).toList();
+      final codeRichText = richTexts.firstWhere(
+        (rt) => (rt.text as TextSpan).style?.fontFamily == 'monospace',
+      );
+      expect(codeRichText, isNotNull);
+    });
+
+    testWidgets('uses appropriate background for isMe=true', (tester) async {
+      await tester.pumpWidget(_wrap(
+        const CodeBlock(
+          code: 'hello',
+          isMe: true,
+        ),
+      ));
+
+      // The outermost Container should have a background color.
+      final containers = tester.widgetList<Container>(
+        find.byType(Container),
+      );
+      final codeContainer = containers.firstWhere(
+        (c) => c.decoration is BoxDecoration &&
+            (c.decoration as BoxDecoration).borderRadius ==
+                BorderRadius.circular(8),
+      );
+      final decoration = codeContainer.decoration as BoxDecoration;
+      expect(decoration.color, isNotNull);
+    });
+
+    testWidgets('uses appropriate background for isMe=false', (tester) async {
+      await tester.pumpWidget(_wrap(
+        const CodeBlock(
+          code: 'hello',
+          isMe: false,
+        ),
+      ));
+
+      final containers = tester.widgetList<Container>(
+        find.byType(Container),
+      );
+      final codeContainer = containers.firstWhere(
+        (c) => c.decoration is BoxDecoration &&
+            (c.decoration as BoxDecoration).borderRadius ==
+                BorderRadius.circular(8),
+      );
+      final decoration = codeContainer.decoration as BoxDecoration;
+      expect(decoration.color, isNotNull);
+    });
+
+    testWidgets('renders empty code block gracefully', (tester) async {
+      await tester.pumpWidget(_wrap(
+        const CodeBlock(
+          code: '',
+          isMe: false,
+        ),
+      ));
+
+      // Should render without crashing.
+      expect(find.byType(CodeBlock), findsOneWidget);
+    });
+
+    testWidgets('applies syntax highlighting with colored spans',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        const CodeBlock(
+          code: 'void main() {\n  print("hello");\n}',
+          language: 'dart',
+          isMe: false,
+        ),
+      ));
+
+      // Find the RichText that contains the code (has monospace font).
+      final richTexts =
+          tester.widgetList<RichText>(find.byType(RichText)).toList();
+      final codeRichText = richTexts.firstWhere(
+        (rt) => (rt.text as TextSpan).style?.fontFamily == 'monospace',
+      );
+      final rootSpan = codeRichText.text as TextSpan;
+
+      // The children should have multiple spans with different styles
+      // (syntax highlighting produces colored spans).
+      expect(rootSpan.children, isNotNull);
+      expect(rootSpan.children!.length, greaterThan(1));
+
+      // At least some spans should have non-null styles with colors set
+      // (indicating syntax highlighting was applied).
+      final styledSpans = rootSpan.children!
+          .whereType<TextSpan>()
+          .where((s) => s.style?.color != null || s.style?.fontWeight != null);
+      expect(styledSpans, isNotEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Implement rich code rendering for Matrix HTML messages (issue #67):

- Add CodeBlock widget with syntax highlighting via highlight package,
  copy-to-clipboard button, language label, and horizontal scrolling
- Handle <pre><code> blocks in HtmlMessageText with language detection
  from class="language-xxx" attributes
- Improve inline <code> styling with rounded background container,
  padding, and scaled monospace font
- Support 22 languages with common aliases (dart, js, python, etc.)
- Material You-aware color theme for syntax highlighting tokens
- Add tests for CodeBlock widget and HtmlMessageText integration

https://claude.ai/code/session_013u6wiJGN4e7UGy6NBm7PMk