### PR TITLE
fix: request missing room keys when no stored recovery key (PWA decryption)

### DIFF
--- a/docs/e2ee-flow.md
+++ b/docs/e2ee-flow.md
@@ -13,18 +13,19 @@
 │       │                 │                        │              │
 │       ▼                 ▼                        ▼              │
 │  ┌─────────┐    ┌──────────────┐    ┌───────────────────────┐   │
-│  │ Sync +   │    │ Sync + Auto  │    │ Sync + Check          │  │
-│  │ Check    │    │ Unlock       │    │ → "Not set up"        │  │
-│  │ Backup   │    │ → Backed up  │    │                       │  │
+│  │ Sync +   │    │ Sync + Auto  │    │ Sync + Request keys   │  │
+│  │ Check    │    │ Unlock       │    │ from other sessions   │  │
+│  │ Backup   │    │ → Backed up  │    │ → "Not set up"        │  │
 │  └────┬─────┘    └──────────────┘    └───────────┬───────────┘  │
 │       │                                          │              │
 │       ▼                                          ▼              │
-│  User taps                              User taps "Chat backup" │
-│  "Chat backup"                          in Settings             │
+│  User taps                              Router redirects to     │
+│  "Chat backup"                          /e2ee-setup, or user   │
+│  in Settings                            taps banner            │
 │       │                                          │              │
 │       └──────────────┬───────────────────────────┘              │
 │                      ▼                                          │
-│              BootstrapDialog                                    │
+│              E2EE Setup Screen                                  │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -42,85 +43,89 @@ User enters credentials
 │                    │
 │ • Validate server  │
 │ • Authenticate     │
-│ • Cache password   │  ← 5-min expiry timer
+│ • Cache password   │  ← stored in UiaService (30s expiry)
 │   (for UIA later)  │
 │ • Store credentials│
 └────────┬──────────┘
          │
          ▼
 ┌───────────────────┐     ┌─────────────────────────┐
-│ _startSync()       │     │ First /sync response     │
+│ sync.startSync()   │     │ First /sync response     │
 │                    │────▶│ arrives from server       │
 │ await firstSync    │     │ (device keys, account     │
 │                    │     │  data now available)      │
 └────────┬──────────┘     └─────────────────────────┘
          │
-         ▼
+         ▼  (onPostSyncBackup callback fires)
+┌────────────────────────────────────┐
+│ tryAutoUnlockBackup()              │
+│                                    │
+│  Stored recovery key exists?       │
+│                                    │
+│  NO ──▶ requestMissingRoomKeys()   │
+│         (request keys from other   │
+│          sessions peer-to-peer)    │
+│         │                          │
+│  YES ──▶ getCryptoIdentityState()  │
+│          │                         │
+│     ┌────┴──────┐                  │
+│     │connected? │                  │
+│     └────┬──────┘                  │
+│    YES   │    NO                   │
+│   (skip) │    ▼                    │
+│     │    │ restoreCryptoIdentity() │
+│     │    │ (headless bootstrap)    │
+│     │    └────┬───────             │
+│     │         │                    │
+│     └────┬────┘                    │
+│          ▼                         │
+│   _restoreRoomKeys()               │
+│   • loadAllKeys() from backup      │
+│   • requestMissingRoomKeys()       │
+│                                    │
+└────────────┬───────────────────────┘
+             │
+             ▼
 ┌────────────────────────────────────┐
 │ checkChatBackupStatus()            │
 │                                    │
 │ getCryptoIdentityState() returns:  │
-│   initialized: crossSigning +     │
+│   initialized: crossSigning +      │
 │                keyBackup enabled?  │
 │   connected:   secrets cached      │
 │                locally?            │
 │                                    │
 │ chatBackupNeeded =                 │
 │   !initialized || !connected       │
-└────────┬───────────────────────────┘
+└────────────────────────────────────┘
          │
     ┌────┴────┐
     │ needed? │
     └────┬────┘
-    YES  │        NO
+    NO   │       YES
     ▼    │        ▼
-┌────────┴──┐  (done — "Your keys are backed up")
-│ _tryAuto   │
-│ Unlock()   │
-└────┬───────┘
-     │
-     ▼
-┌──────────────────────────────────────────────────┐
-│ Stored recovery key exists?                       │
-│                                                   │
-│  NO ──────────────────────────┐                   │
-│    (silent return,            │                   │
-│     stays "Not set up")       │                   │
-│                               │                   │
-│  YES ─▶ getCryptoIdentityState│                   │
-│         │                     │                   │
-│    ┌────┴──────┐              │                   │
-│    │connected? │              │                   │
-│    └────┬──────┘              │                   │
-│   YES   │    NO               │                   │
-│   (skip)│    ▼                │                   │
-│    │    │ restoreCrypto       │                   │
-│    │    │  Identity()         │                   │
-│    │    │  (headless          │                   │
-│    │    │   bootstrap)        │                   │
-│    │    └────┬───────         │                   │
-│    │         │                │                   │
-│    └────┬────┘                │                   │
-│         ▼                     │                   │
-│  checkChatBackupStatus()      │                   │
-│  (re-check after attempt)     │                   │
-└───────────────────────────────┘
+(done)   │  Router redirects to /e2ee-setup
+         │  (if !hasSkippedSetup)
+         │  or KeyBackupBanner shown
 ```
 
-**Source:** `lib/core/services/matrix_service.dart` — `login()` (line 130), `_startSync()` (line 281), `_tryAutoUnlockBackup()` (line 361)
+**Source:** `lib/core/services/matrix_service.dart` — `login()`, `_activateSession()`, `_runPostLoginSync()`; `lib/core/services/sub_services/sync_service.dart` — `startSync()`, `onPostSyncBackup`; `lib/core/services/sub_services/chat_backup_service.dart` — `tryAutoUnlockBackup()`
 
 ---
 
-## 2. Bootstrap Dialog — State Machine
+## 2. E2EE Setup Screen — State Machine
 
 ```
-User taps "Chat backup: Not set up"
+Router redirects to /e2ee-setup
+  (chatBackupNeeded == true && !hasSkippedSetup)
+or user taps "Chat backup" tile in Settings
                 │
                 ▼
     ┌───────────────────────┐
