### PR TITLE
feat: add Windows notification support via flutter_local_notifications upgrade

### DIFF
--- a/lib/features/notifications/services/notification_service.dart
+++ b/lib/features/notifications/services/notification_service.dart
@@ -76,14 +76,21 @@ class NotificationService {
       requestSoundPermission: true,
     );
 
+    const windowsSettings = WindowsInitializationSettings(
+      appName: 'Lattice',
+      appUserModelId: 'com.lattice.app',
+      guid: 'ef82b5e7-fd65-431d-bcbb-9c7fa9acb761',
+    );
+
     const settings = InitializationSettings(
       android: androidSettings,
       iOS: darwinSettings,
       macOS: darwinSettings,
+      windows: windowsSettings,
     );
 
     await _plugin.initialize(
-      settings,
+      settings: settings,
       onDidReceiveNotificationResponse: _onNotificationTap,
     );
 
@@ -345,17 +352,20 @@ class NotificationService {
       presentSound: preferencesService.notificationSoundEnabled,
     );
 
+    const windowsDetails = WindowsNotificationDetails();
+
     final details = NotificationDetails(
       android: androidDetails,
       iOS: darwinDetails,
       macOS: darwinDetails,
+      windows: windowsDetails,
     );
 
     await _plugin.show(
-      notificationId,
-      title,
-      '$senderName: $body',
-      details,
+      id: notificationId,
+      title: title,
+      body: '$senderName: $body',
+      notificationDetails: details,
       payload: roomId,
     );
 
@@ -415,7 +425,7 @@ class NotificationService {
       return;
     }
     final notificationId = _stableNotificationId(roomId);
-    await _plugin.cancel(notificationId);
+    await _plugin.cancel(id: notificationId);
   }
 
   /// Dismiss all active notifications from the system tray.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -402,26 +402,34 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: ef41ae901e7529e52934feba19ed82827b11baa67336829564aeab3129460610
+      sha256: "0d9035862236fe38250fe1644d7ed3b8254e34a21b2c837c9f539fbb3bba5ef1"
       url: "https://pub.dev"
     source: hosted
-    version: "18.0.1"
+    version: "21.0.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: "8f685642876742c941b29c32030f6f4f6dacd0e4eaecb3efbb187d6a3812ca01"
+      sha256: e0f25e243c6c44c825bbbc6b2b2e76f7d9222362adcfe9fd780bf01923c840bd
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "8.0.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "6c5b83c86bf819cdb177a9247a3722067dd8cc6313827ce7c77a4b238a26fd52"
+      sha256: e7db3d5b49c2b7ecc68deba4aaaa67a348f92ee0fef34c8e4b4459dbef0d7307
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "11.0.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "3a2654ba104fbb52c618ebed9def24ef270228470718c43b3a6afcd5c81bef0c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -732,10 +740,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1345,26 +1353,26 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.16"
   timezone:
     dependency: transitive
     description:
       name: timezone
-      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      sha256: "784a5e34d2eb62e1326f24d6f600aaaee452eb8ca8ef2f384a59244e292d158b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.1"
+    version: "0.11.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   clock: ^1.1.1
   go_router: ^14.8.1
   scrollable_positioned_list: ^0.3.8
-  flutter_local_notifications: ^18.0.1
+  flutter_local_notifications: ^21.0.0
   desktop_notifications: ^0.6.3
   sqflite: ^2.4.2
   media_kit: ^1.2.6

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -111,7 +111,7 @@ void main() {
       mockClient.onSync.add(update);
       await Future.delayed(Duration.zero);
 
-      verifyNever(mockPlugin.show(any, any, any, any, payload: anyNamed('payload')));
+      verifyNever(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: anyNamed('payload')));
     });
 
     test('second sync triggers notification', () async {
@@ -129,7 +129,7 @@ void main() {
       mockClient.onSync.add(update);
       await Future.delayed(const Duration(milliseconds: 50));
 
-      verify(mockPlugin.show(any, any, any, any, payload: roomId)).called(1);
+      verify(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: roomId)).called(1);
     });
   });
 
