### PR TITLE
docs: rewrite CLAUDE.md for conciseness and accuracy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,54 +1,32 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+## What is Lattice?
 
-## Project Overview
+Lattice is a Flutter Matrix chat client. It uses the `matrix` Dart SDK for the Matrix protocol, Provider (ChangeNotifier) for state management, GoRouter for navigation, and Material You dynamic color theming. It supports E2EE, voice/video calling (LiveKit), multi-account, and runs on Linux, macOS, and web.
 
-Lattice is a Flutter Matrix chat client built with Dart 3.1+ and Flutter 3.16+. It uses the `matrix` Dart SDK for the Matrix protocol, Provider (ChangeNotifier) for state management, and Material You dynamic color theming.
-
-## Common Commands
+## How to work with this project
 
 ```bash
 flutter pub get                                          # Install dependencies
-flutter analyze                                          # Lint (uses flutter_lints + custom rules)
+flutter analyze                                          # Lint
 dart run build_runner build --delete-conflicting-outputs  # Generate mocks (required before tests)
 flutter test                                             # Run all tests
-flutter test test/services/matrix_service_test.dart      # Run a single test file
-flutter run                                              # Run on default device
+flutter test test/path/to_test.dart                      # Run a single test file
 flutter run -d linux                                     # Run on Linux
-flutter build linux --release                            # Release build
 ```
 
-Mock generation (`build_runner`) must run before `flutter test` whenever `@GenerateMocks` annotations change.
+Mock generation (`build_runner`) must run before `flutter test` whenever `@GenerateNiceMocks` annotations change.
 
-## Architecture
+## Architecture overview
 
-**Directory structure:** Feature-based organization under `lib/`:
-- `core/` — extensions, models, routing, services (MatrixService + mixins), theme, utils
-- `features/` — feature modules: `auth/`, `chat/`, `e2ee/`, `home/`, `notifications/`, `rooms/`, `settings/`, `spaces/`
-- `shared/widgets/` — reusable UI components (avatars, section header, image viewer, speed dial)
+Feature-based organization under `lib/`: `core/` (services, routing, theme, utils), `features/` (auth, calling, chat, e2ee, home, notifications, rooms, settings, spaces), `shared/widgets/`.
 
-Each feature module contains `screens/`, `services/`, and/or `widgets/` subdirectories as needed.
+State is managed via multiple ChangeNotifiers provided at the root. `MatrixService` wraps the Matrix SDK client. Extracted sub-services live in `core/services/sub_services/` (AuthService, SyncService, SelectionService, ChatBackupService, UiaService). Other top-level providers include ClientManager, CallService, PreferencesService, and InboxController.
 
-**State management:** Single `MatrixService` (ChangeNotifier) provided at the root via Provider (`core/services/`). It wraps the Matrix SDK client and manages login, sync, room/space selection, E2EE bootstrap, and UIA flows.
-
-**Responsive layouts:** Three breakpoints in `HomeShell` (`features/home/screens/`) — mobile (<720px, bottom nav), tablet (720–1100px, rail+list), desktop (≥1100px, rail+list+chat). The space rail is Discord/Slack-style vertical icons.
-
-**E2EE architecture:** Separated into three layers (`features/e2ee/widgets/`):
-- `BootstrapController` (ChangeNotifier) — state machine for key backup/cross-signing setup
-- `BootstrapDialog` — modal orchestration
-- `BootstrapViews` — stateless UI components
-- Auto-unlock recovers keys from `FlutterSecureStorage` on startup
-- UIA uses cached password with 5-minute TTL
-
-See `docs/e2ee-flow.md` for detailed state machine diagrams.
-
-**Testing:** Mockito with generated mocks (`*.mocks.dart`). Tests cover MatrixService state, BootstrapController transitions, dialog flows, and key verification.
+See `agent_docs/architecture.md` for detailed architecture, routing, responsive layout, and E2EE docs. See `docs/e2ee-flow.md` for E2EE state machine diagrams.
 
 ## Conventions
 
-- **Commits:** Semantic format — `feat:`, `fix:`, `refactor:`, `style:`, `docs:`, `test:`, `chore:`
+- **Commits:** `feat:`, `fix:`, `refactor:`, `style:`, `docs:`, `test:`, `chore:`
 - **Logging:** `debugPrint('[Lattice] ...')` prefix for all log messages
-- **Code sections:** Organized with `// ── Section Name ──────` markers
-- **Linting:** `avoid_print: false` is intentional (uses `debugPrint` instead of `print`)
-- **Comments:** Avoid comments — code should be self-descriptive. Comments lead to misdirection and increase bugs. Section markers (`// ── Section Name ──────`) are the exception.
+- **No comments** -- code should be self-descriptive. Section markers (`// ── Section Name ──────`) are the exception.

