### PR TITLE
fix(web): defer SW push notification when client is visible

### DIFF
--- a/web/sw.js
+++ b/web/sw.js
@@ -28,26 +28,36 @@ self.addEventListener('push', function (event) {
   }
 
   event.waitUntil(
-    self.registration.showNotification(roomName, {
-      body: body,
-      icon: 'icons/Icon-192.png',
-      badge: 'icons/Icon-maskable-192.png',
-      tag: tag,
-      renotify: tag !== 'kohera-push',
-      data: data,
-      actions: [
-        { action: 'mark_read', title: 'Mark as read' },
-        { action: 'open', title: 'Open' },
-      ],
-    }).then(function () {
-      try {
-        if (self.navigator && self.navigator.setAppBadge && data.unreadCount) {
-          self.navigator.setAppBadge(data.unreadCount);
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true })
+      .then(function (clientList) {
+        var hasVisibleClient = clientList.some(function (c) {
+          return c.visibilityState === 'visible' || c.focused;
+        });
+        if (hasVisibleClient) {
+          return;
         }
-      } catch (e) {}
-    }).catch(function (e) {
-      console.error('[Kohera SW] showNotification failed:', e);
-    })
+        return self.registration.showNotification(roomName, {
+          body: body,
+          icon: 'icons/Icon-192.png',
+          badge: 'icons/Icon-maskable-192.png',
+          tag: tag,
+          renotify: tag !== 'kohera-push',
+          data: data,
+          actions: [
+            { action: 'mark_read', title: 'Mark as read' },
+            { action: 'open', title: 'Open' },
+          ],
+        }).then(function () {
+          try {
+            if (self.navigator && self.navigator.setAppBadge && data.unreadCount) {
+              self.navigator.setAppBadge(data.unreadCount);
+            }
+          } catch (e) {}
+        });
+      })
+      .catch(function (e) {
+        console.error('[Kohera SW] showNotification failed:', e);
+      })
   );
 });
 


### PR DESCRIPTION
## Summary
- SW `push` handler checks `clients.matchAll()` and skips the generic fallback notification when a visible/focused client exists.
- Open PWA's Matrix sync decrypts the event and posts `show_notification` to the SW with real body + avatar — that path now owns the UX without a competing generic notification.
- Closed or hidden-but-alive tabs still receive the SW fallback (the visible/focused check is deliberately narrow so a frozen/crashed tab doesn't silently swallow notifications).

## Context
Regression introduced by the Lattice → Kohera rename (`4ed1b48`), which branched from `626f9e2` and missed the deferral that existed on a separate unmerged branch. Supersedes #307 (rebased from the orphan branch with messy history); this PR is a clean commit off `origin/master`.

## Test plan
- [x] DevTools → Application → Service Workers → Push, with Kohera tab visible → no notification.
- [x] Same Push while on a different tab → rich notification from app sync (visible avatar + body).
- [x] Close PWA entirely, send a message → SW fallback shows generic text.
- [ ] E2EE room with PWA open → real decrypted body shown by the app path, no duplicate.