### PR TITLE
fix: GIF button invisible on web

### DIFF
--- a/lib/features/chat/widgets/compose_bar.dart
+++ b/lib/features/chat/widgets/compose_bar.dart
@@ -400,7 +400,15 @@ class _ComposeBarState extends State<ComposeBar> {
 
   Widget _buildGifButton(ColorScheme cs) {
     return IconButton(
-      icon: Icon(Icons.gif_outlined, color: cs.onSurfaceVariant),
+      icon: Text(
+        'GIF',
+        style: TextStyle(
+          color: cs.onSurfaceVariant,
+          fontSize: 13,
+          fontWeight: FontWeight.bold,
+          letterSpacing: 0.5,
+        ),
+      ),
       onPressed: widget.onGif,
       tooltip: 'Send GIF',
     );

--- a/test/widgets/chat/compose_bar_test.dart
+++ b/test/widgets/chat/compose_bar_test.dart
@@ -26,6 +26,7 @@ Widget _wrap({
   List<Room>? joinedRooms,
   PreferencesService? prefs,
   TypingController? typingController,
+  VoidCallback? onGif,
 }) {
   return ChangeNotifierProvider<PreferencesService>.value(
     value: prefs ?? PreferencesService(),
@@ -41,6 +42,7 @@ Widget _wrap({
           typingController: typingController,
           onRemoveAttachment: (_) {},
           onClearAttachments: () {},
+          onGif: onGif,
         ),
       ),
     ),
@@ -208,6 +210,18 @@ void main() {
             (a.meta || a.control),
       );
       expect(hasDownBinding, isTrue);
+    });
+
+    testWidgets('GIF button uses Text widget not Icon', (tester) async {
+      await tester.pumpWidget(_wrap(
+        controller: controller,
+        onSend: () {},
+        onGif: () {},
+      ),);
+
+      expect(find.text('GIF'), findsOneWidget);
+      expect(find.byIcon(Icons.gif_outlined), findsNothing);
+      expect(find.byIcon(Icons.gif_box_outlined), findsNothing);
     });
 
     testWidgets('TextField uses newline text input action', (tester) async {


### PR DESCRIPTION
## Summary

- Replaces `Icons.gif_outlined` with a styled `Text('GIF')` widget in `_buildGifButton()`
- `Icons.gif_outlined` is not reliably present in Flutter web's runtime icon font, so the button rendered as empty space
- `Text` widget has no font dependency and renders correctly on all platforms

Closes #279

## Test plan

- [x] `flutter test test/widgets/chat/compose_bar_test.dart` — all tests pass (new test: "GIF button uses Text widget not Icon")
- [x] Verify GIF button is visible in web deployment
- [x] Verify GIF button still works on Linux desktop