### PR TITLE
fix(web): defer push notifications to open app when visible

### DIFF
--- a/web/sw.js
+++ b/web/sw.js
@@ -28,26 +28,36 @@ self.addEventListener('push', function (event) {
   }
 
   event.waitUntil(
-    self.registration.showNotification(roomName, {
-      body: body,
-      icon: 'icons/Icon-192.png',
-      badge: 'icons/Icon-maskable-192.png',
-      tag: tag,
-      renotify: tag !== 'kohera-push',
-      data: data,
-      actions: [
-        { action: 'mark_read', title: 'Mark as read' },
-        { action: 'open', title: 'Open' },
-      ],
-    }).then(function () {
-      try {
-        if (self.navigator && self.navigator.setAppBadge && data.unreadCount) {
-          self.navigator.setAppBadge(data.unreadCount);
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true })
+      .then(function (clientList) {
+        var hasVisibleClient = clientList.some(function (c) {
+          return c.visibilityState === 'visible' || c.focused;
+        });
+        if (hasVisibleClient) {
+          return;
         }
-      } catch (e) {}
-    }).catch(function (e) {
-      console.error('[Kohera SW] showNotification failed:', e);
-    })
+        return self.registration.showNotification(roomName, {
+          body: body,
+          icon: 'icons/Icon-192.png',
+          badge: 'icons/Icon-maskable-192.png',
+          tag: tag,
+          renotify: tag !== 'kohera-push',
+          data: data,
+          actions: [
+            { action: 'mark_read', title: 'Mark as read' },
+            { action: 'open', title: 'Open' },
+          ],
+        }).then(function () {
+          try {
+            if (self.navigator && self.navigator.setAppBadge && data.unreadCount) {
+              self.navigator.setAppBadge(data.unreadCount);
+            }
+          } catch (e) {}
+        });
+      })
+      .catch(function (e) {
+        console.error('[Kohera SW] showNotification failed:', e);
+      })
   );
 });
 


### PR DESCRIPTION
## Summary
- SW `push` handler now checks `clients.matchAll()` and suppresses the generic fallback notification when a visible client exists.
- Open app decrypts the event via Matrix sync and posts `show_notification` to the SW with real title, body, and avatar — that path owns the UX when the PWA is open.
- Without this, master always shows `"New message" / "You have a new message"` (or a duplicate alongside the rich one) because the SW has no matrix SDK and cannot decrypt `content.ciphertext`.

## Context
Branch was created from `626f9e2` and never merged. Today's `4ed1b48` (Lattice → Kohera rename) landed on master without picking this up, causing the regression visible in the screenshot reports. Rebased onto current `origin/master` with the conflict resolved toward Kohera naming (`kohera-push` tag, `[Kohera SW]` log prefix).

## Test plan
- [x] Open PWA, send a message from another client → notification shows sender avatar and real body (postMessage path).
- [x] Close PWA, send a message → SW fallback shows `roomName` / generic body (no duplicate).
- [x] E2EE room with PWA open → real decrypted body is shown by the app path.
- [x] Click notification → routes via GoRouter to the room.