@@ -155,63 +155,63 @@ void main() {
 
     test('own messages are ignored', () async {
       await emitMessage(senderId: ownUserId);
-      verifyNever(mockPlugin.show(any, any, any, any, payload: anyNamed('payload')));
+      verifyNever(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: anyNamed('payload')));
     });
 
     test('osNotificationsEnabled=false suppresses all', () async {
       await prefs.setOsNotificationsEnabled(false);
       await emitMessage();
-      verifyNever(mockPlugin.show(any, any, any, any, payload: anyNamed('payload')));
+      verifyNever(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: anyNamed('payload')));
     });
 
     test('notification level off suppresses all', () async {
       await prefs.setNotificationLevel(NotificationLevel.off);
       await emitMessage();
-      verifyNever(mockPlugin.show(any, any, any, any, payload: anyNamed('payload')));
+      verifyNever(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: anyNamed('payload')));
     });
 
     test('per-room dontNotify suppresses notification', () async {
       when(mockRoom.pushRuleState).thenReturn(PushRuleState.dontNotify);
       await emitMessage();
-      verifyNever(mockPlugin.show(any, any, any, any, payload: anyNamed('payload')));
+      verifyNever(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: anyNamed('payload')));
     });
 
     test('currently selected room suppresses notification', () async {
       when(mockMatrix.selectedRoomId).thenReturn(roomId);
       await emitMessage();
-      verifyNever(mockPlugin.show(any, any, any, any, payload: anyNamed('payload')));
+      verifyNever(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: anyNamed('payload')));
     });
 
     test('foreground toggle overrides selected room suppression', () async {
       when(mockMatrix.selectedRoomId).thenReturn(roomId);
       await prefs.setForegroundNotificationsEnabled(true);
       await emitMessage();
-      verify(mockPlugin.show(any, any, any, any, payload: roomId)).called(1);
+      verify(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: roomId)).called(1);
     });
 
     test('mentionsOnly with no match suppresses', () async {
       await prefs.setNotificationLevel(NotificationLevel.mentionsOnly);
       await emitMessage(body: 'just chatting');
-      verifyNever(mockPlugin.show(any, any, any, any, payload: anyNamed('payload')));
+      verifyNever(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: anyNamed('payload')));
     });
 
     test('mentionsOnly with keyword match fires notification', () async {
       await prefs.setNotificationLevel(NotificationLevel.mentionsOnly);
       await prefs.addNotificationKeyword('urgent');
       await emitMessage(body: 'this is URGENT');
-      verify(mockPlugin.show(any, any, any, any, payload: roomId)).called(1);
+      verify(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: roomId)).called(1);
     });
 
     test('mentionsOnly with user mention fires notification', () async {
       await prefs.setNotificationLevel(NotificationLevel.mentionsOnly);
       await emitMessage(body: 'hey @me:example.com check this');
-      verify(mockPlugin.show(any, any, any, any, payload: roomId)).called(1);
+      verify(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: roomId)).called(1);
     });
 
     test('mentionsOnly with display name mention fires notification', () async {
       await prefs.setNotificationLevel(NotificationLevel.mentionsOnly);
       await emitMessage(body: 'hey Me, are you there?');
-      verify(mockPlugin.show(any, any, any, any, payload: roomId)).called(1);
+      verify(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: roomId)).called(1);
     });
   });
 
