### PR TITLE
fix: guard call auto-leave against race before remote participants join

### DIFF
--- a/lib/core/services/call_service.dart
+++ b/lib/core/services/call_service.dart
@@ -194,11 +194,13 @@ class CallService extends ChangeNotifier with WidgetsBindingObserver {
       _hadRemoteParticipant = true;
     }
 
-    if ((_callState == LatticeCallState.connected ||
+    final isDm = _client.getRoomById(roomId)?.isDirectChat ?? false;
+    if (isDm &&
+        (_callState == LatticeCallState.connected ||
             _callState == LatticeCallState.reconnecting) &&
         !hasRemote &&
         _hadRemoteParticipant) {
-      debugPrint('[Lattice] All remote members left, ending call');
+      debugPrint('[Lattice] DM remote member left, ending call');
       unawaited(leaveCall());
       return;
     }

--- a/lib/core/services/call_service.dart
+++ b/lib/core/services/call_service.dart
@@ -167,6 +167,7 @@ class CallService extends ChangeNotifier with WidgetsBindingObserver {
 
   String? _activeCallId;
   String? _lastInitiatedRoomId;
+  bool _hadRemoteParticipant = false;
 
   // ── Membership Watcher ──────────────────────────────────────
 
@@ -189,9 +190,14 @@ class CallService extends ChangeNotifier with WidgetsBindingObserver {
       return;
     }
 
+    if (hasRemote) {
+      _hadRemoteParticipant = true;
+    }
+
     if ((_callState == LatticeCallState.connected ||
             _callState == LatticeCallState.reconnecting) &&
-        !hasRemote) {
+        !hasRemote &&
+        _hadRemoteParticipant) {
       debugPrint('[Lattice] All remote members left, ending call');
       unawaited(leaveCall());
       return;
@@ -238,6 +244,7 @@ class CallService extends ChangeNotifier with WidgetsBindingObserver {
     _ringing.disposeRingtone();
     _activeCallId = null;
     _callStartTime = null;
+    _hadRemoteParticipant = false;
     unawaited(_signalingEventSub?.cancel());
     _signalingEventSub = null;
     unawaited(_nativeActionSub?.cancel());
@@ -299,6 +306,7 @@ class CallService extends ChangeNotifier with WidgetsBindingObserver {
     }
     _activeCallRoomId = null;
     _callStartTime = null;
+    _hadRemoteParticipant = false;
   }
 
   // ── Join / Leave ───────────────────────────────────────────

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -8,30 +8,25 @@ import 'package:lattice/core/models/upload_state.dart';
 import 'package:lattice/core/services/app_config.dart';
 import 'package:lattice/core/services/call_service.dart';
 import 'package:lattice/core/services/matrix_service.dart';
-import 'package:lattice/core/services/preferences_service.dart';
 import 'package:lattice/core/services/sub_services/selection_service.dart';
 import 'package:lattice/core/utils/platform_info.dart';
-import 'package:lattice/features/calling/models/call_constants.dart';
 import 'package:lattice/features/chat/services/chat_message_actions.dart';
 import 'package:lattice/features/chat/services/chat_search_controller.dart';
 import 'package:lattice/features/chat/services/compose_state_controller.dart';
 import 'package:lattice/features/chat/services/typing_controller.dart';
 import 'package:lattice/features/chat/services/voice_recording_controller.dart';
 import 'package:lattice/features/chat/services/voice_recording_mixin.dart';
-import 'package:lattice/features/chat/widgets/call_event_tile.dart';
 import 'package:lattice/features/chat/widgets/chat_app_bar.dart';
-import 'package:lattice/features/chat/widgets/chat_message_item.dart';
 import 'package:lattice/features/chat/widgets/compose_bar_section.dart';
 import 'package:lattice/features/chat/widgets/desktop_drop_wrapper.dart';
 import 'package:lattice/features/chat/widgets/file_send_handler.dart';
 import 'package:lattice/features/chat/widgets/gif_send_handler.dart';
 import 'package:lattice/features/chat/widgets/join_call_banner.dart';
-import 'package:lattice/features/chat/widgets/read_receipts.dart';
+import 'package:lattice/features/chat/widgets/message_list_view.dart';
 import 'package:lattice/features/chat/widgets/search_results_body.dart';
 import 'package:lattice/features/chat/widgets/typing_indicator.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
-import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 class ChatScreen extends StatefulWidget {
   const ChatScreen({
@@ -58,7 +53,7 @@ class _ChatScreenState extends State<ChatScreen>
     with VoiceRecordingMixin<ChatScreen> {
   final _msgCtrl = TextEditingController();
   final _composeFocusNode = FocusNode();
-  final _messageListKey = GlobalKey<_MessageListViewState>();
+  final _messageListKey = GlobalKey<MessageListViewState>();
 
   // ── Compose state ───────────────────────────────────────
   final _compose = ComposeStateController();
@@ -272,7 +267,7 @@ class _ChatScreenState extends State<ChatScreen>
         if (roomHasCall && !isInCall)
           JoinCallBanner(room: room, callService: callService),
         Expanded(
-          child: _MessageListView(
+          child: MessageListView(
             key: _messageListKey,
             room: room,
             matrix: matrix,
@@ -342,385 +337,6 @@ class _ChatScreenState extends State<ChatScreen>
       enabled: _isDesktop || kIsWeb,
       onFileDropped: _addAttachment,
       child: column,
-    );
-  }
-}
-
-// ── Message list (owns timeline, scroll state, history) ───────────
-
-class _MessageListView extends StatefulWidget {
-  const _MessageListView({
-    required this.room,
-    required this.matrix,
-    required this.onReply,
-    required this.onEdit,
-    required this.onToggleReaction,
-    required this.onPin,
-    required this.onHighlight,
-    this.initialEventId,
-    this.highlightedEventId,
-    super.key,
-  });
-
-  final Room room;
-  final MatrixService matrix;
-  final String? initialEventId;
-  final String? highlightedEventId;
-  final void Function(Event event) onReply;
-  final void Function(Event event, Timeline? timeline) onEdit;
-  final Future<void> Function(Event event, String emoji) onToggleReaction;
-  final Future<void> Function(Event event) onPin;
-  final void Function(String eventId) onHighlight;
-
-  @override
-  State<_MessageListView> createState() => _MessageListViewState();
-}
-
-class _MessageListViewState extends State<_MessageListView> {
-  static const _historyLoadThreshold = 15;
-  static const _scrollAnimationDuration = Duration(milliseconds: 400);
-  static const _readMarkerDelay = Duration(seconds: 1);
-
-  final _itemScrollCtrl = ItemScrollController();
-  final _itemPosListener = ItemPositionsListener.create();
-  Timeline? _timeline;
-  bool _loadingHistory = false;
-  Timer? _readMarkerTimer;
-  int _initGeneration = 0;
-  List<Event>? _cachedVisibleEvents;
-
-  Timeline? get timeline => _timeline;
-
-  @override
-  void initState() {
-    super.initState();
-    _itemPosListener.itemPositions.addListener(_onScroll);
-    unawaited(_initTimeline());
-  }
-
-  @override
-  void didUpdateWidget(_MessageListView old) {
-    super.didUpdateWidget(old);
-    if (old.room.id != widget.room.id ||
-        old.initialEventId != widget.initialEventId) {
-      _timeline?.cancelSubscriptions();
-      _readMarkerTimer?.cancel();
-      _cachedVisibleEvents = null;
-      unawaited(_initTimeline());
-    }
-  }
-
-  // ── Timeline ───────────────────────────────────────────
-
-  Future<void> _initTimeline() async {
-    final gen = ++_initGeneration;
-    _timeline = await widget.room.getTimeline(
-      eventContextId: widget.initialEventId,
-      onUpdate: () {
-        if (mounted) {
-          _cachedVisibleEvents = null;
-          setState(() {});
-        }
-        _markAsRead();
-      },
-    );
-    if (gen != _initGeneration) return;
-    if (mounted) setState(() {});
-    _markAsRead();
-    _requestMissingKeys();
-    if (widget.initialEventId != null) _jumpToEvent(widget.initialEventId!);
-  }
-
-  void _requestMissingKeys() {
-    final encryption = widget.room.client.encryption;
-    if (encryption == null) return;
-
-    final events = _timeline?.events;
-    if (events == null) return;
-
-    final requested = <String>{};
-    for (final event in events) {
-      if (event.type == EventTypes.Encrypted &&
-          event.messageType == MessageTypes.BadEncrypted) {
-        final sessionId = event.content.tryGet<String>('session_id');
-        final senderKey = event.content.tryGet<String>('sender_key');
-        if (sessionId != null && requested.add(sessionId)) {
-          unawaited(
-            encryption.keyManager.loadSingleKey(widget.room.id, sessionId).catchError(
-              (Object e) {
-                debugPrint('[Lattice] Key load failed for $sessionId: $e');
-              },
-            ),
-          );
-          if (senderKey != null) {
-            try {
-              encryption.keyManager.maybeAutoRequest(
-                widget.room.id,
-                sessionId,
-                senderKey,
-              );
-            } catch (e) {
-              debugPrint('[Lattice] P2P key request failed for $sessionId: $e');
-            }
-          }
-        }
-      }
-    }
-  }
-
-  List<Event> get _visibleEvents {
-    if (_cachedVisibleEvents != null) return _cachedVisibleEvents!;
-    final events = _timeline?.events;
-    if (events == null) return [];
-    _cachedVisibleEvents = events
-        .where((e) =>
-            ((e.type == EventTypes.Message || e.type == EventTypes.Encrypted) &&
-                e.relationshipType != RelationshipTypes.edit &&
-                !_isCallMemberEvent(e)) ||
-            callEventTypes.contains(e.type),)
-        .toList();
-    return _cachedVisibleEvents!;
-  }
-
-  void _markAsRead() {
-    _readMarkerTimer?.cancel();
-    _readMarkerTimer = Timer(_readMarkerDelay, () async {
-      if (!mounted) return;
-      final lastEvent = widget.room.lastEvent;
-      if (lastEvent != null && widget.room.notificationCount > 0) {
-        try {
-          final sendPublic = context.read<PreferencesService>().readReceipts;
-          await widget.room.setReadMarker(
-            lastEvent.eventId,
-            mRead: sendPublic ? lastEvent.eventId : null,
-          );
-        } catch (e) {
-          debugPrint('[Lattice] Failed to mark as read: $e');
-        }
-      }
-    });
-  }
-
-  // ── Scroll & history ───────────────────────────────────
-
-  void _onScroll() {
-    final positions = _itemPosListener.itemPositions.value;
-    if (positions.isEmpty) return;
-    final maxIndex = positions.map((p) => p.index).reduce((a, b) => a > b ? a : b);
-    if (maxIndex >= _visibleEvents.length - _historyLoadThreshold && !_loadingHistory) {
-      unawaited(_loadMore());
-    }
-  }
-
-  Future<void> _loadMore() async {
-    if (_timeline == null || !_timeline!.canRequestHistory || _loadingHistory) {
-      return;
-    }
-    setState(() => _loadingHistory = true);
-    try {
-      while (mounted && _timeline!.canRequestHistory) {
-        await _timeline!.requestHistory();
-        _cachedVisibleEvents = null;
-        final positions = _itemPosListener.itemPositions.value;
-        if (positions.isEmpty) break;
-        final maxIndex =
-            positions.map((p) => p.index).reduce((a, b) => a > b ? a : b);
-        if (maxIndex < _visibleEvents.length - _historyLoadThreshold) break;
-      }
-    } catch (e) {
-      debugPrint('[Lattice] Failed to load history: $e');
-    } finally {
-      if (mounted) setState(() => _loadingHistory = false);
-    }
-  }
-
-  // ── Navigation ─────────────────────────────────────────
-
-  void navigateToEvent(Event event) {
-    unawaited(_navigateToEvent(event));
-  }
-
-  Future<void> _navigateToEvent(Event event) async {
-    final index = _visibleEvents.indexWhere((e) => e.eventId == event.eventId);
-    if (index == -1) {
-      debugPrint(
-        '[Lattice] Event not in loaded timeline, reloading: ${event.eventId}',
-      );
-      await _reloadTimelineAt(event.eventId);
-      return;
-    }
-    _scrollToIndex(index, event.eventId);
-  }
-
-  Future<void> _reloadTimelineAt(String eventId) async {
-    _timeline?.cancelSubscriptions();
-    _cachedVisibleEvents = null;
-    setState(() => _timeline = null);
-
-    final gen = ++_initGeneration;
-    _timeline = await widget.room.getTimeline(
-      eventContextId: eventId,
-      onUpdate: () {
-        if (mounted) {
-          _cachedVisibleEvents = null;
-          setState(() {});
-        }
-        _markAsRead();
-      },
-    );
-    if (gen != _initGeneration || !mounted) return;
-    setState(() {});
-    _jumpToEvent(eventId);
-  }
-
-  void _jumpToEvent(String eventId) {
-    final index = _visibleEvents.indexWhere((e) => e.eventId == eventId);
-    if (index == -1) {
-      debugPrint('[Lattice] Event not found after context load: $eventId');
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Could not load the target message'),
-            duration: Duration(seconds: 2),
-          ),
-        );
-      }
-      return;
-    }
-    _scrollToIndex(index, eventId);
-  }
-
-  void _scrollToIndex(int index, String eventId) {
-    widget.onHighlight(eventId);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_itemScrollCtrl.isAttached) {
-        unawaited(
-          _itemScrollCtrl.scrollTo(
-            index: index,
-            duration: _scrollAnimationDuration,
-            curve: Curves.easeInOut,
-            alignment: 0.5,
-          ),
-        );
-      }
-    });
-  }
-
-  // ── Helpers ────────────────────────────────────────────
-
-  static bool _isCallEvent(Event event) => callEventTypes.contains(event.type);
-
-  static bool _isCallMemberEvent(Event event) =>
-      event.type == kCallMember ||
-      event.type == kCallMemberMsc ||
-      event.body.contains(kCallMember) ||
-      event.body.contains(kCallMemberMsc);
-
-  Duration? _callDuration(Event event) {
-    if (event.type != kCallHangup) return null;
-    final reason = event.content.tryGet<String>('reason');
-    if (reason == 'invite_timeout') return null;
-
-    final hangupCallId = event.content.tryGet<String>('call_id');
-    final events = _timeline?.events;
-    if (events == null) return null;
-
-    Event? matchedInvite;
-    for (final e in events) {
-      if (e.type != kCallInvite) continue;
-      if (!e.originServerTs.isBefore(event.originServerTs)) continue;
-      if (hangupCallId != null &&
-          hangupCallId.isNotEmpty &&
-          e.content.tryGet<String>('call_id') == hangupCallId) {
-        matchedInvite = e;
-        break;
-      }
-      matchedInvite ??= e;
-    }
-
-    if (matchedInvite == null) return null;
-    final d = event.originServerTs.difference(matchedInvite.originServerTs);
-    if (d.isNegative || d.inHours >= 24) return null;
-    return d;
-  }
-
-  @override
-  void dispose() {
-    _itemPosListener.itemPositions.removeListener(_onScroll);
-    _readMarkerTimer?.cancel();
-    _timeline?.cancelSubscriptions();
-    super.dispose();
-  }
-
-  // ── Build ──────────────────────────────────────────────
-
-  @override
-  Widget build(BuildContext context) {
-    if (_timeline == null) {
-      return const Center(child: CircularProgressIndicator());
-    }
-
-    final events = _visibleEvents;
-    if (events.isEmpty) {
-      final cs = Theme.of(context).colorScheme;
-      final tt = Theme.of(context).textTheme;
-      return Center(
-        child: Text(
-          'No messages yet.\nSay hello!',
-          textAlign: TextAlign.center,
-          style: tt.bodyMedium?.copyWith(
-            color: cs.onSurfaceVariant.withValues(alpha: 0.5),
-          ),
-        ),
-      );
-    }
-
-    final isMobile = isTouchDevice;
-    final showReceipts = context.watch<PreferencesService>().readReceipts;
-    final receiptMap = showReceipts
-        ? buildReceiptMap(widget.room, widget.matrix.client.userID)
-        : <String, List<Receipt>>{};
-    final hasLoadingIndicator = _loadingHistory;
-    final totalCount = events.length + (hasLoadingIndicator ? 1 : 0);
-
-    return ScrollablePositionedList.builder(
-      itemScrollController: _itemScrollCtrl,
-      itemPositionsListener: _itemPosListener,
-      reverse: true,
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      itemCount: totalCount,
-      itemBuilder: (context, i) {
-        if (hasLoadingIndicator && i == totalCount - 1) {
-          return const Padding(
-            padding: EdgeInsets.symmetric(vertical: 16),
-            child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
-          );
-        }
-        final event = events[i];
-        if (_isCallEvent(event)) {
-          return CallEventTile(
-            event: event,
-            isMe: event.senderId == widget.matrix.client.userID,
-            duration: _callDuration(event),
-          );
-        }
-        final prevSender = i + 1 < events.length ? events[i + 1].senderId : null;
-        return ChatMessageItem(
-          event: event,
-          isMe: event.senderId == widget.matrix.client.userID,
-          isFirst: event.senderId != prevSender,
-          isMobile: isMobile,
-          timeline: _timeline,
-          client: widget.matrix.client,
-          highlightedEventId: widget.highlightedEventId,
-          receiptMap: receiptMap,
-          onReply: widget.onReply,
-          onEdit: (event) => widget.onEdit(event, _timeline),
-          onToggleReaction: widget.onToggleReaction,
-          onPin: widget.onPin,
-          onTapReply: _navigateToEvent,
-        );
-      },
     );
   }
 }

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -56,19 +56,9 @@ class ChatScreen extends StatefulWidget {
 
 class _ChatScreenState extends State<ChatScreen>
     with VoiceRecordingMixin<ChatScreen> {
-  static const _historyLoadThreshold = 15;
-  static const _scrollAnimationDuration = Duration(milliseconds: 400);
-  static const _readMarkerDelay = Duration(seconds: 1);
-
   final _msgCtrl = TextEditingController();
   final _composeFocusNode = FocusNode();
-  final _itemScrollCtrl = ItemScrollController();
-  final _itemPosListener = ItemPositionsListener.create();
-  Timeline? _timeline;
-  bool _loadingHistory = false;
-  Timer? _readMarkerTimer;
-  int _initGeneration = 0;
-  List<Event>? _cachedVisibleEvents;
+  final _messageListKey = GlobalKey<_MessageListViewState>();
 
   // ── Compose state ───────────────────────────────────────
   final _compose = ComposeStateController();
@@ -102,8 +92,7 @@ class _ChatScreenState extends State<ChatScreen>
     super.initState();
     _actions = _createActions();
     _search = _createSearchController();
-    unawaited(_initTimeline());
-    _itemPosListener.itemPositions.addListener(_onScroll);
+    _initControllers();
     _composeFocusNode.requestFocus();
   }
 
@@ -112,18 +101,23 @@ class _ChatScreenState extends State<ChatScreen>
     super.didUpdateWidget(old);
     if (old.roomId != widget.roomId ||
         old.initialEventId != widget.initialEventId) {
-      _timeline?.cancelSubscriptions();
-      _readMarkerTimer?.cancel();
       _compose.reset(_msgCtrl);
-      _cachedVisibleEvents = null;
       _typingCtrl?.dispose();
       _voiceCtrl?.dispose();
+      _initControllers();
       _search.removeListener(_onSearchChanged);
       _search.dispose();
       _actions = _createActions();
       _search = _createSearchController();
-      unawaited(_initTimeline());
       _composeFocusNode.requestFocus();
+    }
+  }
+
+  void _initControllers() {
+    final room = context.read<MatrixService>().client.getRoomById(widget.roomId);
+    if (room != null) {
+      _typingCtrl = TypingController(room: room);
+      _voiceCtrl = VoiceRecordingController();
     }
   }
 
@@ -131,7 +125,7 @@ class _ChatScreenState extends State<ChatScreen>
     return ChatMessageActions(
       getRoomId: () => widget.roomId,
       getRoom: () => context.read<MatrixService>().client.getRoomById(widget.roomId),
-      getTimeline: () => _timeline,
+      getTimeline: () => _messageListKey.currentState?.timeline,
       compose: _compose,
       msgCtrl: _msgCtrl,
       getScaffold: () => ScaffoldMessenger.of(context),
@@ -150,144 +144,11 @@ class _ChatScreenState extends State<ChatScreen>
     if (mounted) setState(() {});
   }
 
-  // ── Timeline ───────────────────────────────────────────
-
-  Future<void> _initTimeline() async {
-    final gen = ++_initGeneration;
-    final matrix = context.read<MatrixService>();
-    final room = matrix.client.getRoomById(widget.roomId);
-    if (room == null) return;
-
-    _typingCtrl = TypingController(room: room);
-    _voiceCtrl = VoiceRecordingController();
-
-    _timeline = await room.getTimeline(
-      eventContextId: widget.initialEventId,
-      onUpdate: () {
-        if (mounted) {
-          _cachedVisibleEvents = null;
-          setState(() {});
-        }
-        _markAsRead(room);
-      },
-    );
-    if (gen != _initGeneration) return;
-    if (mounted) setState(() {});
-    _markAsRead(room);
-    _requestMissingKeys(room);
-    if (widget.initialEventId != null) _jumpToEvent(widget.initialEventId!);
-  }
-
-  void _requestMissingKeys(Room room) {
-    final encryption = room.client.encryption;
-    if (encryption == null) return;
-
-    final events = _timeline?.events;
-    if (events == null) return;
-
-    final requested = <String>{};
-    for (final event in events) {
-      if (event.type == EventTypes.Encrypted &&
-          event.messageType == MessageTypes.BadEncrypted) {
-        final sessionId = event.content.tryGet<String>('session_id');
-        final senderKey = event.content.tryGet<String>('sender_key');
-        if (sessionId != null && requested.add(sessionId)) {
-          unawaited(
-            encryption.keyManager.loadSingleKey(room.id, sessionId).catchError(
-              (Object e) {
-                debugPrint('[Lattice] Key load failed for $sessionId: $e');
-              },
-            ),
-          );
-          if (senderKey != null) {
-            try {
-              encryption.keyManager.maybeAutoRequest(
-                room.id,
-                sessionId,
-                senderKey,
-              );
-            } catch (e) {
-              debugPrint('[Lattice] P2P key request failed for $sessionId: $e');
-            }
-          }
-        }
-      }
-    }
-  }
-
-  List<Event> get _visibleEvents {
-    if (_cachedVisibleEvents != null) return _cachedVisibleEvents!;
-    final events = _timeline?.events;
-    if (events == null) return [];
-    _cachedVisibleEvents = events
-        .where((e) =>
-            ((e.type == EventTypes.Message || e.type == EventTypes.Encrypted) &&
-                e.relationshipType != RelationshipTypes.edit &&
-                !_isCallMemberEvent(e)) ||
-            callEventTypes.contains(e.type),)
-        .toList();
-    return _cachedVisibleEvents!;
-  }
-
-  void _markAsRead(Room room) {
-    _readMarkerTimer?.cancel();
-    _readMarkerTimer = Timer(_readMarkerDelay, () async {
-      if (!mounted) return;
-      final lastEvent = room.lastEvent;
-      if (lastEvent != null && room.notificationCount > 0) {
-        try {
-          final sendPublic = context.read<PreferencesService>().readReceipts;
-          await room.setReadMarker(
-            lastEvent.eventId,
-            mRead: sendPublic ? lastEvent.eventId : null,
-          );
-        } catch (e) {
-          debugPrint('[Lattice] Failed to mark as read: $e');
-        }
-      }
-    });
-  }
-
-  void _onScroll() {
-    final positions = _itemPosListener.itemPositions.value;
-    if (positions.isEmpty) return;
-    final maxIndex = positions.map((p) => p.index).reduce((a, b) => a > b ? a : b);
-    if (maxIndex >= _visibleEvents.length - _historyLoadThreshold && !_loadingHistory) {
-      unawaited(_loadMore());
-    }
-  }
-
-  Future<void> _loadMore() async {
-    if (_timeline == null || !_timeline!.canRequestHistory || _loadingHistory) {
-      return;
-    }
-    setState(() => _loadingHistory = true);
-    try {
-      while (mounted && _timeline!.canRequestHistory) {
-        await _timeline!.requestHistory();
-        _cachedVisibleEvents = null;
-        final positions = _itemPosListener.itemPositions.value;
-        if (positions.isEmpty) break;
-        final maxIndex =
-            positions.map((p) => p.index).reduce((a, b) => a > b ? a : b);
-        if (maxIndex < _visibleEvents.length - _historyLoadThreshold) break;
-      }
-    } catch (e) {
-      debugPrint('[Lattice] Failed to load history: $e');
-    } finally {
-      if (mounted) setState(() => _loadingHistory = false);
-    }
-  }
-
   // ── Reply / Edit helpers ────────────────────────────────
 
   void _setReplyTo(Event event) {
     _compose.setReplyTo(event);
     _composeFocusNode.requestFocus();
-  }
-
-  void _setEditEvent(Event event) {
-    _compose.setEditEvent(event, _timeline, _msgCtrl);
   }
 
   // ── Attachments ─────────────────────────────────────────
@@ -333,81 +194,11 @@ class _ChatScreenState extends State<ChatScreen>
 
   void _scrollToEvent(Event event, {bool closeSearch = true}) {
     if (closeSearch) _closeSearch();
-    unawaited(_navigateToEvent(event));
-  }
-
-  Future<void> _navigateToEvent(Event event) async {
-    final index = _visibleEvents.indexWhere((e) => e.eventId == event.eventId);
-    if (index == -1) {
-      debugPrint(
-        '[Lattice] Event not in loaded timeline, reloading: ${event.eventId}',
-      );
-      await _reloadTimelineAt(event.eventId);
-      return;
-    }
-    _scrollToIndex(index, event.eventId);
-  }
-
-  Future<void> _reloadTimelineAt(String eventId) async {
-    _timeline?.cancelSubscriptions();
-    _cachedVisibleEvents = null;
-    setState(() => _timeline = null);
-
-    final room = context.read<MatrixService>().client.getRoomById(widget.roomId);
-    if (room == null) return;
-
-    final gen = ++_initGeneration;
-    _timeline = await room.getTimeline(
-      eventContextId: eventId,
-      onUpdate: () {
-        if (mounted) {
-          _cachedVisibleEvents = null;
-          setState(() {});
-        }
-        _markAsRead(room);
-      },
-    );
-    if (gen != _initGeneration || !mounted) return;
-    setState(() {});
-    _jumpToEvent(eventId);
-  }
-
-  void _jumpToEvent(String eventId) {
-    final index = _visibleEvents.indexWhere((e) => e.eventId == eventId);
-    if (index == -1) {
-      debugPrint('[Lattice] Event not found after context load: $eventId');
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Could not load the target message'),
-            duration: Duration(seconds: 2),
-          ),
-        );
-      }
-      return;
-    }
-    _scrollToIndex(index, eventId);
-  }
-
-  void _scrollToIndex(int index, String eventId) {
-    _search.setHighlight(eventId);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_itemScrollCtrl.isAttached) {
-        unawaited(
-          _itemScrollCtrl.scrollTo(
-            index: index,
-            duration: _scrollAnimationDuration,
-            curve: Curves.easeInOut,
-            alignment: 0.5,
-          ),
-        );
-      }
-    });
+    _messageListKey.currentState?.navigateToEvent(event);
   }
 
   @override
   void dispose() {
-    _itemPosListener.itemPositions.removeListener(_onScroll);
     _msgCtrl.dispose();
     _compose.dispose();
     _searchCtrl.dispose();
@@ -415,10 +206,8 @@ class _ChatScreenState extends State<ChatScreen>
     _composeFocusNode.dispose();
     _typingCtrl?.dispose();
     _voiceCtrl?.dispose();
-    _readMarkerTimer?.cancel();
     _search.removeListener(_onSearchChanged);
     _search.dispose();
-    _timeline?.cancelSubscriptions();
     super.dispose();
   }
 
