### PR TITLE
fix(web): defer push notifications to open app when visible

### DIFF
--- a/web/sw.js
+++ b/web/sw.js
@@ -28,26 +28,38 @@ self.addEventListener('push', function (event) {
   }
 
   event.waitUntil(
-    self.registration.showNotification(roomName, {
-      body: body,
-      icon: 'icons/Icon-192.png',
-      badge: 'icons/Icon-maskable-192.png',
-      tag: tag,
-      renotify: tag !== 'lattice-push',
-      data: data,
-      actions: [
-        { action: 'mark_read', title: 'Mark as read' },
-        { action: 'open', title: 'Open' },
-      ],
-    }).then(function () {
-      try {
-        if (self.navigator && self.navigator.setAppBadge && data.unreadCount) {
-          self.navigator.setAppBadge(data.unreadCount);
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true })
+      .then(function (clientList) {
+        var hasVisibleClient = clientList.some(function (c) {
+          return c.visibilityState === 'visible' || c.focused;
+        });
+        if (hasVisibleClient) {
+          // Open app will decrypt via matrix sync and post a
+          // 'show_notification' message with the real body.
+          return;
         }
-      } catch (e) {}
-    }).catch(function (e) {
-      console.error('[Lattice SW] showNotification failed:', e);
-    })
+        return self.registration.showNotification(roomName, {
+          body: body,
+          icon: 'icons/Icon-192.png',
+          badge: 'icons/Icon-maskable-192.png',
+          tag: tag,
+          renotify: tag !== 'lattice-push',
+          data: data,
+          actions: [
+            { action: 'mark_read', title: 'Mark as read' },
+            { action: 'open', title: 'Open' },
+          ],
+        }).then(function () {
+          try {
+            if (self.navigator && self.navigator.setAppBadge && data.unreadCount) {
+              self.navigator.setAppBadge(data.unreadCount);
+            }
+          } catch (e) {}
+        });
+      })
+      .catch(function (e) {
+        console.error('[Lattice SW] showNotification failed:', e);
+      })
   );
 });
 


### PR DESCRIPTION
## Summary
- Service worker push handler was showing fallback text (\`Cody: New message\`) for encrypted rooms, because it has no matrix SDK and cannot decrypt \`content.ciphertext\`.
- When the app is open and visible, \`notification_service.dart\` already decrypts the event via matrix sync and forwards the real body to the SW through \`showWebNotification\` -> \`postMessage\` (handled by \`sw.js\` \`message\` event, not \`push\`).
- This PR skips the SW \`push\` handler's \`showNotification\` call when a visible client exists. Fallback only fires when the app is closed or hidden — preserving the previous UX where decrypted content was always displayed for active users.

## Context
Previously hidden by a gateway-side dedup bug that dropped the web push POST when another pusher (e.g. iOS) had already delivered the same event_id. After fixing that dedup to be per-pushkey, the SW started firing for every event and overwrote the decrypted notification from the sync path (both use \`tag: roomId\`).

## Test plan
- [ ] Open web app, have another user send an encrypted message — notification shows decrypted body (sync path).
- [ ] Close/hide web app, receive an encrypted message — notification shows \`sender: New message\` fallback (SW push path).
- [ ] Open web app, receive an unencrypted message — still shows decrypted body.
- [ ] Badge count still updates correctly.