### PR TITLE
fix: display recovery key during E2EE bootstrap

### DIFF
--- a/lib/features/e2ee/widgets/bootstrap_driver.dart
+++ b/lib/features/e2ee/widgets/bootstrap_driver.dart
@@ -95,6 +95,10 @@ class BootstrapDriver {
     _bootstrap = bootstrap;
     _state = bootstrap.state;
 
+    if (_awaitingKeyAck && _state != BootstrapState.error) {
+      return;
+    }
+
     switch (_state) {
       case BootstrapState.askWipeSsss:
         debugPrint('[Bootstrap] Auto-advancing: wipeSsss($_wipeExisting)');
@@ -156,10 +160,6 @@ class BootstrapDriver {
         return;
       default:
         break;
-    }
-
-    if (_awaitingKeyAck && _state != BootstrapState.error) {
-      return;
     }
 
     final phase = _phaseFromState(_state);

--- a/test/widgets/bootstrap_controller_test.dart
+++ b/test/widgets/bootstrap_controller_test.dart
@@ -112,6 +112,38 @@ void main() {
       controller.dispose();
     });
 
+    test('phase stays savingKey when bootstrap advances during key gen',
+        () async {
+      late void Function(Bootstrap) onUpdateCb;
+      when(mockEncryption.bootstrap(onUpdate: anyNamed('onUpdate')))
+          .thenAnswer((invocation) {
+        onUpdateCb = invocation.namedArguments[const Symbol('onUpdate')]
+            as void Function(Bootstrap);
+        return MockBootstrap();
+      });
+
+      final controller = createController();
+      await controller.startBootstrap();
+
+      final mockBootstrap = MockBootstrap();
+      when(mockBootstrap.state).thenReturn(BootstrapState.askNewSsss);
+      when(mockBootstrap.newSsss()).thenAnswer((_) async {
+        when(mockBootstrap.state)
+            .thenReturn(BootstrapState.askSetupCrossSigning);
+        onUpdateCb(mockBootstrap);
+      });
+      final mockSsssKey = MockOpenSSSS();
+      when(mockBootstrap.newSsssKey).thenReturn(mockSsssKey);
+      when(mockSsssKey.recoveryKey).thenReturn('EsTc ABCD 1234 5678');
+
+      onUpdateCb(mockBootstrap);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.phase, SetupPhase.savingKey);
+      expect(controller.newRecoveryKey, 'EsTc ABCD 1234 5678');
+      controller.dispose();
+    });
+
     test('restartWithWipe resets all state', () async {
       late void Function(Bootstrap) onUpdateCb;
       when(mockEncryption.bootstrap(onUpdate: anyNamed('onUpdate')))


### PR DESCRIPTION
## Summary
- Move the `_awaitingKeyAck` guard in `BootstrapDriver._onBootstrapUpdate()` from after the switch statement to before it
- This prevents auto-advancing states (e.g. `askSetupCrossSigning`) from overwriting the `savingKey` phase while the user is viewing their recovery key
- Add regression test verifying the phase stays `savingKey` when the bootstrap advances during key generation

## Test plan
- [x] `flutter test test/widgets/bootstrap_controller_test.dart` — all 5 tests pass
- [x] Manual test: bootstrap E2EE on a fresh account, confirm recovery key is visible and copyable on the "Save your recovery key" screen