### PR TITLE
fix: don't redirect to E2EE setup screen on app reopen

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -48,7 +48,7 @@ GoRouter buildRouter(MatrixService matrixService) {
           !onSetupRoute &&
           !onAuthRoute &&
           !onAddAccountRoute &&
-          matrixService.chatBackup.chatBackupNeeded != false &&
+          matrixService.chatBackup.chatBackupNeeded == true &&
           !matrixService.hasSkippedSetup) {
         return '/e2ee-setup';
       }

--- a/lib/core/services/matrix_service.dart
+++ b/lib/core/services/matrix_service.dart
@@ -45,10 +45,7 @@ class MatrixService extends ChangeNotifier {
     sync = SyncService(
       client: _client,
       onPostSyncBackup: () async {
-        await chatBackup.checkChatBackupStatus();
-        if (chatBackup.chatBackupNeeded == true) {
-          await chatBackup.tryAutoUnlockBackup();
-        }
+        await chatBackup.tryAutoUnlockBackup();
       },
     );
     auth = AuthService(

--- a/lib/core/services/sub_services/chat_backup_service.dart
+++ b/lib/core/services/sub_services/chat_backup_service.dart
@@ -45,20 +45,20 @@ class ChatBackupService extends ChangeNotifier {
 
   Future<void> tryAutoUnlockBackup() async {
     final storedKey = await getStoredRecoveryKey();
-    if (storedKey == null) return;
+    if (storedKey != null) {
+      debugPrint('[Lattice] Attempting auto-unlock with stored key');
 
-    debugPrint('[Lattice] Attempting auto-unlock with stored key');
-
-    try {
-      final state = await _client.getCryptoIdentityState();
-      if (state.connected) {
-        debugPrint('[Lattice] Skip restore: already connected');
-      } else {
-        await _client.restoreCryptoIdentity(storedKey);
+      try {
+        final state = await _client.getCryptoIdentityState();
+        if (state.connected) {
+          debugPrint('[Lattice] Skip restore: already connected');
+        } else {
+          await _client.restoreCryptoIdentity(storedKey);
+        }
+        await _restoreRoomKeys();
+      } catch (e) {
+        debugPrint('[Lattice] Failed: $e');
       }
-      await _restoreRoomKeys();
-    } catch (e) {
-      debugPrint('[Lattice] Failed: $e');
     }
 
     await checkChatBackupStatus();

--- a/test/services/chat_backup_service_test.dart
+++ b/test/services/chat_backup_service_test.dart
@@ -81,12 +81,18 @@ void main() {
   });
 
   group('tryAutoUnlockBackup', () {
-    test('is a no-op when no stored recovery key', () async {
+    test('checks backup status even when no stored recovery key', () async {
       when(mockClient.userID).thenReturn('@user:example.com');
       when(mockStorage.read(key: 'ssss_recovery_key_@user:example.com'))
           .thenAnswer((_) async => null);
+      when(mockCrossSigning.enabled).thenReturn(false);
+      when(mockKeyManager.enabled).thenReturn(false);
+      when(mockCrossSigning.isCached()).thenAnswer((_) async => false);
+      when(mockKeyManager.isCached()).thenAnswer((_) async => false);
 
       await service.tryAutoUnlockBackup();
+
+      expect(service.chatBackupNeeded, isTrue);
     });
 
     test('skips restore when already connected', () async {


### PR DESCRIPTION
## Summary

- The E2EE setup screen appeared every time the app was reopened, even when encryption was already configured and a recovery key was stored on the device
- Root cause: race condition between the router redirect and the async backup check + auto-unlock flow
- `chatBackupNeeded` starts as `null`; the router condition `!= false` matched `null`, redirecting to `/e2ee-setup` before auto-unlock could restore the stored key

## Changes

- **Router** (`app_router.dart`): change redirect condition from `chatBackupNeeded != false` to `chatBackupNeeded == true` — `null` (loading) no longer triggers a redirect
- **`tryAutoUnlockBackup()`** (`chat_backup_service.dart`): always call `checkChatBackupStatus()` at the end, even when no stored key exists, so status is only published after the unlock opportunity has passed
- **`onPostSyncBackup`** (`matrix_service.dart`): simplify to a single `tryAutoUnlockBackup()` call — the separate `checkChatBackupStatus()` + conditional unlock is no longer needed
- **Test** (`chat_backup_service_test.dart`): update "no stored key" test to account for the status check now always running

## Test plan

- [ ] App reopen with encryption configured + stored key → goes straight to home screen
- [ ] App reopen with encryption configured but no stored key → shows E2EE setup (correct)
- [ ] Fresh login with no encryption → shows E2EE setup (correct)
- [ ] Navigate to E2EE from Settings → shows management screen (unchanged)
- [ ] `flutter test test/services/chat_backup_service_test.dart test/services/matrix_service_test.dart` — all pass