### PR TITLE
refactor: consistent rail/back-button visibility across screens

### DIFF
--- a/lib/features/home/widgets/narrow_layout.dart
+++ b/lib/features/home/widgets/narrow_layout.dart
@@ -49,7 +49,12 @@ class NarrowLayout extends StatelessWidget {
       content = routerChild;
     }
 
-    final hideRail = (name == Routes.room || name == Routes.call) && roomId != null;
+    final hideRail =
+        ((name == Routes.room || name == Routes.call || name == Routes.roomDetails) && roomId != null) ||
+        name == Routes.settings ||
+        name == Routes.settingsNotifications ||
+        name == Routes.settingsDevices ||
+        name == Routes.spaceDetails;
     if (hideRail) {
       return Scaffold(body: content);
     }

--- a/lib/features/rooms/widgets/room_details_panel.dart
+++ b/lib/features/rooms/widgets/room_details_panel.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:lattice/core/routing/route_names.dart';
 import 'package:lattice/core/services/matrix_service.dart';
 import 'package:lattice/features/e2ee/widgets/key_verification_dialog.dart';
 import 'package:lattice/features/rooms/widgets/admin_settings_section.dart';
@@ -168,6 +170,13 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
     if (widget.isFullPage) {
       return Scaffold(
         appBar: AppBar(
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () => context.goNamed(
+              Routes.room,
+              pathParameters: {'roomId': widget.roomId},
+            ),
+          ),
           title: Text(room.getLocalizedDisplayname()),
         ),
         body: content,

--- a/lib/features/settings/screens/devices_screen.dart
+++ b/lib/features/settings/screens/devices_screen.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:lattice/core/extensions/device_extension.dart';
+import 'package:lattice/core/routing/route_names.dart';
 import 'package:lattice/core/services/matrix_service.dart';
 import 'package:lattice/features/e2ee/widgets/key_verification_dialog.dart';
 import 'package:lattice/features/settings/widgets/device_list_item.dart';
@@ -318,7 +320,13 @@ class _DevicesScreenState extends State<DevicesScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Devices')),
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.goNamed(Routes.settings),
+        ),
+        title: const Text('Devices'),
+      ),
       body: _buildBody(),
     );
   }

--- a/lib/features/settings/screens/notification_settings_screen.dart
+++ b/lib/features/settings/screens/notification_settings_screen.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:lattice/core/routing/route_names.dart';
 import 'package:lattice/core/services/preferences_service.dart';
 import 'package:lattice/shared/widgets/section_header.dart';
 import 'package:provider/provider.dart';
@@ -45,7 +47,13 @@ class _NotificationSettingsScreenState
     final keywords = prefs.notificationKeywords;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Notifications')),
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.goNamed(Routes.settings),
+        ),
+        title: const Text('Notifications'),
+      ),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -9,7 +9,6 @@ import 'package:lattice/core/services/matrix_service.dart';
 import 'package:lattice/core/services/preferences_service.dart';
 import 'package:lattice/features/e2ee/widgets/backup_info_dialog.dart';
 import 'package:lattice/features/e2ee/widgets/bootstrap_dialog.dart';
-import 'package:lattice/features/home/screens/home_shell.dart';
 import 'package:lattice/features/settings/widgets/density_picker_dialog.dart';
 import 'package:lattice/features/settings/widgets/theme_picker_dialog.dart';
 import 'package:lattice/shared/widgets/section_header.dart';
@@ -158,12 +157,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        leading: MediaQuery.sizeOf(context).width < HomeShell.wideBreakpoint
-            ? IconButton(
-                icon: const Icon(Icons.arrow_back),
-                onPressed: () => context.goNamed(Routes.home),
-              )
-            : null,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.goNamed(Routes.home),
+        ),
         title: const Text('Settings'),
       ),
       body: ListView(

--- a/lib/features/spaces/widgets/space_details_panel.dart
+++ b/lib/features/spaces/widgets/space_details_panel.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:lattice/core/routing/route_names.dart';
 import 'package:lattice/core/services/matrix_service.dart';
 import 'package:lattice/features/rooms/widgets/admin_settings_section.dart';
 import 'package:lattice/features/rooms/widgets/invite_user_dialog.dart';
@@ -89,6 +91,10 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
     if (widget.isFullPage) {
       return Scaffold(
         appBar: AppBar(
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () => context.goNamed(Routes.home),
+          ),
           title: Text(space.getLocalizedDisplayname()),
         ),
         body: content,


### PR DESCRIPTION
## Summary
- Hide the space rail on all pushed screens (Settings, Devices, Notifications, Room Details, Space Details) to match existing Chat/Call behavior
- Replace Flutter's automatic AppBar back buttons with explicit `leading:` widgets using `context.goNamed()` for consistent navigation
- Remove breakpoint check from Settings screen — rail visibility is now controlled by NarrowLayout's `hideRail` logic

Closes #213

## Test plan
- [x] Mobile (<720px): Navigate to each screen — rail should be hidden, back button visible
- [x] Back button navigates to correct destination (Settings→Home, Devices→Settings, Room Details→Chat, etc.)
- [x] Tablet/Desktop (≥720px): WideLayout still shows rail — no regressions
- [x] `flutter analyze` passes with no issues
- [x] `flutter test` — all 1379 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)