### PR TITLE
fix: add missing platform notification support for iOS, macOS, Windows, and Android 13+

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <application
         android:label="lattice"
         android:name="${applicationName}"

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -80,6 +80,11 @@ class NotificationService {
       android: androidSettings,
       iOS: darwinSettings,
       macOS: darwinSettings,
+      windows: WindowsInitializationSettings(
+        appName: 'Lattice',
+        appUserModelId: 'com.example.lattice',
+        guid: 'd3b0a4a0-7b1c-4e5a-9c8f-2d6e4f8a1b3c',
+      ),
     );
 
     await _plugin.initialize(
@@ -339,8 +344,16 @@ class NotificationService {
       enableVibration: preferencesService.notificationVibrationEnabled,
     );
 
+    final darwinDetails = DarwinNotificationDetails(
+      presentAlert: true,
+      presentBadge: true,
+      presentSound: preferencesService.notificationSoundEnabled,
+    );
+
     final details = NotificationDetails(
       android: androidDetails,
+      iOS: darwinDetails,
+      macOS: darwinDetails,
     );
 
     await _plugin.show(


### PR DESCRIPTION
- Add DarwinNotificationDetails for iOS/macOS so user sound preferences
  are respected and foreground presentation works correctly
- Add WindowsInitializationSettings so notifications fire on Windows
- Declare POST_NOTIFICATIONS permission in AndroidManifest for Android 13+

https://claude.ai/code/session_01GJ6FSxPskgRUJiXnx9nCrz