### PR TITLE
refactor: rename Lattice to Kohera + traefik deploy

### DIFF
--- a/assets/config/app_config.json
+++ b/assets/config/app_config.json
@@ -1,4 +1,5 @@
 {
   "defaultHomeserver": "quantum-matrix.xyz",
-  "apnsPushGatewayUrl": "http://matrix-push-gateway:7002/_matrix/push/v1/notify"
+  "apnsPushGatewayUrl": "https://push.quantum-matrix.xyz/_matrix/push/v1/notify",
+  "webPushGatewayUrl": "https://push.quantum-matrix.xyz/_matrix/push/v1/notify"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  kohera:
+    container_name: kohera
+    image: ghcr.io/quantumheart/kohera:latest
+    restart: unless-stopped
+    volumes:
+      - ./app_config.json:/srv/assets/assets/config/app_config.json:ro
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=traefik"
+      - "traefik.http.routers.kohera.rule=Host(`kohera.quantum-matrix.xyz`)"
+      - "traefik.http.routers.kohera.entrypoints=web-secure"
+      - "traefik.http.routers.kohera.tls=true"
+      - "traefik.http.routers.kohera.tls.certresolver=default"
+      - "traefik.http.services.kohera.loadbalancer.server.port=80"
+    networks:
+      - traefik
+
+networks:
+  traefik:
+    external: true

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -905,10 +905,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1670,18 +1670,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.15"
   timezone:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -905,10 +905,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1670,18 +1670,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.16"
   timezone:
     dependency: "direct dev"
     description:


### PR DESCRIPTION
## Summary
- Rename Lattice → Kohera across codebase, assets, platform configs, and tests
- Switch APNs/web push gateway URL to `https://push.quantum-matrix.xyz` and add VAPID key slot in `app_config.json`
- Add `docker-compose.yml` for traefik-fronted web deploy (`kohera.quantum-matrix.xyz`)

## Test plan
- [ ] `flutter analyze` clean
- [ ] `flutter test` passes (after `dart run build_runner build --delete-conflicting-outputs`)
- [ ] Web build boots behind traefik at `kohera.quantum-matrix.xyz`
- [ ] Push pusher registers against new gateway URL (APNs + web)
- [ ] Replace `REPLACE_WITH_VAPID_PUBLIC_KEY` before web push goes live