### PR TITLE
feat: add action bar to fullscreen image viewer

### DIFF
--- a/lib/shared/widgets/full_image_view.dart
+++ b/lib/shared/widgets/full_image_view.dart
@@ -1,16 +1,29 @@
+import 'dart:async';
+import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:lattice/core/utils/media_auth.dart';
+import 'package:lattice/core/utils/time_format.dart';
+import 'package:lattice/shared/widgets/user_avatar.dart';
 
-/// Opens a dialog displaying the full-resolution image for [event].
 void showFullImageDialog(BuildContext context, Event event) {
-  showDialog(
+  showGeneralDialog(
     context: context,
-    builder: (ctx) => Dialog(
-      child: FullImageView(event: event),
+    barrierColor: Colors.black,
+    barrierDismissible: true,
+    barrierLabel: 'Close image',
+    transitionDuration: const Duration(milliseconds: 200),
+    transitionBuilder: (_, animation, __, child) =>
+        FadeTransition(opacity: animation, child: child),
+    pageBuilder: (ctx, _, __) => SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+        child: FullImageView(event: event),
+      ),
     ),
   );
 }
@@ -30,11 +43,33 @@ class FullImageViewState extends State<FullImageView> {
   Uint8List? _imageBytes;
   String? _imageUrl;
   bool _loading = true;
+  bool _barVisible = true;
+  bool _downloading = false;
+  Timer? _autoHideTimer;
 
   @override
   void initState() {
     super.initState();
     _loadFullImage();
+    _startAutoHideTimer();
+  }
+
+  @override
+  void dispose() {
+    _autoHideTimer?.cancel();
+    super.dispose();
+  }
+
+  void _startAutoHideTimer() {
+    _autoHideTimer?.cancel();
+    _autoHideTimer = Timer(const Duration(seconds: 3), () {
+      if (mounted) setState(() => _barVisible = false);
+    });
+  }
+
+  void _toggleBar() {
+    setState(() => _barVisible = !_barVisible);
+    if (_barVisible) _startAutoHideTimer();
   }
 
   Future<void> _loadFullImage() async {
@@ -62,45 +97,152 @@ class FullImageViewState extends State<FullImageView> {
     }
   }
 
+  Future<void> _download() async {
+    final scaffold = ScaffoldMessenger.of(context);
+    setState(() => _downloading = true);
+
+    try {
+      final file = await widget.event.downloadAndDecryptAttachment();
+      final path = await FilePicker.platform.saveFile(
+        fileName: widget.event.body,
+        bytes: file.bytes,
+      );
+
+      if (path != null && file.bytes.isNotEmpty) {
+        await File(path).writeAsBytes(file.bytes);
+        scaffold.showSnackBar(
+          const SnackBar(content: Text('Image saved')),
+        );
+      }
+    } catch (e) {
+      debugPrint('[Lattice] Image download failed: $e');
+      scaffold.showSnackBar(
+        const SnackBar(content: Text('Failed to save image')),
+      );
+    } finally {
+      if (mounted) setState(() => _downloading = false);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    if (_loading) {
-      return const SizedBox(
-        width: 300,
-        height: 300,
-        child: Center(child: CircularProgressIndicator()),
-      );
-    }
-
     final cs = Theme.of(context).colorScheme;
-    final image = _imageBytes != null
-        ? Image.memory(_imageBytes!, fit: BoxFit.contain)
-        : _imageUrl != null
-            ? Image.network(
-                _imageUrl!,
-                fit: BoxFit.contain,
-                headers: mediaAuthHeaders(
-                  widget.event.room.client,
-                  _imageUrl!,
-                ),
-                errorBuilder: (_, __, ___) => SizedBox(
-                  width: 300,
-                  height: 300,
-                  child: Center(
-                    child: Icon(
-                      Icons.broken_image_rounded,
-                      color: cs.onSurfaceVariant,
-                      size: 48,
+
+    final image = _loading
+        ? const Center(child: CircularProgressIndicator())
+        : _imageBytes != null
+            ? Image.memory(_imageBytes!, fit: BoxFit.contain)
+            : _imageUrl != null
+                ? Image.network(
+                    _imageUrl!,
+                    fit: BoxFit.contain,
+                    headers: mediaAuthHeaders(
+                      widget.event.room.client,
+                      _imageUrl!,
+                    ),
+                    errorBuilder: (_, __, ___) => Center(
+                      child: Icon(
+                        Icons.broken_image_rounded,
+                        color: cs.onSurfaceVariant,
+                        size: 48,
+                      ),
+                    ),
+                  )
+                : const Center(child: Text('Failed to load image'));
+
+    final sender = widget.event.senderFromMemoryOrFallback;
+
+    return Stack(
+        children: [
+          Positioned.fill(
+            child: GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onTap: _toggleBar,
+              child: InteractiveViewer(child: image),
+            ),
+          ),
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            child: AnimatedOpacity(
+              opacity: _barVisible ? 1.0 : 0.0,
+              duration: const Duration(milliseconds: 200),
+              child: IgnorePointer(
+                ignoring: !_barVisible,
+                child: SafeArea(
+                  bottom: false,
+                  child: Container(
+                    color: Colors.black54,
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 4,
+                    ),
+                    child: Row(
+                      children: [
+                        UserAvatar(
+                          client: widget.event.room.client,
+                          avatarUrl: sender.avatarUrl,
+                          userId: sender.id,
+                          size: 32,
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Text(
+                                sender.displayName ?? widget.event.senderId,
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                              Text(
+                                formatRelativeTimestamp(
+                                  widget.event.originServerTs,
+                                ),
+                                style: const TextStyle(
+                                  color: Colors.white70,
+                                  fontSize: 12,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        _downloading
+                            ? const Padding(
+                                padding: EdgeInsets.all(12),
+                                child: SizedBox(
+                                  width: 20,
+                                  height: 20,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                    color: Colors.white,
+                                  ),
+                                ),
+                              )
+                            : IconButton(
+                                icon: const Icon(Icons.download_rounded),
+                                color: Colors.white,
+                                onPressed: _download,
+                              ),
+                        IconButton(
+                          icon: const Icon(Icons.close_rounded),
+                          color: Colors.white,
+                          onPressed: () => Navigator.of(context).pop(),
+                        ),
+                      ],
                     ),
                   ),
                 ),
-              )
-            : const SizedBox(
-                width: 300,
-                height: 300,
-                child: Center(child: Text('Failed to load image')),
-              );
-
-    return InteractiveViewer(child: image);
+              ),
+            ),
+          ),
+        ],
+    );
   }
 }


### PR DESCRIPTION
## Summary
- Replace dialog-based image viewer with a fullscreen route (`showGeneralDialog`) with fade transition and dismissible barrier padding
- Add auto-hiding overlay bar with sender avatar, display name, relative timestamp, download button, and close button
- Download uses `downloadAndDecryptAttachment()` for both encrypted and unencrypted images, with `FilePicker.platform.saveFile()` for save location

## Test plan
- [x] Tap an image in chat — fullscreen viewer opens with fade transition
- [x] Verify sender avatar, name, and timestamp display correctly in overlay bar
- [x] Bar auto-hides after 3 seconds; tap image to toggle visibility
- [x] Tap Download — file picker dialog appears, image saves successfully
- [x] Tap Close (×) — viewer dismisses
- [x] Tap outside the image content area (padded edges) — viewer dismisses
- [x] Test with both encrypted and unencrypted images
- [x] Run `flutter analyze` — no issues

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)