@@ -256,7 +256,7 @@ void main() {
       mockClient.onSync.add(update);
       await Future.delayed(const Duration(milliseconds: 50));
 
-      verify(mockPlugin.show(any, 'General', argThat(contains('invited you to join')), any,
+      verify(mockPlugin.show(id: anyNamed('id'), title: 'General', body: argThat(contains('invited you to join'), named: 'body'), notificationDetails: anyNamed('notificationDetails'),
               payload: roomId))
           .called(1);
     });
@@ -273,7 +273,7 @@ void main() {
       mockClient.onSync.add(update);
       await Future.delayed(const Duration(milliseconds: 50));
 
-      verify(mockPlugin.show(any, any, any, any, payload: roomId)).called(1);
+      verify(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: roomId)).called(1);
     });
 
     test('suppressed when app is in foreground', () async {
@@ -284,7 +284,7 @@ void main() {
       mockClient.onSync.add(update);
       await Future.delayed(const Duration(milliseconds: 50));
 
-      verifyNever(mockPlugin.show(any, any, any, any, payload: anyNamed('payload')));
+      verifyNever(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: anyNamed('payload')));
     });
 
     test('shown when app in foreground but foreground notifications enabled', () async {
@@ -296,7 +296,7 @@ void main() {
       mockClient.onSync.add(update);
       await Future.delayed(const Duration(milliseconds: 50));
 
-      verify(mockPlugin.show(any, any, any, any, payload: roomId)).called(1);
+      verify(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: roomId)).called(1);
     });
 
     test('suppressed when room push rule is dontNotify', () async {
@@ -308,7 +308,7 @@ void main() {
       mockClient.onSync.add(update);
       await Future.delayed(const Duration(milliseconds: 50));
 
-      verifyNever(mockPlugin.show(any, any, any, any, payload: anyNamed('payload')));
+      verifyNever(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: anyNamed('payload')));
     });
 
     test('allows re-invite notification after room is left', () async {
@@ -319,7 +319,7 @@ void main() {
       final invite1 = makeInviteSyncUpdate(roomId: roomId);
       mockClient.onSync.add(invite1);
       await Future.delayed(const Duration(milliseconds: 50));
-      verify(mockPlugin.show(any, any, any, any, payload: roomId)).called(1);
+      verify(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: roomId)).called(1);
 
       // Room left (declined).
       final leaveSync = SyncUpdate(
@@ -332,7 +332,7 @@ void main() {
       // Re-invite — should notify again.
       mockClient.onSync.add(invite1);
       await Future.delayed(const Duration(milliseconds: 50));
-      verify(mockPlugin.show(any, any, any, any, payload: roomId)).called(1);
+      verify(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: roomId)).called(1);
     });
 
     test('allows re-invite notification after room is joined', () async {
@@ -343,7 +343,7 @@ void main() {
       final invite1 = makeInviteSyncUpdate(roomId: roomId);
       mockClient.onSync.add(invite1);
       await Future.delayed(const Duration(milliseconds: 50));
-      verify(mockPlugin.show(any, any, any, any, payload: roomId)).called(1);
+      verify(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: roomId)).called(1);
 
       // Room joined.
       final joinSync = SyncUpdate(
@@ -356,7 +356,7 @@ void main() {
       // Re-invite — should notify again.
       mockClient.onSync.add(invite1);
       await Future.delayed(const Duration(milliseconds: 50));
-      verify(mockPlugin.show(any, any, any, any, payload: roomId)).called(1);
+      verify(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: roomId)).called(1);
     });
   });
 
@@ -380,7 +380,7 @@ void main() {
         hash = (hash * 0x01000193) & 0xFFFFFFFF;
       }
       final expectedId = hash & 0x7FFFFFFF;
-      verify(mockPlugin.show(expectedId, any, any, any, payload: roomId)).called(1);
+      verify(mockPlugin.show(id: expectedId, title: anyNamed('title'), body: anyNamed('body'), notificationDetails: anyNamed('notificationDetails'), payload: roomId)).called(1);
     });
 
     test('notification shows room name as title', () async {
@@ -395,7 +395,7 @@ void main() {
       mockClient.onSync.add(update);
       await Future.delayed(const Duration(milliseconds: 50));
 
-      verify(mockPlugin.show(any, 'General', 'Alice: hey', any, payload: roomId))
+      verify(mockPlugin.show(id: anyNamed('id'), title: 'General', body: 'Alice: hey', notificationDetails: anyNamed('notificationDetails'), payload: roomId))
           .called(1);
     });
   });
