### PR TITLE
fix: add unsafe-eval to CSP for Dart compiled JS

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -18,7 +18,7 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://www.gstatic.com/flutter-canvaskit/ 'unsafe-inline' 'wasm-unsafe-eval'; frame-src 'self' https://www.google.com/recaptcha/ https://recaptcha.google.com/recaptcha/ blob:; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; connect-src 'self' https:; font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; base-uri 'self';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://www.gstatic.com/flutter-canvaskit/ 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'; frame-src 'self' https://www.google.com/recaptcha/ https://recaptcha.google.com/recaptcha/ blob:; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; connect-src 'self' https:; font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; base-uri 'self';">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta name="description" content="A new Flutter project.">


### PR DESCRIPTION
## Summary
- Add `'unsafe-eval'` to `script-src` in the Content-Security-Policy
- Dart's compiled JavaScript uses `eval()` internally, which was blocked after the CSP was added in #256

## Test plan
- [ ] Verify app loads on web deployment