### PR TITLE
Add verification request listener for incoming key verification

### DIFF
--- a/lib/features/e2ee/widgets/verification_request_listener.dart
+++ b/lib/features/e2ee/widgets/verification_request_listener.dart
@@ -1,0 +1,65 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:lattice/core/services/matrix_service.dart';
+import 'package:lattice/features/e2ee/widgets/key_verification_dialog.dart';
+import 'package:matrix/matrix.dart';
+import 'package:provider/provider.dart';
+
+class VerificationRequestListener extends StatefulWidget {
+  const VerificationRequestListener({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  State<VerificationRequestListener> createState() =>
+      _VerificationRequestListenerState();
+}
+
+class _VerificationRequestListenerState
+    extends State<VerificationRequestListener> {
+  StreamSubscription<KeyVerification>? _sub;
+  MatrixService? _matrix;
+  bool _dialogOpen = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final matrix = context.read<MatrixService>();
+    if (_matrix != matrix) {
+      _matrix = matrix;
+      _subscribe(matrix);
+    }
+  }
+
+  void _subscribe(MatrixService matrix) {
+    unawaited(_sub?.cancel());
+    _sub = matrix.client.onKeyVerificationRequest.stream.listen(_onRequest);
+  }
+
+  void _onRequest(KeyVerification verification) {
+    if (!mounted) return;
+    if (_dialogOpen) return;
+    if (verification.state == KeyVerificationState.done ||
+        verification.state == KeyVerificationState.error) {
+      return;
+    }
+
+    debugPrint('[Lattice] Incoming verification request from '
+        '${verification.userId}');
+
+    _dialogOpen = true;
+    KeyVerificationDialog.show(context, verification: verification).then((_) {
+      _dialogOpen = false;
+    });
+  }
+
+  @override
+  void dispose() {
+    unawaited(_sub?.cancel());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'package:lattice/core/utils/vodozemac_init.dart';
 import 'package:lattice/features/auth/services/sso_web_init.dart';
 import 'package:lattice/features/calling/services/ringtone_service.dart';
 import 'package:lattice/features/calling/widgets/incoming_call_overlay.dart';
+import 'package:lattice/features/e2ee/widgets/verification_request_listener.dart';
 import 'package:lattice/features/chat/services/media_playback_service.dart';
 import 'package:lattice/features/chat/services/opengraph_service.dart';
 import 'package:lattice/features/notifications/services/inbox_controller.dart';
@@ -179,9 +180,12 @@ class _LatticeAppState extends State<LatticeApp> {
                             darkTheme: darkTheme,
                             themeMode: themeMode,
                             routerConfig: router,
-                            builder: (context, child) => IncomingCallOverlay(
-                              router: router,
-                              child: child ?? const SizedBox.shrink(),
+                            builder: (context, child) =>
+                                VerificationRequestListener(
+                              child: IncomingCallOverlay(
+                                router: router,
+                                child: child ?? const SizedBox.shrink(),
+                              ),
                             ),
                           ),
                         );


### PR DESCRIPTION
## Summary
This PR adds a new `VerificationRequestListener` widget that listens for incoming key verification requests and automatically displays a verification dialog when a request is received.

## Key Changes
- **New Widget**: Created `VerificationRequestListener` as a stateful widget that wraps the app and listens to incoming key verification requests from the Matrix client
- **Request Handling**: Implements logic to:
  - Listen to `onKeyVerificationRequest` stream from the Matrix client
  - Filter out already-completed or errored verification states
  - Prevent multiple dialogs from opening simultaneously with `_dialogOpen` flag
  - Display `KeyVerificationDialog` when a valid request is received
- **Integration**: Integrated `VerificationRequestListener` into the app's widget tree in `main.dart`, wrapping it around `IncomingCallOverlay` to ensure verification requests are handled at the app level
- **Lifecycle Management**: Properly manages stream subscriptions with cleanup in `dispose()` and re-subscription when the `MatrixService` dependency changes

## Notable Implementation Details
- Uses `didChangeDependencies()` to detect when the `MatrixService` provider changes and re-subscribes to the verification stream
- Includes safety checks for widget mounting and dialog state to prevent memory leaks and duplicate dialogs
- Logs incoming verification requests for debugging purposes

https://claude.ai/code/session_01S3FJR7TSFPQ67p2ow4Jyog