### PR TITLE
fix: allow CanvasKit and WebAssembly in CSP

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -18,7 +18,7 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ 'unsafe-inline'; frame-src 'self' https://www.google.com/recaptcha/ https://recaptcha.google.com/recaptcha/ blob:; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; connect-src 'self' https:; font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; base-uri 'self';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://www.gstatic.com/flutter-canvaskit/ 'unsafe-inline' 'wasm-unsafe-eval'; frame-src 'self' https://www.google.com/recaptcha/ https://recaptcha.google.com/recaptcha/ blob:; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; connect-src 'self' https:; font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; base-uri 'self';">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta name="description" content="A new Flutter project.">


### PR DESCRIPTION
## Summary
- Add `https://www.gstatic.com/flutter-canvaskit/` to `script-src` for Flutter's CanvasKit renderer
- Add `'wasm-unsafe-eval'` for WebAssembly compilation

The CSP added in 497f064 blocked CanvasKit and WASM, preventing the app from loading.

## Test plan
- [ ] Verify app loads on web deployment