### PR TITLE
Fix call icon visibility in dark mode

### DIFF
--- a/lib/features/rooms/widgets/room_tile.dart
+++ b/lib/features/rooms/widgets/room_tile.dart
@@ -446,7 +446,7 @@ class _TrailingTimeBadge extends StatelessWidget {
                 constraints: const BoxConstraints(),
                 tooltip: 'Start call',
                 style: IconButton.styleFrom(
-                  foregroundColor: cs.onSurfaceVariant.withValues(alpha: 0.5),
+                  foregroundColor: cs.onSurfaceVariant,
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- The room tile headphones (start call) icon was nearly invisible on dark backgrounds due to `0.5` alpha applied to `onSurfaceVariant`
- Removed the alpha override so the icon uses the full `onSurfaceVariant` color, matching the timestamp text visibility

## Test plan
- [x] Verify headphones icon is clearly visible on room tiles with 0 unread in dark mode
- [x] Verify icon remains appropriate (not too prominent) in light mode