### PR TITLE
fix: handle macOS TCC permissions and add screen share audio toggle

### DIFF
--- a/lib/core/services/call_service.dart
+++ b/lib/core/services/call_service.dart
@@ -96,6 +96,7 @@ class CallService extends ChangeNotifier with WidgetsBindingObserver {
   bool get isMicEnabled => _liveKit.isMicEnabled;
   bool get isCameraEnabled => _liveKit.isCameraEnabled;
   bool get isScreenShareEnabled => _liveKit.isScreenShareEnabled;
+  bool get isScreenAudioEnabled => _liveKit.isScreenAudioEnabled;
   List<livekit.Participant> get activeSpeakers => _liveKit.activeSpeakers;
   String? get cachedLivekitServiceUrl => _liveKit.cachedLivekitServiceUrl;
   bool get isCallingAvailable => _liveKit.cachedLivekitServiceUrl != null;
@@ -105,8 +106,15 @@ class CallService extends ChangeNotifier with WidgetsBindingObserver {
 
   Future<void> toggleMicrophone() => _liveKit.toggleMicrophone();
   Future<void> toggleCamera() => _liveKit.toggleCamera();
-  Future<void> toggleScreenShare({String? sourceId}) =>
-      _liveKit.toggleScreenShare(sourceId: sourceId);
+  Future<void> toggleScreenShare({
+    String? sourceId,
+    bool captureScreenAudio = false,
+  }) =>
+      _liveKit.toggleScreenShare(
+        sourceId: sourceId,
+        captureScreenAudio: captureScreenAudio,
+      );
+  Future<void> toggleScreenAudio() => _liveKit.toggleScreenAudio();
   Future<void> setOutputVolume(double volume) =>
       _liveKit.setOutputVolume(volume);
 

--- a/lib/core/services/macos_permissions.dart
+++ b/lib/core/services/macos_permissions.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/services.dart';
+
+// coverage:ignore-start
+abstract class MacOsPermissions {
+  static const _channel = MethodChannel('com.lattice.app/tcc');
+
+  static Future<bool> checkScreenCapture() async {
+    final granted =
+        await _channel.invokeMethod<bool>('checkScreenCapturePermission');
+    return granted ?? false;
+  }
+
+  static Future<bool> requestScreenCapture() async {
+    final granted =
+        await _channel.invokeMethod<bool>('requestScreenCapturePermission');
+    return granted ?? false;
+  }
+
+  static Future<bool> checkMedia(String type) async {
+    final granted =
+        await _channel.invokeMethod<bool>('checkMediaPermission', {'type': type});
+    return granted ?? false;
+  }
+
+  static Future<bool> requestMedia(String type) async {
+    final granted =
+        await _channel.invokeMethod<bool>('requestMediaPermission', {'type': type});
+    return granted ?? false;
+  }
+
+  static Future<bool> requestCameraAndMicrophone() async {
+    final camera = await checkMedia('camera') || await requestMedia('camera');
+    final mic = await checkMedia('microphone') || await requestMedia('microphone');
+    return camera && mic;
+  }
+}
+// coverage:ignore-end

--- a/lib/features/calling/services/call_permission_service_native.dart
+++ b/lib/features/calling/services/call_permission_service_native.dart
@@ -1,13 +1,13 @@
+import 'package:lattice/core/services/macos_permissions.dart';
 import 'package:lattice/core/utils/platform_info.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 // coverage:ignore-start
 abstract class CallPermissionService {
-  static bool get _needsPermissionRequest =>
-      isNativeAndroid || isNativeIOS || isNativeMacOS;
-
   static Future<bool> request() async {
-    if (!_needsPermissionRequest) return true;
+    if (isNativeMacOS) return MacOsPermissions.requestCameraAndMicrophone();
+    if (!(isNativeAndroid || isNativeIOS)) return true;
+
     final statuses = await [
       Permission.camera,
       Permission.microphone,
@@ -25,7 +25,13 @@ abstract class CallPermissionService {
   }
 
   static Future<bool> check() async {
-    if (!_needsPermissionRequest) return true;
+    if (isNativeMacOS) {
+      final camera = await MacOsPermissions.checkMedia('camera');
+      final mic = await MacOsPermissions.checkMedia('microphone');
+      return camera && mic;
+    }
+    if (!(isNativeAndroid || isNativeIOS)) return true;
+
     final camera = await Permission.camera.isGranted;
     final microphone = await Permission.microphone.isGranted;
     return camera && microphone;

--- a/lib/features/calling/services/livekit_service.dart
+++ b/lib/features/calling/services/livekit_service.dart
@@ -80,6 +80,9 @@ class LiveKitService {
   bool _isScreenShareEnabled = false;
   bool get isScreenShareEnabled => _isScreenShareEnabled;
 
+  bool _isScreenAudioEnabled = false;
+  bool get isScreenAudioEnabled => _isScreenAudioEnabled;
+
   double _outputVolume = 1;
 
   List<livekit.Participant> _activeSpeakers = [];
@@ -195,7 +198,10 @@ class LiveKitService {
     );
   }
 
-  Future<void> toggleScreenShare({String? sourceId}) async {
+  Future<void> toggleScreenShare({
+    String? sourceId,
+    bool captureScreenAudio = false,
+  }) async {
     final localParticipant = _livekitRoom?.localParticipant;
     if (localParticipant == null) return;
 
@@ -215,14 +221,38 @@ class LiveKitService {
       label: 'screen share',
       apply: (enabled) => localParticipant.setScreenShareEnabled(
         enabled,
-        captureScreenAudio: true,
+        captureScreenAudio: isNativeLinux || captureScreenAudio,
         screenShareCaptureOptions: options,
       ),
     );
 
+    _isScreenAudioEnabled = _isScreenShareEnabled &&
+        (isNativeLinux || captureScreenAudio);
+
     if (isNativeAndroid && !_isScreenShareEnabled) {
       await _stopAndroidMediaProjectionService();
     }
+  }
+
+  Future<void> toggleScreenAudio() async {
+    if (!_isScreenShareEnabled) return;
+    final localParticipant = _livekitRoom?.localParticipant;
+    if (localParticipant == null) return;
+
+    final newAudioState = !_isScreenAudioEnabled;
+
+    await localParticipant.setScreenShareEnabled(
+      false,
+      captureScreenAudio: false,
+    );
+
+    await localParticipant.setScreenShareEnabled(
+      true,
+      captureScreenAudio: newAudioState,
+    );
+
+    _isScreenAudioEnabled = newAudioState;
+    _onChanged();
   }
 
   static const _androidBgConfig = FlutterBackgroundAndroidConfig(
@@ -418,6 +448,7 @@ class LiveKitService {
     }
     _isCameraEnabled = false;
     _isScreenShareEnabled = false;
+    _isScreenAudioEnabled = false;
     _syncParticipants();
 
     if (inputVolume != 1.0) {
@@ -561,6 +592,7 @@ class LiveKitService {
     _isMicEnabled = false;
     _isCameraEnabled = false;
     _isScreenShareEnabled = false;
+    _isScreenAudioEnabled = false;
     _outputVolume = 1;
 
     try {

--- a/lib/features/calling/widgets/call_control_bar.dart
+++ b/lib/features/calling/widgets/call_control_bar.dart
@@ -13,6 +13,8 @@ class CallControlBar extends StatelessWidget {
     required this.onToggleScreenShare,
     required this.onHangUp,
     this.onFlipCamera,
+    this.isScreenAudioEnabled = false,
+    this.onToggleScreenAudio,
     this.isPTTActive = false,
     this.isPTTKeyHeld = false,
     this.isSpeakerOn,
@@ -28,6 +30,8 @@ class CallControlBar extends StatelessWidget {
   final VoidCallback onToggleScreenShare;
   final VoidCallback onHangUp;
   final VoidCallback? onFlipCamera;
+  final bool isScreenAudioEnabled;
+  final VoidCallback? onToggleScreenAudio;
   final bool isPTTActive;
   final bool isPTTKeyHeld;
   final bool? isSpeakerOn;
@@ -74,6 +78,16 @@ class CallControlBar extends StatelessWidget {
               onPressed: onToggleScreenShare,
               tooltip: isScreenSharing ? 'Stop sharing' : 'Share screen',
             ),
+            if (isScreenSharing && onToggleScreenAudio != null)
+              _ControlButton(
+                icon: Icons.volume_up,
+                activeIcon: Icons.volume_off,
+                isActive: !isScreenAudioEnabled,
+                onPressed: onToggleScreenAudio!,
+                tooltip: isScreenAudioEnabled
+                    ? 'Stop sharing audio'
+                    : 'Share system audio',
+              ),
             if (onToggleSpeaker != null && isSpeakerOn != null)
               _ControlButton(
                 icon: Icons.volume_up_rounded,

--- a/lib/features/calling/widgets/connected_call_view.dart
+++ b/lib/features/calling/widgets/connected_call_view.dart
@@ -106,10 +106,13 @@ class ConnectedCallView extends StatelessWidget {
               isMicMuted: !callService.isMicEnabled,
               isCameraOff: !callService.isCameraEnabled,
               isScreenSharing: callService.isScreenShareEnabled,
+              isScreenAudioEnabled: callService.isScreenAudioEnabled,
               onToggleMic: callService.toggleMicrophone,
               onToggleCamera: callService.toggleCamera,
               onToggleScreenShare: () =>
                   _toggleScreenShare(context, callService),
+              onToggleScreenAudio:
+                  isNativeDesktop ? callService.toggleScreenAudio : null,
               onHangUp: callService.leaveCall,
               isPTTActive: prefs.pushToTalkEnabled,
               isPTTKeyHeld: ptt.isKeyHeld,

--- a/lib/features/calling/widgets/connected_call_view.dart
+++ b/lib/features/calling/widgets/connected_call_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:lattice/core/services/call_service.dart';
+import 'package:lattice/core/services/macos_permissions.dart';
 import 'package:lattice/core/services/preferences_service.dart';
 import 'package:lattice/core/utils/platform_info.dart';
 import 'package:lattice/features/calling/services/push_to_talk_service.dart';
@@ -23,8 +24,17 @@ class ConnectedCallView extends StatelessWidget {
       return;
     }
 
-    final needsSourcePicker =
-        isNativeMacOS || isNativeWindows;
+    if (isNativeMacOS) {
+      final hasPermission = await MacOsPermissions.checkScreenCapture() ||
+          await MacOsPermissions.requestScreenCapture();
+      if (!hasPermission) {
+        if (context.mounted) await _showScreenCapturePermissionDialog(context);
+        return;
+      }
+    }
+
+    if (!context.mounted) return;
+    final needsSourcePicker = isNativeMacOS || isNativeWindows;
     if (needsSourcePicker) {
       final source = await showScreenSourcePicker(context);
       if (source == null) return;
@@ -32,6 +42,26 @@ class ConnectedCallView extends StatelessWidget {
     } else {
       await callService.toggleScreenShare();
     }
+  }
+
+  Future<void> _showScreenCapturePermissionDialog(BuildContext context) {
+    return showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Screen Recording Permission Required'),
+        content: const Text(
+          'Lattice needs screen recording permission to share your screen. '
+          'Please enable it in System Settings > Privacy & Security > '
+          'Screen Recording, then try again.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
   }
 
   @override

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Cocoa
 import FlutterMacOS
 
@@ -10,6 +11,46 @@ class MainFlutterWindow: NSWindow {
 
     RegisterGeneratedPlugins(registry: flutterViewController)
 
+    let channel = FlutterMethodChannel(
+      name: "com.lattice.app/tcc",
+      binaryMessenger: flutterViewController.engine.binaryMessenger
+    )
+    channel.setMethodCallHandler { (call, result) in
+      switch call.method {
+      case "checkScreenCapturePermission":
+        result(CGPreflightScreenCaptureAccess())
+      case "requestScreenCapturePermission":
+        result(CGRequestScreenCaptureAccess())
+      case "checkMediaPermission":
+        guard let mediaType = self.parseMediaType(call) else {
+          result(FlutterError(code: "INVALID_ARG", message: "Expected 'camera' or 'microphone'", details: nil))
+          return
+        }
+        let status = AVCaptureDevice.authorizationStatus(for: mediaType)
+        result(status == .authorized)
+      case "requestMediaPermission":
+        guard let mediaType = self.parseMediaType(call) else {
+          result(FlutterError(code: "INVALID_ARG", message: "Expected 'camera' or 'microphone'", details: nil))
+          return
+        }
+        AVCaptureDevice.requestAccess(for: mediaType) { granted in
+          DispatchQueue.main.async { result(granted) }
+        }
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+
     super.awakeFromNib()
+  }
+
+  private func parseMediaType(_ call: FlutterMethodCall) -> AVMediaType? {
+    guard let args = call.arguments as? [String: Any],
+          let type = args["type"] as? String else { return nil }
+    switch type {
+    case "camera": return .video
+    case "microphone": return .audio
+    default: return nil
+    }
   }
 }

--- a/test/screens/devices_screen_test.mocks.dart
+++ b/test/screens/devices_screen_test.mocks.dart
@@ -7967,6 +7967,25 @@ class MockChatBackupService extends _i1.Mock implements _i8.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> disableChatBackup() => (super.noSuchMethod(
+        Invocation.method(
+          #disableChatBackup,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  void resetChatBackupState() => super.noSuchMethod(
+        Invocation.method(
+          #resetChatBackupState,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> tryAutoUnlockBackup() => (super.noSuchMethod(
         Invocation.method(
           #tryAutoUnlockBackup,
@@ -8014,25 +8033,6 @@ class MockChatBackupService extends _i1.Mock implements _i8.ChatBackupService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> disableChatBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #disableChatBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void resetChatBackupState() => super.noSuchMethod(
-        Invocation.method(
-          #resetChatBackupState,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(

--- a/test/widgets/bootstrap_controller_test.mocks.dart
+++ b/test/widgets/bootstrap_controller_test.mocks.dart
@@ -8072,6 +8072,25 @@ class MockChatBackupService extends _i1.Mock implements _i8.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> disableChatBackup() => (super.noSuchMethod(
+        Invocation.method(
+          #disableChatBackup,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  void resetChatBackupState() => super.noSuchMethod(
+        Invocation.method(
+          #resetChatBackupState,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> tryAutoUnlockBackup() => (super.noSuchMethod(
         Invocation.method(
           #tryAutoUnlockBackup,
@@ -8119,25 +8138,6 @@ class MockChatBackupService extends _i1.Mock implements _i8.ChatBackupService {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> disableChatBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #disableChatBackup,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void resetChatBackupState() => super.noSuchMethod(
-        Invocation.method(
-          #resetChatBackupState,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(

--- a/test/widgets/key_backup_banner_test.mocks.dart
+++ b/test/widgets/key_backup_banner_test.mocks.dart
@@ -61,6 +61,25 @@ class MockChatBackupService extends _i1.Mock implements _i2.ChatBackupService {
       ) as _i3.Future<void>);
 
   @override
+  _i3.Future<void> disableChatBackup() => (super.noSuchMethod(
+        Invocation.method(
+          #disableChatBackup,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+
+  @override
+  void resetChatBackupState() => super.noSuchMethod(
+        Invocation.method(
+          #resetChatBackupState,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i3.Future<void> tryAutoUnlockBackup() => (super.noSuchMethod(
         Invocation.method(
           #tryAutoUnlockBackup,
@@ -108,25 +127,6 @@ class MockChatBackupService extends _i1.Mock implements _i2.ChatBackupService {
         returnValue: _i3.Future<void>.value(),
         returnValueForMissingStub: _i3.Future<void>.value(),
       ) as _i3.Future<void>);
-
-  @override
-  _i3.Future<void> disableChatBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #disableChatBackup,
-          [],
-        ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
-
-  @override
-  void resetChatBackupState() => super.noSuchMethod(
-        Invocation.method(
-          #resetChatBackupState,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   void addListener(_i4.VoidCallback? listener) => super.noSuchMethod(

--- a/test/widgets/recovery_key_handler_test.mocks.dart
+++ b/test/widgets/recovery_key_handler_test.mocks.dart
@@ -1239,6 +1239,25 @@ class MockChatBackupService extends _i1.Mock implements _i4.ChatBackupService {
       ) as _i11.Future<void>);
 
   @override
+  _i11.Future<void> disableChatBackup() => (super.noSuchMethod(
+        Invocation.method(
+          #disableChatBackup,
+          [],
+        ),
+        returnValue: _i11.Future<void>.value(),
+        returnValueForMissingStub: _i11.Future<void>.value(),
+      ) as _i11.Future<void>);
+
+  @override
+  void resetChatBackupState() => super.noSuchMethod(
+        Invocation.method(
+          #resetChatBackupState,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i11.Future<void> tryAutoUnlockBackup() => (super.noSuchMethod(
         Invocation.method(
           #tryAutoUnlockBackup,
@@ -1286,25 +1305,6 @@ class MockChatBackupService extends _i1.Mock implements _i4.ChatBackupService {
         returnValue: _i11.Future<void>.value(),
         returnValueForMissingStub: _i11.Future<void>.value(),
       ) as _i11.Future<void>);
-
-  @override
-  _i11.Future<void> disableChatBackup() => (super.noSuchMethod(
-        Invocation.method(
-          #disableChatBackup,
-          [],
-        ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
-
-  @override
-  void resetChatBackupState() => super.noSuchMethod(
-        Invocation.method(
-          #resetChatBackupState,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(

--- a/test/widgets/room_tile_test.mocks.dart
+++ b/test/widgets/room_tile_test.mocks.dart
@@ -11076,6 +11076,13 @@ class MockCallService extends _i1.Mock implements _i19.CallService {
       ) as bool);
 
   @override
+  bool get isScreenAudioEnabled => (super.noSuchMethod(
+        Invocation.getter(#isScreenAudioEnabled),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   List<_i21.Participant<_i21.TrackPublication<_i21.Track>>>
       get activeSpeakers => (super.noSuchMethod(
             Invocation.getter(#activeSpeakers),
@@ -11211,12 +11218,28 @@ class MockCallService extends _i1.Mock implements _i19.CallService {
       ) as _i10.Future<void>);
 
   @override
-  _i10.Future<void> toggleScreenShare({String? sourceId}) =>
+  _i10.Future<void> toggleScreenShare({
+    String? sourceId,
+    bool? captureScreenAudio = false,
+  }) =>
       (super.noSuchMethod(
         Invocation.method(
           #toggleScreenShare,
           [],
-          {#sourceId: sourceId},
+          {
+            #sourceId: sourceId,
+            #captureScreenAudio: captureScreenAudio,
+          },
+        ),
+        returnValue: _i10.Future<void>.value(),
+        returnValueForMissingStub: _i10.Future<void>.value(),
+      ) as _i10.Future<void>);
+
+  @override
+  _i10.Future<void> toggleScreenAudio() => (super.noSuchMethod(
+        Invocation.method(
+          #toggleScreenAudio,
+          [],
         ),
         returnValue: _i10.Future<void>.value(),
         returnValueForMissingStub: _i10.Future<void>.value(),


### PR DESCRIPTION
## Summary

- Fixes `MissingPluginException` on macOS calls caused by `permission_handler_apple` not supporting macOS
- Adds screen recording TCC pre-check before screen share on macOS
- Adds opt-in system audio toggle in the call control bar for desktop screen sharing

## Changes

### Native Swift method channel (`com.lattice.app/tcc`)

Added to `MainFlutterWindow.swift` with four handlers:
- `checkScreenCapturePermission` / `requestScreenCapturePermission` — via `CGPreflightScreenCaptureAccess` / `CGRequestScreenCaptureAccess`
- `checkMediaPermission` / `requestMediaPermission` — via `AVCaptureDevice` (camera & mic)

### `MacOsPermissions` Dart wrapper (`lib/core/services/macos_permissions.dart`)

New class exposing screen capture and camera/mic permission checks through the method channel.

### `CallPermissionService` fix

macOS now routes camera/mic permission requests through `MacOsPermissions` instead of `permission_handler`, which doesn't support macOS and was throwing `MissingPluginException` on every call attempt.

### Screen recording pre-check

`ConnectedCallView._toggleScreenShare` now checks screen recording TCC permission before showing the source picker on macOS. If denied, shows a dialog directing the user to System Settings > Privacy & Security > Screen Recording.

### Screen share audio toggle

A volume button appears in the call control bar on desktop platforms while screen sharing is active. Toggling it restarts the screen share with/without system audio capture. Linux screen audio remains always-on via PulseAudio. macOS audio capture requires Quantumheart/flutter-webrtc#1 to be implemented in the native layer.

## Test plan

- [ ] Join a call on macOS — no `MissingPluginException` on camera/mic permission request
- [ ] Start screen share on macOS for the first time — TCC prompt appears
- [ ] Deny screen recording permission — dialog shown with System Settings instructions
- [ ] Grant screen recording permission — source picker appears normally
- [ ] Start screen share — volume button appears in control bar
- [ ] Toggle audio on/off — button state updates correctly
- [ ] End screen share — volume button disappears
- [ ] Linux screen share — audio captured automatically, no toggle shown