### PR TITLE
feat: add admin registration token management and invite deep links

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <application
-        android:label="Kohera"
+        android:label="Lattice"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity
@@ -42,6 +42,12 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="lattice"/>
             </intent-filter>
         </activity>
         <service

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,26 +2,21 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSUserActivityTypes</key>
-	<array>
-		<string>INSendMessageIntent</string>
-	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>Kohera needs camera access for video calls.</string>
+	<string>Lattice needs camera access for video calls.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Kohera needs microphone access for voice and video calls.</string>
+	<string>Lattice needs microphone access for voice and video calls.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
-		<string>remote-notification</string>
 		<string>voip</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Kohera</string>
+	<string>Lattice</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -29,7 +24,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>kohera</string>
+	<string>lattice</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -61,6 +56,17 @@
 			</array>
 		</dict>
 	</dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>lattice</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>io.github.quantumheart.lattice</string>
+		</dict>
+	</array>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/lib/core/routing/route_names.dart
+++ b/lib/core/routing/route_names.dart
@@ -12,6 +12,7 @@ abstract class Routes {
   static const settingsNotifications = 'settings-notifications';
   static const settingsDevices = 'settings-devices';
   static const settingsVoiceVideo = 'settings-voice-video';
+  static const settingsAdmin = 'settings-admin';
   static const inbox = 'inbox';
   static const spaceDetails = 'space-details';
   static const call = 'call';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: kohera
+name: lattice
 description: A Flutter Matrix client with multiple adaptive layouts.
 publish_to: "none"
 version: 1.0.0+1
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   animations: ^2.0.11
+  app_links: ^6.3.3
   cached_network_image: ^3.3.1
   cached_network_image_platform_interface: ^4.0.0
   canonical_json: ^1.1.2


### PR DESCRIPTION
Adds end-to-end server invite workflow for Synapse admins:
- Admin check after login (probes Synapse admin API, caches isServerAdmin)
- Registration Tokens screen under Settings for creating, viewing, and
  revoking tokens with configurable expiry and usage limits
- Invite link generation with copyable landing page HTML for homeservers
- lattice:// custom URI scheme for deep linking (Android + iOS)
- Registration screen accepts pre-filled token from deep links
- SERVER ADMIN section in Settings only visible to admins

https://claude.ai/code/session_01Gu25gi3QishR4wNW3SXAKj