### PR TITLE
fix: restore crypto identity after device verification to update backup status

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -18,7 +18,7 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://www.gstatic.com/flutter-canvaskit/ 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'; frame-src 'self' https://www.google.com/recaptcha/ https://recaptcha.google.com/recaptcha/ blob:; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; connect-src 'self' https:; font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; base-uri 'self';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://www.gstatic.com/flutter-canvaskit/ 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'; frame-src 'self' https://www.google.com/recaptcha/ https://recaptcha.google.com/recaptcha/ blob:; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; connect-src 'self' https:; font-src 'self' data:; worker-src 'self' blob: 'wasm-unsafe-eval'; object-src 'none'; base-uri 'self';">
   <meta http-equiv="X-Content-Type-Options" content="nosniff">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta name="description" content="A new Flutter project.">


### PR DESCRIPTION
After device verification via SAS, the SSSS key is not directly unlocked
(unlike the recovery key path), so the caching/self-signing block in onDone()
was skipped entirely. This left getCryptoIdentityState() returning
connected=false, causing the settings screen to show "Not set up" despite
successful verification.

Now falls back to restoreCryptoIdentity with the stored recovery key when
no SSSS key was unlocked. Also increases the secret propagation wait from
5s to 10s to give the other device more time to respond.

https://claude.ai/code/session_015ioYanXucg17D32Y2xSL28