@@ -450,28 +239,30 @@ class _ChatScreenState extends State<ChatScreen>
         onBack: widget.onBack,
         onShowDetails: widget.onShowDetails,
         onSearch: _openSearch,
-        onPinnedEvent: _navigateToEvent,
+        onPinnedEvent: (event) =>
+            _messageListKey.currentState?.navigateToEvent(event),
       );
     }
 
     return Scaffold(
       appBar: appBar,
-      body: _search.isSearching
-          ? SearchResultsBody(
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          _buildChatBody(matrix, room),
+          if (_search.isSearching)
+            SearchResultsBody(
               search: _search,
               onTapResult: _scrollToEvent,
-            )
-          : _buildChatBody(matrix, room),
+            ),
+        ],
+      ),
     );
   }
 
   // ── Chat body (messages + compose) ────────────────────────
 
   Widget _buildChatBody(MatrixService matrix, Room room) {
-    final cs = Theme.of(context).colorScheme;
-    final tt = Theme.of(context).textTheme;
-    final events = _visibleEvents;
-
     final callService = context.watch<CallService>();
     final roomHasCall = callService.roomHasActiveCall(room.id);
     final isInCall = callService.activeCallRoomId == room.id;
@@ -481,19 +272,19 @@ class _ChatScreenState extends State<ChatScreen>
         if (roomHasCall && !isInCall)
           JoinCallBanner(room: room, callService: callService),
         Expanded(
-          child: _timeline == null
-              ? const Center(child: CircularProgressIndicator())
-              : events.isEmpty
-                  ? Center(
-                      child: Text(
-                        'No messages yet.\nSay hello!',
-                        textAlign: TextAlign.center,
-                        style: tt.bodyMedium?.copyWith(
-                          color: cs.onSurfaceVariant.withValues(alpha: 0.5),
-                        ),
-                      ),
-                    )
-                  : _buildMessageList(events, matrix, room),
+          child: _MessageListView(
+            key: _messageListKey,
+            room: room,
+            matrix: matrix,
+            initialEventId: widget.initialEventId,
+            highlightedEventId: _search.highlightedEventId,
+            onReply: _setReplyTo,
+            onEdit: (event, timeline) =>
+                _compose.setEditEvent(event, timeline, _msgCtrl),
+            onToggleReaction: _actions.toggleReaction,
+            onPin: _actions.togglePin,
+            onHighlight: _search.setHighlight,
+          ),
         ),
         TypingIndicator(
           room: room,
@@ -553,6 +344,269 @@ class _ChatScreenState extends State<ChatScreen>
       child: column,
     );
   }
