### PR TITLE
fix: improve iOS PWA push notification reliability

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -905,10 +905,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1670,18 +1670,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.16"
   timezone:
     dependency: "direct dev"
     description:

--- a/web/index.html
+++ b/web/index.html
@@ -40,7 +40,7 @@
   <meta name="description" content="A new Flutter project.">
 
   <!-- iOS meta tags & icons -->
-  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="lattice">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">

--- a/web/sw.js
+++ b/web/sw.js
@@ -2,34 +2,45 @@
 
 // ── Push event ────────────────────────────────────────────────
 self.addEventListener('push', function (event) {
-  if (!event.data) return;
+  var roomName = 'New message';
+  var body = 'You have a new message';
+  var tag = 'lattice-push';
+  var data = {};
 
-  var payload;
-  try {
-    payload = event.data.json();
-  } catch (e) {
-    return;
+  if (event.data) {
+    try {
+      var payload = event.data.json();
+      var notification = payload.notification || {};
+      var roomId = notification.room_id;
+      var senderName = notification.sender_display_name;
+      var counts = notification.counts || {};
+
+      if (notification.room_name) roomName = notification.room_name;
+      if (senderName) body = senderName + ': New message';
+      if (roomId) tag = roomId;
+      data = { roomId: roomId || null, unreadCount: counts.unread || 0 };
+    } catch (e) {
+      // Parse failed — fall through to show a generic notification.
+    }
   }
-
-  var notification = payload.notification || {};
-  var roomId = notification.room_id;
-  var roomName = notification.room_name || 'New message';
-  var senderName = notification.sender_display_name;
-  var body = senderName ? senderName + ': New message' : 'You have a new message';
-  var counts = notification.counts || {};
 
   event.waitUntil(
     self.registration.showNotification(roomName, {
       body: body,
       icon: 'icons/Icon-192.png',
-      badge: 'icons/Icon-maskable-192.png',
-      tag: roomId || 'lattice-push',
-      renotify: !!roomId,
-      data: { roomId: roomId, unreadCount: counts.unread || 0 },
+      tag: tag,
+      data: data,
     }).then(function () {
-      if (navigator.setAppBadge) {
-        navigator.setAppBadge(counts.unread || 0);
+      try {
+        if (self.navigator && self.navigator.setAppBadge && data.unreadCount) {
+          self.navigator.setAppBadge(data.unreadCount);
+        }
+      } catch (e) {
+        // Badge API not supported — ignore.
       }
+    }).catch(function (e) {
+      // showNotification failed — log for debugging.
+      console.error('[Lattice SW] showNotification failed:', e);
     })
   );
 });
@@ -37,8 +48,12 @@ self.addEventListener('push', function (event) {
 // ── Notification click ────────────────────────────────────────
 self.addEventListener('notificationclick', function (event) {
   event.notification.close();
-  if (navigator.clearAppBadge) {
-    navigator.clearAppBadge();
+  try {
+    if (self.navigator && self.navigator.clearAppBadge) {
+      self.navigator.clearAppBadge();
+    }
+  } catch (e) {
+    // Badge API not supported — ignore.
   }
 
   var roomId = (event.notification.data || {}).roomId;


### PR DESCRIPTION
- Always show a notification in the push handler, even when payload
  parsing fails (iOS revokes push permission if events don't produce
  visible notifications)
- Remove `renotify` and `badge` notification options unsupported by
  Safari
- Wrap Badge API calls in try/catch and use `self.navigator` for
  service worker context safety
- Add `.catch()` to showNotification promise to prevent silent failures
- Fix iOS meta tag: `mobile-web-app-capable` → `apple-mobile-web-app-capable`

https://claude.ai/code/session_015BRg7UrBqiubgVasQouutq