### PR TITLE
fix: remove unsupported WindowsInitializationSettings from notification init

### DIFF
--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -80,11 +80,6 @@ class NotificationService {
       android: androidSettings,
       iOS: darwinSettings,
       macOS: darwinSettings,
-      windows: WindowsInitializationSettings(
-        appName: 'Lattice',
-        appUserModelId: 'com.example.lattice',
-        guid: 'd3b0a4a0-7b1c-4e5a-9c8f-2d6e4f8a1b3c',
-      ),
     );
 
     await _plugin.initialize(


### PR DESCRIPTION
flutter_local_notifications v18.0.1 does not include a Windows platform
plugin, so the `windows` named parameter and `WindowsInitializationSettings`
class do not exist, causing three analysis errors that broke CI.

https://claude.ai/code/session_01ENmwUrppWQTos5WeqV1nFE