### PR TITLE
fix: PWA touch gesture interactions

### DIFF
--- a/lib/core/utils/platform_info_native.dart
+++ b/lib/core/utils/platform_info_native.dart
@@ -8,3 +8,4 @@ bool get isNativeWindows => Platform.isWindows;
 bool get isNativeMobile => Platform.isAndroid || Platform.isIOS;
 bool get isNativeDesktop =>
     Platform.isLinux || Platform.isMacOS || Platform.isWindows;
+bool get isTouchDevice => Platform.isAndroid || Platform.isIOS;

--- a/lib/core/utils/platform_info_web.dart
+++ b/lib/core/utils/platform_info_web.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart' show TargetPlatform, defaultTargetPlatform;
+
 bool get isNativeAndroid => false;
 bool get isNativeIOS => false;
 bool get isNativeLinux => false;
@@ -5,3 +7,6 @@ bool get isNativeMacOS => false;
 bool get isNativeWindows => false;
 bool get isNativeMobile => false;
 bool get isNativeDesktop => false;
+bool get isTouchDevice =>
+    defaultTargetPlatform == TargetPlatform.android ||
+    defaultTargetPlatform == TargetPlatform.iOS;

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -579,7 +579,7 @@ class _ChatScreenState extends State<ChatScreen>
 
   Widget _buildMessageList(
       List<Event> events, MatrixService matrix, Room room,) {
-    final isMobile = !(kIsWeb || isNativeDesktop);
+    final isMobile = isTouchDevice;
     final showReceipts = context.watch<PreferencesService>().readReceipts;
     final receiptMap = showReceipts
         ? buildReceiptMap(room, matrix.client.userID)

--- a/lib/features/chat/widgets/message_bubble.dart
+++ b/lib/features/chat/widgets/message_bubble.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:lattice/core/services/preferences_service.dart';
@@ -100,7 +99,7 @@ class _MessageBubbleState extends State<MessageBubble> {
     final maxWidth = screenWidth * 0.72;
     final density = context.watch<PreferencesService>().messageDensity;
     final metrics = DensityMetrics.of(density);
-    final isDesktop = kIsWeb || isNativeDesktop;
+    final isDesktop = !isTouchDevice;
 
     final isRedacted = widget.event.redacted;
 

--- a/test/core/utils/platform_info_web_test.dart
+++ b/test/core/utils/platform_info_web_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lattice/core/utils/platform_info_web.dart';
+
+void main() {
+  group('isTouchDevice (web)', () {
+    tearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    test('returns true for Android', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      expect(isTouchDevice, isTrue);
+    });
+
+    test('returns true for iOS', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      expect(isTouchDevice, isTrue);
+    });
+
+    test('returns false for Linux', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      expect(isTouchDevice, isFalse);
+    });
+
+    test('returns false for macOS', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      expect(isTouchDevice, isFalse);
+    });
+
+    test('returns false for Windows', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      expect(isTouchDevice, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `isTouchDevice` getter to `platform_info_native.dart` and `platform_info_web.dart`
  - Native: `Platform.isAndroid || Platform.isIOS`
  - Web: `defaultTargetPlatform == TargetPlatform.android || == TargetPlatform.iOS` (Flutter sets this from the browser user agent)
- Replaces `!(kIsWeb || isNativeDesktop)` in `chat_screen.dart` with `isTouchDevice` so mobile PWA users get `LongPressWrapper` + `SwipeableMessage`
- Replaces `kIsWeb || isNativeDesktop` in `message_bubble.dart` with `!isTouchDevice` so mobile PWA users don't get the hover/right-click path

Closes #281

## Test plan

- [ ] `flutter test test/core/utils/platform_info_web_test.dart` — 5 tests pass covering Android/iOS (touch) and Linux/macOS/Windows (non-touch)
- [ ] Verify long-press opens context menu on mobile PWA (Android Chrome)
- [ ] Verify swipe-to-reply works on mobile PWA
- [ ] Verify hover action bar still appears on desktop web (Linux/macOS browser)
- [ ] Verify right-click context menu still works on desktop web