### PR TITLE
fix: logout router redirect and auth state refactor

### DIFF
--- a/integration_test/helpers/test_app.dart
+++ b/integration_test/helpers/test_app.dart
@@ -341,6 +341,5 @@ Future<void> completePostLoginSync(
 ) async {
   syncController.add(SyncUpdate(nextBatch: 'batch_1', rooms: RoomsUpdate()));
   await tester.pumpAndSettle();
-  await matrixService.auth.postLoginSyncFuture;
   matrixService.dispose();
 }

--- a/lib/core/services/matrix_service.dart
+++ b/lib/core/services/matrix_service.dart
@@ -267,6 +267,7 @@ class MatrixService extends ChangeNotifier {
     unawaited(_loginStateSub?.cancel());
     sync.cancelSyncSub();
     _isLoggedIn = false;
+    notifyListeners();
     await auth.awaitPostLoginSync();
 
     try {

--- a/lib/core/services/matrix_service.dart
+++ b/lib/core/services/matrix_service.dart
@@ -56,6 +56,7 @@ class MatrixService extends ChangeNotifier {
       storage: _storage,
       clientName: clientName,
     );
+    auth.addListener(_onAuthChanged);
   }
 
   // ── Fields ──────────────────────────────────────────────────────
@@ -66,11 +67,10 @@ class MatrixService extends ChangeNotifier {
   final Client _client;
   Client get client => _client;
 
-  bool _isLoggedIn = false;
-  bool get isLoggedIn => _isLoggedIn;
+  bool get isLoggedIn => auth.isLoggedIn;
 
   @visibleForTesting
-  set isLoggedInForTest(bool value) => _isLoggedIn = value;
+  set isLoggedInForTest(bool value) => auth.isLoggedIn = value;
 
   bool _disposed = false;
   bool get disposed => _disposed;
@@ -98,9 +98,18 @@ class MatrixService extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<String?> _readRefreshToken() async {
-    final stored = await _client.database.getClient(clientName);
-    return stored?.tryGet<String>('refresh_token');
+  @override
+  void dispose() {
+    _disposed = true;
+    auth.removeListener(_onAuthChanged);
+    auth.isLoggedIn = false;
+    sync.cancelSyncSub();
+    uia.dispose();
+    selection.dispose();
+    chatBackup.dispose();
+    sync.dispose();
+    unawaited(_loginStateSub?.cancel());
+    super.dispose();
   }
 
   // ── Public API ──────────────────────────────────────────────────
@@ -113,37 +122,6 @@ class MatrixService extends ChangeNotifier {
     }
   }
 
-  Future<void> saveSessionBackup() async {
-    final backup = SessionBackup(
-      accessToken: _client.accessToken!,
-      refreshToken: await _readRefreshToken(),
-      userId: _client.userID!,
-      homeserver: _client.homeserver.toString(),
-      deviceId: _client.deviceID!,
-      deviceName: 'Lattice Flutter',
-      olmAccount: _client.encryption?.pickledOlmAccount,
-    );
-    await SessionBackup.save(
-      backup,
-      clientName: clientName,
-      storage: _storage,
-    );
-    debugPrint('[Lattice] Session backup saved for $clientName');
-  }
-
-  @override
-  void dispose() {
-    _disposed = true;
-    _isLoggedIn = false;
-    sync.cancelSyncSub();
-    uia.dispose();
-    selection.dispose();
-    chatBackup.dispose();
-    sync.dispose();
-    unawaited(_loginStateSub?.cancel());
-    super.dispose();
-  }
-
   // ── Login ──────────────────────────────────────────────────────
 
   Future<bool> login({
@@ -151,48 +129,21 @@ class MatrixService extends ChangeNotifier {
     required String username,
     required String password,
   }) async {
-    auth.loginError = null;
-    notifyListeners();
-
-    try {
-      var hs = homeserver.trim();
-      if (hs.isEmpty) throw ArgumentError('Homeserver cannot be empty');
-      if (!hs.startsWith('http')) hs = 'https://$hs';
-
-      debugPrint('[Lattice] Checking homeserver: $hs');
-      await _client.checkHomeserver(Uri.parse(hs));
-      debugPrint('[Lattice] Homeserver OK');
-
-      debugPrint('[Lattice] Logging in as $username ...');
-      await _client.login(
-        LoginType.mLoginPassword,
-        identifier: AuthenticationUserIdentifier(user: username.trim()),
-        password: password,
-        initialDeviceDisplayName: 'Lattice Flutter',
-        refreshToken: true,
-      );
-      debugPrint('[Lattice] Login complete – '
-          'deviceId=${_client.deviceID}, '
-          'userId=${_client.userID}, '
-          'encryption=${_client.encryption != null ? "available" : "null"}, '
-          'encryptionEnabled=${_client.encryptionEnabled}');
-
+    final success = await auth.login(
+      homeserver: homeserver,
+      username: username,
+      password: password,
+    );
+    if (success) {
       uia.setCachedPassword(password);
-      uia.listenForUia();
-      _listenForLoginState();
-      _isLoggedIn = true;
-      notifyListeners();
-
-      _postLoginSync();
-
-      return true;
-    } catch (e, s) {
-      debugPrint('[Lattice] Login failed: $e');
-      debugPrint('[Lattice] Stack trace:\n$s');
-      auth.loginError = e.toString();
-      notifyListeners();
-      return false;
+      try {
+        await sync.startSync(timeout: const Duration(minutes: 5));
+        await auth.saveSessionBackup();
+      } catch (e) {
+        debugPrint('[Lattice] Post-login sync error: $e');
+      }
     }
+    return success;
   }
 
   // ── SSO Login ──────────────────────────────────────────────────
@@ -201,42 +152,19 @@ class MatrixService extends ChangeNotifier {
     required String homeserver,
     required String loginToken,
   }) async {
-    auth.loginError = null;
-    notifyListeners();
-
-    try {
-      var hs = homeserver.trim();
-      if (hs.isEmpty) throw ArgumentError('Homeserver cannot be empty');
-      if (!hs.startsWith('http')) hs = 'https://$hs';
-
-      await _client.checkHomeserver(Uri.parse(hs));
-
-      debugPrint('[Lattice] Completing SSO login ...');
-      await _client.login(
-        LoginType.mLoginToken,
-        token: loginToken,
-        initialDeviceDisplayName: 'Lattice Flutter',
-        refreshToken: true,
-      );
-      debugPrint('[Lattice] SSO login complete – '
-          'deviceId=${_client.deviceID}, '
-          'userId=${_client.userID}');
-
-      uia.listenForUia();
-      _listenForLoginState();
-      _isLoggedIn = true;
-      notifyListeners();
-
-      _postLoginSync();
-
-      return true;
-    } catch (e, s) {
-      debugPrint('[Lattice] SSO login failed: $e');
-      debugPrint('[Lattice] Stack trace:\n$s');
-      auth.loginError = e.toString();
-      notifyListeners();
-      return false;
+    final success = await auth.completeSsoLogin(
+      homeserver: homeserver,
+      loginToken: loginToken,
+    );
+    if (success) {
+      try {
+        await sync.startSync(timeout: const Duration(minutes: 5));
+        await auth.saveSessionBackup();
+      } catch (e) {
+        debugPrint('[Lattice] Post-login sync error: $e');
+      }
     }
+    return success;
   }
 
   // ── Registration ──────────────────────────────────────────────
@@ -245,47 +173,21 @@ class MatrixService extends ChangeNotifier {
     RegisterResponse response, {
     String? password,
   }) async {
-    debugPrint('[Lattice] Registration complete – userId=${response.userId}');
-
-    if (_client.accessToken == null || _client.userID == null) {
-      throw StateError('Client was not initialized after register(). '
-          'accessToken=${_client.accessToken}, userID=${_client.userID}');
-    }
-
     if (password != null) uia.setCachedPassword(password);
-    uia.listenForUia();
-    _listenForLoginState();
-    _isLoggedIn = true;
-    notifyListeners();
-
-    _postLoginSync();
+    await auth.completeRegistration(response, password: password);
+    try {
+      await sync.startSync(timeout: const Duration(minutes: 5));
+      await auth.saveSessionBackup();
+    } catch (e) {
+      debugPrint('[Lattice] Post-login sync error: $e');
+    }
   }
 
   // ── Logout ────────────────────────────────────────────────────
 
   Future<void> logout() async {
-    unawaited(_loginStateSub?.cancel());
-    sync.cancelSyncSub();
-    _isLoggedIn = false;
-    notifyListeners();
-    await auth.awaitPostLoginSync();
-
-    try {
-      if (_client.homeserver != null && _client.accessToken != null) {
-        await _client.logout();
-      }
-    } catch (e) {
-      debugPrint('[Lattice] Logout error: $e');
-    }
-    await auth.clearSessionKeys();
-    await SessionBackup.delete(clientName: clientName, storage: _storage);
+    await auth.logout();
     await chatBackup.deleteStoredRecoveryKey();
-    uia.clearCachedPassword();
-    uia.cancelUiaSub();
-    selection.resetSelection();
-    chatBackup.resetChatBackupState();
-    _hasSkippedSetup = false;
-    notifyListeners();
   }
 
   // ── Soft Logout ──────────────────────────────────────────────
@@ -294,38 +196,33 @@ class MatrixService extends ChangeNotifier {
     debugPrint('[Lattice] Soft logout detected, attempting token refresh...');
     try {
       await _client.refreshAccessToken();
-      final refreshToken = await _readRefreshToken();
-      await Future.wait([
-        _storage.write(
-          key: latticeKey(clientName, 'access_token'),
-          value: _client.accessToken,
-        ),
-        _storage.write(
-          key: latticeKey(clientName, 'refresh_token'),
-          value: refreshToken,
-        ),
-      ]);
-      await saveSessionBackup();
+      await auth.persistCredentials();
+      await auth.saveSessionBackup();
       debugPrint('[Lattice] Token refreshed successfully');
     } catch (e) {
       debugPrint('[Lattice] Token refresh failed: $e');
+      await auth.logout();
+      await chatBackup.deleteStoredRecoveryKey();
+    }
+  }
+
+  // ── Private: Auth Observer ──────────────────────────────────────
+
+  void _onAuthChanged() {
+    if (auth.isLoggedIn) {
+      uia.listenForUia();
+      _listenForLoginState();
+    } else {
       unawaited(_loginStateSub?.cancel());
+      _loginStateSub = null;
       sync.cancelSyncSub();
-      _isLoggedIn = false;
-      await auth.awaitPostLoginSync();
-      uia.cancelUiaSub();
       uia.clearCachedPassword();
+      uia.cancelUiaSub();
       selection.resetSelection();
       chatBackup.resetChatBackupState();
       _hasSkippedSetup = false;
-      await auth.clearSessionKeys();
-      await SessionBackup.delete(clientName: clientName, storage: _storage);
-      await chatBackup.deleteStoredRecoveryKey();
-      try {
-        await _client.logout();
-      } catch (_) {}
-      notifyListeners();
     }
+    notifyListeners();
   }
 
   // ── Private: Login State Stream ─────────────────────────────────
@@ -333,57 +230,18 @@ class MatrixService extends ChangeNotifier {
   void _listenForLoginState() {
     unawaited(_loginStateSub?.cancel());
     _loginStateSub = _client.onLoginStateChanged.stream.listen((state) async {
-      if (state == LoginState.loggedOut && _isLoggedIn) {
+      if (state == LoginState.loggedOut && auth.isLoggedIn) {
         debugPrint('[Lattice] Server-side logout detected');
-        unawaited(_loginStateSub?.cancel());
-        _loginStateSub = null;
-        sync.cancelSyncSub();
-        _isLoggedIn = false;
-        uia.cancelUiaSub();
-        uia.clearCachedPassword();
-        selection.resetSelection();
-        chatBackup.resetChatBackupState();
-        _hasSkippedSetup = false;
-        await auth.clearSessionKeys();
-        await SessionBackup.delete(clientName: clientName, storage: _storage);
+        await auth.handleServerLogout();
         await chatBackup.deleteStoredRecoveryKey();
-        notifyListeners();
       }
     });
-  }
-
-  // ── Private: Post-login Background Sync ─────────────────────────
-
-  void _postLoginSync() {
-    auth.startPostLoginSync(_runPostLoginSync);
-  }
-
-  Future<void> _runPostLoginSync() async {
-    try {
-      try {
-        await auth.persistCredentials();
-      } catch (e) {
-        debugPrint('[Lattice] Credential persistence failed (non-fatal): $e');
-      }
-      if (!_isLoggedIn) return;
-      await sync.startSync(timeout: const Duration(minutes: 5));
-      if (!_isLoggedIn) return;
-      await saveSessionBackup();
-    } catch (e) {
-      debugPrint('[Lattice] Post-login sync error: $e');
-      if (_isLoggedIn) {
-        auth.postLoginSyncError = friendlyAuthError(e);
-        notifyListeners();
-      }
-    }
   }
 
   // ── Private: Initialization ─────────────────────────────────────
 
   Future<void> _activateSession() async {
-    uia.listenForUia();
-    _listenForLoginState();
-    _isLoggedIn = true;
+    auth.activateRestoredSession();
     try {
       await sync.startSync();
     } on TimeoutException {
@@ -470,7 +328,7 @@ class MatrixService extends ChangeNotifier {
           'encryption=${_client.encryption != null ? "available" : "null"}, '
           'encryptionEnabled=${_client.encryptionEnabled}');
       await _activateSession();
-      await saveSessionBackup();
+      await auth.saveSessionBackup();
     } catch (e, s) {
       debugPrint('[Lattice] Session restore failed: $e');
       debugPrint('[Lattice] Stack trace:\n$s');
@@ -482,7 +340,7 @@ class MatrixService extends ChangeNotifier {
         if (refreshed) return;
       }
 
-      _isLoggedIn = false;
+      auth.isLoggedIn = false;
       if (auth.isPermanentAuthFailure(cause)) {
         await _clearSessionAndBackup();
       }
@@ -495,20 +353,10 @@ class MatrixService extends ChangeNotifier {
       await _client.init();
       if (_client.isLogged()) {
         if (_client.accessToken != null) {
-          final refreshToken = await _readRefreshToken();
-          await Future.wait([
-            _storage.write(
-              key: latticeKey(clientName, 'access_token'),
-              value: _client.accessToken,
-            ),
-            _storage.write(
-              key: latticeKey(clientName, 'refresh_token'),
-              value: refreshToken,
-            ),
-          ]);
+          await auth.persistCredentials();
         }
         await _activateSession();
-        await saveSessionBackup();
+        await auth.saveSessionBackup();
         debugPrint('[Lattice] Session restored via database token refresh');
         return true;
       }

--- a/lib/core/services/matrix_service.dart
+++ b/lib/core/services/matrix_service.dart
@@ -70,7 +70,10 @@ class MatrixService extends ChangeNotifier {
   bool get isLoggedIn => auth.isLoggedIn;
 
   @visibleForTesting
-  set isLoggedInForTest(bool value) => auth.isLoggedIn = value;
+  set isLoggedInForTest(bool value) {
+    auth.isLoggedIn = value;
+    auth.notifyListeners();
+  }
 
   bool _disposed = false;
   bool get disposed => _disposed;
@@ -228,7 +231,7 @@ class MatrixService extends ChangeNotifier {
   // ── Private: Login State Stream ─────────────────────────────────
 
   void _listenForLoginState() {
-    unawaited(_loginStateSub?.cancel());
+    if (_loginStateSub != null) return;
     _loginStateSub = _client.onLoginStateChanged.stream.listen((state) async {
       if (state == LoginState.loggedOut && auth.isLoggedIn) {
         debugPrint('[Lattice] Server-side logout detected');

--- a/lib/core/services/sub_services/auth_service.dart
+++ b/lib/core/services/sub_services/auth_service.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:lattice/core/models/server_auth_capabilities.dart';
 import 'package:lattice/core/services/matrix_service.dart' show latticeKey;
+import 'package:lattice/core/services/session_backup.dart';
 import 'package:matrix/matrix.dart';
 // ignore: implementation_imports, no public API for ClientInitException
 import 'package:matrix/src/utils/client_init_exception.dart';
@@ -22,6 +23,8 @@ class AuthService extends ChangeNotifier {
   final String _clientName;
 
   // ── Auth state ────────────────────────────────────────────────
+  bool isLoggedIn = false;
+
   String? _loginError;
   String? get loginError => _loginError;
   set loginError(String? value) {
@@ -29,18 +32,181 @@ class AuthService extends ChangeNotifier {
     notifyListeners();
   }
 
-  String? _postLoginSyncError;
-  String? get postLoginSyncError => _postLoginSyncError;
-  set postLoginSyncError(String? value) {
-    _postLoginSyncError = value;
+  Completer<void>? _capabilitiesLock;
+
+  // ── Login ─────────────────────────────────────────────────────
+
+  Future<bool> login({
+    required String homeserver,
+    required String username,
+    required String password,
+  }) async {
+    loginError = null;
+
+    try {
+      var hs = homeserver.trim();
+      if (hs.isEmpty) throw ArgumentError('Homeserver cannot be empty');
+      if (!hs.startsWith('http')) hs = 'https://$hs';
+
+      debugPrint('[Lattice] Checking homeserver: $hs');
+      await _client.checkHomeserver(Uri.parse(hs));
+      debugPrint('[Lattice] Homeserver OK');
+
+      debugPrint('[Lattice] Logging in as $username ...');
+      await _client.login(
+        LoginType.mLoginPassword,
+        identifier: AuthenticationUserIdentifier(user: username.trim()),
+        password: password,
+        initialDeviceDisplayName: 'Lattice Flutter',
+        refreshToken: true,
+      );
+      debugPrint('[Lattice] Login complete – '
+          'deviceId=${_client.deviceID}, '
+          'userId=${_client.userID}, '
+          'encryption=${_client.encryption != null ? "available" : "null"}, '
+          'encryptionEnabled=${_client.encryptionEnabled}');
+
+      isLoggedIn = true;
+      notifyListeners();
+
+      try {
+        await persistCredentials();
+      } catch (e) {
+        debugPrint('[Lattice] Credential persistence failed (non-fatal): $e');
+      }
+
+      return true;
+    } catch (e, s) {
+      debugPrint('[Lattice] Login failed: $e');
+      debugPrint('[Lattice] Stack trace:\n$s');
+      loginError = e.toString();
+      return false;
+    }
+  }
+
+  // ── SSO Login ─────────────────────────────────────────────────
+
+  Future<bool> completeSsoLogin({
+    required String homeserver,
+    required String loginToken,
+  }) async {
+    loginError = null;
+
+    try {
+      var hs = homeserver.trim();
+      if (hs.isEmpty) throw ArgumentError('Homeserver cannot be empty');
+      if (!hs.startsWith('http')) hs = 'https://$hs';
+
+      await _client.checkHomeserver(Uri.parse(hs));
+
+      debugPrint('[Lattice] Completing SSO login ...');
+      await _client.login(
+        LoginType.mLoginToken,
+        token: loginToken,
+        initialDeviceDisplayName: 'Lattice Flutter',
+        refreshToken: true,
+      );
+      debugPrint('[Lattice] SSO login complete – '
+          'deviceId=${_client.deviceID}, '
+          'userId=${_client.userID}');
+
+      isLoggedIn = true;
+      notifyListeners();
+
+      try {
+        await persistCredentials();
+      } catch (e) {
+        debugPrint('[Lattice] Credential persistence failed (non-fatal): $e');
+      }
+
+      return true;
+    } catch (e, s) {
+      debugPrint('[Lattice] SSO login failed: $e');
+      debugPrint('[Lattice] Stack trace:\n$s');
+      loginError = e.toString();
+      return false;
+    }
+  }
+
+  // ── Registration ──────────────────────────────────────────────
+
+  Future<void> completeRegistration(
+    RegisterResponse response, {
+    String? password,
+  }) async {
+    debugPrint('[Lattice] Registration complete – userId=${response.userId}');
+
+    if (_client.accessToken == null || _client.userID == null) {
+      throw StateError('Client was not initialized after register(). '
+          'accessToken=${_client.accessToken}, userID=${_client.userID}');
+    }
+
+    isLoggedIn = true;
+    notifyListeners();
+
+    try {
+      await persistCredentials();
+    } catch (e) {
+      debugPrint('[Lattice] Credential persistence failed (non-fatal): $e');
+    }
+  }
+
+  // ── Session Restore ───────────────────────────────────────────
+
+  void activateRestoredSession() {
+    isLoggedIn = true;
     notifyListeners();
   }
 
-  Completer<void>? _postLoginSyncCompleter;
+  // ── Logout ────────────────────────────────────────────────────
 
-  Future<void>? get postLoginSyncFuture => _postLoginSyncCompleter?.future;
+  Future<void> logout() async {
+    isLoggedIn = false;
+    notifyListeners();
 
-  Completer<void>? _capabilitiesLock;
+    try {
+      if (_client.homeserver != null && _client.accessToken != null) {
+        await _client.logout();
+      }
+    } catch (e) {
+      debugPrint('[Lattice] Logout error: $e');
+    }
+    await clearSessionKeys();
+    await SessionBackup.delete(clientName: _clientName, storage: _storage);
+  }
+
+  Future<void> handleServerLogout() async {
+    isLoggedIn = false;
+    notifyListeners();
+
+    await clearSessionKeys();
+    await SessionBackup.delete(clientName: _clientName, storage: _storage);
+  }
+
+  // ── Session Backup ────────────────────────────────────────────
+
+  Future<void> saveSessionBackup() async {
+    final backup = SessionBackup(
+      accessToken: _client.accessToken!,
+      refreshToken: await _readRefreshToken(),
+      userId: _client.userID!,
+      homeserver: _client.homeserver.toString(),
+      deviceId: _client.deviceID!,
+      deviceName: 'Lattice Flutter',
+      olmAccount: _client.encryption?.pickledOlmAccount,
+    );
+    await SessionBackup.save(
+      backup,
+      clientName: _clientName,
+      storage: _storage,
+    );
+    debugPrint('[Lattice] Session backup saved for $_clientName');
+  }
+
+  Future<String?> _readRefreshToken() async {
+    final stored = await _client.database.getClient(_clientName);
+    return stored?.tryGet<String>('refresh_token');
+  }
 
   // ── Server Capabilities ──────────────────────────────────────
 
@@ -206,22 +372,6 @@ class AuthService extends ChangeNotifier {
       _storage.write(
           key: latticeKey(_clientName, 'device_id'), value: _client.deviceID,),
     ]);
-  }
-
-  // ── Post-login Background Sync ──────────────────────────────
-
-  void startPostLoginSync(Future<void> Function() runSync) {
-    postLoginSyncError = null;
-    final completer = Completer<void>();
-    _postLoginSyncCompleter = completer;
-    unawaited(runSync().whenComplete(() {
-      completer.complete();
-      _postLoginSyncCompleter = null;
-    },),);
-  }
-
-  Future<void> awaitPostLoginSync() async {
-    await _postLoginSyncCompleter?.future;
   }
 
 }

--- a/lib/core/services/sub_services/sync_service.dart
+++ b/lib/core/services/sub_services/sync_service.dart
@@ -21,6 +21,13 @@ class SyncService extends ChangeNotifier {
   String? get autoUnlockError => _autoUnlockError;
 
   StreamSubscription<SyncUpdate>? _syncSub;
+  bool _disposed = false;
+
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
+  }
 
   Future<void> startSync({Duration? timeout = const Duration(seconds: 30)}) async {
     _syncing = true;
@@ -37,6 +44,7 @@ class SyncService extends ChangeNotifier {
       return _onPostSyncBackup();
     }).catchError((Object e) {
       debugPrint('[Lattice] Background E2EE auto-unlock error: $e');
+      if (_disposed) return;
       _autoUnlockError = e.toString();
       notifyListeners();
     },),);

--- a/test/e2e/login_flow_test.dart
+++ b/test/e2e/login_flow_test.dart
@@ -265,7 +265,6 @@ void main() {
   Future<void> completePostLoginSync(WidgetTester tester) async {
     syncController.add(SyncUpdate(nextBatch: 'batch_1', rooms: RoomsUpdate()));
     await tester.pumpAndSettle();
-    await matrixService.auth.postLoginSyncFuture;
     matrixService.dispose();
   }
 

--- a/test/screens/chat_search_test.mocks.dart
+++ b/test/screens/chat_search_test.mocks.dart
@@ -7884,6 +7884,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -7893,25 +7902,6 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i5.Future<bool> login({

--- a/test/screens/devices_screen_test.mocks.dart
+++ b/test/screens/devices_screen_test.mocks.dart
@@ -7820,6 +7820,15 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -7829,25 +7838,6 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i5.Future<bool> login({

--- a/test/services/auth_service_test.dart
+++ b/test/services/auth_service_test.dart
@@ -256,27 +256,11 @@ void main() {
     });
   });
 
-  group('loginError and postLoginSyncError', () {
-    test('getters and setters work', () {
+  group('loginError', () {
+    test('getter and setter work', () {
       expect(service.loginError, isNull);
       service.loginError = 'bad';
       expect(service.loginError, 'bad');
-
-      expect(service.postLoginSyncError, isNull);
-      service.postLoginSyncError = 'sync failed';
-      expect(service.postLoginSyncError, 'sync failed');
-    });
-  });
-
-  group('startPostLoginSync', () {
-    test('exposes postLoginSyncFuture', () async {
-      expect(service.postLoginSyncFuture, isNull);
-
-      service.startPostLoginSync(() async {});
-
-      expect(service.postLoginSyncFuture, isNotNull);
-      await service.postLoginSyncFuture;
-      expect(service.postLoginSyncFuture, isNull);
     });
   });
 }

--- a/test/services/chat_message_actions_test.mocks.dart
+++ b/test/services/chat_message_actions_test.mocks.dart
@@ -10982,6 +10982,15 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i6.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -10991,25 +11000,6 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
         returnValue: _i6.Future<void>.value(),
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
-
-  @override
-  _i6.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i6.Future<bool> login({

--- a/test/services/matrix_service_auth_test.dart
+++ b/test/services/matrix_service_auth_test.dart
@@ -307,8 +307,6 @@ void main() {
       expect(result, isTrue);
       expect(service.isLoggedIn, isTrue);
 
-      await service.auth.postLoginSyncFuture;
-
       // Verify login was called with mLoginToken
       verify(mockClient.login(
         LoginType.mLoginToken,
@@ -451,9 +449,6 @@ void main() {
         accessToken: 'reg_token',
         deviceId: 'REG_DEV',
       ),);
-
-      // Wait for background sync + session backup to complete.
-      await service.auth.postLoginSyncFuture;
 
       verify(mockStorage.write(
         key: 'lattice_session_backup_test',

--- a/test/services/matrix_service_test.dart
+++ b/test/services/matrix_service_test.dart
@@ -326,6 +326,56 @@ void main() {
       verify(mockStorage.delete(key: 'lattice_session_backup_test')).called(1);
       verifyNever(mockStorage.deleteAll());
     });
+
+    test('notifies listeners immediately when isLoggedIn is set to false', () async {
+      when(mockClient.checkHomeserver(any)).thenAnswer((_) async => (
+            null,
+            GetVersionsResponse.fromJson({'versions': ['v1.1']}),
+            <LoginFlow>[],
+            null,
+          ),);
+      when(mockClient.login(
+        any,
+        identifier: anyNamed('identifier'),
+        password: anyNamed('password'),
+        initialDeviceDisplayName: anyNamed('initialDeviceDisplayName'),
+        refreshToken: anyNamed('refreshToken'),
+      ),).thenAnswer((_) async => LoginResponse.fromJson({
+            'access_token': 'token123',
+            'device_id': 'DEV1',
+            'user_id': '@user:example.com',
+          }),);
+      when(mockClient.accessToken).thenReturn('token123');
+      when(mockClient.userID).thenReturn('@user:example.com');
+      when(mockClient.homeserver).thenReturn(Uri.parse('https://example.com'));
+      when(mockClient.deviceID).thenReturn('DEV1');
+      when(mockClient.encryption).thenReturn(null);
+      final syncController = CachedStreamController<SyncUpdate>();
+      when(mockClient.onSync).thenReturn(syncController);
+      when(mockClient.onUiaRequest).thenReturn(CachedStreamController());
+      when(mockClient.onLoginStateChanged).thenReturn(CachedStreamController());
+
+      Future<void>.delayed(Duration.zero, () => syncController.add(SyncUpdate(nextBatch: 'batch1')));
+      await service.login(
+        homeserver: 'example.com',
+        username: 'user',
+        password: 'pass',
+      );
+      expect(service.isLoggedIn, isTrue);
+
+      var notifiedWhileLogoutInProgress = false;
+      service.addListener(() {
+        if (!service.isLoggedIn) notifiedWhileLogoutInProgress = true;
+      });
+
+      final logoutFuture = service.logout();
+      // isLoggedIn and notifyListeners() must fire before the first async suspension,
+      // so they are observable here without awaiting the full logout.
+      expect(service.isLoggedIn, isFalse);
+      expect(notifiedWhileLogoutInProgress, isTrue);
+
+      await logoutFuture;
+    });
   });
 
   group('soft logout', () {

--- a/test/services/matrix_service_test.dart
+++ b/test/services/matrix_service_test.dart
@@ -229,9 +229,6 @@ void main() {
       expect(result, isTrue);
       expect(service.isLoggedIn, isTrue);
 
-      // Wait for background sync + session backup to complete.
-      await service.auth.postLoginSyncFuture;
-
       // Verify namespaced storage keys.
       verify(mockStorage.write(
               key: 'lattice_test_access_token', value: 'token123',),)
@@ -376,6 +373,7 @@ void main() {
 
       await logoutFuture;
     });
+
   });
 
   group('soft logout', () {
@@ -441,9 +439,6 @@ void main() {
         username: 'user',
         password: 'pass',
       );
-
-      // Wait for background sync + session backup to complete before adding listener.
-      await service.auth.postLoginSyncFuture;
 
       var notifyCount = 0;
       service.addListener(() => notifyCount++);

--- a/test/services/notification_service_test.mocks.dart
+++ b/test/services/notification_service_test.mocks.dart
@@ -1042,6 +1042,15 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i10.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -1051,25 +1060,6 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
         returnValue: _i10.Future<void>.value(),
         returnValueForMissingStub: _i10.Future<void>.value(),
       ) as _i10.Future<void>);
-
-  @override
-  _i10.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i10.Future<void>.value(),
-        returnValueForMissingStub: _i10.Future<void>.value(),
-      ) as _i10.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i10.Future<bool> login({

--- a/test/widgets/add_existing_rooms_dialog_test.mocks.dart
+++ b/test/widgets/add_existing_rooms_dialog_test.mocks.dart
@@ -1030,6 +1030,15 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i10.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -1039,25 +1048,6 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
         returnValue: _i10.Future<void>.value(),
         returnValueForMissingStub: _i10.Future<void>.value(),
       ) as _i10.Future<void>);
-
-  @override
-  _i10.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i10.Future<void>.value(),
-        returnValueForMissingStub: _i10.Future<void>.value(),
-      ) as _i10.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i10.Future<bool> login({

--- a/test/widgets/add_room_to_space_dialog_test.mocks.dart
+++ b/test/widgets/add_room_to_space_dialog_test.mocks.dart
@@ -1030,6 +1030,15 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i10.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -1039,25 +1048,6 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
         returnValue: _i10.Future<void>.value(),
         returnValueForMissingStub: _i10.Future<void>.value(),
       ) as _i10.Future<void>);
-
-  @override
-  _i10.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i10.Future<void>.value(),
-        returnValueForMissingStub: _i10.Future<void>.value(),
-      ) as _i10.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i10.Future<bool> login({

--- a/test/widgets/bootstrap_controller_test.mocks.dart
+++ b/test/widgets/bootstrap_controller_test.mocks.dart
@@ -7925,6 +7925,15 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -7934,25 +7943,6 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i5.Future<bool> login({

--- a/test/widgets/bootstrap_driver_test.mocks.dart
+++ b/test/widgets/bootstrap_driver_test.mocks.dart
@@ -7914,6 +7914,15 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -7923,25 +7932,6 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i5.Future<bool> login({

--- a/test/widgets/chat/message_actions_test.mocks.dart
+++ b/test/widgets/chat/message_actions_test.mocks.dart
@@ -7904,6 +7904,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -7913,25 +7922,6 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i5.Future<bool> login({

--- a/test/widgets/chat/pinned_messages_test.mocks.dart
+++ b/test/widgets/chat/pinned_messages_test.mocks.dart
@@ -7904,6 +7904,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -7913,25 +7922,6 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i5.Future<bool> login({

--- a/test/widgets/create_subspace_dialog_test.mocks.dart
+++ b/test/widgets/create_subspace_dialog_test.mocks.dart
@@ -7863,6 +7863,15 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -7872,25 +7881,6 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i5.Future<bool> login({

--- a/test/widgets/homeserver_controller_test.mocks.dart
+++ b/test/widgets/homeserver_controller_test.mocks.dart
@@ -303,6 +303,15 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i11.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -312,25 +321,6 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
         returnValue: _i11.Future<void>.value(),
         returnValueForMissingStub: _i11.Future<void>.value(),
       ) as _i11.Future<void>);
-
-  @override
-  _i11.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i11.Future<bool> login({
@@ -429,18 +419,25 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
 /// See the documentation for Mockito's code generation for more information.
 class MockAuthService extends _i1.Mock implements _i7.AuthService {
   @override
-  set loginError(String? value) => super.noSuchMethod(
+  bool get isLoggedIn => (super.noSuchMethod(
+        Invocation.getter(#isLoggedIn),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  set isLoggedIn(bool? value) => super.noSuchMethod(
         Invocation.setter(
-          #loginError,
+          #isLoggedIn,
           value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set postLoginSyncError(String? value) => super.noSuchMethod(
+  set loginError(String? value) => super.noSuchMethod(
         Invocation.setter(
-          #postLoginSyncError,
+          #loginError,
           value,
         ),
         returnValueForMissingStub: null,
@@ -452,6 +449,98 @@ class MockAuthService extends _i1.Mock implements _i7.AuthService {
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
+  @override
+  _i11.Future<bool> login({
+    required String? homeserver,
+    required String? username,
+    required String? password,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #login,
+          [],
+          {
+            #homeserver: homeserver,
+            #username: username,
+            #password: password,
+          },
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  _i11.Future<bool> completeSsoLogin({
+    required String? homeserver,
+    required String? loginToken,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #completeSsoLogin,
+          [],
+          {
+            #homeserver: homeserver,
+            #loginToken: loginToken,
+          },
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  _i11.Future<void> completeRegistration(
+    _i2.RegisterResponse? response, {
+    String? password,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #completeRegistration,
+          [response],
+          {#password: password},
+        ),
+        returnValue: _i11.Future<void>.value(),
+        returnValueForMissingStub: _i11.Future<void>.value(),
+      ) as _i11.Future<void>);
+
+  @override
+  void activateRestoredSession() => super.noSuchMethod(
+        Invocation.method(
+          #activateRestoredSession,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<void> logout() => (super.noSuchMethod(
+        Invocation.method(
+          #logout,
+          [],
+        ),
+        returnValue: _i11.Future<void>.value(),
+        returnValueForMissingStub: _i11.Future<void>.value(),
+      ) as _i11.Future<void>);
+
+  @override
+  _i11.Future<void> handleServerLogout() => (super.noSuchMethod(
+        Invocation.method(
+          #handleServerLogout,
+          [],
+        ),
+        returnValue: _i11.Future<void>.value(),
+        returnValueForMissingStub: _i11.Future<void>.value(),
+      ) as _i11.Future<void>);
+
+  @override
+  _i11.Future<void> saveSessionBackup() => (super.noSuchMethod(
+        Invocation.method(
+          #saveSessionBackup,
+          [],
+        ),
+        returnValue: _i11.Future<void>.value(),
+        returnValueForMissingStub: _i11.Future<void>.value(),
+      ) as _i11.Future<void>);
 
   @override
   _i11.Future<_i8.ServerAuthCapabilities> getServerAuthCapabilities(
@@ -519,26 +608,6 @@ class MockAuthService extends _i1.Mock implements _i7.AuthService {
   _i11.Future<void> persistCredentials() => (super.noSuchMethod(
         Invocation.method(
           #persistCredentials,
-          [],
-        ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
-
-  @override
-  void startPostLoginSync(_i11.Future<void> Function()? runSync) =>
-      super.noSuchMethod(
-        Invocation.method(
-          #startPostLoginSync,
-          [runSync],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  _i11.Future<void> awaitPostLoginSync() => (super.noSuchMethod(
-        Invocation.method(
-          #awaitPostLoginSync,
           [],
         ),
         returnValue: _i11.Future<void>.value(),

--- a/test/widgets/invite_dialog_test.mocks.dart
+++ b/test/widgets/invite_dialog_test.mocks.dart
@@ -1030,6 +1030,15 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i10.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -1039,25 +1048,6 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
         returnValue: _i10.Future<void>.value(),
         returnValueForMissingStub: _i10.Future<void>.value(),
       ) as _i10.Future<void>);
-
-  @override
-  _i10.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i10.Future<void>.value(),
-        returnValueForMissingStub: _i10.Future<void>.value(),
-      ) as _i10.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i10.Future<bool> login({

--- a/test/widgets/invite_tile_test.mocks.dart
+++ b/test/widgets/invite_tile_test.mocks.dart
@@ -1030,6 +1030,15 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i10.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -1039,25 +1048,6 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
         returnValue: _i10.Future<void>.value(),
         returnValueForMissingStub: _i10.Future<void>.value(),
       ) as _i10.Future<void>);
-
-  @override
-  _i10.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i10.Future<void>.value(),
-        returnValueForMissingStub: _i10.Future<void>.value(),
-      ) as _i10.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i10.Future<bool> login({

--- a/test/widgets/login_controller_test.mocks.dart
+++ b/test/widgets/login_controller_test.mocks.dart
@@ -1010,6 +1010,15 @@ class MockMatrixService extends _i1.Mock implements _i8.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i11.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -1019,25 +1028,6 @@ class MockMatrixService extends _i1.Mock implements _i8.MatrixService {
         returnValue: _i11.Future<void>.value(),
         returnValueForMissingStub: _i11.Future<void>.value(),
       ) as _i11.Future<void>);
-
-  @override
-  _i11.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i11.Future<bool> login({
@@ -8148,18 +8138,25 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// See the documentation for Mockito's code generation for more information.
 class MockAuthService extends _i1.Mock implements _i7.AuthService {
   @override
-  set loginError(String? value) => super.noSuchMethod(
+  bool get isLoggedIn => (super.noSuchMethod(
+        Invocation.getter(#isLoggedIn),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  set isLoggedIn(bool? value) => super.noSuchMethod(
         Invocation.setter(
-          #loginError,
+          #isLoggedIn,
           value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set postLoginSyncError(String? value) => super.noSuchMethod(
+  set loginError(String? value) => super.noSuchMethod(
         Invocation.setter(
-          #postLoginSyncError,
+          #loginError,
           value,
         ),
         returnValueForMissingStub: null,
@@ -8171,6 +8168,98 @@ class MockAuthService extends _i1.Mock implements _i7.AuthService {
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
+  @override
+  _i11.Future<bool> login({
+    required String? homeserver,
+    required String? username,
+    required String? password,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #login,
+          [],
+          {
+            #homeserver: homeserver,
+            #username: username,
+            #password: password,
+          },
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  _i11.Future<bool> completeSsoLogin({
+    required String? homeserver,
+    required String? loginToken,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #completeSsoLogin,
+          [],
+          {
+            #homeserver: homeserver,
+            #loginToken: loginToken,
+          },
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  _i11.Future<void> completeRegistration(
+    _i2.RegisterResponse? response, {
+    String? password,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #completeRegistration,
+          [response],
+          {#password: password},
+        ),
+        returnValue: _i11.Future<void>.value(),
+        returnValueForMissingStub: _i11.Future<void>.value(),
+      ) as _i11.Future<void>);
+
+  @override
+  void activateRestoredSession() => super.noSuchMethod(
+        Invocation.method(
+          #activateRestoredSession,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<void> logout() => (super.noSuchMethod(
+        Invocation.method(
+          #logout,
+          [],
+        ),
+        returnValue: _i11.Future<void>.value(),
+        returnValueForMissingStub: _i11.Future<void>.value(),
+      ) as _i11.Future<void>);
+
+  @override
+  _i11.Future<void> handleServerLogout() => (super.noSuchMethod(
+        Invocation.method(
+          #handleServerLogout,
+          [],
+        ),
+        returnValue: _i11.Future<void>.value(),
+        returnValueForMissingStub: _i11.Future<void>.value(),
+      ) as _i11.Future<void>);
+
+  @override
+  _i11.Future<void> saveSessionBackup() => (super.noSuchMethod(
+        Invocation.method(
+          #saveSessionBackup,
+          [],
+        ),
+        returnValue: _i11.Future<void>.value(),
+        returnValueForMissingStub: _i11.Future<void>.value(),
+      ) as _i11.Future<void>);
 
   @override
   _i11.Future<_i13.ServerAuthCapabilities> getServerAuthCapabilities(
@@ -8238,26 +8327,6 @@ class MockAuthService extends _i1.Mock implements _i7.AuthService {
   _i11.Future<void> persistCredentials() => (super.noSuchMethod(
         Invocation.method(
           #persistCredentials,
-          [],
-        ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
-
-  @override
-  void startPostLoginSync(_i11.Future<void> Function()? runSync) =>
-      super.noSuchMethod(
-        Invocation.method(
-          #startPostLoginSync,
-          [runSync],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  _i11.Future<void> awaitPostLoginSync() => (super.noSuchMethod(
-        Invocation.method(
-          #awaitPostLoginSync,
           [],
         ),
         returnValue: _i11.Future<void>.value(),

--- a/test/widgets/message_reply_test.mocks.dart
+++ b/test/widgets/message_reply_test.mocks.dart
@@ -7904,6 +7904,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -7913,25 +7922,6 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i5.Future<bool> login({

--- a/test/widgets/new_dm_dialog_test.mocks.dart
+++ b/test/widgets/new_dm_dialog_test.mocks.dart
@@ -7863,6 +7863,15 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -7872,25 +7881,6 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i5.Future<bool> login({

--- a/test/widgets/new_room_dialog_test.mocks.dart
+++ b/test/widgets/new_room_dialog_test.mocks.dart
@@ -7820,6 +7820,15 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -7829,25 +7838,6 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i5.Future<bool> login({

--- a/test/widgets/recovery_key_handler_test.mocks.dart
+++ b/test/widgets/recovery_key_handler_test.mocks.dart
@@ -1092,6 +1092,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i11.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -1101,25 +1110,6 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         returnValue: _i11.Future<void>.value(),
         returnValueForMissingStub: _i11.Future<void>.value(),
       ) as _i11.Future<void>);
-
-  @override
-  _i11.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i11.Future<bool> login({

--- a/test/widgets/registration_controller_test.mocks.dart
+++ b/test/widgets/registration_controller_test.mocks.dart
@@ -7832,6 +7832,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -7841,25 +7850,6 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i5.Future<bool> login({
@@ -7958,18 +7948,25 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
 /// See the documentation for Mockito's code generation for more information.
 class MockAuthService extends _i1.Mock implements _i11.AuthService {
   @override
-  set loginError(String? value) => super.noSuchMethod(
+  bool get isLoggedIn => (super.noSuchMethod(
+        Invocation.getter(#isLoggedIn),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  set isLoggedIn(bool? value) => super.noSuchMethod(
         Invocation.setter(
-          #loginError,
+          #isLoggedIn,
           value,
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  set postLoginSyncError(String? value) => super.noSuchMethod(
+  set loginError(String? value) => super.noSuchMethod(
         Invocation.setter(
-          #postLoginSyncError,
+          #loginError,
           value,
         ),
         returnValueForMissingStub: null,
@@ -7981,6 +7978,98 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
+  @override
+  _i5.Future<bool> login({
+    required String? homeserver,
+    required String? username,
+    required String? password,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #login,
+          [],
+          {
+            #homeserver: homeserver,
+            #username: username,
+            #password: password,
+          },
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> completeSsoLogin({
+    required String? homeserver,
+    required String? loginToken,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #completeSsoLogin,
+          [],
+          {
+            #homeserver: homeserver,
+            #loginToken: loginToken,
+          },
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<void> completeRegistration(
+    _i2.RegisterResponse? response, {
+    String? password,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #completeRegistration,
+          [response],
+          {#password: password},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  void activateRestoredSession() => super.noSuchMethod(
+        Invocation.method(
+          #activateRestoredSession,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<void> logout() => (super.noSuchMethod(
+        Invocation.method(
+          #logout,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> handleServerLogout() => (super.noSuchMethod(
+        Invocation.method(
+          #handleServerLogout,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> saveSessionBackup() => (super.noSuchMethod(
+        Invocation.method(
+          #saveSessionBackup,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
   _i5.Future<_i12.ServerAuthCapabilities> getServerAuthCapabilities(
@@ -8048,26 +8137,6 @@ class MockAuthService extends _i1.Mock implements _i11.AuthService {
   _i5.Future<void> persistCredentials() => (super.noSuchMethod(
         Invocation.method(
           #persistCredentials,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void startPostLoginSync(_i5.Future<void> Function()? runSync) =>
-      super.noSuchMethod(
-        Invocation.method(
-          #startPostLoginSync,
-          [runSync],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  _i5.Future<void> awaitPostLoginSync() => (super.noSuchMethod(
-        Invocation.method(
-          #awaitPostLoginSync,
           [],
         ),
         returnValue: _i5.Future<void>.value(),

--- a/test/widgets/room_context_menu_test.mocks.dart
+++ b/test/widgets/room_context_menu_test.mocks.dart
@@ -7863,6 +7863,15 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -7872,25 +7881,6 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i5.Future<bool> login({

--- a/test/widgets/room_details_panel_test.mocks.dart
+++ b/test/widgets/room_details_panel_test.mocks.dart
@@ -7863,6 +7863,15 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -7872,25 +7881,6 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i5.Future<bool> login({

--- a/test/widgets/room_members_section_test.mocks.dart
+++ b/test/widgets/room_members_section_test.mocks.dart
@@ -7873,6 +7873,15 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -7882,25 +7891,6 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i5.Future<bool> login({

--- a/test/widgets/room_section_header_test.mocks.dart
+++ b/test/widgets/room_section_header_test.mocks.dart
@@ -7876,6 +7876,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -7885,25 +7894,6 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i5.Future<bool> login({

--- a/test/widgets/room_tile_test.mocks.dart
+++ b/test/widgets/room_tile_test.mocks.dart
@@ -1082,6 +1082,15 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i10.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -1091,25 +1100,6 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
         returnValue: _i10.Future<void>.value(),
         returnValueForMissingStub: _i10.Future<void>.value(),
       ) as _i10.Future<void>);
-
-  @override
-  _i10.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i10.Future<void>.value(),
-        returnValueForMissingStub: _i10.Future<void>.value(),
-      ) as _i10.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i10.Future<bool> login({

--- a/test/widgets/space_action_dialog_test.mocks.dart
+++ b/test/widgets/space_action_dialog_test.mocks.dart
@@ -7863,6 +7863,15 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -7872,25 +7881,6 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i5.Future<bool> login({

--- a/test/widgets/space_context_menu_test.mocks.dart
+++ b/test/widgets/space_context_menu_test.mocks.dart
@@ -7893,6 +7893,15 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -7902,25 +7911,6 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i5.Future<bool> login({

--- a/test/widgets/space_details_panel_test.mocks.dart
+++ b/test/widgets/space_details_panel_test.mocks.dart
@@ -7863,6 +7863,15 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
@@ -7872,25 +7881,6 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> saveSessionBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #saveSessionBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   _i5.Future<bool> login({


### PR DESCRIPTION
## Summary

- Moves auth state (`isLoggedIn`) and all login/logout operations into `AuthService`; `MatrixService` coordinates via a `_onAuthChanged` listener so the router redirects immediately on logout without waiting for async cleanup
- Fixes `isLoggedInForTest` setter to call `auth.notifyListeners()` so tests receive state-change callbacks
- Guards `_listenForLoginState()` against creating duplicate subscriptions on rapid logout/login cycles

## Test plan

- [x] Log out — router should redirect to login screen immediately
- [x] Log in, log out, log in again — verify no duplicate server-logout events fire
- [x] Run `flutter test` — confirm tests using `isLoggedInForTest` pass