+}
+
+// ── Message list (owns timeline, scroll state, history) ───────────
+
+class _MessageListView extends StatefulWidget {
+  const _MessageListView({
+    required this.room,
+    required this.matrix,
+    required this.onReply,
+    required this.onEdit,
+    required this.onToggleReaction,
+    required this.onPin,
+    required this.onHighlight,
+    this.initialEventId,
+    this.highlightedEventId,
+    super.key,
+  });
+
+  final Room room;
+  final MatrixService matrix;
+  final String? initialEventId;
+  final String? highlightedEventId;
+  final void Function(Event event) onReply;
+  final void Function(Event event, Timeline? timeline) onEdit;
+  final Future<void> Function(Event event, String emoji) onToggleReaction;
+  final Future<void> Function(Event event) onPin;
+  final void Function(String eventId) onHighlight;
+
+  @override
+  State<_MessageListView> createState() => _MessageListViewState();
+}
+
+class _MessageListViewState extends State<_MessageListView> {
+  static const _historyLoadThreshold = 15;
+  static const _scrollAnimationDuration = Duration(milliseconds: 400);
+  static const _readMarkerDelay = Duration(seconds: 1);
+
+  final _itemScrollCtrl = ItemScrollController();
+  final _itemPosListener = ItemPositionsListener.create();
+  Timeline? _timeline;
+  bool _loadingHistory = false;
+  Timer? _readMarkerTimer;
+  int _initGeneration = 0;
+  List<Event>? _cachedVisibleEvents;
+
+  Timeline? get timeline => _timeline;
+
+  @override
+  void initState() {
+    super.initState();
+    _itemPosListener.itemPositions.addListener(_onScroll);
+    unawaited(_initTimeline());
+  }
+
+  @override
+  void didUpdateWidget(_MessageListView old) {
+    super.didUpdateWidget(old);
+    if (old.room.id != widget.room.id ||
+        old.initialEventId != widget.initialEventId) {
+      _timeline?.cancelSubscriptions();
+      _readMarkerTimer?.cancel();
+      _cachedVisibleEvents = null;
+      unawaited(_initTimeline());
+    }
+  }
+
+  // ── Timeline ───────────────────────────────────────────
+
+  Future<void> _initTimeline() async {
+    final gen = ++_initGeneration;
+    _timeline = await widget.room.getTimeline(
+      eventContextId: widget.initialEventId,
+      onUpdate: () {
+        if (mounted) {
+          _cachedVisibleEvents = null;
+          setState(() {});
+        }
+        _markAsRead();
+      },
+    );
+    if (gen != _initGeneration) return;
+    if (mounted) setState(() {});
+    _markAsRead();
+    _requestMissingKeys();
+    if (widget.initialEventId != null) _jumpToEvent(widget.initialEventId!);
+  }
+
+  void _requestMissingKeys() {
+    final encryption = widget.room.client.encryption;
+    if (encryption == null) return;
+
+    final events = _timeline?.events;
+    if (events == null) return;
+
+    final requested = <String>{};
+    for (final event in events) {
+      if (event.type == EventTypes.Encrypted &&
+          event.messageType == MessageTypes.BadEncrypted) {
+        final sessionId = event.content.tryGet<String>('session_id');
+        final senderKey = event.content.tryGet<String>('sender_key');
+        if (sessionId != null && requested.add(sessionId)) {
+          unawaited(
+            encryption.keyManager.loadSingleKey(widget.room.id, sessionId).catchError(
+              (Object e) {
+                debugPrint('[Lattice] Key load failed for $sessionId: $e');
+              },
+            ),
+          );
+          if (senderKey != null) {
+            try {
+              encryption.keyManager.maybeAutoRequest(
+                widget.room.id,
+                sessionId,
+                senderKey,
+              );
+            } catch (e) {
+              debugPrint('[Lattice] P2P key request failed for $sessionId: $e');
+            }
+          }
+        }
+      }
+    }
+  }
+
+  List<Event> get _visibleEvents {
+    if (_cachedVisibleEvents != null) return _cachedVisibleEvents!;
+    final events = _timeline?.events;
+    if (events == null) return [];
+    _cachedVisibleEvents = events
+        .where((e) =>
+            ((e.type == EventTypes.Message || e.type == EventTypes.Encrypted) &&
+                e.relationshipType != RelationshipTypes.edit &&
+                !_isCallMemberEvent(e)) ||
+            callEventTypes.contains(e.type),)
+        .toList();
+    return _cachedVisibleEvents!;
+  }
+
+  void _markAsRead() {
+    _readMarkerTimer?.cancel();
+    _readMarkerTimer = Timer(_readMarkerDelay, () async {
+      if (!mounted) return;
+      final lastEvent = widget.room.lastEvent;
+      if (lastEvent != null && widget.room.notificationCount > 0) {
+        try {
+          final sendPublic = context.read<PreferencesService>().readReceipts;
+          await widget.room.setReadMarker(
+            lastEvent.eventId,
+            mRead: sendPublic ? lastEvent.eventId : null,
+          );
+        } catch (e) {
+          debugPrint('[Lattice] Failed to mark as read: $e');
+        }
+      }
+    });
+  }
+
+  // ── Scroll & history ───────────────────────────────────
+
+  void _onScroll() {
+    final positions = _itemPosListener.itemPositions.value;
+    if (positions.isEmpty) return;
+    final maxIndex = positions.map((p) => p.index).reduce((a, b) => a > b ? a : b);
+    if (maxIndex >= _visibleEvents.length - _historyLoadThreshold && !_loadingHistory) {
+      unawaited(_loadMore());
+    }
+  }
+
+  Future<void> _loadMore() async {
+    if (_timeline == null || !_timeline!.canRequestHistory || _loadingHistory) {
+      return;
+    }
+    setState(() => _loadingHistory = true);
+    try {
+      while (mounted && _timeline!.canRequestHistory) {
+        await _timeline!.requestHistory();
+        _cachedVisibleEvents = null;
+        final positions = _itemPosListener.itemPositions.value;
+        if (positions.isEmpty) break;
+        final maxIndex =
+            positions.map((p) => p.index).reduce((a, b) => a > b ? a : b);
+        if (maxIndex < _visibleEvents.length - _historyLoadThreshold) break;
+      }
+    } catch (e) {
+      debugPrint('[Lattice] Failed to load history: $e');
+    } finally {
+      if (mounted) setState(() => _loadingHistory = false);
+    }
+  }
+
+  // ── Navigation ─────────────────────────────────────────
+
+  void navigateToEvent(Event event) {
+    unawaited(_navigateToEvent(event));
+  }
+
+  Future<void> _navigateToEvent(Event event) async {
+    final index = _visibleEvents.indexWhere((e) => e.eventId == event.eventId);
+    if (index == -1) {
+      debugPrint(
+        '[Lattice] Event not in loaded timeline, reloading: ${event.eventId}',
+      );
+      await _reloadTimelineAt(event.eventId);
+      return;
+    }
+    _scrollToIndex(index, event.eventId);
+  }
+
+  Future<void> _reloadTimelineAt(String eventId) async {
+    _timeline?.cancelSubscriptions();
+    _cachedVisibleEvents = null;
+    setState(() => _timeline = null);
+
+    final gen = ++_initGeneration;
+    _timeline = await widget.room.getTimeline(
+      eventContextId: eventId,
+      onUpdate: () {
+        if (mounted) {
+          _cachedVisibleEvents = null;
+          setState(() {});
+        }
+        _markAsRead();
+      },
+    );
+    if (gen != _initGeneration || !mounted) return;
+    setState(() {});
+    _jumpToEvent(eventId);
+  }
+
+  void _jumpToEvent(String eventId) {
+    final index = _visibleEvents.indexWhere((e) => e.eventId == eventId);
+    if (index == -1) {
+      debugPrint('[Lattice] Event not found after context load: $eventId');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Could not load the target message'),
+            duration: Duration(seconds: 2),
+          ),
+        );
+      }
+      return;
+    }
+    _scrollToIndex(index, eventId);
+  }
+
+  void _scrollToIndex(int index, String eventId) {
+    widget.onHighlight(eventId);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_itemScrollCtrl.isAttached) {
+        unawaited(
+          _itemScrollCtrl.scrollTo(
+            index: index,
+            duration: _scrollAnimationDuration,
+            curve: Curves.easeInOut,
+            alignment: 0.5,
+          ),
+        );
+      }
+    });
+  }
+
+  // ── Helpers ────────────────────────────────────────────
 
   static bool _isCallEvent(Event event) => callEventTypes.contains(event.type);
 
