### PR TITLE
fix: show loader during homeserver screen fade-in

### DIFF
--- a/lib/features/auth/screens/homeserver_screen.dart
+++ b/lib/features/auth/screens/homeserver_screen.dart
@@ -106,115 +106,126 @@ class _HomeserverScreenState extends State<HomeserverScreen>
               ),
             )
           : null,
-      body: Center(
-        child: FadeTransition(
-          opacity: _fadeAnim,
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.symmetric(horizontal: 32),
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 380),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const AppLogoHeader(
-                    subtitle: 'Connect to the Matrix network',
-                  ),
-
-                  // ── Homeserver ──
-                  TextField(
-                    controller: _homeserverCtrl,
-                    enabled: !isChecking,
-                    decoration: InputDecoration(
-                      prefixIcon: Icon(Icons.dns_outlined,
-                          color: cs.onSurfaceVariant,),
-                      hintText: 'Homeserver',
-                      errorText: hasError ? _controller.error : null,
-                      suffixIcon: isChecking
-                          ? const Padding(
-                              padding: EdgeInsets.all(12),
-                              child: SizedBox(
-                                width: 20,
-                                height: 20,
-                                child:
-                                    CircularProgressIndicator(strokeWidth: 2),
-                              ),
-                            )
-                          : null,
-                    ),
-                    textInputAction: TextInputAction.done,
-                    onSubmitted: isChecking ? null : (_) => _continue(),
-                  ),
-                  const SizedBox(height: 4),
-
-                  // ── Set as default ──
-                  Transform.translate(
-                    offset: const Offset(-8, 0),
-                    child: GestureDetector(
-                      onTap: isChecking
-                          ? null
-                          : () => setState(
-                              () => _setAsDefault = !_setAsDefault,),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Checkbox.adaptive(
-                            value: _setAsDefault,
-                            visualDensity: VisualDensity.compact,
-                            materialTapTargetSize:
-                                MaterialTapTargetSize.shrinkWrap,
-                            splashRadius: 16,
-                            onChanged: isChecking
-                                ? null
-                                : (v) => setState(
-                                    () => _setAsDefault = v ?? false,),
-                          ),
-                          Text(
-                            'Set as default',
-                            style: Theme.of(context).textTheme.labelSmall
-                                ?.copyWith(color: cs.onSurfaceVariant),
-                          ),
-                        ],
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          FadeTransition(
+            opacity: ReverseAnimation(_fadeAnim),
+            child: const Center(child: CircularProgressIndicator()),
+          ),
+          Center(
+            child: FadeTransition(
+              opacity: _fadeAnim,
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.symmetric(horizontal: 32),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 380),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const AppLogoHeader(
+                        subtitle: 'Connect to the Matrix network',
                       ),
-                    ),
-                  ),
-                  const SizedBox(height: 8),
 
-                  // ── Continue button ──
-                  SizedBox(
-                    width: double.infinity,
-                    height: 52,
-                    child: FilledButton(
-                      onPressed: isChecking ? null : _continue,
-                      style: FilledButton.styleFrom(
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(16),
+                      // ── Homeserver ──
+                      TextField(
+                        controller: _homeserverCtrl,
+                        enabled: !isChecking,
+                        decoration: InputDecoration(
+                          prefixIcon: Icon(Icons.dns_outlined,
+                              color: cs.onSurfaceVariant,),
+                          hintText: 'Homeserver',
+                          errorText: hasError ? _controller.error : null,
+                          suffixIcon: isChecking
+                              ? const Padding(
+                                  padding: EdgeInsets.all(12),
+                                  child: SizedBox(
+                                    width: 20,
+                                    height: 20,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                    ),
+                                  ),
+                                )
+                              : null,
+                        ),
+                        textInputAction: TextInputAction.done,
+                        onSubmitted:
+                            isChecking ? null : (_) => _continue(),
+                      ),
+                      const SizedBox(height: 4),
+
+                      // ── Set as default ──
+                      Transform.translate(
+                        offset: const Offset(-8, 0),
+                        child: GestureDetector(
+                          onTap: isChecking
+                              ? null
+                              : () => setState(
+                                  () => _setAsDefault = !_setAsDefault,),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Checkbox.adaptive(
+                                value: _setAsDefault,
+                                visualDensity: VisualDensity.compact,
+                                materialTapTargetSize:
+                                    MaterialTapTargetSize.shrinkWrap,
+                                splashRadius: 16,
+                                onChanged: isChecking
+                                    ? null
+                                    : (v) => setState(
+                                        () => _setAsDefault = v ?? false,),
+                              ),
+                              Text(
+                                'Set as default',
+                                style: Theme.of(context).textTheme.labelSmall
+                                    ?.copyWith(color: cs.onSurfaceVariant),
+                              ),
+                            ],
+                          ),
                         ),
                       ),
-                      child: isChecking
-                          ? SizedBox(
-                              width: 22,
-                              height: 22,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2.5,
-                                color: cs.onPrimary,
-                              ),
-                            )
-                          : const Text('Continue'),
-                    ),
+                      const SizedBox(height: 8),
+
+                      // ── Continue button ──
+                      SizedBox(
+                        width: double.infinity,
+                        height: 52,
+                        child: FilledButton(
+                          onPressed: isChecking ? null : _continue,
+                          style: FilledButton.styleFrom(
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(16),
+                            ),
+                          ),
+                          child: isChecking
+                              ? SizedBox(
+                                  width: 22,
+                                  height: 22,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2.5,
+                                    color: cs.onPrimary,
+                                  ),
+                                )
+                              : const Text('Continue'),
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      TextButton(
+                        onPressed: _openRegistration,
+                        child: Text(
+                          'Create an account',
+                          style: TextStyle(color: cs.primary),
+                        ),
+                      ),
+                    ],
                   ),
