### PR TITLE
fix: focus compose input when replying to a message

### DIFF
--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -235,6 +235,7 @@ class _ChatScreenState extends State<ChatScreen> {
 
   void _setReplyTo(Event event) {
     _replyNotifier.value = event;
+    _composeFocusNode.requestFocus();
   }
 
   void _cancelReply() {


### PR DESCRIPTION
## Summary
- Auto-focus the compose text input when a user replies to a message (via swipe, hover action bar, or long-press menu)

## Test plan
- [x] Swipe-to-reply on mobile focuses the compose input
- [x] Clicking the reply button on hover (desktop) focuses the compose input
- [ ] Selecting "Reply" from the long-press action menu focuses the compose input

🤖 Generated with [Claude Code](https://claude.com/claude-code)