### PR TITLE
feat: package Windows exe installer in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - run: flutter analyze
       - run: flutter test
 
-  build-and-release:
+  build-linux:
     needs: analyze-and-test
     runs-on: ubuntu-latest
     permissions:
@@ -33,8 +33,48 @@ jobs:
       - run: flutter build linux --release
       - name: Archive build
         run: tar -czf lattice-linux-x64.tar.gz -C build/linux/x64/release/bundle .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-release
+          path: lattice-linux-x64.tar.gz
+
+  build-windows:
+    needs: analyze-and-test
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter build windows --release
+      - name: Build installer
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart('v')
+          iscc /DAppVersion=$version windows\packaging\inno_setup.iss
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-release
+          path: build/windows/installer/lattice-windows-x64-setup.exe
+
+  publish-release:
+    needs: [build-linux, build-windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: linux-release
+      - uses: actions/download-artifact@v4
+        with:
+          name: windows-release
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: lattice-linux-x64.tar.gz
+          files: |
+            lattice-linux-x64.tar.gz
+            lattice-windows-x64-setup.exe
           generate_release_notes: true

--- a/windows/packaging/inno_setup.iss
+++ b/windows/packaging/inno_setup.iss
@@ -1,0 +1,33 @@
+[Setup]
+AppId={{com.example.lattice}
+AppName=Lattice
+AppVersion={#AppVersion}
+AppPublisher=Lattice
+AppPublisherURL=https://github.com/Quantumheart/Lattice
+DefaultDirName={autopf}\Lattice
+DefaultGroupName=Lattice
+DisableProgramGroupPage=yes
+OutputDir=..\..\build\windows\installer
+OutputBaseFilename=lattice-windows-x64-setup
+SetupIconFile=..\runner\resources\app_icon.ico
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+ArchitecturesInstallIn64BitMode=x64compatible
+ArchitecturesAllowed=x64compatible
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+Source: "..\..\build\windows\x64\runner\Release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\Lattice"; Filename: "{app}\lattice.exe"
+Name: "{autodesktop}\Lattice"; Filename: "{app}\lattice.exe"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\lattice.exe"; Description: "{cm:LaunchProgram,Lattice}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
Add Inno Setup script and a Windows build job to the release workflow.
The release now builds both Linux (tar.gz) and Windows (setup exe) in
parallel, then publishes both artifacts to the GitHub Release.

https://claude.ai/code/session_018rq4pY1EMYtj6xySCwchCu