### PR TITLE
feat: add web loading spinner during Flutter engine init

### DIFF
--- a/web/flutter_bootstrap.js
+++ b/web/flutter_bootstrap.js
@@ -1,0 +1,9 @@
+{{flutter_js}}
+{{flutter_build_config}}
+
+_flutter.loader.load({
+  onEntrypointLoaded: async function(engineInitializer) {
+    const appRunner = await engineInitializer.initializeEngine();
+    await appRunner.runApp();
+  }
+});

--- a/web/index.html
+++ b/web/index.html
@@ -39,28 +39,48 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background-color: #fafafa;
+      background-color: #FEF7FF;
     }
 
     @media (prefers-color-scheme: dark) {
-      body { background-color: #1c1b1f; }
-      .loader { border-color: rgba(255,255,255,.12); border-top-color: #90caf9; }
+      body { background-color: #1C1B1F; }
+      .loader circle { stroke: rgba(255,255,255,.12); }
+      .loader circle:last-child { stroke: #90CAF9; }
     }
 
     .loader {
       width: 36px;
       height: 36px;
-      border: 3.5px solid rgba(0,0,0,.12);
-      border-top-color: #1976D2;
-      border-radius: 50%;
-      animation: spin .8s linear infinite;
+      animation: rotate 1.4s linear infinite;
     }
 
-    @keyframes spin { to { transform: rotate(360deg); } }
+    .loader circle {
+      fill: none;
+      stroke: rgba(0,0,0,.12);
+      stroke-width: 3.5;
+    }
+
+    .loader circle:last-child {
+      stroke: #1976D2;
+      stroke-dasharray: 80, 200;
+      stroke-dashoffset: 0;
+      stroke-linecap: round;
+      animation: sweep 1.4s ease-in-out infinite;
+    }
+
+    @keyframes rotate { to { transform: rotate(360deg); } }
+    @keyframes sweep {
+      0%   { stroke-dasharray: 1, 200; stroke-dashoffset: 0; }
+      50%  { stroke-dasharray: 80, 200; stroke-dashoffset: -35; }
+      100% { stroke-dasharray: 1, 200; stroke-dashoffset: -125; }
+    }
   </style>
 </head>
 <body>
-  <div id="loading" class="loader"></div>
+  <svg id="loading" class="loader" viewBox="0 0 44 44">
+    <circle cx="22" cy="22" r="20" />
+    <circle cx="22" cy="22" r="20" />
+  </svg>
   <script src="flutter_bootstrap.js" async></script>
   <script>
     window.addEventListener('flutter-first-frame', function () {


### PR DESCRIPTION
## Summary
- Adds an SVG arc-style loading spinner to `web/index.html` that displays while the Flutter engine initializes, matching the Material 3 `CircularProgressIndicator` style
- Uses M3 surface colors with dark mode support via `prefers-color-scheme`
- Adds custom `web/flutter_bootstrap.js` to disable Flutter's default built-in loader
- Spinner auto-removes on the `flutter-first-frame` event

## Test plan
- [ ] Run `flutter build web` and serve `build/web/` — verify spinner appears and dismisses once the app loads
- [ ] Test in light and dark mode browser settings
- [ ] Verify no duplicate loader (Flutter's default should be suppressed)