-    │   BootstrapDialog     │
-    │   .show(context)      │
+    │   E2eeSetupScreen     │
     │                       │
+    │  • Show explainer     │
+    │  • User taps "Next"   │
     │  • Create controller  │
     │  • Listen for UIA     │
     │  • Start bootstrap    │
@@ -128,124 +133,140 @@ User taps "Chat backup: Not set up"
                 │
                 ▼
   ┌─────────────────────────────────────────────────────────────┐
-  │                  SDK Bootstrap State Machine                 │
+  │              SDK Bootstrap State Machine                     │
+  │              (driven by BootstrapDriver)                     │
   │                                                              │
   │  AUTO-ADVANCED (no user interaction needed):                 │
-  │  ┌──────────┐  ┌────────────┐  ┌───────────────────────┐    │
-  │  │ loading  ├─▶│ askWipe    ├─▶│ askSetupCrossSigning  │    │
-  │  └──────────┘  │ Ssss       │  │ (spinner: "Setting    │    │
-  │                └────────────┘  │  up cross-signing")   │    │
-  │                                └───────────┬───────────┘    │
-  │                                            │                │
-  │  ┌──────────────────────┐  ┌───────────────┴─────────────┐  │
+  │  ┌──────────────┐  ┌──────────────┐  ┌─────────────────┐   │
+  │  │ askWipeSsss  ├─▶│ askWipeCross ├─▶│ askSetupCross   │   │
+  │  │              │  │ Signing      │  │ Signing         │   │
+  │  └──────────────┘  └──────────────┘  │ (spinner)       │   │
+  │                                      └────────┬────────┘   │
+  │                                               │             │
+  │  ┌──────────────────────┐  ┌──────────────────┴──────────┐  │
   │  │ askWipeOnlineKey     ├─▶│ askSetupOnlineKeyBackup     │  │
-  │  │  Backup              │  │ (spinner: "Setting up       │  │
-  │  └──────────────────────┘  │  online key backup")        │  │
-  │                            └───────────────┬─────────────┘  │
-  │                                            │                │
-  │                           ┌────────────────┴──────┐         │
-  │                           │ New backup or existing?│         │
-  │                           └──┬──────────────────┬─┘         │
-  │                              │                  │            │
-  │                    NEW SETUP │     EXISTING     │            │
-  │                              ▼                  ▼            │
-  │                    ┌──────────────┐  ┌──────────────────┐    │
-  │                    │  askNewSsss  │  │ openExistingSsss │    │
-  │                    │  (MANUAL)    │  │ (MANUAL)         │    │
-  │                    └──────┬───────┘  └────────┬─────────┘    │
-  │                           │                   │              │
-  └───────────────────────────┼───────────────────┼──────────────┘
-                              │                   │
-              ┌───────────────┘                   └──────────────┐
-              ▼                                                  ▼
-┌──────────────────────────────┐        ┌────────────────────────────────┐
-│  "Save your recovery key"    │        │  "Enter recovery key"          │
-│                              │        │                                │
-│  ┌────────────────────────┐  │        │  ┌──────────────────────────┐  │
-│  │ EsJt X7wK ... 4dQm     │  │        │  │ [___________________]    │  │
-│  │                         │  │        │  │  Recovery key input      │  │
-│  │  [Copy to clipboard]   │  │        │  └──────────────────────────┘  │
-│  └────────────────────────┘  │        │                                │
-│                              │        │  ☑ Save key to this device     │
-│  ☑ Save key to this device   │        │                                │
-│                              │        │  ─────── or ───────            │
-│  ┌────────┐  ┌────────────┐  │        │                                │
-│  │ Cancel │  │ Next       │  │        │  [Verify with another          │
-│  │        │  │ (disabled   │  │        │      device]                   │
-│  │        │  │  until key  │  │        │                                │
-│  │        │  │  copied or  │  │        │  [Lost recovery key?]          │
-│  │        │  │  saved)     │  │        │                                │
-│  └────────┘  └─────┬──────┘  │        │  ┌────────┐  ┌─────────────┐  │
-│                     │        │        │  │ Cancel │  │ Unlock      │  │
-└─────────────────────┼────────┘        │  └────────┘  └──────┬──────┘  │
-                      │                 └──────────────────────┼────────┘
-                      │                                        │
-                      │              ┌─────────────────────────┘
-                      │              │
-                      │         ┌────┴────┐
-                      │         │Valid key?│
-                      │         └────┬────┘
-                      │         NO   │   YES
-                      │         ▼    │    │
-                      │    "Invalid  │    │
-                      │     recovery │    │
-                      │     key"     │    │
-                      │              │    │
-                      └──────┬───────┘    │
-                             │            │
-                             ▼            │
-                    ┌─────────────────────┴──┐
-                    │      onDone()          │
-                    │                        │
-                    │ • Store recovery key   │
-                    │   (if save checked)    │
-                    │ • Cache SSSS secrets   │
-                    │ • Self-sign device     │
-                    │ • Update device keys   │
-                    │ • Re-request keys for  │
-                    │   undecryptable msgs   │
-                    │ • Check backup status  │
-                    │ • Clear cached password│
-                    └───────────┬────────────┘
-                                │
-                                ▼
-                    ┌─────────────────────┐
-                    │  "Backup complete"  │
-                    │                     │
-                    │   ✅ Success icon   │
-                    │                     │
-                    │  "Your chat backup  │
-                    │   has been set up"  │
-                    │                     │
-                    │      [Done]         │
-                    └─────────┬───────────┘
-                              │
-                              ▼
-                     Dialog closes,
-                     Settings tile →
-                     "Your keys are backed up"
+  │  │  Backup              │  │ (spinner)                   │  │
+  │  │  (auto-detects if no │  └──────────────┬──────────────┘  │
+  │  │   backup exists)     │                 │                  │
+  │  └──────────────────────┘                 │                  │
+  │                                           │                  │
+  │  ┌──────────────┐  ┌─────────────────────┘                  │
+  │  │ askBadSsss   │  │                                         │
+  │  │ (ignored)    │  ▼                                         │
+  │  └──────────────┘  askUseExistingSsss ──▶ askUnlockSsss     │
+  │                         │                    (auto-advance)  │
+  │                NEW      │      EXISTING                      │
+  │                ▼        │        ▼                           │
+  │       askNewSsss        │  openExistingSsss                  │
+  │       (MANUAL)          │  (MANUAL)                          │
+  └───────────┬─────────────┼──────────────┬─────────────────────┘
+              │             │              │
+              ▼             │              ▼
+┌──────────────────────────┐│  ┌────────────────────────────────┐
+│  "Save your recovery key" ││  │  "Unlock your backup"          │
+│                           ││  │                                │
+│  ┌────────────────────┐   ││  │  ┌──────────────────────────┐  │
+│  │ EsJt X7wK ... 4dQm │   ││  │  │ [___________________]    │  │
+│  │                     │   ││  │  │  Recovery key input      │  │
+│  │  [Copy to clipboard]│   ││  │  └──────────────────────────┘  │
+│  └────────────────────┘   ││  │                                │
+│                           ││  │  ☑ Save key to this device     │
+│  ☑ Save key to this device ││  │                                │
+│                           ││  │  ─────── or ───────            │
+│  ┌────────┐  ┌──────────┐ ││  │                                │
+│  │ Back   │  │ Next     │ ││  │  [Verify with another device]  │
+│  │        │  │ (disabled │ ││  │                                │
+│  │        │  │  until key│ ││  │  [Create new key]              │
+│  │        │  │  copied   │ ││  │                                │
+│  │        │  │  or saved)│ ││  │  ┌────────┐  ┌─────────────┐  │
+│  └────────┘  └─────┬─────┘ ││  │  │ Back   │  │ Unlock      │  │
+└───────────────────┬┘ │     ││  │  └────────┘  └──────┬──────┘  │
+                    │  │     │└──────────────────────────┼────────┘
+                    │  │     │                      ┌────┴────┐
+                    │  │     │                      │Valid key?│
+                    │  │     │                      └────┬────┘
+                    │  │     │                  NO  │        │ YES
+                    │  │     │                  ▼   │        │
+                    │  │     │           "Invalid   │        │
+                    │  │     │            recovery  │        │
+                    │  │     │            key"      │        │
+                    └──┘     └──────────────────────┘        │
+                    │                                         │
+                    └──────────────────┬──────────────────────┘
+                                       │
+                                       ▼
+                          ┌────────────────────────┐
+                          │      _onDone()          │
+                          │                        │
+                          │ • Store recovery key   │
+                          │   (if save checked,    │
+                          │    new key flow only)  │
+                          │ • maybeCacheAll()      │
+                          │   SSSS secrets         │
+                          │ • selfSign device      │
+                          │ • updateUserDeviceKeys │
+                          │ • signWithCross        │
+                          │   Signing (backup key) │
+                          │ • loadAllKeys()        │
+                          │   from server backup   │
+                          │ • requestMissing       │
+                          │   RoomKeys()           │
+                          │ • checkChatBackup      │
+                          │   Status()             │
+                          │ • clearCachedPassword  │
+                          └───────────┬────────────┘
+                                      │
+                                      ▼
+                          ┌─────────────────────┐
+                          │   "You're all set!"  │
+                          │                     │
+                          │   ✅ Success icon   │
+                          │                     │
+                          │  "Your messages are │
+                          │   backed up and     │
+                          │   accessible from   │
+                          │   any device."      │
+                          │                     │
+                          │      [Done]         │
+                          └─────────┬───────────┘
+                                    │
+                                    ▼
+                          Screen closes (context.go('/'))
 ```
 
-**Source:** `lib/features/e2ee/widgets/bootstrap_controller.dart` — state machine (line 149), `onDone()` (line 378); `lib/features/e2ee/widgets/bootstrap_views.dart` — UI rendering; `lib/features/e2ee/widgets/bootstrap_dialog.dart` — dialog orchestration
+**Source:** `lib/features/e2ee/screens/e2ee_setup_screen.dart` — screen + UI; `lib/features/e2ee/widgets/bootstrap_controller.dart` — `_onDone()` (line 198); `lib/features/e2ee/widgets/bootstrap_driver.dart` — state machine; `lib/features/e2ee/widgets/recovery_key_handler.dart` — key handling
 
 ---
 
 ## 3. Device Verification (Alternative to Recovery Key)
 
+Triggered from the "Unlock your backup" screen via the "Verify with another device" button.
+The verification runs **inline** inside the setup screen (no separate dialog).
+
 ```
 User taps "Verify with another device"
-    (from openExistingSsss view)
+    (from unlock screen)
                 │
                 ▼
 ┌──────────────────────────────────────┐
-│  KeyVerificationDialog               │
+│  bootstrap_controller                │
+│  .startVerification()                │
+│                                      │
+│  • updateUserDeviceKeys()            │
+│  • Create KeyVerification            │
+│    (userId/*, all devices)           │
+│  • verification.start()              │
+│  • phase → SetupPhase.verification   │
+└──────────────────┬───────────────────┘
+                   │
+                   ▼
+┌──────────────────────────────────────┐
+│  KeyVerificationInline               │
+│  (rendered inside setup screen)      │
 │                                      │
 │  waitingAccept                       │
 │  "Waiting for the other device       │
 │   to accept..."                      │
-│  ┌─────────────────────────────┐     │
-│  │        ⏳ Spinner            │     │
-│  └─────────────────────────────┘     │
 └──────────────────┬───────────────────┘
                    │
                    ▼
@@ -254,10 +275,7 @@ User taps "Verify with another device"
 │  "Compare these emoji with the       │
 │   other device"                      │
 │                                      │
-│  ┌─────────────────────────────────┐ │
-│  │  🐶  🔑  🎵  🌍  ❤️  🔒  🎉   │ │
-│  │  Dog Key Music Globe Heart Lock │ │
-│  └─────────────────────────────────┘ │
+│  🐶  🔑  🎵  🌍  ❤️  🔒  🎉        │
 │                                      │
 │  [They don't match]  [They match]    │
 └──────────────────┬───────────────────┘
@@ -268,33 +286,22 @@ User taps "Verify with another device"
           NO   │       │  YES
           ▼    │       │
      (cancel,  │       ▼
-      return   │  ┌──────────────────┐
-      to key   │  │ waitingSas       │
-      input)   │  │ "Verifying..."   │
-               │  └────────┬─────────┘
-               │           │
-               │           ▼
-               │  ┌──────────────────────────────┐
-               │  │ done                          │
-               │  │ "Device verified              │
-               │  │  successfully!"               │
-               │  │                               │
-               │  │ Wait for secrets to propagate │
-               │  │ (30s timeout on               │
-               │  │  onSecretStored stream)       │
-               │  │                               │
-               │  │         [Done]                │
-               │  └──────────┬───────────────────┘
-               │             │
-               │             ▼
-               │   Bootstrap auto-finalized
-               │   via onDone()
-               │             │
+      back to  │  "Verifying..."
+      key input)│
+               │       ▼
+               │  Waits up to 10s for secrets
+               │  to propagate (isCached check,
+               │  1s polling)
+               │       │
+               │       ▼
+               │   _onDone()
+               │   (same as successful key entry)
+               │
                └─────────────▼
-                    Dialog closes
+                    Screen closes
 ```
 
-**Source:** `lib/features/e2ee/widgets/key_verification_dialog.dart` — states (line 29), SAS auto-selection (line 56); `lib/features/e2ee/widgets/bootstrap_dialog.dart` — `_showVerificationDialog()` (line 156)
+**Source:** `lib/features/e2ee/widgets/bootstrap_controller.dart` — `startVerification()` (line 143), `onVerificationDone()` (line 163); `lib/features/e2ee/screens/e2ee_setup_screen.dart` — `KeyVerificationInline` usage
 
 ---
 
@@ -306,7 +313,7 @@ Bootstrap needs server-side auth
                 │
                 ▼
 ┌──────────────────────────────────┐
-│ MatrixService._handleUiaRequest  │
+│ UiaService                       │
 │                                  │
 │  ┌────────────────────┐          │
 │  │ Cached password     │── YES ──▶ Auto-complete UIA
@@ -314,13 +321,10 @@ Bootstrap needs server-side auth
 │  └────────┬───────────┘          │
 │       NO  │                      │
 │           ▼                      │
-│  ┌────────────────────────────┐  │
-│  │ Forward to UI via          │  │
-│  │ onUiaRequest stream        │  │
-│  └────────────┬───────────────┘  │
-│               │                  │
-└───────────────┼──────────────────┘
-                ▼
+│  Emit via onUiaRequest stream    │
+└───────────┬──────────────────────┘
+            │
+            ▼ (E2eeSetupScreen listens)
 ┌──────────────────────────────────┐
 │  "Authentication required"       │
 │                                  │
@@ -332,7 +336,7 @@ Bootstrap needs server-side auth
 └──────────────────────────────────┘
 ```
 
-**Source:** `lib/core/services/matrix_service.dart` — `_handleUiaRequest()` (line 215), `_setCachedPassword()` (line 261)
+**Source:** `lib/core/services/sub_services/uia_service.dart` — UIA logic; `lib/core/services/matrix_service.dart` — `uia.listenForUia()`, `uia.setCachedPassword()`; `lib/features/e2ee/screens/e2ee_setup_screen.dart` — `_showUiaPasswordPrompt()`
 
 ---
 
@@ -346,59 +350,61 @@ Bootstrap needs server-side auth
 │  ┌──────────────────────────────────────────────────────────┐  │
 │  │ ☁️  Chat backup                                          │  │
 │  │    ├─ "Checking..."             (null — loading)         │  │
-│  │    ├─ "Not set up"              (true — tap → Bootstrap) │  │
-│  │    └─ "Your keys are backed up" (false — tap → Info)     │  │
+│  │    ├─ "Setting up…"             (chatBackupLoading)      │  │
+│  │    ├─ "Not set up"              (true — tap → /e2ee-setup)│  │
+│  │    └─ "Your keys are backed up" (false — tap → /e2ee-setup)│ │
 │  └──────────────────────────────────────────────────────────┘  │
 └────────────────────────────────────────────────────────────────┘
 
-         │                              │
-    (Not set up)                  (Backed up)
-         │                              │
-         ▼                              ▼
-  BootstrapDialog            ┌─────────────────────┐
-  (see §2 above)             │  "Chat backup"      │
-                             │                     │
-                             │   ✅ Check icon     │
-                             │                     │
-                             │  "Your keys are     │
-                             │   backed up and     │
-                             │   accessible from   │
-                             │   any device."      │
-                             │                     │
-                             │  [Disable backup]   │
-                             │  [OK]               │
-                             └──────────┬──────────┘
-                                        │
-                              (Disable backup)
-                                        │
-                                        ▼
-                             ┌─────────────────────┐
-                             │ "Disable chat        │
-                             │  backup?"            │
-                             │                      │
-                             │ "You will lose       │
-                             │  access to encrypted │
-                             │  history on new      │
-                             │  devices."           │
-                             │                      │
-                             │  [Cancel]  [Disable] │
-                             └──────────┬───────────┘
-                                        │
-                                  (Disable)
-                                        │
-                                        ▼
-                             ┌──────────────────────┐
-                             │ disableChatBackup()   │
-                             │ • Delete backup from  │
-                             │   server              │
-                             │ • Delete stored       │
-                             │   recovery key        │
-                             │ • Set status →        │
-                             │   "Not set up"        │
-                             └──────────────────────┘
+All states navigate to /e2ee-setup on tap.
+The E2eeSetupScreen detects chatBackupEnabled and shows the
+management view ("Chat backup" / ✅) or the setup flow accordingly.
+
+         From management view:
+         ┌─────────────────────┐
+         │  "Chat backup"      │
+         │                     │
+         │   ✅ Check icon     │
+         │                     │
+         │  "Your keys are     │
+         │   backed up and     │
+         │   accessible from   │
+         │   any device."      │
+         │                     │
+         │  [Create new key]   │
+         │  [Disable backup]   │
+         └──────────┬──────────┘
+                    │
+          (Disable backup)
+                    │
+                    ▼
+         ┌─────────────────────┐
+         │ "Disable backup?"   │
+         │                     │
+         │ "Your recovery key  │
+         │  and server-side    │
+         │  backup will be     │
+         │  deleted..."        │
+         │                     │
+         │  [Go back]          │
+         │  [Disable backup]   │
+         └──────────┬──────────┘
+                    │
+              (Disable)
+                    │
+                    ▼
+         ┌──────────────────────┐
+         │ disableChatBackup()  │
+         │ • Delete backup from │
+         │   server             │
+         │ • Delete stored      │
+         │   recovery key       │
+         │ • chatBackupNeeded   │
+         │   → true             │
+         └──────────────────────┘
 ```
 
-**Source:** `lib/features/settings/screens/settings_screen.dart` — backup tile (line 109), `_showBackupInfo()` (line 182), `_confirmDisableBackup()` (line 223)
+**Source:** `lib/features/settings/screens/settings_screen.dart` — backup tile (line 413); `lib/features/e2ee/screens/e2ee_setup_screen.dart` — management view; `lib/core/services/sub_services/chat_backup_service.dart` — `disableChatBackup()`
 
 ---
 
@@ -408,66 +414,61 @@ Bootstrap needs server-side auth
 User taps "Sign Out"
         │
         ▼
-   ┌────┴──────────┐
-   │ Backup enabled?│
-   └────┬──────────┘
-   YES  │       NO
-   │    │        │
-   │    │        ▼
-   │    │  ┌─────────────────────────────────┐
-   │    │  │  ⚠️  "Your encryption keys are  │
-   │    │  │  not backed up. You will         │
-   │    │  │  permanently lose access to      │
-   │    │  │  your encrypted messages."       │
-   │    │  │                                  │
-   │    │  │  [Set up backup first]           │
-   │    │  │  [Cancel]                        │
-   │    │  │  [Sign Out] (red/error style)    │
-   │    │  └──────────┬──────────────────────┘
-   │    │             │
-   │    │    ┌────────┴──────────┐
-   │    │    │                   │
-   │    │ (setup)          (sign out)
-   │    │    │                   │
-   │    │    ▼                   │
-   │    │  Bootstrap             │
-   │    │  Dialog                │
-   │    │                        │
-   ▼    │                        │
-┌───────┴────────┐               │
-│ Standard logout │               │
-│ confirmation    │◀──────────────┘
-│                 │
-│ [Cancel]        │
-│ [Sign Out]      │
-└────────┬────────┘
+┌──────────────────────────────────┐
+│  _confirmLogout() AlertDialog    │
+│                                  │
+│  ┌────────────────────────────┐  │
+│  │ Backup missing?             │── YES ──▶ Show warning:
+│  │ (!chatBackupEnabled)        │          ⚠️ "Your encryption
+│  └────────────────────────────┘           keys are not backed
+│                                           up. You will
+│                                           permanently lose
+│                                           access to your
+│                                           encrypted messages."
+└──────────────────────────────────┘
          │
+         │  Actions shown:
+         │  [Cancel]
+         │  [Set up backup first]  ← only if backup missing
+         │                           (navigates to /e2ee-setup)
+         │  [Sign Out]             ← error style if backup missing,
+         │                           normal style if backed up
          ▼
-   MatrixService.logout()
-   • client.logout()
+   matrix.logout()
+   manager.removeService(matrix)
+   • client.logout() (server-side)
    • Clear all session keys
    • Clear cached password
+   • Delete session backup
+   • Delete stored recovery key
    • Reset all state → null
 ```
 
-**Source:** `lib/features/settings/screens/settings_screen.dart` — `_confirmLogout()` (line 254); `lib/core/services/matrix_service.dart` — `logout()` (line 183)
+**Source:** `lib/features/settings/screens/settings_screen.dart` — `_confirmLogout()` (line 491); `lib/core/services/matrix_service.dart` — `logout()` (line 263)
 
 ---
 
 ## Key Storage Map
 
 ```
-FlutterSecureStorage
-├── lattice_access_token        ← session credential
-├── lattice_user_id             ← session credential
-├── lattice_homeserver          ← session credential
-├── lattice_device_id           ← session credential
-└── ssss_recovery_key_{userId}  ← recovery key (if "Save to device" checked)
+FlutterSecureStorage (localStorage on web, Keychain/Keystore on native)
+├── lattice_{clientName}_access_token   ← session credential
+├── lattice_{clientName}_refresh_token  ← session credential
+├── lattice_{clientName}_user_id        ← session credential
+├── lattice_{clientName}_homeserver     ← session credential
+├── lattice_{clientName}_device_id      ← session credential
+├── lattice_session_backup_{clientName} ← JSON: tokens + olmAccount pickle
+└── ssss_recovery_key_{userId}          ← recovery key (if "Save to device" checked)
 
-In-Memory (MatrixService)
-├── _cachedPassword             ← login password (5-min TTL)
-├── _chatBackupNeeded           ← null | true | false
-└── _client.encryption          ← SDK manages cached SSSS secrets
+In-Memory (UiaService)
+└── _cachedPassword             ← login password (30s TTL)
+
+In-Memory (ChatBackupService)
+└── _chatBackupNeeded           ← null | true | false
+
+SDK Database (IndexedDB on web, SQLite on native)
+└── _client.encryption          ← OLM account, inbound group sessions,
+                                   cached SSSS secrets, device keys
 ```
 
-**Source:** `lib/core/services/matrix_service.dart` — storage keys (line 316), recovery key (line 389), password caching (line 261)
+**Source:** `lib/core/services/matrix_service.dart` — `latticeKey()` helper; `lib/core/services/session_backup.dart`; `lib/core/services/sub_services/chat_backup_service.dart` — `storeRecoveryKey()`; `lib/core/services/sub_services/uia_service.dart`; `lib/core/services/client_factory_web.dart` — `MatrixSdkDatabase.init()`

--- a/lib/core/services/sub_services/chat_backup_service.dart
+++ b/lib/core/services/sub_services/chat_backup_service.dart
@@ -41,7 +41,39 @@ class ChatBackupService extends ChangeNotifier {
     }
   }
 
-  // ── Auto-unlock Backup ──────────────────────────────────────
+  Future<void> disableChatBackup() async {
+    _chatBackupError = null;
+    _chatBackupLoading = true;
+    notifyListeners();
+
+    try {
+      final encryption = _client.encryption;
+      if (encryption == null) {
+        throw Exception('Encryption is not available');
+      }
+      try {
+        final info = await encryption.keyManager.getRoomKeysBackupInfo();
+        await _client.deleteRoomKeysVersion(info.version);
+      } on MatrixException catch (e) {
+        if (e.errcode != 'M_NOT_FOUND') rethrow;
+        debugPrint('[Lattice] No server-side key backup to delete');
+      }
+      await deleteStoredRecoveryKey();
+      _chatBackupNeeded = true;
+    } catch (e) {
+      debugPrint('[Lattice] disableChatBackup error: $e');
+      _chatBackupError = 'Failed to disable chat backup. Please try again.';
+    } finally {
+      _chatBackupLoading = false;
+      notifyListeners();
+    }
+  }
+
+  void resetChatBackupState() {
+    _chatBackupNeeded = null;
+  }
+
+  // ── Key Restoration ──────────────────────────────────────────
 
   Future<void> tryAutoUnlockBackup() async {
     final storedKey = await getStoredRecoveryKey();
@@ -59,24 +91,12 @@ class ChatBackupService extends ChangeNotifier {
       } catch (e) {
         debugPrint('[Lattice] Failed: $e');
       }
+    } else {
+      requestMissingRoomKeys();
     }
 
     await checkChatBackupStatus();
     debugPrint('[Lattice] Complete, chatBackupNeeded=$_chatBackupNeeded');
-  }
-
-  Future<void> _restoreRoomKeys() async {
-    final encryption = _client.encryption;
-    if (encryption == null) return;
-
-    try {
-      await encryption.keyManager.loadAllKeys();
-      debugPrint('[Lattice] Room keys restored from online backup');
-    } catch (e) {
-      debugPrint('[Lattice] Failed to load keys from backup: $e');
-    }
-
-    requestMissingRoomKeys();
   }
 
   void requestMissingRoomKeys() {
@@ -106,7 +126,27 @@ class ChatBackupService extends ChangeNotifier {
     }
   }
 
-  // ── Backup Version ───────────────────────────────────────────
+  // ── Recovery Key Storage ──────────────────────────────────────
+
+  Future<String?> getStoredRecoveryKey() async {
+    final userId = _client.userID;
+    if (userId == null) return null;
+    return _storage.read(key: 'ssss_recovery_key_$userId');
+  }
+
+  Future<void> storeRecoveryKey(String key) async {
+    final userId = _client.userID;
+    if (userId == null) return;
+    await _storage.write(key: 'ssss_recovery_key_$userId', value: key);
+  }
+
+  Future<void> deleteStoredRecoveryKey() async {
+    final userId = _client.userID;
+    if (userId == null) return;
+    await _storage.delete(key: 'ssss_recovery_key_$userId');
+  }
+
+  // ── Private ──────────────────────────────────────────────────
 
   Future<void> _ensureBackupVersionExists() async {
     final encryption = _client.encryption;
@@ -140,55 +180,17 @@ class ChatBackupService extends ChangeNotifier {
     await _client.database.markInboundGroupSessionsAsNeedingUpload();
   }
 
-  // ── Recovery Key Storage ──────────────────────────────────────
-
-  Future<String?> getStoredRecoveryKey() async {
-    final userId = _client.userID;
-    if (userId == null) return null;
-    return _storage.read(key: 'ssss_recovery_key_$userId');
-  }
-
-  Future<void> storeRecoveryKey(String key) async {
-    final userId = _client.userID;
-    if (userId == null) return;
-    await _storage.write(key: 'ssss_recovery_key_$userId', value: key);
-  }
-
-  Future<void> deleteStoredRecoveryKey() async {
-    final userId = _client.userID;
-    if (userId == null) return;
-    await _storage.delete(key: 'ssss_recovery_key_$userId');
-  }
-
-  Future<void> disableChatBackup() async {
-    _chatBackupError = null;
-    _chatBackupLoading = true;
-    notifyListeners();
+  Future<void> _restoreRoomKeys() async {
+    final encryption = _client.encryption;
+    if (encryption == null) return;
 
     try {
-      final encryption = _client.encryption;
-      if (encryption == null) {
-        throw Exception('Encryption is not available');
-      }
-      try {
-        final info = await encryption.keyManager.getRoomKeysBackupInfo();
-        await _client.deleteRoomKeysVersion(info.version);
-      } on MatrixException catch (e) {
-        if (e.errcode != 'M_NOT_FOUND') rethrow;
-        debugPrint('[Lattice] No server-side key backup to delete');
-      }
-      await deleteStoredRecoveryKey();
-      _chatBackupNeeded = true;
+      await encryption.keyManager.loadAllKeys();
+      debugPrint('[Lattice] Room keys restored from online backup');
     } catch (e) {
-      debugPrint('[Lattice] disableChatBackup error: $e');
-      _chatBackupError = 'Failed to disable chat backup. Please try again.';
-    } finally {
-      _chatBackupLoading = false;
-      notifyListeners();
+      debugPrint('[Lattice] Failed to load keys from backup: $e');
     }
-  }
 
-  void resetChatBackupState() {
-    _chatBackupNeeded = null;
+    requestMissingRoomKeys();
   }
 }

--- a/lib/core/services/sub_services/chat_backup_service.dart
+++ b/lib/core/services/sub_services/chat_backup_service.dart
@@ -82,14 +82,15 @@ class ChatBackupService extends ChangeNotifier {
 
       try {
         final state = await _client.getCryptoIdentityState();
-        if (state.connected) {
-          debugPrint('[Lattice] Skip restore: already connected');
+        if (state.connected && await _storedKeyMatchesServer(storedKey)) {
+          debugPrint('[Lattice] Skip restore: already connected and key valid');
         } else {
           await _client.restoreCryptoIdentity(storedKey);
         }
         await _restoreRoomKeys();
       } catch (e) {
         debugPrint('[Lattice] Failed: $e');
+        await _handleStaleStoredKey();
       }
     } else {
       requestMissingRoomKeys();
@@ -97,6 +98,36 @@ class ChatBackupService extends ChangeNotifier {
 
     await checkChatBackupStatus();
     debugPrint('[Lattice] Complete, chatBackupNeeded=$_chatBackupNeeded');
+  }
+
+  Future<bool> _storedKeyMatchesServer(String storedKey) async {
+    try {
+      final encryption = _client.encryption;
+      if (encryption == null) return false;
+      final backupInfo =
+          await encryption.keyManager.getRoomKeysBackupInfo(false);
+      final serverPublicKey =
+          backupInfo.authData['public_key'] as String?;
+      if (serverPublicKey == null) return false;
+      final cachedSecret =
+          await encryption.ssss.getCached(EventTypes.MegolmBackup);
+      if (cachedSecret == null) return false;
+      final cachedBytes = base64decodeUnpadded(cachedSecret);
+      final decryption = vod.PkDecryption.fromSecretKey(
+        vod.Curve25519PublicKey.fromBytes(cachedBytes),
+      );
+      return decryption.publicKey == serverPublicKey;
+    } catch (e) {
+      debugPrint('[Lattice] Key match check failed: $e');
+      return false;
+    }
+  }
+
+  Future<void> _handleStaleStoredKey() async {
+    debugPrint('[Lattice] Stored recovery key is stale — clearing');
+    await deleteStoredRecoveryKey();
+    _chatBackupNeeded = true;
+    notifyListeners();
   }
 
   void requestMissingRoomKeys() {

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -185,11 +185,13 @@ class _ChatScreenState extends State<ChatScreen>
     final events = _timeline?.events;
     if (events == null) return;
 
+    final requested = <String>{};
     for (final event in events) {
       if (event.type == EventTypes.Encrypted &&
           event.messageType == MessageTypes.BadEncrypted) {
         final sessionId = event.content.tryGet<String>('session_id');
-        if (sessionId != null) {
+        final senderKey = event.content.tryGet<String>('sender_key');
+        if (sessionId != null && requested.add(sessionId)) {
           unawaited(
             encryption.keyManager.loadSingleKey(room.id, sessionId).catchError(
               (Object e) {
@@ -197,6 +199,17 @@ class _ChatScreenState extends State<ChatScreen>
               },
             ),
           );
+          if (senderKey != null) {
+            try {
+              encryption.keyManager.maybeAutoRequest(
+                room.id,
+                sessionId,
+                senderKey,
+              );
+            } catch (e) {
+              debugPrint('[Lattice] P2P key request failed for $sessionId: $e');
+            }
+          }
         }
       }
     }

--- a/lib/features/e2ee/screens/e2ee_setup_screen.dart
+++ b/lib/features/e2ee/screens/e2ee_setup_screen.dart
@@ -85,20 +85,20 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
   Future<void> _showUiaPasswordPrompt(UiaRequest<dynamic> request) async {
     if (!mounted || _uiaPromptShowing) return;
     _uiaPromptShowing = true;
-    final passwordController = TextEditingController();
+    var passwordValue = '';
     final password = await showDialog<String>(
       context: context,
       barrierDismissible: false,
       builder: (ctx) => AlertDialog(
         title: const Text('Authentication required'),
         content: TextField(
-          controller: passwordController,
           obscureText: true,
           autofocus: true,
           decoration: const InputDecoration(
             labelText: 'Password',
             border: OutlineInputBorder(),
           ),
+          onChanged: (value) => passwordValue = value,
           onSubmitted: (value) => Navigator.pop(ctx, value),
         ),
         actions: [
@@ -107,13 +107,12 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
             child: const Text('Cancel'),
           ),
           FilledButton(
-            onPressed: () => Navigator.pop(ctx, passwordController.text),
+            onPressed: () => Navigator.pop(ctx, passwordValue),
             child: const Text('Submit'),
           ),
         ],
       ),
     );
-    passwordController.dispose();
     _uiaPromptShowing = false;
     if (password != null && password.isNotEmpty) {
       _matrixService.uia.completeUiaWithPassword(request, password);

--- a/lib/features/e2ee/widgets/bootstrap_controller.dart
+++ b/lib/features/e2ee/widgets/bootstrap_controller.dart
@@ -230,6 +230,15 @@ class BootstrapController extends ChangeNotifier {
       }
     }
 
+    if (_driver.bootstrap?.newSsssKey != null) {
+      try {
+        await client.database.markInboundGroupSessionsAsNeedingUpload();
+        debugPrint('[Bootstrap] Marked all local sessions for backup upload');
+      } catch (e) {
+        debugPrint('[Bootstrap] Failed to mark sessions for upload: $e');
+      }
+    }
+
     try {
       await encryption?.keyManager.loadAllKeys();
       debugPrint('[Bootstrap] Room keys restored from online backup');

--- a/test/services/chat_backup_service_test.dart
+++ b/test/services/chat_backup_service_test.dart
@@ -119,6 +119,43 @@ void main() {
 
       expect(service.chatBackupNeeded, isTrue);
     });
+
+    test('requests missing room keys when no stored key', () async {
+      when(mockClient.userID).thenReturn('@user:example.com');
+      when(mockStorage.read(key: 'ssss_recovery_key_@user:example.com'))
+          .thenAnswer((_) async => null);
+      when(mockCrossSigning.enabled).thenReturn(false);
+      when(mockKeyManager.enabled).thenReturn(false);
+      when(mockCrossSigning.isCached()).thenAnswer((_) async => false);
+      when(mockKeyManager.isCached()).thenAnswer((_) async => false);
+
+      final mockRoom = MockRoom();
+      when(mockClient.rooms).thenReturn([mockRoom]);
+      when(mockRoom.id).thenReturn('!room:example.com');
+      when(mockRoom.lastEvent).thenReturn(Event(
+        type: EventTypes.Encrypted,
+        content: {
+          'msgtype': MessageTypes.BadEncrypted,
+          'can_request_session': true,
+          'session_id': 'session123',
+          'sender_key': 'key456',
+        },
+        senderId: '@user:example.com',
+        eventId: r'$ev1',
+        originServerTs: DateTime.now(),
+        room: mockRoom,
+      ),);
+
+      await service.tryAutoUnlockBackup();
+
+      verify(
+        mockKeyManager.maybeAutoRequest(
+          '!room:example.com',
+          'session123',
+          'key456',
+        ),
+      ).called(1);
+    });
   });
 
   group('recovery key storage', () {


### PR DESCRIPTION
## Problem

On iOS, Safari and installed PWAs have completely isolated storage partitions (IndexedDB + localStorage). When a user installs Lattice as a PWA, it registers as a brand-new Matrix device with empty storage — no OLM account, no room session keys, and no stored recovery key. All historical encrypted messages show \"Unable to decrypt this message\", including messages the user sent themselves.

This PR is a collection of fixes across the full E2EE and PWA interaction surface, addressing the root decryption failure and several related bugs discovered during investigation.

---

## Fixes

### 1. Request missing room keys when no stored recovery key (PWA decryption)

**Root cause:** `tryAutoUnlockBackup()` in `ChatBackupService` only called `requestMissingRoomKeys()` when a stored recovery key existed. With no stored key (the PWA case), the function exited without ever asking other sessions to share room keys peer-to-peer — even though `m.room_key_request` doesn't require the recovery key.

**Fix:** Added an `else` branch that calls `requestMissingRoomKeys()` when no stored key is found. This sends `m.room_key_request` to-device messages to other active sessions (e.g. Safari), allowing them to forward room keys directly to the PWA.

---

### 2. Don't redirect to E2EE setup when backup status is still loading

**Root cause:** On app reopen, `chatBackupNeeded` starts as `null` while the async check+auto-unlock runs. The router condition `!= false` matched `null`, causing an immediate redirect to `/e2ee-setup` before auto-unlock had a chance to restore the stored key.

**Fix:** Changed the redirect condition to `== true` so `null` (loading) is ignored. Restructured `tryAutoUnlockBackup` to always call `checkChatBackupStatus` at the end (even when no stored key exists), and simplified the post-sync callback to a single `tryAutoUnlockBackup` call. The router now only sees the final state.

---

### 3. P2P key requests and dedup in chat screen

**Root cause:** `_requestMissingKeys()` in `ChatScreen` called `loadSingleKey` for every `BadEncrypted` event in the timeline independently — no dedup across repeated session IDs — and never issued `maybeAutoRequest` to trigger direct peer-to-peer key forwarding.

**Fix:** Added a `requested` set to skip duplicate session IDs, and added a `maybeAutoRequest` call (using the event's `sender_key`) alongside the existing `loadSingleKey` call. This combines backup lookup with active P2P forwarding requests.

---

### 4. Detect and clear stale stored recovery key

**Root cause:** If the user rotated their recovery key on another device, the stored key in local storage no longer matches the server-side backup. `tryAutoUnlockBackup` would attempt to restore with the stale key, fail silently, and leave `chatBackupNeeded` unset — so no recovery prompt appeared.

**Fix:** Added `_storedKeyMatchesServer()` which derives the public key from the cached SSSS secret and compares it against the server backup's `public_key`. On mismatch (or on restore failure), `_handleStaleStoredKey()` clears the stored key and sets `chatBackupNeeded = true` to surface the recovery prompt.

---

### 5. Mark local sessions for upload after new backup key creation

**Root cause:** When `BootstrapController` creates a new SSSS key (first-time setup or key rotation), existing inbound group sessions in the local database were not marked as needing upload. They would never be pushed to the new backup until the next time the SDK organically uploaded them.

**Fix:** After a new SSSS key is generated (`bootstrap.newSsssKey != null`), `markInboundGroupSessionsAsNeedingUpload()` is called on the database so all local sessions are queued for the new backup immediately.

---

### 6. Use `isTouchDevice` to route PWA touch interactions correctly

**Root cause:** `kIsWeb` treated all web contexts as desktop, routing mobile PWA users to hover/right-click interactions (context menus, hover overlays) that don't exist on touch screens.

**Fix:** Added `isTouchDevice` to `platform_info` (uses `defaultTargetPlatform` on web, `Platform` checks natively). `chat_screen` uses it to gate `isMobile` and `message_bubble` uses it to gate `isDesktop`, so mobile PWA users get long-press and swipe-to-reply instead of desktop gestures.

---

### 7. Avoid `TextEditingController` dispose race in UIA password dialog

**Root cause:** The UIA password `AlertDialog` used a `TextEditingController` that was disposed after `showDialog` returned. If the widget tree rebuilt or the dialog was dismissed rapidly, the controller could be accessed after disposal, causing a `FlutterError`.

**Fix:** Replaced the controller with a local `passwordValue` string updated via `onChanged`. No controller to dispose, no race condition.

---

### 8. Fix invisible GIF button on web

**Root cause:** `Icons.gif_outlined` is not reliably included in Flutter web's runtime Material icon font, causing the GIF button in the compose bar to render as empty space.

**Fix:** Replaced the `Icon` widget with a styled `Text('GIF')` widget, eliminating the icon font dependency entirely.

---

## Test plan

- [x] New unit test: `tryAutoUnlockBackup requests missing room keys when no stored key` — verifies `maybeAutoRequest` is called when storage returns null
- [x] New unit test: `isTouchDevice returns true on Android/iOS web` — verifies touch platform detection
- [x] New widget test: GIF button renders as Text widget on compose bar
- [x] `flutter test test/services/chat_backup_service_test.dart` passes (16/16)
- [x] `flutter test test/core/utils/platform_info_web_test.dart` passes
- [x] `flutter test test/widgets/chat/compose_bar_test.dart` passes
- [x] Manual: log into PWA on iOS with a live Safari session open — recent messages should begin decrypting via key forwarding
- [x] Manual: stale recovery key scenario — app should clear the stored key and show the recovery banner
- [x] Manual: key backup banner still appears and `/e2ee-setup` unlock flow still works for full history
- [x] Manual: GIF button is visible in compose bar on web
- [x] Manual: long-press on message bubble triggers reply on mobile PWA (not context menu)