### PR TITLE
fix: reduce cached password TTL from 5 minutes to 30 seconds

### DIFF
--- a/lib/core/services/mixins/uia_mixin.dart
+++ b/lib/core/services/mixins/uia_mixin.dart
@@ -86,7 +86,7 @@ mixin UiaMixin on ChangeNotifier {
   void setCachedPassword(String password) {
     _cachedPassword = password;
     _passwordExpiryTimer?.cancel();
-    _passwordExpiryTimer = Timer(const Duration(minutes: 5), () {
+    _passwordExpiryTimer = Timer(const Duration(seconds: 30), () {
       _cachedPassword = null;
       _passwordExpiryTimer = null;
     });


### PR DESCRIPTION
Minimizes the window during which the user's password lingers in memory
after UIA authentication.

https://claude.ai/code/session_01PBPM59AP94eBbhumhCQpm4