-                  const SizedBox(height: 16),
-                  TextButton(
-                    onPressed: _openRegistration,
-                    child: Text(
-                      'Create an account',
-                      style: TextStyle(color: cs.primary),
-                    ),
-                  ),
-                ],
+                ),
               ),
             ),
           ),
-        ),
+        ],
       ),
     );
   }

--- a/lib/features/auth/screens/homeserver_screen.dart
+++ b/lib/features/auth/screens/homeserver_screen.dart
@@ -44,6 +44,7 @@ class _HomeserverScreenState extends State<HomeserverScreen>
       duration: const Duration(milliseconds: 800),
     );
     _fadeAnim = CurvedAnimation(parent: _fadeCtrl, curve: Curves.easeOut);
+    _fadeCtrl.addStatusListener(_onFadeStatus);
     unawaited(_fadeCtrl.forward());
 
     _controller = HomeserverController(
@@ -56,9 +57,14 @@ class _HomeserverScreenState extends State<HomeserverScreen>
   void dispose() {
     _controller.removeListener(_onControllerChanged);
     _controller.dispose();
+    _fadeCtrl.removeStatusListener(_onFadeStatus);
     _fadeCtrl.dispose();
     _homeserverCtrl.dispose();
     super.dispose();
+  }
+
+  void _onFadeStatus(AnimationStatus status) {
+    if (status == AnimationStatus.completed && mounted) setState(() {});
   }
 
   void _onControllerChanged() {
@@ -109,10 +115,11 @@ class _HomeserverScreenState extends State<HomeserverScreen>
       body: Stack(
         fit: StackFit.expand,
         children: [
-          FadeTransition(
-            opacity: ReverseAnimation(_fadeAnim),
-            child: const Center(child: CircularProgressIndicator()),
-          ),
+          if (!_fadeCtrl.isCompleted)
+            FadeTransition(
+              opacity: ReverseAnimation(_fadeAnim),
+              child: const Center(child: CircularProgressIndicator()),
+            ),
           Center(
             child: FadeTransition(
               opacity: _fadeAnim,

--- a/test/screens/homeserver_screen_test.dart
+++ b/test/screens/homeserver_screen_test.dart
@@ -130,6 +130,17 @@ void main() {
   }
 
   group('HomeserverScreen', () {
+    testWidgets('shows loader during fade-in then removes it', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    });
+
     testWidgets('shows subtitle and Continue button', (tester) async {
       await tester.pumpWidget(buildTestWidget());
       await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary

- Show a `CircularProgressIndicator` behind the homeserver form during the 800ms fade-in, eliminating the white flash on iOS (and other platforms).
- The spinner uses `ReverseAnimation` on the existing `_fadeCtrl` — no extra controller or dispose needed.
- Once the fade completes, a status listener triggers a rebuild that removes the spinner from the widget tree entirely, so it doesn't keep painting at opacity 0.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test test/screens/homeserver_screen_test.dart` — 11 tests pass
- [x] New test: loader visible at `pump(0)`, gone after `pumpAndSettle`
- [ ] Manual: cold-launch on iOS simulator — spinner visible briefly, form fades in smoothly, no white flash