@@ -590,15 +644,45 @@ class _ChatScreenState extends State<ChatScreen>
     return d;
   }
 
-  Widget _buildMessageList(
-      List<Event> events, MatrixService matrix, Room room,) {
+  @override
+  void dispose() {
+    _itemPosListener.itemPositions.removeListener(_onScroll);
+    _readMarkerTimer?.cancel();
+    _timeline?.cancelSubscriptions();
+    super.dispose();
+  }
+
+  // ── Build ──────────────────────────────────────────────
+
+  @override
+  Widget build(BuildContext context) {
+    if (_timeline == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    final events = _visibleEvents;
+    if (events.isEmpty) {
+      final cs = Theme.of(context).colorScheme;
+      final tt = Theme.of(context).textTheme;
+      return Center(
+        child: Text(
+          'No messages yet.\nSay hello!',
+          textAlign: TextAlign.center,
+          style: tt.bodyMedium?.copyWith(
+            color: cs.onSurfaceVariant.withValues(alpha: 0.5),
+          ),
+        ),
+      );
+    }
+
     final isMobile = isTouchDevice;
     final showReceipts = context.watch<PreferencesService>().readReceipts;
     final receiptMap = showReceipts
-        ? buildReceiptMap(room, matrix.client.userID)
+        ? buildReceiptMap(widget.room, widget.matrix.client.userID)
         : <String, List<Receipt>>{};
     final hasLoadingIndicator = _loadingHistory;
     final totalCount = events.length + (hasLoadingIndicator ? 1 : 0);
+
     return ScrollablePositionedList.builder(
       itemScrollController: _itemScrollCtrl,
       itemPositionsListener: _itemPosListener,
@@ -616,24 +700,24 @@ class _ChatScreenState extends State<ChatScreen>
         if (_isCallEvent(event)) {
           return CallEventTile(
             event: event,
-            isMe: event.senderId == matrix.client.userID,
+            isMe: event.senderId == widget.matrix.client.userID,
             duration: _callDuration(event),
           );
         }
         final prevSender = i + 1 < events.length ? events[i + 1].senderId : null;
         return ChatMessageItem(
           event: event,
-          isMe: event.senderId == matrix.client.userID,
+          isMe: event.senderId == widget.matrix.client.userID,
           isFirst: event.senderId != prevSender,
           isMobile: isMobile,
           timeline: _timeline,
-          client: matrix.client,
-          highlightedEventId: _search.highlightedEventId,
+          client: widget.matrix.client,
+          highlightedEventId: widget.highlightedEventId,
           receiptMap: receiptMap,
-          onReply: _setReplyTo,
-          onEdit: _setEditEvent,
-          onToggleReaction: _actions.toggleReaction,
-          onPin: _actions.togglePin,
+          onReply: widget.onReply,
+          onEdit: (event) => widget.onEdit(event, _timeline),
+          onToggleReaction: widget.onToggleReaction,
+          onPin: widget.onPin,
           onTapReply: _navigateToEvent,
         );
       },

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:giphy_get/giphy_get.dart';
@@ -246,9 +244,12 @@ class _ChatScreenState extends State<ChatScreen>
         children: [
           _buildChatBody(matrix, room),
           if (_search.isSearching)
-            SearchResultsBody(
-              search: _search,
-              onTapResult: _scrollToEvent,
+            ColoredBox(
+              color: Theme.of(context).colorScheme.surface,
+              child: SearchResultsBody(
+                search: _search,
+                onTapResult: _scrollToEvent,
+              ),
             ),
         ],
       ),

--- a/lib/features/chat/widgets/compose_bar.dart
+++ b/lib/features/chat/widgets/compose_bar.dart
@@ -100,7 +100,6 @@ class _ComposeBarState extends State<ComposeBar> {
   void didUpdateWidget(ComposeBar old) {
     super.didUpdateWidget(old);
     if (old.room?.id != widget.room?.id) {
-      _mentionController?.removeListener(_onMentionChanged);
       _mentionController?.dispose();
       _initMentionController();
     }
@@ -117,14 +116,9 @@ class _ComposeBarState extends State<ComposeBar> {
         room: widget.room!,
         joinedRooms: widget.joinedRooms!,
       );
-      _mentionController!.addListener(_onMentionChanged);
     } else {
       _mentionController = null;
     }
-  }
-
-  void _onMentionChanged() {
-    if (mounted) setState(() {});
   }
 
   void _onTextChangedForTyping() {
@@ -142,7 +136,6 @@ class _ComposeBarState extends State<ComposeBar> {
   void dispose() {
     widget.controller.removeListener(_onTextChangedForTyping);
     _focusNode.removeListener(_onFocusChanged);
-    _mentionController?.removeListener(_onMentionChanged);
     _mentionController?.dispose();
     _ownedFocusNode?.dispose();
     super.dispose();
@@ -212,10 +205,6 @@ class _ComposeBarState extends State<ComposeBar> {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final showSuggestions = _mentionController != null &&
-        _mentionController!.isActive &&
-        _mentionController!.suggestions.isNotEmpty;
-
     return Container(
       padding: EdgeInsets.only(
         left: 12,
@@ -233,10 +222,19 @@ class _ComposeBarState extends State<ComposeBar> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (showSuggestions)
-            MentionSuggestionList(
-              controller: _mentionController!,
-              client: widget.room!.client,
+          if (_mentionController != null)
+            ListenableBuilder(
+              listenable: _mentionController!,
+              builder: (context, _) {
+                if (!_mentionController!.isActive ||
+                    _mentionController!.suggestions.isEmpty) {
+                  return const SizedBox.shrink();
+                }
+                return MentionSuggestionList(
+                  controller: _mentionController!,
+                  client: widget.room!.client,
+                );
+              },
             ),
           if (widget.editEvent != null)
             EditPreviewBanner(

--- a/lib/features/chat/widgets/html_message_text.dart
+++ b/lib/features/chat/widgets/html_message_text.dart
@@ -1,22 +1,10 @@
-import 'dart:async';
-
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:html/dom.dart' as dom;
 import 'package:html/parser.dart' as html_parser;
-import 'package:lattice/core/utils/emoji_spans.dart';
-import 'package:lattice/core/utils/media_auth.dart';
-import 'package:lattice/features/chat/widgets/code_block.dart';
-import 'package:lattice/features/chat/widgets/linkable_text.dart';
-import 'package:lattice/features/chat/widgets/mention_pill.dart';
+import 'package:lattice/features/chat/widgets/html_span_builder.dart';
+import 'package:lattice/features/chat/widgets/linkable_span_builder.dart';
 import 'package:matrix/matrix.dart';
-import 'package:url_launcher/url_launcher.dart';
 
-/// Renders Matrix HTML `formatted_body` as a styled [Text.rich] widget.
-///
-/// Supported tags: b, strong, i, em, s, del, strike, u, ins, code, pre,
-/// br, p, h1–h6, blockquote, ol, ul, li, a[href], mx-reply (stripped).
-/// Unsupported tags degrade gracefully — text content is preserved.
 class HtmlMessageText extends StatefulWidget {
   const HtmlMessageText({
     required this.html, required this.style, required this.isMe, super.key,
@@ -28,14 +16,8 @@ class HtmlMessageText extends StatefulWidget {
   final String html;
   final TextStyle? style;
   final bool isMe;
-
-  /// The room this message belongs to, used for resolving mention display names.
   final Room? room;
-
-  /// Optional maximum number of lines before truncating.
   final int? maxLines;
-
-  /// How to handle text overflow (defaults to clip).
   final TextOverflow? overflow;
 
   @override
@@ -43,10 +25,6 @@ class HtmlMessageText extends StatefulWidget {
 }
 
 class _HtmlMessageTextState extends State<HtmlMessageText> {
-  static final _matrixToRegex = RegExp(
-    r'^https://matrix\.to/#/([^?]+)',
-  );
-
   static final _mxReplyRegex = RegExp(
     '<mx-reply>.*?</mx-reply>',
     dotAll: true,
@@ -89,14 +67,27 @@ class _HtmlMessageTextState extends State<HtmlMessageText> {
       }
       _recognizers.clear();
 
+      final linkBuilder = LinkableSpanBuilder(
+        room: widget.room,
+        isMe: widget.isMe,
+        createRecognizer: _createRecognizer,
+      );
+      final spanBuilder = HtmlSpanBuilder(
+        isMe: widget.isMe,
+        client: widget.room?.client,
+        linkBuilder: linkBuilder,
+      );
+
       final cleaned = widget.html.replaceAll(_mxReplyRegex, '');
       final document = html_parser.parseFragment(cleaned);
 
       final spans = <InlineSpan>[];
       for (final node in document.nodes) {
-        _buildSpans(node, widget.style ?? const TextStyle(), linkColor, spans);
+        spanBuilder.buildSpans(
+          node, widget.style ?? const TextStyle(), linkColor, spans,
+        );
       }
-      _trimNewlines(spans);
+      HtmlSpanBuilder.trimNewlines(spans);
 
       _cachedSpans = spans;
       _cachedHtml = widget.html;
@@ -108,518 +99,6 @@ class _HtmlMessageTextState extends State<HtmlMessageText> {
       TextSpan(children: _cachedSpans),
       maxLines: widget.maxLines,
       overflow: widget.overflow ?? TextOverflow.clip,
-    );
-  }
-
-  void _buildSpans(
-    dom.Node node,
-    TextStyle currentStyle,
-    Color linkColor,
-    List<InlineSpan> spans,
-  ) {
-    if (node is dom.Text) {
-      _addTextWithLinks(node.text, currentStyle, linkColor, spans);
-      return;
-    }
-
-    if (node is! dom.Element) return;
-
-    final tag = node.localName?.toLowerCase() ?? '';
-
-    // Strip mx-reply entirely (belt-and-suspenders for DOM-level).
-    if (tag == 'mx-reply') return;
-
-    switch (tag) {
-      case 'br':
-        spans.add(const TextSpan(text: '\n'));
-        return;
-
-      case 'p':
-        if (spans.isNotEmpty) {
-          spans.add(const TextSpan(text: '\n\n'));
-        }
-        for (final child in node.nodes) {
-          _buildSpans(child, currentStyle, linkColor, spans);
-        }
-        return;
-
-      case 'h1':
-      case 'h2':
-      case 'h3':
-      case 'h4':
-      case 'h5':
-      case 'h6':
-        if (spans.isNotEmpty) {
-          spans.add(const TextSpan(text: '\n\n'));
-        }
-        final level = int.parse(tag.substring(1));
-        final scale = 1.0 + (7 - level) * 0.1; // h1=1.6, h2=1.5, ..., h6=1.1
-        final headingStyle = currentStyle.copyWith(
-          fontWeight: FontWeight.bold,
-          fontSize: (currentStyle.fontSize ?? 14) * scale,
-        );
-        for (final child in node.nodes) {
-          _buildSpans(child, headingStyle, linkColor, spans);
-        }
-        return;
-
-      case 'blockquote':
-        if (spans.isNotEmpty) {
-          spans.add(const TextSpan(text: '\n'));
-        }
-        final quoteSpans = <InlineSpan>[];
-        final quoteStyle = currentStyle.copyWith(fontStyle: FontStyle.italic);
-        for (final child in node.nodes) {
-          _buildSpans(child, quoteStyle, linkColor, quoteSpans);
-        }
-        _trimNewlines(quoteSpans);
-        spans.add(WidgetSpan(
-          child: Container(
-            decoration: BoxDecoration(
-              border: Border(
-                left: BorderSide(
-                  color: linkColor,
-                  width: 3,
-                ),
-              ),
-            ),
-            padding: const EdgeInsets.only(left: 8),
-            child: Text.rich(TextSpan(children: quoteSpans)),
-          ),
-        ),);
-        return;
-
-      case 'ol':
-      case 'ul':
-        if (spans.isNotEmpty) {
-          spans.add(const TextSpan(text: '\n'));
-        }
-        var index = 1;
-        for (final child in node.nodes) {
-          if (child is dom.Element && child.localName == 'li') {
-            final prefix = tag == 'ol' ? '${index++}. ' : '• ';
-            spans.add(TextSpan(text: prefix, style: currentStyle));
-            for (final liChild in child.nodes) {
-              _buildSpans(liChild, currentStyle, linkColor, spans);
-            }
-            spans.add(const TextSpan(text: '\n'));
-          }
-        }
-        return;
-
-      case 'b':
-      case 'strong':
-        final bold = currentStyle.copyWith(fontWeight: FontWeight.bold);
-        for (final child in node.nodes) {
-          _buildSpans(child, bold, linkColor, spans);
-        }
-        return;
-
-      case 'i':
-      case 'em':
-        final italic = currentStyle.copyWith(fontStyle: FontStyle.italic);
-        for (final child in node.nodes) {
-          _buildSpans(child, italic, linkColor, spans);
-        }
-        return;
-
-      case 's':
-      case 'del':
-      case 'strike':
-        final strike = currentStyle.copyWith(
-          decoration: TextDecoration.lineThrough,
-        );
-        for (final child in node.nodes) {
-          _buildSpans(child, strike, linkColor, spans);
-        }
-        return;
-
-      case 'u':
-      case 'ins':
-        final underline = currentStyle.copyWith(
-          decoration: TextDecoration.underline,
-        );
-        for (final child in node.nodes) {
-          _buildSpans(child, underline, linkColor, spans);
-        }
-        return;
-
-      case 'pre':
-        if (spans.isNotEmpty) {
-          spans.add(const TextSpan(text: '\n'));
-        }
-        String? language;
-        var codeText = node.text;
-        for (final child in node.nodes) {
-          if (child is dom.Element && child.localName == 'code') {
-            final cls = child.attributes['class'] ?? '';
-            final langMatch = RegExp(r'language-(\w+)').firstMatch(cls);
-            language = langMatch?.group(1);
-            codeText = child.text;
-            break;
-          }
-        }
-        spans.add(WidgetSpan(
-          child: CodeBlock(code: codeText, language: language, isMe: widget.isMe),
-        ),);
-        return;
-
-      case 'code':
-        final bgColor = widget.isMe
-            ? Colors.black.withValues(alpha: 0.15)
-            : currentStyle.color?.withValues(alpha: 0.08) ??
-                Colors.grey.withValues(alpha: 0.08);
-        spans.add(WidgetSpan(
-          alignment: PlaceholderAlignment.middle,
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
-            decoration: BoxDecoration(
-              color: bgColor,
-              borderRadius: BorderRadius.circular(4),
-            ),
-            child: Text(
-              node.text,
-              style: currentStyle.copyWith(
-                fontFamily: 'monospace',
-                fontSize: (currentStyle.fontSize ?? 14) * 0.9,
-              ),
-            ),
-          ),
-        ),);
-        return;
-
-      case 'a':
-        final href = node.attributes['href'];
-        if (href != null && href.isNotEmpty) {
-          // Check for matrix.to mention links.
-          final mentionMatch = _matrixToRegex.firstMatch(href);
-          if (mentionMatch != null) {
-            final identifier =
-                Uri.decodeComponent(mentionMatch.group(1)!);
-            final pill = _buildMentionPill(identifier, currentStyle);
-            if (pill != null) {
-              spans.add(WidgetSpan(
-                alignment: PlaceholderAlignment.middle,
-                child: pill,
-              ),);
-              return;
-            }
-          }
-
-          final aStyle = currentStyle.copyWith(
-            color: linkColor,
-            decoration: TextDecoration.underline,
-            decorationColor: linkColor,
-          );
-          final text = node.text;
-          spans.add(TextSpan(
-            text: text,
-            style: aStyle,
-            recognizer: _createRecognizer(() {
-              final uri = Uri.tryParse(href);
-              if (uri != null) {
-                unawaited(launchUrl(uri, mode: LaunchMode.externalApplication));
-              }
-            }),
-          ),);
-          return;
-        }
-        // No href — just render children.
-        for (final child in node.nodes) {
-          _buildSpans(child, currentStyle, linkColor, spans);
-        }
-        return;
-
-      case 'img':
-        final src = node.attributes['src'] ?? '';
-        final alt = node.attributes['alt'] ?? '';
-        final isCustomEmoji =
-            node.attributes.containsKey('data-mx-emoticon');
-
-        if (src.isEmpty) {
-          if (alt.isNotEmpty) {
-            spans.add(TextSpan(text: alt, style: currentStyle));
-          }
-          return;
-        }
-
-        final client = widget.room?.client;
-
-        if (isCustomEmoji) {
-          final emojiSize = (currentStyle.fontSize ?? 14) * 1.4;
-          spans.add(WidgetSpan(
-            alignment: PlaceholderAlignment.middle,
-            child: _MxcImage(
-              mxcUrl: src,
-              client: client,
-              width: emojiSize,
-              height: emojiSize,
-              fallbackText: alt.isNotEmpty ? alt : ':emoji:',
-              fallbackStyle: currentStyle,
-            ),
-          ),);
-        } else {
-          spans.add(WidgetSpan(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(vertical: 4),
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(8),
-                child: ConstrainedBox(
-                  constraints:
-                      const BoxConstraints(maxWidth: 256, maxHeight: 256),
-                  child: _MxcImage(
-                    mxcUrl: src,
-                    client: client,
-                    fallbackText: alt.isNotEmpty ? alt : '[image]',
-                    fallbackStyle: currentStyle,
-                  ),
-                ),
-              ),
-            ),
-          ),);
-        }
-        return;
-
-      default:
-        // Unsupported tag — just render children (text content preserved).
-        for (final child in node.nodes) {
-          _buildSpans(child, currentStyle, linkColor, spans);
-        }
-    }
-  }
-
-  /// Builds a [MentionPill] for a Matrix identifier, or returns null if
-  /// the identifier is not a recognized mention format.
-  Widget? _buildMentionPill(String identifier, TextStyle currentStyle) {
-    if (identifier.startsWith('@')) {
-      // User mention.
-      final displayName = widget.room
-              ?.unsafeGetUserFromMemoryOrFallback(identifier)
-              .displayName ??
-          identifier;
-      return MentionPill(
-        displayName: displayName,
-        matrixId: identifier,
-        type: MentionType.user,
-        isMe: widget.isMe,
-        style: currentStyle,
-      );
-    } else if (identifier.startsWith('!') || identifier.startsWith('#')) {
-      // Room mention (room ID or alias).
-      const type = MentionType.room;
-      String displayName;
-      if (identifier.startsWith('#')) {
-        // Alias — show it directly (without the leading #, MentionPill adds it).
-        displayName = identifier.substring(1);
-      } else {
-        // Room ID — try to resolve a local display name.
-        final resolved = widget.room?.client.getRoomById(identifier);
-        displayName =
-            resolved?.getLocalizedDisplayname() ?? identifier;
-      }
-      return MentionPill(
-        displayName: displayName,
-        matrixId: identifier,
-        type: type,
-        isMe: widget.isMe,
-        style: currentStyle,
-      );
-    }
-    return null;
-  }
-
-  /// Adds text with auto-linked URLs, reusing [LinkableText]'s regex.
-  void _addTextWithLinks(
-    String text,
-    TextStyle currentStyle,
-    Color linkColor,
-    List<InlineSpan> spans,
-  ) {
-    final matches = LinkableText.urlRegex.allMatches(text).toList();
-    if (matches.isEmpty) {
-      spans.addAll(buildEmojiSpans(text, currentStyle));
-      return;
-    }
-
-    var lastEnd = 0;
-    for (final match in matches) {
-      final rawUrl = match.group(0)!;
-      final cleanedUrl = LinkableText.cleanUrl(rawUrl);
-      final urlEnd = match.start + cleanedUrl.length;
-
-      if (match.start > lastEnd) {
-        spans.addAll(
-            buildEmojiSpans(text.substring(lastEnd, match.start), currentStyle),);
-      }
-
-      spans.add(TextSpan(
-        text: cleanedUrl,
-        style: currentStyle.copyWith(
-          color: linkColor,
-          decoration: TextDecoration.underline,
-          decorationColor: linkColor,
-        ),
-        recognizer: _createRecognizer(() {
-          final uri = Uri.tryParse(cleanedUrl);
-          if (uri != null) {
-            unawaited(launchUrl(uri, mode: LaunchMode.externalApplication));
-          }
-        }),
-      ),);
-
-      lastEnd = urlEnd;
-    }
-
-    if (lastEnd < text.length) {
-      spans.addAll(buildEmojiSpans(text.substring(lastEnd), currentStyle));
-    }
-  }
-
-  /// Trim leading and trailing newline-only TextSpans.
-  void _trimNewlines(List<InlineSpan> spans) {
-    while (spans.isNotEmpty) {
-      final first = spans.first;
-      if (first is TextSpan && first.text != null) {
-        final trimmed = first.text!.replaceAll(RegExp(r'^\n+'), '');
-        if (trimmed.isEmpty) {
-          spans.removeAt(0);
-        } else if (trimmed != first.text) {
-          spans[0] = TextSpan(text: trimmed, style: first.style);
-          break;
-        } else {
-          break;
-        }
-      } else {
-        break;
-      }
-    }
-    while (spans.isNotEmpty) {
-      final last = spans.last;
-      if (last is TextSpan && last.text != null) {
-        final trimmed = last.text!.replaceAll(RegExp(r'\n+$'), '');
-        if (trimmed.isEmpty) {
-          spans.removeLast();
-        } else if (trimmed != last.text) {
-          spans[spans.length - 1] = TextSpan(text: trimmed, style: last.style);
-          break;
-        } else {
-          break;
-        }
-      } else {
-        break;
-      }
-    }
-  }
-}
-
-// ── MXC image loader ─────────────────────────────────────────
-
-/// Resolves an mxc:// URI asynchronously and displays the image.
-class _MxcImage extends StatefulWidget {
-  const _MxcImage({
-    required this.mxcUrl,
-    required this.client,
-    required this.fallbackText, required this.fallbackStyle, this.width,
-    this.height,
-  });
-
-  final String mxcUrl;
-  final Client? client;
-  final double? width;
-  final double? height;
-  final String fallbackText;
-  final TextStyle? fallbackStyle;
-
-  @override
-  State<_MxcImage> createState() => _MxcImageState();
-}
-
-class _MxcImageState extends State<_MxcImage> {
-  String? _resolvedUrl;
-  bool _loading = true;
-
-  @override
-  void initState() {
-    super.initState();
-    unawaited(_resolve());
-  }
-
-  @override
-  void didUpdateWidget(_MxcImage old) {
-    super.didUpdateWidget(old);
-    if (old.mxcUrl != widget.mxcUrl) {
-      unawaited(_resolve());
-    }
-  }
-
-  Future<void> _resolve() async {
-    final src = widget.mxcUrl;
-    final client = widget.client;
-
-    if (!src.startsWith('mxc://') || client == null) {
-      // Not an mxc URI — use directly (e.g. https://).
-      if (mounted) {
-        setState(() {
-          _resolvedUrl = src.startsWith('http') ? src : null;
-          _loading = false;
-        });
-      }
-      return;
-    }
-
-    final mxc = Uri.tryParse(src);
-    if (mxc == null) {
-      if (mounted) setState(() => _loading = false);
-      return;
-    }
-
-    try {
-      final useThumb = widget.width != null && widget.width! <= 96;
-      final Uri uri;
-      if (useThumb) {
-        uri = await mxc.getThumbnailUri(
-          client,
-          width: 48,
-          height: 48,
-          method: ThumbnailMethod.scale,
-        );
-      } else {
-        uri = await mxc.getDownloadUri(client);
-      }
-      if (mounted) {
-        setState(() {
-          _resolvedUrl = uri.toString();
-          _loading = false;
-        });
-      }
-    } catch (e) {
-      debugPrint('[Lattice] Failed to resolve mxc image: $e');
-      if (mounted) setState(() => _loading = false);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (_loading) {
-      return SizedBox(
-        width: widget.width,
-        height: widget.height,
-      );
-    }
-
-    if (_resolvedUrl == null) {
-      return Text(widget.fallbackText, style: widget.fallbackStyle);
-    }
-
-    return Image.network(
-      _resolvedUrl!,
-      width: widget.width,
-      height: widget.height,
-      headers: widget.client != null
-          ? mediaAuthHeaders(widget.client!, _resolvedUrl!)
-          : null,
-      errorBuilder: (_, __, ___) =>
-          Text(widget.fallbackText, style: widget.fallbackStyle),
     );
   }
 }

--- a/lib/features/chat/widgets/html_message_text.dart
+++ b/lib/features/chat/widgets/html_message_text.dart
@@ -54,6 +54,11 @@ class _HtmlMessageTextState extends State<HtmlMessageText> {
 
   final _recognizers = <TapGestureRecognizer>[];
 
+  List<InlineSpan>? _cachedSpans;
+  String? _cachedHtml;
+  TextStyle? _cachedStyle;
+  Color? _cachedLinkColor;
+
   @override
   void dispose() {
     for (final r in _recognizers) {
@@ -70,31 +75,37 @@ class _HtmlMessageTextState extends State<HtmlMessageText> {
 
   @override
   Widget build(BuildContext context) {
-    // Dispose previous recognizers before rebuilding.
-    for (final r in _recognizers) {
-      r.dispose();
-    }
-    _recognizers.clear();
-
     final cs = Theme.of(context).colorScheme;
     final linkColor = widget.isMe
         ? cs.onPrimary.withValues(alpha: 0.85)
         : cs.primary;
 
-    // Strip mx-reply blocks before parsing.
-    final cleaned = widget.html.replaceAll(_mxReplyRegex, '');
-    final document = html_parser.parseFragment(cleaned);
+    if (_cachedSpans == null ||
+        _cachedHtml != widget.html ||
+        _cachedStyle != widget.style ||
+        _cachedLinkColor != linkColor) {
+      for (final r in _recognizers) {
+        r.dispose();
+      }
+      _recognizers.clear();
 
-    final spans = <InlineSpan>[];
-    for (final node in document.nodes) {
-      _buildSpans(node, widget.style ?? const TextStyle(), linkColor, spans);
+      final cleaned = widget.html.replaceAll(_mxReplyRegex, '');
+      final document = html_parser.parseFragment(cleaned);
+
+      final spans = <InlineSpan>[];
+      for (final node in document.nodes) {
+        _buildSpans(node, widget.style ?? const TextStyle(), linkColor, spans);
+      }
+      _trimNewlines(spans);
+
+      _cachedSpans = spans;
+      _cachedHtml = widget.html;
+      _cachedStyle = widget.style;
+      _cachedLinkColor = linkColor;
     }
 
-    // Trim leading/trailing newlines.
-    _trimNewlines(spans);
-
     return Text.rich(
-      TextSpan(children: spans),
+      TextSpan(children: _cachedSpans),
       maxLines: widget.maxLines,
       overflow: widget.overflow ?? TextOverflow.clip,
     );

--- a/lib/features/chat/widgets/html_span_builder.dart
+++ b/lib/features/chat/widgets/html_span_builder.dart
@@ -1,0 +1,298 @@
+import 'package:flutter/material.dart';
+import 'package:html/dom.dart' as dom;
+import 'package:lattice/features/chat/widgets/code_block.dart';
+import 'package:lattice/features/chat/widgets/linkable_span_builder.dart';
+import 'package:lattice/shared/widgets/mxc_image.dart';
+import 'package:matrix/matrix.dart';
+
+class HtmlSpanBuilder {
+  HtmlSpanBuilder({
+    required this.isMe,
+    required this.client,
+    required this.linkBuilder,
+  });
+
+  final bool isMe;
+  final Client? client;
+  final LinkableSpanBuilder linkBuilder;
+
+  void buildSpans(
+    dom.Node node,
+    TextStyle currentStyle,
+    Color linkColor,
+    List<InlineSpan> spans,
+  ) {
+    if (node is dom.Text) {
+      linkBuilder.addTextWithLinks(node.text, currentStyle, linkColor, spans);
+      return;
+    }
+
+    if (node is! dom.Element) return;
+
+    final tag = node.localName?.toLowerCase() ?? '';
+
+    if (tag == 'mx-reply') return;
+
+    switch (tag) {
+      case 'br':
+        spans.add(const TextSpan(text: '\n'));
+        return;
+
+      case 'p':
+        if (spans.isNotEmpty) {
+          spans.add(const TextSpan(text: '\n\n'));
+        }
+        for (final child in node.nodes) {
+          buildSpans(child, currentStyle, linkColor, spans);
+        }
+        return;
+
+      case 'h1':
+      case 'h2':
+      case 'h3':
+      case 'h4':
+      case 'h5':
+      case 'h6':
+        if (spans.isNotEmpty) {
+          spans.add(const TextSpan(text: '\n\n'));
+        }
+        final level = int.parse(tag.substring(1));
+        final scale = 1.0 + (7 - level) * 0.1;
+        final headingStyle = currentStyle.copyWith(
+          fontWeight: FontWeight.bold,
+          fontSize: (currentStyle.fontSize ?? 14) * scale,
+        );
+        for (final child in node.nodes) {
+          buildSpans(child, headingStyle, linkColor, spans);
+        }
+        return;
+
+      case 'blockquote':
+        if (spans.isNotEmpty) {
+          spans.add(const TextSpan(text: '\n'));
+        }
+        final quoteSpans = <InlineSpan>[];
+        final quoteStyle = currentStyle.copyWith(fontStyle: FontStyle.italic);
+        for (final child in node.nodes) {
+          buildSpans(child, quoteStyle, linkColor, quoteSpans);
+        }
+        trimNewlines(quoteSpans);
+        spans.add(WidgetSpan(
+          child: Container(
+            decoration: BoxDecoration(
+              border: Border(
+                left: BorderSide(
+                  color: linkColor,
+                  width: 3,
+                ),
+              ),
+            ),
+            padding: const EdgeInsets.only(left: 8),
+            child: Text.rich(TextSpan(children: quoteSpans)),
+          ),
+        ),);
+        return;
+
+      case 'ol':
+      case 'ul':
+        if (spans.isNotEmpty) {
+          spans.add(const TextSpan(text: '\n'));
+        }
+        var index = 1;
+        for (final child in node.nodes) {
+          if (child is dom.Element && child.localName == 'li') {
+            final prefix = tag == 'ol' ? '${index++}. ' : '• ';
+            spans.add(TextSpan(text: prefix, style: currentStyle));
+            for (final liChild in child.nodes) {
+              buildSpans(liChild, currentStyle, linkColor, spans);
+            }
+            spans.add(const TextSpan(text: '\n'));
+          }
+        }
+        return;
+
+      case 'b':
+      case 'strong':
+        final bold = currentStyle.copyWith(fontWeight: FontWeight.bold);
+        for (final child in node.nodes) {
+          buildSpans(child, bold, linkColor, spans);
+        }
+        return;
+
+      case 'i':
+      case 'em':
+        final italic = currentStyle.copyWith(fontStyle: FontStyle.italic);
+        for (final child in node.nodes) {
+          buildSpans(child, italic, linkColor, spans);
+        }
+        return;
+
+      case 's':
+      case 'del':
+      case 'strike':
+        final strike = currentStyle.copyWith(
+          decoration: TextDecoration.lineThrough,
+        );
+        for (final child in node.nodes) {
+          buildSpans(child, strike, linkColor, spans);
+        }
+        return;
+
+      case 'u':
+      case 'ins':
+        final underline = currentStyle.copyWith(
+          decoration: TextDecoration.underline,
+        );
+        for (final child in node.nodes) {
+          buildSpans(child, underline, linkColor, spans);
+        }
+        return;
+
+      case 'pre':
+        if (spans.isNotEmpty) {
+          spans.add(const TextSpan(text: '\n'));
+        }
+        String? language;
+        var codeText = node.text;
+        for (final child in node.nodes) {
+          if (child is dom.Element && child.localName == 'code') {
+            final cls = child.attributes['class'] ?? '';
+            final langMatch = RegExp(r'language-(\w+)').firstMatch(cls);
+            language = langMatch?.group(1);
+            codeText = child.text;
+            break;
+          }
+        }
+        spans.add(WidgetSpan(
+          child: CodeBlock(code: codeText, language: language, isMe: isMe),
+        ),);
+        return;
+
+      case 'code':
+        final bgColor = isMe
+            ? Colors.black.withValues(alpha: 0.15)
+            : currentStyle.color?.withValues(alpha: 0.08) ??
+                Colors.grey.withValues(alpha: 0.08);
+        spans.add(WidgetSpan(
+          alignment: PlaceholderAlignment.middle,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+            decoration: BoxDecoration(
+              color: bgColor,
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              node.text,
+              style: currentStyle.copyWith(
+                fontFamily: 'monospace',
+                fontSize: (currentStyle.fontSize ?? 14) * 0.9,
+              ),
+            ),
+          ),
+        ),);
+        return;
+
+      case 'a':
+        linkBuilder.addAnchor(
+          node, currentStyle, linkColor, spans,
+          buildSpans: buildSpans,
+        );
+        return;
+
+      case 'img':
+        _buildImage(node, currentStyle, spans);
+        return;
+
+      default:
+        for (final child in node.nodes) {
+          buildSpans(child, currentStyle, linkColor, spans);
+        }
+    }
+  }
+
+  void _buildImage(
+    dom.Element node,
+    TextStyle currentStyle,
+    List<InlineSpan> spans,
+  ) {
+    final src = node.attributes['src'] ?? '';
+    final alt = node.attributes['alt'] ?? '';
+    final isCustomEmoji = node.attributes.containsKey('data-mx-emoticon');
+
+    if (src.isEmpty) {
+      if (alt.isNotEmpty) {
+        spans.add(TextSpan(text: alt, style: currentStyle));
+      }
+      return;
+    }
+
+    if (isCustomEmoji) {
+      final emojiSize = (currentStyle.fontSize ?? 14) * 1.4;
+      spans.add(WidgetSpan(
+        alignment: PlaceholderAlignment.middle,
+        child: MxcImage(
+          mxcUrl: src,
+          client: client,
+          width: emojiSize,
+          height: emojiSize,
+          fallbackText: alt.isNotEmpty ? alt : ':emoji:',
+          fallbackStyle: currentStyle,
+        ),
+      ),);
+    } else {
+      spans.add(WidgetSpan(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: ConstrainedBox(
+              constraints:
+                  const BoxConstraints(maxWidth: 256, maxHeight: 256),
+              child: MxcImage(
+                mxcUrl: src,
+                client: client,
+                fallbackText: alt.isNotEmpty ? alt : '[image]',
+                fallbackStyle: currentStyle,
+              ),
+            ),
+          ),
+        ),
+      ),);
+    }
+  }
+
+  static void trimNewlines(List<InlineSpan> spans) {
+    while (spans.isNotEmpty) {
+      final first = spans.first;
+      if (first is TextSpan && first.text != null) {
+        final trimmed = first.text!.replaceAll(RegExp(r'^\n+'), '');
+        if (trimmed.isEmpty) {
+          spans.removeAt(0);
+        } else if (trimmed != first.text) {
+          spans[0] = TextSpan(text: trimmed, style: first.style);
+          break;
+        } else {
+          break;
+        }
+      } else {
+        break;
+      }
+    }
+    while (spans.isNotEmpty) {
+      final last = spans.last;
+      if (last is TextSpan && last.text != null) {
+        final trimmed = last.text!.replaceAll(RegExp(r'\n+$'), '');
+        if (trimmed.isEmpty) {
+          spans.removeLast();
+        } else if (trimmed != last.text) {
+          spans[spans.length - 1] = TextSpan(text: trimmed, style: last.style);
+          break;
+        } else {
+          break;
+        }
+      } else {
+        break;
+      }
+    }
+  }
+}

--- a/lib/features/chat/widgets/linkable_span_builder.dart
+++ b/lib/features/chat/widgets/linkable_span_builder.dart
@@ -1,0 +1,153 @@
+import 'dart:async';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:html/dom.dart' as dom;
+import 'package:lattice/core/utils/emoji_spans.dart';
+import 'package:lattice/features/chat/widgets/linkable_text.dart';
+import 'package:lattice/features/chat/widgets/mention_pill.dart';
+import 'package:matrix/matrix.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+typedef RecognizerFactory = TapGestureRecognizer Function(VoidCallback onTap);
+
+class LinkableSpanBuilder {
+  LinkableSpanBuilder({
+    required this.room,
+    required this.isMe,
+    required this.createRecognizer,
+  });
+
+  final Room? room;
+  final bool isMe;
+  final RecognizerFactory createRecognizer;
+
+  static final _matrixToRegex = RegExp(
+    r'^https://matrix\.to/#/([^?]+)',
+  );
+
+  void addTextWithLinks(
+    String text,
+    TextStyle currentStyle,
+    Color linkColor,
+    List<InlineSpan> spans,
+  ) {
+    final matches = LinkableText.urlRegex.allMatches(text).toList();
+    if (matches.isEmpty) {
+      spans.addAll(buildEmojiSpans(text, currentStyle));
+      return;
+    }
+
+    var lastEnd = 0;
+    for (final match in matches) {
+      final rawUrl = match.group(0)!;
+      final cleanedUrl = LinkableText.cleanUrl(rawUrl);
+      final urlEnd = match.start + cleanedUrl.length;
+
+      if (match.start > lastEnd) {
+        spans.addAll(
+            buildEmojiSpans(text.substring(lastEnd, match.start), currentStyle),);
+      }
+
+      spans.add(TextSpan(
+        text: cleanedUrl,
+        style: currentStyle.copyWith(
+          color: linkColor,
+          decoration: TextDecoration.underline,
+          decorationColor: linkColor,
+        ),
+        recognizer: createRecognizer(() {
+          final uri = Uri.tryParse(cleanedUrl);
+          if (uri != null) {
+            unawaited(launchUrl(uri, mode: LaunchMode.externalApplication));
+          }
+        }),
+      ),);
+
+      lastEnd = urlEnd;
+    }
+
+    if (lastEnd < text.length) {
+      spans.addAll(buildEmojiSpans(text.substring(lastEnd), currentStyle));
+    }
+  }
+
+  void addAnchor(
+    dom.Element node,
+    TextStyle currentStyle,
+    Color linkColor,
+    List<InlineSpan> spans, {
+    required void Function(dom.Node, TextStyle, Color, List<InlineSpan>) buildSpans,
+  }
+  ) {
+    final href = node.attributes['href'];
+    if (href != null && href.isNotEmpty) {
+      final mentionMatch = _matrixToRegex.firstMatch(href);
+      if (mentionMatch != null) {
+        final identifier = Uri.decodeComponent(mentionMatch.group(1)!);
+        final pill = buildMentionPill(identifier, currentStyle);
+        if (pill != null) {
+          spans.add(WidgetSpan(
+            alignment: PlaceholderAlignment.middle,
+            child: pill,
+          ),);
+          return;
+        }
+      }
+
+      final aStyle = currentStyle.copyWith(
+        color: linkColor,
+        decoration: TextDecoration.underline,
+        decorationColor: linkColor,
+      );
+      final text = node.text;
+      spans.add(TextSpan(
+        text: text,
+        style: aStyle,
+        recognizer: createRecognizer(() {
+          final uri = Uri.tryParse(href);
+          if (uri != null) {
+            unawaited(launchUrl(uri, mode: LaunchMode.externalApplication));
+          }
+        }),
+      ),);
+      return;
+    }
+    for (final child in node.nodes) {
+      buildSpans(child, currentStyle, linkColor, spans);
+    }
+  }
+
+  Widget? buildMentionPill(String identifier, TextStyle currentStyle) {
+    if (identifier.startsWith('@')) {
+      final displayName = room
+              ?.unsafeGetUserFromMemoryOrFallback(identifier)
+              .displayName ??
+          identifier;
+      return MentionPill(
+        displayName: displayName,
+        matrixId: identifier,
+        type: MentionType.user,
+        isMe: isMe,
+        style: currentStyle,
+      );
+    } else if (identifier.startsWith('!') || identifier.startsWith('#')) {
+      const type = MentionType.room;
+      String displayName;
+      if (identifier.startsWith('#')) {
+        displayName = identifier.substring(1);
+      } else {
+        final resolved = room?.client.getRoomById(identifier);
+        displayName = resolved?.getLocalizedDisplayname() ?? identifier;
+      }
+      return MentionPill(
+        displayName: displayName,
+        matrixId: identifier,
+        type: type,
+        isMe: isMe,
+        style: currentStyle,
+      );
+    }
+    return null;
+  }
+}

--- a/lib/features/chat/widgets/mention_autocomplete_controller.dart
+++ b/lib/features/chat/widgets/mention_autocomplete_controller.dart
@@ -48,6 +48,7 @@ class MentionAutocompleteController extends ChangeNotifier {
   final TextEditingController textController;
   final Room room;
   final List<Room> joinedRooms;
+  @visibleForTesting
   final Duration debounceDuration;
 
   static final _specialCharsRegex = RegExp(r'[^\w.-]');

--- a/lib/features/chat/widgets/mention_autocomplete_controller.dart
+++ b/lib/features/chat/widgets/mention_autocomplete_controller.dart
@@ -40,6 +40,7 @@ class MentionAutocompleteController extends ChangeNotifier {
     required this.textController,
     required this.room,
     required this.joinedRooms,
+    this.debounceDuration = const Duration(milliseconds: 150),
   }) {
     textController.addListener(_onTextChanged);
   }
@@ -47,9 +48,11 @@ class MentionAutocompleteController extends ChangeNotifier {
   final TextEditingController textController;
   final Room room;
   final List<Room> joinedRooms;
+  final Duration debounceDuration;
 
   static final _specialCharsRegex = RegExp(r'[^\w.-]');
 
+  Timer? _debounce;
   bool _isActive = false;
   bool _disposed = false;
   MentionTriggerType? _triggerType;
@@ -128,7 +131,12 @@ class MentionAutocompleteController extends ChangeNotifier {
     _isActive = true;
     _selectedIndex = 0;
 
-    _updateSuggestions();
+    _debounce?.cancel();
+    if (debounceDuration == Duration.zero) {
+      _updateSuggestions();
+    } else {
+      _debounce = Timer(debounceDuration, _updateSuggestions);
+    }
   }
 
   // ── Filtering ──────────────────────────────────────────────
@@ -263,6 +271,7 @@ class MentionAutocompleteController extends ChangeNotifier {
   void dismiss() => _dismiss();
 
   void _dismiss() {
+    _debounce?.cancel();
     if (!_isActive) return;
     _isActive = false;
     _triggerType = null;
@@ -275,6 +284,7 @@ class MentionAutocompleteController extends ChangeNotifier {
 
   @override
   void dispose() {
+    _debounce?.cancel();
     _disposed = true;
     textController.removeListener(_onTextChanged);
     super.dispose();

--- a/lib/features/chat/widgets/message_list_view.dart
+++ b/lib/features/chat/widgets/message_list_view.dart
@@ -1,0 +1,390 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:lattice/core/services/matrix_service.dart';
+import 'package:lattice/core/services/preferences_service.dart';
+import 'package:lattice/core/utils/platform_info.dart';
+import 'package:lattice/features/calling/models/call_constants.dart';
+import 'package:lattice/features/chat/widgets/call_event_tile.dart';
+import 'package:lattice/features/chat/widgets/chat_message_item.dart';
+import 'package:lattice/features/chat/widgets/read_receipts.dart';
+import 'package:matrix/matrix.dart';
+import 'package:provider/provider.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+
+class MessageListView extends StatefulWidget {
+  const MessageListView({
+    required this.room,
+    required this.matrix,
+    required this.onReply,
+    required this.onEdit,
+    required this.onToggleReaction,
+    required this.onPin,
+    required this.onHighlight,
+    this.initialEventId,
+    this.highlightedEventId,
+    super.key,
+  });
+
+  final Room room;
+  final MatrixService matrix;
+  final String? initialEventId;
+  final String? highlightedEventId;
+  final void Function(Event event) onReply;
+  final void Function(Event event, Timeline? timeline) onEdit;
+  final Future<void> Function(Event event, String emoji) onToggleReaction;
+  final Future<void> Function(Event event) onPin;
+  final void Function(String eventId) onHighlight;
+
+  @override
+  State<MessageListView> createState() => MessageListViewState();
+}
+
+class MessageListViewState extends State<MessageListView> {
+  static const _historyLoadThreshold = 15;
+  static const _scrollAnimationDuration = Duration(milliseconds: 400);
+  static const _readMarkerDelay = Duration(seconds: 1);
+
+  final _itemScrollCtrl = ItemScrollController();
+  final _itemPosListener = ItemPositionsListener.create();
+  Timeline? _timeline;
+  bool _loadingHistory = false;
+  Timer? _readMarkerTimer;
+  int _initGeneration = 0;
+  List<Event>? _cachedVisibleEvents;
+
+  Timeline? get timeline => _timeline;
+
+  @override
+  void initState() {
+    super.initState();
+    _itemPosListener.itemPositions.addListener(_onScroll);
+    unawaited(_initTimeline());
+  }
+
+  @override
+  void didUpdateWidget(MessageListView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.room.id != widget.room.id ||
+        oldWidget.initialEventId != widget.initialEventId) {
+      _timeline?.cancelSubscriptions();
+      _readMarkerTimer?.cancel();
+      _cachedVisibleEvents = null;
+      unawaited(_initTimeline());
+    }
+  }
+
+  // ── Timeline ───────────────────────────────────────────
+
+  Future<void> _initTimeline() async {
+    final gen = ++_initGeneration;
+    _timeline = await widget.room.getTimeline(
+      eventContextId: widget.initialEventId,
+      onUpdate: () {
+        if (mounted) {
+          _cachedVisibleEvents = null;
+          setState(() {});
+        }
+        _markAsRead();
+      },
+    );
+    if (gen != _initGeneration) return;
+    if (mounted) setState(() {});
+    _markAsRead();
+    _requestMissingKeys();
+    if (widget.initialEventId != null) _jumpToEvent(widget.initialEventId!);
+  }
+
+  void _requestMissingKeys() {
+    final encryption = widget.room.client.encryption;
+    if (encryption == null) return;
+
+    final events = _timeline?.events;
+    if (events == null) return;
+
+    final requested = <String>{};
+    for (final event in events) {
+      if (event.type == EventTypes.Encrypted &&
+          event.messageType == MessageTypes.BadEncrypted) {
+        final sessionId = event.content.tryGet<String>('session_id');
+        final senderKey = event.content.tryGet<String>('sender_key');
+        if (sessionId != null && requested.add(sessionId)) {
+          unawaited(
+            encryption.keyManager.loadSingleKey(widget.room.id, sessionId).catchError(
+              (Object e) {
+                debugPrint('[Lattice] Key load failed for $sessionId: $e');
+              },
+            ),
+          );
+          if (senderKey != null) {
+            try {
+              encryption.keyManager.maybeAutoRequest(
+                widget.room.id,
+                sessionId,
+                senderKey,
+              );
+            } catch (e) {
+              debugPrint('[Lattice] P2P key request failed for $sessionId: $e');
+            }
+          }
+        }
+      }
+    }
+  }
+
+  List<Event> get _visibleEvents {
+    if (_cachedVisibleEvents != null) return _cachedVisibleEvents!;
+    final events = _timeline?.events;
+    if (events == null) return [];
+    _cachedVisibleEvents = events
+        .where((e) =>
+            ((e.type == EventTypes.Message || e.type == EventTypes.Encrypted) &&
+                e.relationshipType != RelationshipTypes.edit &&
+                !_isCallMemberEvent(e)) ||
+            callEventTypes.contains(e.type),)
+        .toList();
+    return _cachedVisibleEvents!;
+  }
+
+  void _markAsRead() {
+    _readMarkerTimer?.cancel();
+    _readMarkerTimer = Timer(_readMarkerDelay, () async {
+      if (!mounted) return;
+      final lastEvent = widget.room.lastEvent;
+      if (lastEvent != null && widget.room.notificationCount > 0) {
+        try {
+          final sendPublic = context.read<PreferencesService>().readReceipts;
+          await widget.room.setReadMarker(
+            lastEvent.eventId,
+            mRead: sendPublic ? lastEvent.eventId : null,
+          );
+        } catch (e) {
+          debugPrint('[Lattice] Failed to mark as read: $e');
+        }
+      }
+    });
+  }
+
+  // ── Scroll & history ───────────────────────────────────
+
+  void _onScroll() {
+    final positions = _itemPosListener.itemPositions.value;
+    if (positions.isEmpty) return;
+    final maxIndex = positions.map((p) => p.index).reduce((a, b) => a > b ? a : b);
+    if (maxIndex >= _visibleEvents.length - _historyLoadThreshold && !_loadingHistory) {
+      unawaited(_loadMore());
+    }
+  }
+
+  Future<void> _loadMore() async {
+    if (_timeline == null || !_timeline!.canRequestHistory || _loadingHistory) {
+      return;
+    }
+    setState(() => _loadingHistory = true);
+    try {
+      while (mounted && _timeline!.canRequestHistory) {
+        await _timeline!.requestHistory();
+        _cachedVisibleEvents = null;
+        final positions = _itemPosListener.itemPositions.value;
+        if (positions.isEmpty) break;
+        final maxIndex =
+            positions.map((p) => p.index).reduce((a, b) => a > b ? a : b);
+        if (maxIndex < _visibleEvents.length - _historyLoadThreshold) break;
+      }
+    } catch (e) {
+      debugPrint('[Lattice] Failed to load history: $e');
+    } finally {
+      if (mounted) setState(() => _loadingHistory = false);
+    }
+  }
+
+  // ── Navigation ─────────────────────────────────────────
+
+  void navigateToEvent(Event event) {
+    unawaited(_navigateToEvent(event));
+  }
+
+  Future<void> _navigateToEvent(Event event) async {
+    final index = _visibleEvents.indexWhere((e) => e.eventId == event.eventId);
+    if (index == -1) {
+      debugPrint(
+        '[Lattice] Event not in loaded timeline, reloading: ${event.eventId}',
+      );
+      await _reloadTimelineAt(event.eventId);
+      return;
+    }
+    _scrollToIndex(index, event.eventId);
+  }
+
+  Future<void> _reloadTimelineAt(String eventId) async {
+    _timeline?.cancelSubscriptions();
+    _cachedVisibleEvents = null;
+    setState(() => _timeline = null);
+
+    final gen = ++_initGeneration;
+    _timeline = await widget.room.getTimeline(
+      eventContextId: eventId,
+      onUpdate: () {
+        if (mounted) {
+          _cachedVisibleEvents = null;
+          setState(() {});
+        }
+        _markAsRead();
+      },
+    );
+    if (gen != _initGeneration || !mounted) return;
+    setState(() {});
+    _jumpToEvent(eventId);
+  }
+
+  void _jumpToEvent(String eventId) {
+    final index = _visibleEvents.indexWhere((e) => e.eventId == eventId);
+    if (index == -1) {
+      debugPrint('[Lattice] Event not found after context load: $eventId');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Could not load the target message'),
+            duration: Duration(seconds: 2),
+          ),
+        );
+      }
+      return;
+    }
+    _scrollToIndex(index, eventId);
+  }
+
+  void _scrollToIndex(int index, String eventId) {
+    widget.onHighlight(eventId);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_itemScrollCtrl.isAttached) {
+        unawaited(
+          _itemScrollCtrl.scrollTo(
+            index: index,
+            duration: _scrollAnimationDuration,
+            curve: Curves.easeInOut,
+            alignment: 0.5,
+          ),
+        );
+      }
+    });
+  }
+
+  // ── Helpers ────────────────────────────────────────────
+
+  static bool _isCallEvent(Event event) => callEventTypes.contains(event.type);
+
+  static bool _isCallMemberEvent(Event event) =>
+      event.type == kCallMember ||
+      event.type == kCallMemberMsc ||
+      event.body.contains(kCallMember) ||
+      event.body.contains(kCallMemberMsc);
+
+  Duration? _callDuration(Event event) {
+    if (event.type != kCallHangup) return null;
+    final reason = event.content.tryGet<String>('reason');
+    if (reason == 'invite_timeout') return null;
+
+    final hangupCallId = event.content.tryGet<String>('call_id');
+    final events = _timeline?.events;
+    if (events == null) return null;
+
+    Event? matchedInvite;
+    for (final e in events) {
+      if (e.type != kCallInvite) continue;
+      if (!e.originServerTs.isBefore(event.originServerTs)) continue;
+      if (hangupCallId != null &&
+          hangupCallId.isNotEmpty &&
+          e.content.tryGet<String>('call_id') == hangupCallId) {
+        matchedInvite = e;
+        break;
+      }
+      matchedInvite ??= e;
+    }
+
+    if (matchedInvite == null) return null;
+    final d = event.originServerTs.difference(matchedInvite.originServerTs);
+    if (d.isNegative || d.inHours >= 24) return null;
+    return d;
+  }
+
+  @override
+  void dispose() {
+    _itemPosListener.itemPositions.removeListener(_onScroll);
+    _readMarkerTimer?.cancel();
+    _timeline?.cancelSubscriptions();
+    super.dispose();
+  }
+
+  // ── Build ──────────────────────────────────────────────
+
+  @override
+  Widget build(BuildContext context) {
+    if (_timeline == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    final events = _visibleEvents;
+    if (events.isEmpty) {
+      final cs = Theme.of(context).colorScheme;
+      final tt = Theme.of(context).textTheme;
+      return Center(
+        child: Text(
+          'No messages yet.\nSay hello!',
+          textAlign: TextAlign.center,
+          style: tt.bodyMedium?.copyWith(
+            color: cs.onSurfaceVariant.withValues(alpha: 0.5),
+          ),
+        ),
+      );
+    }
+
+    final isMobile = isTouchDevice;
+    final showReceipts = context.watch<PreferencesService>().readReceipts;
+    final receiptMap = showReceipts
+        ? buildReceiptMap(widget.room, widget.matrix.client.userID)
+        : <String, List<Receipt>>{};
+    final hasLoadingIndicator = _loadingHistory;
+    final totalCount = events.length + (hasLoadingIndicator ? 1 : 0);
+
+    return ScrollablePositionedList.builder(
+      itemScrollController: _itemScrollCtrl,
+      itemPositionsListener: _itemPosListener,
+      reverse: true,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      itemCount: totalCount,
+      itemBuilder: (context, i) {
+        if (hasLoadingIndicator && i == totalCount - 1) {
+          return const Padding(
+            padding: EdgeInsets.symmetric(vertical: 16),
+            child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+          );
+        }
+        final event = events[i];
+        if (_isCallEvent(event)) {
+          return CallEventTile(
+            event: event,
+            isMe: event.senderId == widget.matrix.client.userID,
+            duration: _callDuration(event),
+          );
+        }
+        final prevSender = i + 1 < events.length ? events[i + 1].senderId : null;
+        return ChatMessageItem(
+          event: event,
+          isMe: event.senderId == widget.matrix.client.userID,
+          isFirst: event.senderId != prevSender,
+          isMobile: isMobile,
+          timeline: _timeline,
+          client: widget.matrix.client,
+          highlightedEventId: widget.highlightedEventId,
+          receiptMap: receiptMap,
+          onReply: widget.onReply,
+          onEdit: (event) => widget.onEdit(event, _timeline),
+          onToggleReaction: widget.onToggleReaction,
+          onPin: widget.onPin,
+          onTapReply: _navigateToEvent,
+        );
+      },
+    );
+  }
+}

--- a/lib/shared/widgets/mxc_image.dart
+++ b/lib/shared/widgets/mxc_image.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:lattice/core/utils/media_auth.dart';
+import 'package:matrix/matrix.dart';
+
+class MxcImage extends StatefulWidget {
+  const MxcImage({
+    required this.mxcUrl,
+    required this.client,
+    required this.fallbackText,
+    required this.fallbackStyle,
+    this.width,
+    this.height,
+    super.key,
+  });
+
+  final String mxcUrl;
+  final Client? client;
+  final double? width;
+  final double? height;
+  final String fallbackText;
+  final TextStyle? fallbackStyle;
+
+  @override
+  State<MxcImage> createState() => _MxcImageState();
+}
+
+class _MxcImageState extends State<MxcImage> {
+  String? _resolvedUrl;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_resolve());
+  }
+
+  @override
+  void didUpdateWidget(MxcImage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.mxcUrl != widget.mxcUrl) {
+      unawaited(_resolve());
+    }
+  }
+
+  Future<void> _resolve() async {
+    final src = widget.mxcUrl;
+    final client = widget.client;
+
+    if (!src.startsWith('mxc://') || client == null) {
+      if (mounted) {
+        setState(() {
+          _resolvedUrl = src.startsWith('http') ? src : null;
+          _loading = false;
+        });
+      }
+      return;
+    }
+
+    final mxc = Uri.tryParse(src);
+    if (mxc == null) {
+      if (mounted) setState(() => _loading = false);
+      return;
+    }
+
+    try {
+      final useThumb = widget.width != null && widget.width! <= 96;
+      final Uri uri;
+      if (useThumb) {
+        uri = await mxc.getThumbnailUri(
+          client,
+          width: 48,
+          height: 48,
+          method: ThumbnailMethod.scale,
+        );
+      } else {
+        uri = await mxc.getDownloadUri(client);
+      }
+      if (mounted) {
+        setState(() {
+          _resolvedUrl = uri.toString();
+          _loading = false;
+        });
+      }
+    } catch (e) {
+      debugPrint('[Lattice] Failed to resolve mxc image: $e');
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return SizedBox(
+        width: widget.width,
+        height: widget.height,
+      );
+    }
+
+    if (_resolvedUrl == null) {
+      return Text(widget.fallbackText, style: widget.fallbackStyle);
+    }
+
+    return Image.network(
+      _resolvedUrl!,
+      width: widget.width,
+      height: widget.height,
+      headers: widget.client != null
+          ? mediaAuthHeaders(widget.client!, _resolvedUrl!)
+          : null,
+      errorBuilder: (_, __, ___) =>
+          Text(widget.fallbackText, style: widget.fallbackStyle),
+    );
+  }
+}

--- a/test/widgets/chat/compose_bar_test.dart
+++ b/test/widgets/chat/compose_bar_test.dart
@@ -291,7 +291,7 @@ void main() {
       ),);
 
       await tester.enterText(find.byType(TextField), '@');
-      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 150));
 
       expect(find.byType(MentionSuggestionList), findsOneWidget);
     });
@@ -331,7 +331,7 @@ void main() {
       ),);
 
       await tester.enterText(find.byType(TextField), '@ali');
-      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 150));
 
       expect(find.byType(MentionSuggestionList), findsOneWidget);
 
@@ -352,7 +352,7 @@ void main() {
       ),);
 
       await tester.enterText(find.byType(TextField), '@');
-      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 150));
 
       // Tap on Alice suggestion.
       await tester.tap(find.text('Alice'));
@@ -370,7 +370,7 @@ void main() {
       ),);
 
       await tester.enterText(find.byType(TextField), '@');