--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -1,0 +1,98 @@
+# Architecture
+
+## Directory structure
+
+```
+lib/
+  main.dart                         # App bootstrap, Provider tree
+  core/
+    extensions/
+    models/                         # SpaceNode, UploadState, etc.
+    routing/
+      app_router.dart               # GoRouter with auth-aware redirects
+      route_names.dart              # Route constants
+    services/
+      matrix_service.dart           # Main ChangeNotifier wrapping Client
+      client_manager.dart           # Multi-account management
+      call_service.dart             # Call orchestration
+      preferences_service.dart      # SharedPreferences wrapper
+      app_config.dart               # JSON config + env vars
+      sub_services/                 # Extracted ChangeNotifiers
+        auth_service.dart
+        sync_service.dart
+        chat_backup_service.dart
+        selection_service.dart      # Space/room selection
+        uia_service.dart            # User Interactive Auth (cached password, 5-min TTL)
+    theme/
+    utils/
+      platform_info.dart            # Platform-specific via .native.dart / .web.dart
+  features/
+    auth/                           # Login, registration, SSO, reCAPTCHA
+    calling/                        # Voice/video via LiveKit + flutter_webrtc
+    chat/                           # Message rendering, compose, search
+    e2ee/                           # Key backup, cross-signing, device verification
+    home/                           # HomeShell: responsive layout manager
+    notifications/                  # OS notifications, web push, inbox
+    rooms/                          # Room list, details, context menus
+    settings/                       # Appearance, notifications, devices, voice/video
+    spaces/                         # Space rail, space details
+  shared/widgets/                   # Avatars, image viewer, speed dial, section headers
+```
+
+## State management
+
+All state is Provider + ChangeNotifier. The provider tree in `main.dart` provides:
+
+- `ClientManager` -- multi-account management
+- `PreferencesService` -- SharedPreferences wrapper
+- `MediaPlaybackService` -- audio/video playback
+
+Per active account (nested inside a Consumer):
+- `MatrixService` -- wraps matrix.Client, central state
+- `SelectionService` -- room/space selection
+- `ChatBackupService` -- E2EE key backup status
+- `InboxController` -- notification inbox
+- `CallService` -- call orchestration
+- `PushToTalkService` -- PTT state
+
+MatrixService lazy-loads sub-services: AuthService, SyncService, SelectionService, ChatBackupService, UiaService.
+
+## Routing
+
+GoRouter with named routes (`core/routing/`). Auth-aware redirects:
+- Not logged in -> `/login`
+- Logged in + E2EE backup needed -> `/e2ee-setup`
+- Logged in on auth route -> `/`
+
+Shell routes wrap the main layout (`HomeShell`). Full-page routes for login, registration, E2EE setup sit outside the shell.
+
+## Responsive layout
+
+`HomeShell` (`features/home/screens/`) manages three breakpoints:
+- <720px: NarrowLayout (mobile, single column)
+- 720-1100px: WideLayout (tablet, rail + list)
+- >=1100px: WideLayout (desktop, rail + list + chat)
+
+## E2EE
+
+Three layers in `features/e2ee/`:
+- `BootstrapController` (ChangeNotifier) -- state machine for key backup/cross-signing
+- `BootstrapDriver` -- flow orchestration
+- `BootstrapViews` -- stateless UI
+
+Auto-unlock recovers keys from FlutterSecureStorage on startup via SyncService callback. See `docs/e2ee-flow.md` for state diagrams.
+
+## Testing
+
+Mockito with `@GenerateNiceMocks` annotations. Generated files: `*.mocks.dart`. Tests are under `test/` mirroring the lib structure: `services/`, `screens/`, `widgets/`, `e2e/`, `utils/`.
+
+## Platform abstractions
+
+Conditional imports for platform differences:
+- `platform_info.dart` -> `.native.dart` / `.web.dart`
+- `client_factory_native.dart` / `client_factory_web.dart`
+- `file_native.dart` / `file_web.dart`
+
+## CI
+
+GitHub Actions (`.github/workflows/ci.yml`): analyze -> test (with coverage/Codecov) -> build-linux, build-macos. Docker multi-stage build for web deployment (Flutter web + Caddy).


### PR DESCRIPTION
## Summary
- Rewrote CLAUDE.md following progressive disclosure best practices (55 → 33 lines)
- Fixed outdated state management description — now reflects sub-services architecture instead of old "single MatrixService with mixins"
- Moved detailed architecture reference (directory tree, provider tree, routing, responsive layout, E2EE, CI) to `agent_docs/architecture.md`
- Removed linter-like rules that Claude can learn from context (e.g. `avoid_print` explanation)

## Test plan
- [x] Verify `agent_docs/architecture.md` is accurate against current codebase
- [x] Confirm no critical instructions were lost from CLAUDE.md