@@ -415,7 +415,7 @@ void main() {
       mockClient.onSync.add(update);
       await Future.delayed(const Duration(milliseconds: 50));
 
-      verify(mockPlugin.show(any, any, argThat(contains('Encrypted message')), any,
+      verify(mockPlugin.show(id: anyNamed('id'), title: anyNamed('title'), body: argThat(contains('Encrypted message'), named: 'body'), notificationDetails: anyNamed('notificationDetails'),
               payload: roomId))
           .called(1);
     });

--- a/test/services/notification_service_test.mocks.dart
+++ b/test/services/notification_service_test.mocks.dart
@@ -14,10 +14,8 @@ import 'package:flutter_local_notifications/src/initialization_settings.dart'
 import 'package:flutter_local_notifications/src/notification_details.dart'
     as _i20;
 import 'package:flutter_local_notifications/src/platform_specifics/android/schedule_mode.dart'
-    as _i23;
-import 'package:flutter_local_notifications/src/platform_specifics/ios/enums.dart'
     as _i22;
-import 'package:flutter_local_notifications/src/types.dart' as _i24;
+import 'package:flutter_local_notifications/src/types.dart' as _i23;
 import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart'
     as _i19;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i3;
@@ -10006,8 +10004,8 @@ class MockRoom extends _i1.Mock implements _i2.Room {
 class MockFlutterLocalNotificationsPlugin extends _i1.Mock
     implements _i17.FlutterLocalNotificationsPlugin {
   @override
-  _i7.Future<bool?> initialize(
-    _i18.InitializationSettings? initializationSettings, {
+  _i7.Future<bool?> initialize({
+    required _i18.InitializationSettings? settings,
     _i19.DidReceiveNotificationResponseCallback?
         onDidReceiveNotificationResponse,
     _i19.DidReceiveBackgroundNotificationResponseCallback?
@@ -10016,8 +10014,9 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
       (super.noSuchMethod(
         Invocation.method(
           #initialize,
-          [initializationSettings],
+          [],
           {
+            #settings: settings,
             #onDidReceiveNotificationResponse: onDidReceiveNotificationResponse,
             #onDidReceiveBackgroundNotificationResponse:
                 onDidReceiveBackgroundNotificationResponse,
@@ -10040,38 +10039,42 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
           ) as _i7.Future<_i19.NotificationAppLaunchDetails?>);
 
   @override
-  _i7.Future<void> show(
-    int? id,
+  _i7.Future<void> show({
+    required int? id,
     String? title,
     String? body,
-    _i20.NotificationDetails? notificationDetails, {
+    _i20.NotificationDetails? notificationDetails,
     String? payload,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
           #show,
-          [
-            id,
-            title,
-            body,
-            notificationDetails,
-          ],
-          {#payload: payload},
+          [],
+          {
+            #id: id,
+            #title: title,
+            #body: body,
+            #notificationDetails: notificationDetails,
+            #payload: payload,
+          },
         ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<void> cancel(
-    int? id, {
+  _i7.Future<void> cancel({
+    required int? id,
     String? tag,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
           #cancel,
-          [id],
-          {#tag: tag},
+          [],
+          {
+            #id: id,
+            #tag: tag,
+          },
         ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
@@ -10088,32 +10091,37 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<void> zonedSchedule(
-    int? id,
+  _i7.Future<void> cancelAllPendingNotifications() => (super.noSuchMethod(
+        Invocation.method(
+          #cancelAllPendingNotifications,
+          [],
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+
+  @override
+  _i7.Future<void> zonedSchedule({
+    required int? id,
+    required _i21.TZDateTime? scheduledDate,
+    required _i20.NotificationDetails? notificationDetails,
+    required _i22.AndroidScheduleMode? androidScheduleMode,
     String? title,
     String? body,
-    _i21.TZDateTime? scheduledDate,
-    _i20.NotificationDetails? notificationDetails, {
-    required _i22.UILocalNotificationDateInterpretation?
-        uiLocalNotificationDateInterpretation,
-    required _i23.AndroidScheduleMode? androidScheduleMode,
     String? payload,
-    _i24.DateTimeComponents? matchDateTimeComponents,
+    _i23.DateTimeComponents? matchDateTimeComponents,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
           #zonedSchedule,
-          [
-            id,
-            title,
-            body,
-            scheduledDate,
-            notificationDetails,
-          ],
+          [],
           {
-            #uiLocalNotificationDateInterpretation:
-                uiLocalNotificationDateInterpretation,
+            #id: id,
+            #scheduledDate: scheduledDate,
+            #notificationDetails: notificationDetails,
             #androidScheduleMode: androidScheduleMode,
+            #title: title,
+            #body: body,
             #payload: payload,
             #matchDateTimeComponents: matchDateTimeComponents,
           },
@@ -10123,27 +10131,26 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<void> periodicallyShow(
-    int? id,
+  _i7.Future<void> periodicallyShow({
+    required int? id,
+    required _i19.RepeatInterval? repeatInterval,
+    required _i20.NotificationDetails? notificationDetails,
+    required _i22.AndroidScheduleMode? androidScheduleMode,
     String? title,
     String? body,
-    _i19.RepeatInterval? repeatInterval,
-    _i20.NotificationDetails? notificationDetails, {
-    required _i23.AndroidScheduleMode? androidScheduleMode,
     String? payload,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
           #periodicallyShow,
-          [
-            id,
-            title,
-            body,
-            repeatInterval,
-            notificationDetails,
-          ],
+          [],
           {
+            #id: id,
+            #repeatInterval: repeatInterval,
+            #notificationDetails: notificationDetails,
             #androidScheduleMode: androidScheduleMode,
+            #title: title,
+            #body: body,
             #payload: payload,
           },
         ),
@@ -10152,27 +10159,26 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
       ) as _i7.Future<void>);
 
   @override
-  _i7.Future<void> periodicallyShowWithDuration(
-    int? id,
+  _i7.Future<void> periodicallyShowWithDuration({
+    required int? id,
+    required Duration? repeatDurationInterval,
+    required _i20.NotificationDetails? notificationDetails,
     String? title,
     String? body,
-    Duration? repeatDurationInterval,
-    _i20.NotificationDetails? notificationDetails, {
-    _i23.AndroidScheduleMode? androidScheduleMode =
-        _i23.AndroidScheduleMode.exact,
+    _i22.AndroidScheduleMode? androidScheduleMode =
+        _i22.AndroidScheduleMode.exact,
     String? payload,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
           #periodicallyShowWithDuration,
-          [
-            id,
-            title,
-            body,
-            repeatDurationInterval,
-            notificationDetails,
-          ],
+          [],
           {
+            #id: id,
+            #repeatDurationInterval: repeatDurationInterval,
+            #notificationDetails: notificationDetails,
+            #title: title,
+            #body: body,
             #androidScheduleMode: androidScheduleMode,
             #payload: payload,
           },

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -15,6 +15,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  flutter_local_notifications_windows
   flutter_vodozemac
 )
 


### PR DESCRIPTION
Summary
	∙	Upgrade flutter_local_notifications from v18 to v21, which adds native Windows toast notification support
	∙	Add WindowsInitializationSettings and WindowsNotificationDetails to the notification service so Windows receives OS-level notifications
	∙	Update all plugin API call sites and test mocks for v20+ named parameter changes
Test plan
	∙	[x] flutter analyze passes with no issues
	∙	[x] All 749 tests pass (including 22 notification service tests)
	∙	[ ] Manual: run on Windows, receive a message → toast notification appears in Windows notification center
	∙	[ ] Manual: click notification → navigates to the correct room