-      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 150));
 
       expect(find.byType(MentionSuggestionList), findsOneWidget);
 

--- a/test/widgets/chat/mention_autocomplete_controller_test.dart
+++ b/test/widgets/chat/mention_autocomplete_controller_test.dart
@@ -75,6 +75,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -94,6 +95,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -112,6 +114,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -129,6 +132,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -146,6 +150,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -163,6 +168,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -182,6 +188,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -203,6 +210,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -222,6 +230,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -239,6 +248,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -258,6 +268,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -279,6 +290,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -304,6 +316,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -325,6 +338,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -344,6 +358,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -366,6 +381,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -387,6 +403,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -409,6 +426,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -429,6 +447,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -447,6 +466,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -468,6 +488,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -491,6 +512,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       expect(ctrl.hasSuggestions, isFalse);
@@ -522,6 +544,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -554,6 +577,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(
@@ -575,6 +599,7 @@ void main() {
         textController: textCtrl,
         room: mockRoom,
         joinedRooms: joinedRooms,
+        debounceDuration: Duration.zero,
       );
 
       textCtrl.value = const TextEditingValue(

--- a/web/index.html
+++ b/web/index.html
@@ -29,7 +29,7 @@
                 https://recaptcha.google.com/recaptcha/ blob:; 
      img-src 'self' data: https: blob:; 
      style-src 'self' 'unsafe-inline'; 
-     connect-src 'self' https:; 
+     connect-src 'self' https: wss:;
      font-src 'self' data:; 
      worker-src 'self' blob: 'wasm-unsafe-eval'; 
      object-src 'none'; 


### PR DESCRIPTION
## Summary

- Fix broken WebSocket calls: CSP `connect-src` was missing `wss:`, blocking all LiveKit connections
- Fix call auto-leave race: membership watcher ejected users before remote participants could join
- Fix iOS PWA typing lag: timeline sync events were rebuilding the compose bar on every sync
- Reduce mention autocomplete overhead: debounce filtering, scope suggestion UI rebuilds
- Cache HTML message spans to avoid redundant DOM parsing on message list rebuilds
- Split `HtmlMessageText` into single-responsibility components

## Changes

### Call fixes

**`web/index.html`** — Added `wss:` to CSP `connect-src`. Without it, LiveKit WebSocket connections were blocked with `NS_ERROR_CONTENT_BLOCKED`.

**`lib/core/services/call_service.dart`** — Fixed membership watcher race condition: `_onMembershipChanged` checked `!hasRemote` before any remote participant had joined, triggering immediate `leaveCall()`. Now tracks `_hadRemoteParticipant` and restricts auto-leave to DM rooms only.

### iOS PWA typing performance

**`lib/features/chat/widgets/message_list_view.dart`** (new) — Extracted `MessageListView` from `ChatScreen`. Timeline's `onUpdate` callback now calls `setState` only on the message list widget, not the entire chat screen. The compose bar is never part of a timeline-driven rebuild.

**`lib/features/chat/screens/chat_screen.dart`** — Communicates with `MessageListView` via `GlobalKey` for search navigation and timeline access. Uses `Stack` to keep the message list alive during search mode.

**`lib/features/chat/widgets/mention_autocomplete_controller.dart`** — Added 150ms debounce before filtering suggestions. Dismiss fires immediately (no delay).

**`lib/features/chat/widgets/compose_bar.dart`** — Removed `_onMentionChanged` / `setState`. Suggestion list is wrapped in a `ListenableBuilder` scoped to the mention controller — only the suggestion overlay rebuilds, not the entire compose bar.

### HTML message rendering

**`lib/features/chat/widgets/html_message_text.dart`** — Caches parsed `InlineSpan` list in state. Only re-parses when `html`, `style`, or `linkColor` actually changes. Refactored into a thin caching shell that delegates to extracted builders.

**`lib/features/chat/widgets/html_span_builder.dart`** (new) — Recursive DOM walker that maps HTML tags to `InlineSpan` lists.

**`lib/features/chat/widgets/linkable_span_builder.dart`** (new) — URL auto-linking with emoji spans and Matrix mention pill resolution.

**`lib/shared/widgets/mxc_image.dart`** (new) — Extracted `MxcImage` widget for resolving mxc:// URIs with auth headers.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 1471 tests pass
- [x] Join a group room voice chat — call remains active, not immediately ended
- [x] Initiate a 1:1 DM call — callee can accept without being dropped
- [x] Remote party hangs up DM call — local user auto-removed
- [x] Open a room on iOS PWA, type rapidly — no lag or dropped frames
- [x] Type `@` followed by characters — suggestions appear after ~150ms without stutter
- [x] Send a message from another client while typing — message appears without disrupting input
- [x] Toggle light/dark theme — HTML messages re-render with correct colors
- [x] Open room with formatted messages (bold, links, code blocks) — renders correctly