### PR TITLE
fix: remove nested Scaffold causing extra top spacing on mobile

### DIFF
--- a/lib/features/home/widgets/narrow_layout.dart
+++ b/lib/features/home/widgets/narrow_layout.dart
@@ -57,7 +57,7 @@ class NarrowLayout extends StatelessWidget {
         name == Routes.settingsDevices ||
         name == Routes.spaceDetails;
     if (hideRail) {
-      return Scaffold(body: content);
+      return content;
     }
 
     return Scaffold(


### PR DESCRIPTION
The NarrowLayout wrapped child screens (ChatScreen, SettingsScreen, etc.)
in an extra Scaffold when hideRail was true. Since these children already
have their own Scaffolds, the outer one was redundant and its default
primary=true caused it to consume the top safe area padding, creating
a visible gap above the AppBar.

https://claude.ai/code/session_01Cp8YtTYv2x5GuQysaMVXC1