### PR TITLE
Invite deep links: recipient-side (kohera://) + share composer (#327)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -43,6 +43,12 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="kohera"/>
+            </intent-filter>
         </activity>
         <service
             android:name="de.julianassmann.flutter_background.IsolateHolderService"

--- a/docs/invite-landing.md
+++ b/docs/invite-landing.md
@@ -1,0 +1,143 @@
+# Invite landing page
+
+This doc shows homeserver admins how to host a short URL like
+`https://example.com/invite?server=example.com&token=abc123` that opens
+Kohera at the registration screen with the token pre-filled. It pairs
+with the `kohera://` URI scheme wired in the client.
+
+Pick **Option A** (nginx redirect) for most deployments. Fall back to
+**Option B** (HTML page) if your proxy strips non-HTTP redirects or you
+don't control the server-side redirect layer.
+
+## Option A — nginx 302 redirect (preferred)
+
+Simplest, no HTML, no JS. The token never enters any page DOM; the
+browser sees only a redirect header.
+
+```nginx
+# Serve at /invite on the homeserver vhost.
+location = /invite {
+    # Fall back to the current host if ?server= is omitted.
+    set $kohera_server $arg_server;
+    if ($kohera_server = "") {
+        set $kohera_server $host;
+    }
+
+    # Suppress intermediate caching of the invite URL.
+    add_header Cache-Control "no-store" always;
+
+    return 302 "kohera://register?server=$kohera_server&token=$arg_token";
+}
+```
+
+Test:
+
+```bash
+curl -sI 'https://example.com/invite?token=abc123' | grep -i location
+# Location: kohera://register?server=example.com&token=abc123
+```
+
+## Option B — static HTML landing
+
+Use this when Option A isn't available (restrictive proxies, managed
+hosting without redirect control). Any static-file host works.
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
+  <title>Opening Kohera…</title>
+</head>
+<body>
+  <noscript>
+    <p>JavaScript is required to continue. If Kohera does not open,
+      <a href="https://github.com/Quantumheart/kohera/releases">download it here</a>.</p>
+  </noscript>
+  <p id="fallback" style="display:none">
+    If Kohera does not open automatically,
+    <a href="https://github.com/Quantumheart/kohera/releases">download it here</a>.
+  </p>
+  <script>
+    (function () {
+      var params = new URLSearchParams(window.location.search);
+      var token = params.get('token');
+      var server = params.get('server') || window.location.hostname;
+      if (token) {
+        window.location.replace(
+          'kohera://register?server=' + encodeURIComponent(server) +
+          '&token=' + encodeURIComponent(token)
+        );
+        // If the scheme isn't registered, the page stays on screen;
+        // reveal the download link after a short delay.
+        setTimeout(function () {
+          document.getElementById('fallback').style.display = 'block';
+        }, 1500);
+      } else {
+        document.getElementById('fallback').style.display = 'block';
+      }
+    })();
+  </script>
+</body>
+</html>
+```
+
+Serve with a cache-discouraging header:
+
+```nginx
+location = /invite.html {
+    add_header Cache-Control "no-store" always;
+    try_files $uri =404;
+}
+location = /invite {
+    try_files /invite.html =404;
+}
+```
+
+Notes on the HTML:
+
+- `URLSearchParams.get` returns decoded values; `encodeURIComponent`
+  re-encodes them for the scheme URL.
+- The token is never written into the DOM — only passed through
+  `window.location.replace`.
+- `window.location.replace` doesn't push a new history entry.
+- `<meta name="robots">` keeps the page out of search indexes.
+
+## Web app direct link
+
+If you know the user is on `kohera-web`, skip the scheme entirely and
+link straight into the web app. GoRouter accepts `server` and `token`
+on the register route:
+
+```
+https://kohera.example/#/register?server=example.com&token=abc123
+```
+
+This avoids OS-level scheme prompts but only works for the web build.
+
+## Operational notes
+
+- **Use single-use tokens with a short TTL.** Synapse's
+  `/_synapse/admin/v1/registration_tokens` endpoint supports
+  `uses_allowed` and `expiry_time` — set both.
+- **The invite URL is in browser history.** Anyone who clicks the link
+  (or anything with access to their history) sees the token. Mitigate
+  with short TTLs; assume the URL is disclosed the moment it reaches a
+  browser.
+- **Don't log the URL.** Standard access logs capture query strings.
+  Configure nginx to drop query strings for `/invite`:
+
+  ```nginx
+  location = /invite {
+      access_log off;
+      # ... (rest of Option A config)
+  }
+  ```
+
+- **Scheme registration varies per OS.** The Kohera client registers
+  `kohera://` on install (Android manifest, iOS/macOS `CFBundleURLTypes`,
+  Linux `.desktop`). On Linux, users may need
+  `xdg-mime default io.github.quantumheart.kohera.desktop x-scheme-handler/kohera`
+  after install.

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -36,6 +36,19 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>io.github.quantumheart.kohera.invite</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kohera</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -85,10 +85,21 @@ GoRouter buildRouter(ClientManager manager) {
         path: '/register',
         name: Routes.register,
         builder: (context, state) {
-          final homeserver = state.extra as String? ??
+          final queryServer = state.uri.queryParameters['server']?.trim();
+          final queryToken = state.uri.queryParameters['token']?.trim();
+          final homeserver = (state.extra as String?) ??
+              (queryServer != null && queryServer.isNotEmpty
+                  ? queryServer
+                  : null) ??
               context.read<PreferencesService>().defaultHomeserver ??
               AppConfig.instance.defaultHomeserver;
-          return RegistrationScreen(initialHomeserver: homeserver);
+          final token =
+              queryToken != null && queryToken.isNotEmpty ? queryToken : null;
+          return RegistrationScreen(
+            key: ValueKey('register|$homeserver|$token'),
+            initialHomeserver: homeserver,
+            initialToken: token,
+          );
         },
       ),
 

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -140,6 +140,37 @@ GoRouter buildRouter(ClientManager manager) {
               );
             },
           ),
+          GoRoute(
+            path: 'register',
+            name: Routes.addAccountRegister,
+            builder: (context, state) {
+              final manager = context.read<ClientManager>();
+              final queryServer =
+                  state.uri.queryParameters['server']?.trim();
+              final queryToken = state.uri.queryParameters['token']?.trim();
+              final homeserver = (state.extra as String?) ??
+                  (queryServer != null && queryServer.isNotEmpty
+                      ? queryServer
+                      : null) ??
+                  context.read<PreferencesService>().defaultHomeserver ??
+                  AppConfig.instance.defaultHomeserver;
+              final token = queryToken != null && queryToken.isNotEmpty
+                  ? queryToken
+                  : null;
+              return _AddAccountGuard(
+                manager: manager,
+                child: ChangeNotifierProvider<MatrixService>.value(
+                  value: manager.pendingService!,
+                  child: RegistrationScreen(
+                    key: ValueKey('add-account-register|$homeserver|$token'),
+                    initialHomeserver: homeserver,
+                    initialToken: token,
+                    isAddAccount: true,
+                  ),
+                ),
+              );
+            },
+          ),
         ],
       ),
 

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -21,6 +21,7 @@ import 'package:kohera/features/settings/screens/appearance_screen.dart';
 import 'package:kohera/features/settings/screens/devices_screen.dart';
 import 'package:kohera/features/settings/screens/notification_settings_screen.dart';
 import 'package:kohera/features/settings/screens/settings_screen.dart';
+import 'package:kohera/features/settings/screens/share_invite_screen.dart';
 import 'package:kohera/features/settings/screens/voice_video_settings_screen.dart';
 import 'package:kohera/features/spaces/widgets/space_details_panel.dart';
 import 'package:provider/provider.dart';
@@ -277,6 +278,12 @@ GoRouter buildRouter(ClientManager manager) {
                     name: Routes.settingsVoiceVideo,
                     builder: (context, state) =>
                         const VoiceVideoSettingsScreen(),
+                  ),
+                  GoRoute(
+                    path: 'share-invite',
+                    name: Routes.settingsShareInvite,
+                    builder: (context, state) =>
+                        const ShareInviteScreen(),
                   ),
                 ],
               ),

--- a/lib/core/routing/route_names.dart
+++ b/lib/core/routing/route_names.dart
@@ -18,4 +18,5 @@ abstract class Routes {
   static const e2eeSetup = 'e2ee-setup';
   static const addAccount = 'add-account';
   static const addAccountServer = 'add-account-server';
+  static const addAccountRegister = 'add-account-register';
 }

--- a/lib/core/routing/route_names.dart
+++ b/lib/core/routing/route_names.dart
@@ -12,6 +12,7 @@ abstract class Routes {
   static const settingsNotifications = 'settings-notifications';
   static const settingsDevices = 'settings-devices';
   static const settingsVoiceVideo = 'settings-voice-video';
+  static const settingsShareInvite = 'settings-share-invite';
   static const inbox = 'inbox';
   static const spaceDetails = 'space-details';
   static const call = 'call';

--- a/lib/core/utils/log_scrubber.dart
+++ b/lib/core/utils/log_scrubber.dart
@@ -1,0 +1,37 @@
+const _sensitiveKeys = <String>{
+  'token',
+  'access_token',
+  'refresh_token',
+  'nonce',
+  'password',
+  'mac',
+};
+
+const _redacted = '***';
+
+/// Returns a deep copy of [input] with any value under a sensitive key
+/// replaced by `'***'`. Walks nested maps and lists. Primitives and
+/// non-collection objects pass through unchanged. Input is not mutated.
+///
+/// Key match is exact (not substring) after `toString().toLowerCase()`.
+/// Null values on sensitive keys are preserved as null.
+///
+/// No cycle detection — callers must not pass self-referential structures.
+Object? scrubSensitive(Object? input) {
+  if (input is Map) {
+    final out = <dynamic, dynamic>{};
+    input.forEach((key, value) {
+      final normalised = key.toString().toLowerCase();
+      if (_sensitiveKeys.contains(normalised)) {
+        out[key] = value == null ? null : _redacted;
+      } else {
+        out[key] = scrubSensitive(value);
+      }
+    });
+    return out;
+  }
+  if (input is List) {
+    return input.map(scrubSensitive).toList();
+  }
+  return input;
+}

--- a/lib/features/auth/screens/registration_screen.dart
+++ b/lib/features/auth/screens/registration_screen.dart
@@ -10,11 +10,12 @@ import 'package:kohera/features/auth/widgets/registration_views.dart';
 import 'package:provider/provider.dart';
 
 class RegistrationScreen extends StatefulWidget {
-  RegistrationScreen({super.key, String? initialHomeserver})
+  RegistrationScreen({super.key, String? initialHomeserver, this.initialToken})
       : initialHomeserver =
             initialHomeserver ?? AppConfig.instance.defaultHomeserver;
 
   final String initialHomeserver;
+  final String? initialToken;
 
   @override
   State<RegistrationScreen> createState() => _RegistrationScreenState();
@@ -26,7 +27,7 @@ class _RegistrationScreenState extends State<RegistrationScreen>
   final _usernameCtrl = TextEditingController();
   final _passwordCtrl = TextEditingController();
   final _confirmPasswordCtrl = TextEditingController();
-  final _tokenCtrl = TextEditingController();
+  late final TextEditingController _tokenCtrl;
 
   bool _obscurePassword = true;
   bool _obscureConfirmPassword = true;
@@ -42,6 +43,7 @@ class _RegistrationScreenState extends State<RegistrationScreen>
   void initState() {
     super.initState();
     _homeserverCtrl = TextEditingController(text: widget.initialHomeserver);
+    _tokenCtrl = TextEditingController(text: widget.initialToken ?? '');
     _fadeCtrl = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 800),

--- a/lib/features/auth/screens/registration_screen.dart
+++ b/lib/features/auth/screens/registration_screen.dart
@@ -324,8 +324,10 @@ class _RegistrationScreenState extends State<RegistrationScreen>
                     onPressed: () {
                       if (widget.isAddAccount) {
                         context.go('/add-account');
-                      } else {
+                      } else if (context.canPop()) {
                         context.pop();
+                      } else {
+                        context.go('/login');
                       }
                     },
                     child: Text(

--- a/lib/features/auth/screens/registration_screen.dart
+++ b/lib/features/auth/screens/registration_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kohera/core/services/app_config.dart';
+import 'package:kohera/core/services/client_manager.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/features/auth/widgets/app_logo_header.dart';
 import 'package:kohera/features/auth/widgets/registration_controller.dart';
@@ -10,12 +11,17 @@ import 'package:kohera/features/auth/widgets/registration_views.dart';
 import 'package:provider/provider.dart';
 
 class RegistrationScreen extends StatefulWidget {
-  RegistrationScreen({super.key, String? initialHomeserver, this.initialToken})
-      : initialHomeserver =
+  RegistrationScreen({
+    super.key,
+    String? initialHomeserver,
+    this.initialToken,
+    this.isAddAccount = false,
+  }) : initialHomeserver =
             initialHomeserver ?? AppConfig.instance.defaultHomeserver;
 
   final String initialHomeserver;
   final String? initialToken;
+  final bool isAddAccount;
 
   @override
   State<RegistrationScreen> createState() => _RegistrationScreenState();
@@ -83,8 +89,9 @@ class _RegistrationScreenState extends State<RegistrationScreen>
   void _onControllerChanged() {
     if (!mounted) return;
     if (_controller.state == RegistrationState.done) {
-      // Registration complete — the router's redirect will send us
-      // to '/' once MatrixService.isLoggedIn becomes true.
+      if (widget.isAddAccount) {
+        context.read<ClientManager>().commitPendingService();
+      }
       context.go('/');
       return;
     }
@@ -314,7 +321,13 @@ class _RegistrationScreenState extends State<RegistrationScreen>
                   ),
                   const SizedBox(height: 16),
                   TextButton(
-                    onPressed: () => context.pop(),
+                    onPressed: () {
+                      if (widget.isAddAccount) {
+                        context.go('/add-account');
+                      } else {
+                        context.pop();
+                      }
+                    },
                     child: Text(
                       'Already have an account? Sign in',
                       style: TextStyle(color: cs.primary),

--- a/lib/features/auth/services/deep_link_service.dart
+++ b/lib/features/auth/services/deep_link_service.dart
@@ -1,0 +1,110 @@
+import 'dart:async';
+
+import 'package:app_links/app_links.dart';
+import 'package:flutter/foundation.dart';
+
+// ── Intent types ──────────────────────────────────────────────
+
+sealed class DeepLinkIntent {
+  const DeepLinkIntent();
+}
+
+class RegisterInviteIntent extends DeepLinkIntent {
+  const RegisterInviteIntent({required this.server, required this.token});
+
+  final String server;
+  final String token;
+}
+
+// ── URI source abstraction ────────────────────────────────────
+
+abstract class DeepLinkSource {
+  Future<Uri?> getInitialLink();
+  Stream<Uri> get uriLinkStream;
+}
+
+class AppLinksSource implements DeepLinkSource {
+  AppLinksSource() : _impl = AppLinks();
+
+  final AppLinks _impl;
+
+  @override
+  Future<Uri?> getInitialLink() => _impl.getInitialLink();
+
+  @override
+  Stream<Uri> get uriLinkStream => _impl.uriLinkStream;
+}
+
+// ── Service ───────────────────────────────────────────────────
+
+class DeepLinkService extends ChangeNotifier {
+  DeepLinkService({DeepLinkSource? source, DateTime Function()? now})
+      : _source = source ?? AppLinksSource(),
+        _now = now ?? DateTime.now;
+
+  final DeepLinkSource _source;
+  final DateTime Function() _now;
+
+  StreamSubscription<Uri>? _sub;
+  final Map<String, DateTime> _recent = {};
+  static const _dedupWindow = Duration(seconds: 30);
+
+  DeepLinkIntent? _pending;
+  DeepLinkIntent? get pending => _pending;
+
+  bool _started = false;
+
+  Future<void> start() async {
+    if (_started) return;
+    _started = true;
+    try {
+      final initial = await _source.getInitialLink();
+      if (initial != null) _ingest(initial);
+    } catch (e) {
+      debugPrint('[Kohera] DeepLinkService getInitialLink failed: $e');
+    }
+    _sub = _source.uriLinkStream.listen(
+      _ingest,
+      onError: (Object e) =>
+          debugPrint('[Kohera] DeepLinkService stream error: $e'),
+    );
+  }
+
+  void _ingest(Uri uri) {
+    if (uri.scheme != 'kohera') return;
+
+    final key = uri.toString();
+    final now = _now();
+    final last = _recent[key];
+    if (last != null && now.difference(last) < _dedupWindow) return;
+    _recent[key] = now;
+    _recent.removeWhere((_, t) => now.difference(t) > _dedupWindow);
+
+    if (uri.host == 'register') {
+      final server = uri.queryParameters['server']?.trim() ?? '';
+      final token = uri.queryParameters['token']?.trim() ?? '';
+      if (server.isEmpty || token.isEmpty) {
+        debugPrint(
+          '[Kohera] Ignored invite deep link (missing server/token)',
+        );
+        return;
+      }
+      _pending = RegisterInviteIntent(server: server, token: token);
+      notifyListeners();
+    } else {
+      debugPrint('[Kohera] Ignored unknown deep-link host: ${uri.host}');
+    }
+  }
+
+  void consume() {
+    if (_pending == null) return;
+    _pending = null;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    unawaited(_sub?.cancel());
+    super.dispose();
+  }
+}

--- a/lib/features/auth/widgets/deep_link_listener.dart
+++ b/lib/features/auth/widgets/deep_link_listener.dart
@@ -104,7 +104,13 @@ class _DeepLinkListenerState extends State<DeepLinkListener> {
     if (confirmed != true || !mounted) return;
 
     final manager = context.read<ClientManager>();
-    await manager.createLoginService();
+    try {
+      await manager.createLoginService();
+    } catch (e) {
+      debugPrint('[Kohera] createLoginService failed: $e');
+      await _showAddAccountError();
+      return;
+    }
 
     if (!mounted) return;
     final uri = Uri(
@@ -112,6 +118,28 @@ class _DeepLinkListenerState extends State<DeepLinkListener> {
       queryParameters: {'server': intent.server, 'token': intent.token},
     );
     widget.router.go(uri.toString());
+  }
+
+  Future<void> _showAddAccountError() async {
+    final navContext =
+        widget.router.routerDelegate.navigatorKey.currentContext;
+    if (navContext == null) return;
+    await showDialog<void>(
+      context: navContext,
+      builder: (ctx) => AlertDialog(
+        title: const Text("Couldn't start new account"),
+        content: const Text(
+          'Something went wrong setting up a new account slot. Please '
+          'try the invite link again.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
   }
 
   @override

--- a/lib/features/auth/widgets/deep_link_listener.dart
+++ b/lib/features/auth/widgets/deep_link_listener.dart
@@ -1,0 +1,119 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kohera/core/services/client_manager.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/features/auth/services/deep_link_service.dart';
+import 'package:provider/provider.dart';
+
+class DeepLinkListener extends StatefulWidget {
+  const DeepLinkListener({
+    required this.service,
+    required this.router,
+    required this.child,
+    super.key,
+  });
+
+  final DeepLinkService service;
+  final GoRouter router;
+  final Widget child;
+
+  @override
+  State<DeepLinkListener> createState() => _DeepLinkListenerState();
+}
+
+class _DeepLinkListenerState extends State<DeepLinkListener> {
+  bool _handling = false;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.service.addListener(_onIntent);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(widget.service.start());
+    });
+  }
+
+  @override
+  void dispose() {
+    widget.service.removeListener(_onIntent);
+    super.dispose();
+  }
+
+  void _onIntent() {
+    if (widget.service.pending == null) return;
+    scheduleMicrotask(() {
+      if (!mounted) return;
+      unawaited(_handle());
+    });
+  }
+
+  Future<void> _handle() async {
+    if (_handling) return;
+    final intent = widget.service.pending;
+    if (intent is! RegisterInviteIntent) return;
+    _handling = true;
+    try {
+      final matrix = context.read<MatrixService>();
+      if (!matrix.isLoggedIn) {
+        _goRegister(intent);
+        return;
+      }
+      await _promptAddAccount(intent);
+    } finally {
+      widget.service.consume();
+      _handling = false;
+    }
+  }
+
+  void _goRegister(RegisterInviteIntent intent) {
+    final uri = Uri(
+      path: '/register',
+      queryParameters: {'server': intent.server, 'token': intent.token},
+    );
+    widget.router.go(uri.toString());
+  }
+
+  Future<void> _promptAddAccount(RegisterInviteIntent intent) async {
+    final navContext =
+        widget.router.routerDelegate.navigatorKey.currentContext;
+    if (navContext == null) return;
+    final confirmed = await showDialog<bool>(
+      context: navContext,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Use this invite?'),
+        content: Text(
+          'A registration invite for ${intent.server} was shared with '
+          'Kohera. Invite tokens are single-use — this one may be '
+          'invalidated if it expires or is used elsewhere.\n\n'
+          'Create a new account on ${intent.server}?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Create account'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    final manager = context.read<ClientManager>();
+    await manager.createLoginService();
+
+    if (!mounted) return;
+    final uri = Uri(
+      path: '/add-account/register',
+      queryParameters: {'server': intent.server, 'token': intent.token},
+    );
+    widget.router.go(uri.toString());
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/lib/features/home/widgets/narrow_layout.dart
+++ b/lib/features/home/widgets/narrow_layout.dart
@@ -56,6 +56,7 @@ class _NarrowLayoutState extends State<NarrowLayout> {
         name == Routes.settingsNotifications ||
         name == Routes.settingsDevices ||
         name == Routes.settingsVoiceVideo ||
+        name == Routes.settingsShareInvite ||
         name == Routes.spaceDetails;
   }
 

--- a/lib/features/home/widgets/wide_layout.dart
+++ b/lib/features/home/widgets/wide_layout.dart
@@ -123,6 +123,7 @@ class _WideLayoutState extends State<WideLayout> {
         name == Routes.settingsNotifications ||
         name == Routes.settingsDevices ||
         name == Routes.settingsVoiceVideo ||
+        name == Routes.settingsShareInvite ||
         name == Routes.spaces ||
         name == Routes.spaceDetails ||
         name == Routes.inbox) {

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -442,6 +442,24 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
           const SizedBox(height: 16),
 
+          // ── Invites ──
+          const SectionHeader(label: 'INVITES'),
+          Card(
+            child: Column(
+              children: [
+                _SettingsTile(
+                  icon: Icons.qr_code_2_rounded,
+                  title: 'Share an invite',
+                  subtitle:
+                      'Turn a registration token into a link or QR code',
+                  onTap: () => context.pushOrGo(Routes.settingsShareInvite),
+                ),
+              ],
+            ),
+          ),
+
+          const SizedBox(height: 16),
+
           // ── About ──
           const SectionHeader(label: 'ABOUT'),
           Card(

--- a/lib/features/settings/screens/share_invite_screen.dart
+++ b/lib/features/settings/screens/share_invite_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:kohera/core/services/matrix_service.dart';
@@ -62,7 +64,7 @@ class _ShareInviteScreenState extends State<ShareInviteScreen> {
     <a href="https://github.com/Quantumheart/kohera/releases">download it</a>.
   </p>
   <script>
-    window.location.replace(${_jsonString(_deepLink)});
+    window.location.replace(${_jsScriptSafeString(_deepLink)});
     setTimeout(function () {
       document.getElementById('fallback').style.display = 'block';
     }, 2500);
@@ -71,13 +73,12 @@ class _ShareInviteScreenState extends State<ShareInviteScreen> {
 </html>
 ''';
 
-  static String _jsonString(String s) {
-    final escaped = s
-        .replaceAll(r'\', r'\\')
-        .replaceAll("'", r"\'")
-        .replaceAll('\n', r'\n');
-    return "'$escaped'";
-  }
+  /// JSON-encodes [s] for embedding inside an HTML `<script>` block.
+  /// `jsonEncode` handles quote/backslash/control-char escaping; the extra
+  /// `</` → `<\/` replacement prevents the encoded string from prematurely
+  /// closing the surrounding `<script>` tag if [s] contains `</script>`.
+  static String _jsScriptSafeString(String s) =>
+      jsonEncode(s).replaceAll('</', r'<\/');
 
   Future<void> _copy(String value, String label) async {
     await Clipboard.setData(ClipboardData(text: value));

--- a/lib/features/settings/screens/share_invite_screen.dart
+++ b/lib/features/settings/screens/share_invite_screen.dart
@@ -1,0 +1,245 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:provider/provider.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+
+class ShareInviteScreen extends StatefulWidget {
+  const ShareInviteScreen({super.key});
+
+  @override
+  State<ShareInviteScreen> createState() => _ShareInviteScreenState();
+}
+
+class _ShareInviteScreenState extends State<ShareInviteScreen> {
+  late final TextEditingController _serverCtrl;
+  final _tokenCtrl = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    final host =
+        context.read<MatrixService>().client.homeserver?.host ?? '';
+    _serverCtrl = TextEditingController(text: host);
+    _serverCtrl.addListener(_onChanged);
+    _tokenCtrl.addListener(_onChanged);
+  }
+
+  @override
+  void dispose() {
+    _serverCtrl
+      ..removeListener(_onChanged)
+      ..dispose();
+    _tokenCtrl
+      ..removeListener(_onChanged)
+      ..dispose();
+    super.dispose();
+  }
+
+  void _onChanged() => setState(() {});
+
+  String get _server => _serverCtrl.text.trim();
+  String get _token => _tokenCtrl.text.trim();
+  bool get _ready => _server.isNotEmpty && _token.isNotEmpty;
+
+  String get _deepLink => Uri(
+        scheme: 'kohera',
+        host: 'register',
+        queryParameters: {'server': _server, 'token': _token},
+      ).toString();
+
+  String get _landingHtml => '''
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="robots" content="noindex,nofollow">
+  <title>Opening Kohera…</title>
+</head>
+<body>
+  <p id="fallback" style="display:none">
+    If Kohera does not open,
+    <a href="https://github.com/Quantumheart/kohera/releases">download it</a>.
+  </p>
+  <script>
+    window.location.replace(${_jsonString(_deepLink)});
+    setTimeout(function () {
+      document.getElementById('fallback').style.display = 'block';
+    }, 2500);
+  </script>
+</body>
+</html>
+''';
+
+  static String _jsonString(String s) {
+    final escaped = s
+        .replaceAll(r'\', r'\\')
+        .replaceAll("'", r"\'")
+        .replaceAll('\n', r'\n');
+    return "'$escaped'";
+  }
+
+  Future<void> _copy(String value, String label) async {
+    await Clipboard.setData(ClipboardData(text: value));
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('$label copied to clipboard')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Share an invite')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text(
+            'Paste a registration token obtained from your homeserver '
+            'admin. Kohera turns it into a link, QR code, or landing-page '
+            'snippet you can share. Nothing is sent or stored.',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _serverCtrl,
+            decoration: const InputDecoration(
+              labelText: 'Homeserver',
+              prefixIcon: Icon(Icons.dns_outlined),
+            ),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _tokenCtrl,
+            decoration: const InputDecoration(
+              labelText: 'Registration token',
+              prefixIcon: Icon(Icons.vpn_key_outlined),
+            ),
+          ),
+          const SizedBox(height: 24),
+          if (!_ready)
+            Card(
+              color: cs.surfaceContainerHighest,
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  'Enter a homeserver and token to generate outputs.',
+                  style: TextStyle(color: cs.onSurfaceVariant),
+                ),
+              ),
+            )
+          else ...[
+            _OutputCard(
+              icon: Icons.link,
+              title: 'Deep link',
+              value: _deepLink,
+              monospace: true,
+              onCopy: () => _copy(_deepLink, 'Link'),
+            ),
+            const SizedBox(height: 12),
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(Icons.qr_code_2),
+                        const SizedBox(width: 8),
+                        Text(
+                          'QR code',
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    Center(
+                      child: QrImageView(
+                        data: _deepLink,
+                        size: 220,
+                        backgroundColor: Colors.white,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            _OutputCard(
+              icon: Icons.code,
+              title: 'Landing-page HTML',
+              value: _landingHtml,
+              monospace: true,
+              onCopy: () => _copy(_landingHtml, 'HTML'),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _OutputCard extends StatelessWidget {
+  const _OutputCard({
+    required this.icon,
+    required this.title,
+    required this.value,
+    required this.onCopy,
+    this.monospace = false,
+  });
+
+  final IconData icon;
+  final String title;
+  final String value;
+  final VoidCallback onCopy;
+  final bool monospace;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(icon),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    title,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ),
+                IconButton(
+                  tooltip: 'Copy',
+                  icon: const Icon(Icons.copy),
+                  onPressed: onCopy,
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: cs.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: SelectableText(
+                value,
+                style: monospace
+                    ? const TextStyle(fontFamily: 'monospace', fontSize: 12)
+                    : null,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,7 +14,9 @@ import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/core/theme/kohera_theme.dart';
 import 'package:kohera/core/theme/theme_presets.dart';
 import 'package:kohera/core/utils/vodozemac_init.dart';
+import 'package:kohera/features/auth/services/deep_link_service.dart';
 import 'package:kohera/features/auth/services/sso_web_init.dart';
+import 'package:kohera/features/auth/widgets/deep_link_listener.dart';
 import 'package:kohera/features/calling/services/push_to_talk_service.dart';
 import 'package:kohera/features/calling/services/ringtone_service.dart';
 import 'package:kohera/features/calling/widgets/incoming_call_overlay.dart';
@@ -42,6 +44,7 @@ class _KoheraAppState extends State<KoheraApp> {
   ClientManager? _clientManager;
   PreferencesService? _preferencesService;
   GoRouter? _router;
+  DeepLinkService? _deepLinkService;
   Object? _initError;
   final _ringtoneService = RingtoneService();
 
@@ -74,6 +77,7 @@ class _KoheraAppState extends State<KoheraApp> {
         _clientManager = clientManager;
         _preferencesService = prefs;
         _router = buildRouter(clientManager);
+        _deepLinkService = DeepLinkService();
       });
     } catch (e) {
       debugPrint('[Kohera] Initialization failed: $e');
@@ -133,6 +137,9 @@ class _KoheraAppState extends State<KoheraApp> {
         ),
         ChangeNotifierProvider<PreferencesService>.value(
           value: _preferencesService!,
+        ),
+        ChangeNotifierProvider<DeepLinkService>.value(
+          value: _deepLinkService!,
         ),
         ChangeNotifierProvider(create: (_) => MediaPlaybackService()),
         Provider(
@@ -250,12 +257,15 @@ class _KoheraAppState extends State<KoheraApp> {
                           darkTheme: darkTheme,
                           themeMode: themeMode,
                           routerConfig: router,
-                          builder: (context, child) =>
-                              VerificationRequestListener(
+                          builder: (context, child) => DeepLinkListener(
+                            service: context.read<DeepLinkService>(),
                             router: router,
-                            child: IncomingCallOverlay(
+                            child: VerificationRequestListener(
                               router: router,
-                              child: child ?? const SizedBox.shrink(),
+                              child: IncomingCallOverlay(
+                                router: router,
+                                child: child ?? const SizedBox.shrink(),
+                              ),
                             ),
                           ),
                         ),

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -12,6 +12,7 @@
 #include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <flutter_webrtc/flutter_web_r_t_c_plugin.h>
+#include <gtk/gtk_plugin.h>
 #include <livekit_client/live_kit_plugin.h>
 #include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
 #include <media_kit_video/media_kit_video_plugin.h>
@@ -42,6 +43,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_webrtc_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterWebRTCPlugin");
   flutter_web_r_t_c_plugin_register_with_registrar(flutter_webrtc_registrar);
+  g_autoptr(FlPluginRegistrar) gtk_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
+  gtk_plugin_register_with_registrar(gtk_registrar);
   g_autoptr(FlPluginRegistrar) livekit_client_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "LiveKitPlugin");
   live_kit_plugin_register_with_registrar(livekit_client_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -9,6 +9,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
   flutter_secure_storage_linux
   flutter_webrtc
+  gtk
   livekit_client
   media_kit_libs_linux
   media_kit_video

--- a/linux/io.github.quantumheart.kohera.desktop
+++ b/linux/io.github.quantumheart.kohera.desktop
@@ -8,4 +8,4 @@ Terminal=false
 Type=Application
 Categories=Network;InstantMessaging;Chat;
 StartupWMClass=io.github.quantumheart.kohera
-MimeType=x-scheme-handler/matrix;
+MimeType=x-scheme-handler/matrix;x-scheme-handler/kohera;

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -22,6 +22,14 @@ static void first_frame_cb(MyApplication* self, FlView* view) {
 // Implements GApplication::activate.
 static void my_application_activate(GApplication* application) {
   MyApplication* self = MY_APPLICATION(application);
+
+  // Single-instance: present the existing window if any.
+  GList* windows = gtk_application_get_windows(GTK_APPLICATION(application));
+  if (windows) {
+    gtk_window_present(GTK_WINDOW(windows->data));
+    return;
+  }
+
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
@@ -96,7 +104,10 @@ static gboolean my_application_local_command_line(GApplication* application,
   g_application_activate(application);
   *exit_status = 0;
 
-  return TRUE;
+  // Return FALSE so GApplication's default handling continues and fires
+  // the `command-line` / `open` signals that app_links listens on for
+  // deep-link delivery.
+  return FALSE;
 }
 
 // Implements GApplication::startup.
@@ -142,7 +153,11 @@ MyApplication* my_application_new() {
   // the application to be recognized beyond its binary name.
   g_set_prgname(APPLICATION_ID);
 
-  return MY_APPLICATION(g_object_new(my_application_get_type(),
-                                     "application-id", APPLICATION_ID, "flags",
-                                     G_APPLICATION_NON_UNIQUE, nullptr));
+  // HANDLES_COMMAND_LINE routes URI argv (e.g. `kohera://register?...`) to
+  // the `command-line` signal that app_links_linux listens on.
+  // HANDLES_OPEN would route them to the `open` signal, which app_links
+  // does not subscribe to — URIs would be silently dropped.
+  return MY_APPLICATION(g_object_new(
+      my_application_get_type(), "application-id", APPLICATION_ID, "flags",
+      G_APPLICATION_HANDLES_COMMAND_LINE, nullptr));
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import app_links
 import connectivity_plus
 import desktop_drop
 import device_info_plus
@@ -31,6 +32,7 @@ import webcrypto
 import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -18,6 +18,19 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(FLUTTER_BUILD_NAME)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>io.github.quantumheart.kohera.invite</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kohera</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSMinimumSystemVersion</key>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  app_links:
+    dependency: "direct main"
+    description:
+      name: app_links
+      sha256: "5f88447519add627fe1cbcab4fd1da3d4fed15b9baf29f28b22535c95ecee3e8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  app_links_linux:
+    dependency: transitive
+    description:
+      name: app_links_linux
+      sha256: f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  app_links_platform_interface:
+    dependency: transitive
+    description:
+      name: app_links_platform_interface
+      sha256: "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
+  app_links_web:
+    dependency: transitive
+    description:
+      name: app_links_web
+      sha256: af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   archive:
     dependency: transitive
     description:
@@ -672,6 +704,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  gtk:
+    dependency: transitive
+    description:
+      name: gtk
+      sha256: e8ce9ca4b1df106e4d72dad201d345ea1a036cc12c360f1a7d5a758f78ffa42c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   highlight:
     dependency: "direct main"
     description:
@@ -905,10 +945,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1670,18 +1710,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.15"
   timezone:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1325,6 +1325,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  qr_flutter:
+    dependency: "direct main"
+    description:
+      name: qr_flutter
+      sha256: "5095f0fc6e3f71d08adef8feccc8cea4f12eec18a2e31c2e8d82cb6019f4b097"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   random_string:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   path_provider: ^2.1.5
   permission_handler: ^11.4.0
   provider: ^6.1.2
+  qr_flutter: ^4.1.0
   record: ^6.2.0
   scrollable_positioned_list: ^0.3.8
   shared_preferences: ^2.3.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   animations: ^2.0.11
+  app_links: ^6.3.3
   cached_network_image: ^3.3.1
   cached_network_image_platform_interface: ^4.0.0
   canonical_json: ^1.1.2

--- a/test/core/routing/app_router_test.dart
+++ b/test/core/routing/app_router_test.dart
@@ -1,0 +1,277 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kohera/core/routing/route_names.dart';
+import 'package:kohera/core/services/app_config.dart';
+import 'package:kohera/core/services/call_service.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/core/services/preferences_service.dart';
+import 'package:kohera/features/auth/screens/registration_screen.dart';
+import 'package:matrix/matrix.dart';
+import 'package:matrix/src/utils/cached_stream_controller.dart';
+import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../services/matrix_service_test.mocks.dart';
+
+void main() {
+  late MockClient mockClient;
+  late MockFlutterSecureStorage mockStorage;
+  late MatrixService matrixService;
+  late PreferencesService prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await AppConfig.load();
+
+    mockClient = MockClient();
+    mockStorage = MockFlutterSecureStorage();
+    when(mockClient.rooms).thenReturn([]);
+    when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
+    when(mockClient.getLoginFlows()).thenAnswer((_) async => [
+          LoginFlow(type: AuthenticationTypes.password),
+        ],);
+    when(mockClient.request(
+      RequestType.POST,
+      '/client/v3/register',
+      data: anyNamed('data'),
+    ),).thenThrow(MatrixException.fromJson({
+      'errcode': 'M_FORBIDDEN',
+      'error': 'UIA required',
+      'flows': [
+        {'stages': ['m.login.registration_token', 'm.login.dummy']},
+      ],
+      'params': <String, dynamic>{},
+      'session': 'test-session',
+    }),);
+
+    matrixService = MatrixService(
+      client: mockClient,
+      storage: mockStorage,
+      clientName: 'test',
+    );
+    prefs = PreferencesService();
+    await prefs.init();
+  });
+
+  GoRouter buildMinimalRouter({String initialLocation = '/register'}) {
+    return GoRouter(
+      initialLocation: initialLocation,
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) =>
+              const Scaffold(body: Center(child: Text('start'))),
+        ),
+        GoRoute(
+          path: '/register',
+          name: Routes.register,
+          builder: (context, state) {
+            final queryServer = state.uri.queryParameters['server']?.trim();
+            final queryToken = state.uri.queryParameters['token']?.trim();
+            final homeserver = (state.extra as String?) ??
+                (queryServer != null && queryServer.isNotEmpty
+                    ? queryServer
+                    : null) ??
+                context.read<PreferencesService>().defaultHomeserver ??
+                AppConfig.instance.defaultHomeserver;
+            final token = queryToken != null && queryToken.isNotEmpty
+                ? queryToken
+                : null;
+            return RegistrationScreen(
+              key: ValueKey('register|$homeserver|$token'),
+              initialHomeserver: homeserver,
+              initialToken: token,
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget buildApp(GoRouter router) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider<MatrixService>.value(value: matrixService),
+        ChangeNotifierProvider<PreferencesService>.value(value: prefs),
+        ChangeNotifierProvider(
+          create: (ctx) =>
+              CallService(client: ctx.read<MatrixService>().client),
+        ),
+      ],
+      child: MaterialApp.router(routerConfig: router),
+    );
+  }
+
+  group('/register query params', () {
+    testWidgets('server + token pre-fill the form', (tester) async {
+      final router = buildMinimalRouter(
+        initialLocation: '/register?server=matrix.org&token=abc',
+      );
+      await tester.pumpWidget(buildApp(router));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RegistrationScreen), findsOneWidget);
+
+      final hsField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Homeserver'),
+      );
+      expect(hsField.controller?.text, 'matrix.org');
+
+      final tokenField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Registration token'),
+      );
+      expect(tokenField.controller?.text, 'abc');
+    });
+
+    testWidgets('no params falls back to prefs defaultHomeserver',
+        (tester) async {
+      await prefs.setDefaultHomeserver('prefs.example');
+      final router = buildMinimalRouter();
+      await tester.pumpWidget(buildApp(router));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RegistrationScreen), findsOneWidget);
+
+      final hsField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Homeserver'),
+      );
+      expect(hsField.controller?.text, 'prefs.example');
+    });
+
+    testWidgets('empty query values fall back to prefs', (tester) async {
+      await prefs.setDefaultHomeserver('prefs.example');
+      final router = buildMinimalRouter(
+        initialLocation: '/register?server=&token=',
+      );
+      await tester.pumpWidget(buildApp(router));
+      await tester.pumpAndSettle();
+
+      final hsField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Homeserver'),
+      );
+      expect(hsField.controller?.text, 'prefs.example');
+    });
+
+    testWidgets('whitespace-only query values fall back to prefs',
+        (tester) async {
+      await prefs.setDefaultHomeserver('prefs.example');
+      final router = buildMinimalRouter(
+        initialLocation: '/register?server=%20%20&token=%20',
+      );
+      await tester.pumpWidget(buildApp(router));
+      await tester.pumpAndSettle();
+
+      final hsField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Homeserver'),
+      );
+      expect(hsField.controller?.text, 'prefs.example');
+
+      final tokenField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Registration token'),
+      );
+      expect(tokenField.controller?.text, '');
+    });
+
+    testWidgets('only server query param — token empty', (tester) async {
+      final router = buildMinimalRouter(
+        initialLocation: '/register?server=matrix.org',
+      );
+      await tester.pumpWidget(buildApp(router));
+      await tester.pumpAndSettle();
+
+      final hsField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Homeserver'),
+      );
+      expect(hsField.controller?.text, 'matrix.org');
+
+      final tokenField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Registration token'),
+      );
+      expect(tokenField.controller?.text, '');
+    });
+
+    testWidgets('only token query param — homeserver falls back to prefs',
+        (tester) async {
+      await prefs.setDefaultHomeserver('prefs.example');
+      final router = buildMinimalRouter(
+        initialLocation: '/register?token=solo',
+      );
+      await tester.pumpWidget(buildApp(router));
+      await tester.pumpAndSettle();
+
+      final hsField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Homeserver'),
+      );
+      expect(hsField.controller?.text, 'prefs.example');
+
+      final tokenField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Registration token'),
+      );
+      expect(tokenField.controller?.text, 'solo');
+    });
+
+    testWidgets('URL-encoded token is decoded', (tester) async {
+      final router = buildMinimalRouter(
+        initialLocation: '/register?server=matrix.org&token=abc%20xyz',
+      );
+      await tester.pumpWidget(buildApp(router));
+      await tester.pumpAndSettle();
+
+      final tokenField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Registration token'),
+      );
+      expect(tokenField.controller?.text, 'abc xyz');
+    });
+
+    testWidgets('in-app navigation via router.go pre-fills form',
+        (tester) async {
+      final router = buildMinimalRouter(initialLocation: '/');
+      await tester.pumpWidget(buildApp(router));
+      await tester.pumpAndSettle();
+
+      expect(find.text('start'), findsOneWidget);
+
+      router.go('/register?server=matrix.org&token=abc');
+      await tester.pumpAndSettle();
+
+      final hsField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Homeserver'),
+      );
+      expect(hsField.controller?.text, 'matrix.org');
+
+      final tokenField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Registration token'),
+      );
+      expect(tokenField.controller?.text, 'abc');
+    });
+
+    testWidgets('re-navigating with different params resets pre-fill',
+        (tester) async {
+      final router = buildMinimalRouter(
+        initialLocation: '/register?server=first.example&token=t1',
+      );
+      await tester.pumpWidget(buildApp(router));
+      await tester.pumpAndSettle();
+
+      var hsField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Homeserver'),
+      );
+      expect(hsField.controller?.text, 'first.example');
+
+      router.go('/register?server=second.example&token=t2');
+      await tester.pumpAndSettle();
+
+      hsField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Homeserver'),
+      );
+      expect(hsField.controller?.text, 'second.example');
+
+      final tokenField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Registration token'),
+      );
+      expect(tokenField.controller?.text, 't2');
+    });
+  });
+}

--- a/test/core/routing/app_router_test.dart
+++ b/test/core/routing/app_router_test.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/app_config.dart';
 import 'package:kohera/core/services/call_service.dart';
+import 'package:kohera/core/services/client_manager.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/features/auth/screens/registration_screen.dart';
@@ -14,6 +15,7 @@ import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../services/matrix_service_test.mocks.dart';
+import '../../widgets/login_controller_test.mocks.dart' as login_mocks;
 
 void main() {
   late MockClient mockClient;
@@ -272,6 +274,90 @@ void main() {
         find.widgetWithText(TextField, 'Registration token'),
       );
       expect(tokenField.controller?.text, 't2');
+    });
+  });
+
+  group('/add-account/register query params', () {
+    testWidgets('server + token pre-fill with pendingService wrap',
+        (tester) async {
+      final mockManager = login_mocks.MockClientManager();
+      when(mockManager.pendingService).thenReturn(matrixService);
+
+      when(mockClient.getLoginFlows()).thenAnswer((_) async => [
+            LoginFlow(type: AuthenticationTypes.password),
+          ],);
+      when(mockClient.request(
+        RequestType.POST,
+        '/client/v3/register',
+        data: anyNamed('data'),
+      ),).thenThrow(MatrixException.fromJson({
+        'errcode': 'M_FORBIDDEN',
+        'error': 'UIA required',
+        'flows': [
+          {'stages': ['m.login.registration_token', 'm.login.dummy']},
+        ],
+        'params': <String, dynamic>{},
+        'session': 'test-session',
+      }),);
+
+      final router = GoRouter(
+        initialLocation:
+            '/add-account/register?server=addacct.example&token=tok9',
+        routes: [
+          GoRoute(
+            path: '/add-account/register',
+            builder: (context, state) {
+              final manager = context.read<ClientManager>();
+              final queryServer =
+                  state.uri.queryParameters['server']?.trim();
+              final queryToken =
+                  state.uri.queryParameters['token']?.trim();
+              final homeserver = (state.extra as String?) ??
+                  (queryServer != null && queryServer.isNotEmpty
+                      ? queryServer
+                      : null) ??
+                  context.read<PreferencesService>().defaultHomeserver ??
+                  AppConfig.instance.defaultHomeserver;
+              final token = queryToken != null && queryToken.isNotEmpty
+                  ? queryToken
+                  : null;
+              return ChangeNotifierProvider<MatrixService>.value(
+                value: manager.pendingService!,
+                child: RegistrationScreen(
+                  key: ValueKey(
+                      'add-account-register|$homeserver|$token',),
+                  initialHomeserver: homeserver,
+                  initialToken: token,
+                  isAddAccount: true,
+                ),
+              );
+            },
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(MultiProvider(
+        providers: [
+          ChangeNotifierProvider<ClientManager>.value(value: mockManager),
+          ChangeNotifierProvider<PreferencesService>.value(value: prefs),
+          ChangeNotifierProvider(
+            create: (ctx) =>
+                CallService(client: ctx.read<MatrixService>().client),
+          ),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),);
+      await tester.pumpAndSettle();
+
+      final hsField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Homeserver'),
+      );
+      expect(hsField.controller?.text, 'addacct.example');
+
+      final tokenField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Registration token'),
+      );
+      expect(tokenField.controller?.text, 'tok9');
     });
   });
 }

--- a/test/e2e/settings_screen_test.dart
+++ b/test/e2e/settings_screen_test.dart
@@ -233,7 +233,12 @@ void main() {
         (tester) async {
       await tester.pumpWidget(buildSettingsApp());
       await tester.pumpAndSettle();
-      await scrollToBottom(tester);
+
+      await tester.dragUntilVisible(
+        find.text('SECURITY'),
+        find.byType(ListView),
+        const Offset(0, -200),
+      );
 
       expect(find.text('SECURITY'), findsOneWidget);
       expect(find.text('Devices'), findsOneWidget);

--- a/test/features/auth/services/deep_link_service_test.dart
+++ b/test/features/auth/services/deep_link_service_test.dart
@@ -1,0 +1,165 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/features/auth/services/deep_link_service.dart';
+
+class _FakeSource implements DeepLinkSource {
+  Uri? initial;
+  final _controller = StreamController<Uri>.broadcast();
+
+  void emit(Uri uri) => _controller.add(uri);
+
+  @override
+  Future<Uri?> getInitialLink() async => initial;
+
+  @override
+  Stream<Uri> get uriLinkStream => _controller.stream;
+
+  bool get hasListener => _controller.hasListener;
+
+  Future<void> close() => _controller.close();
+}
+
+void main() {
+  late _FakeSource source;
+  late DateTime fakeNow;
+
+  DateTime nowFn() => fakeNow;
+
+  setUp(() {
+    source = _FakeSource();
+    fakeNow = DateTime(2026, 1, 1, 12);
+  });
+
+  group('DeepLinkService', () {
+    test('non-kohera scheme ignored', () async {
+      final service = DeepLinkService(source: source, now: nowFn);
+      await service.start();
+      source.emit(Uri.parse('https://example.com/register?token=x'));
+      await Future<void>.delayed(Duration.zero);
+      expect(service.pending, isNull);
+    });
+
+    test('kohera://register with server + token yields intent', () async {
+      final service = DeepLinkService(source: source, now: nowFn);
+      await service.start();
+      source.emit(
+        Uri.parse('kohera://register?server=matrix.org&token=abc'),
+      );
+      await Future<void>.delayed(Duration.zero);
+      final intent = service.pending;
+      expect(intent, isA<RegisterInviteIntent>());
+      final invite = intent! as RegisterInviteIntent;
+      expect(invite.server, 'matrix.org');
+      expect(invite.token, 'abc');
+    });
+
+    test('missing server ignored', () async {
+      final service = DeepLinkService(source: source, now: nowFn);
+      await service.start();
+      source.emit(Uri.parse('kohera://register?token=abc'));
+      await Future<void>.delayed(Duration.zero);
+      expect(service.pending, isNull);
+    });
+
+    test('missing token ignored', () async {
+      final service = DeepLinkService(source: source, now: nowFn);
+      await service.start();
+      source.emit(Uri.parse('kohera://register?server=matrix.org'));
+      await Future<void>.delayed(Duration.zero);
+      expect(service.pending, isNull);
+    });
+
+    test('whitespace-only server/token trimmed to empty and ignored',
+        () async {
+      final service = DeepLinkService(source: source, now: nowFn);
+      await service.start();
+      source.emit(
+        Uri.parse('kohera://register?server=%20%20&token=%20'),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(service.pending, isNull);
+    });
+
+    test('unknown host ignored', () async {
+      final service = DeepLinkService(source: source, now: nowFn);
+      await service.start();
+      source.emit(Uri.parse('kohera://foo?server=x&token=y'));
+      await Future<void>.delayed(Duration.zero);
+      expect(service.pending, isNull);
+    });
+
+    test('dedup: same URI within 30s ignored', () async {
+      final service = DeepLinkService(source: source, now: nowFn);
+      await service.start();
+
+      source.emit(
+        Uri.parse('kohera://register?server=matrix.org&token=abc'),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(service.pending, isA<RegisterInviteIntent>());
+      service.consume();
+
+      fakeNow = fakeNow.add(const Duration(seconds: 10));
+      source.emit(
+        Uri.parse('kohera://register?server=matrix.org&token=abc'),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(service.pending, isNull, reason: 'second within window ignored');
+    });
+
+    test('dedup: same URI accepted after window', () async {
+      final service = DeepLinkService(source: source, now: nowFn);
+      await service.start();
+
+      source.emit(
+        Uri.parse('kohera://register?server=matrix.org&token=abc'),
+      );
+      await Future<void>.delayed(Duration.zero);
+      service.consume();
+
+      fakeNow = fakeNow.add(const Duration(seconds: 31));
+      source.emit(
+        Uri.parse('kohera://register?server=matrix.org&token=abc'),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(service.pending, isA<RegisterInviteIntent>());
+    });
+
+    test('initial link (cold start) is processed', () async {
+      source.initial =
+          Uri.parse('kohera://register?server=matrix.org&token=abc');
+      final service = DeepLinkService(source: source, now: nowFn);
+      await service.start();
+      expect(service.pending, isA<RegisterInviteIntent>());
+    });
+
+    test('consume clears pending', () async {
+      final service = DeepLinkService(source: source, now: nowFn);
+      await service.start();
+      source.emit(
+        Uri.parse('kohera://register?server=matrix.org&token=abc'),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(service.pending, isNotNull);
+      service.consume();
+      expect(service.pending, isNull);
+    });
+
+    test('start is idempotent', () async {
+      final service = DeepLinkService(source: source, now: nowFn);
+      await service.start();
+      await service.start();
+      expect(source.hasListener, isTrue);
+    });
+
+    test('dispose cancels subscription', () async {
+      final service = DeepLinkService(source: source, now: nowFn);
+      await service.start();
+      expect(source.hasListener, isTrue);
+      service.dispose();
+      await Future<void>.delayed(Duration.zero);
+      expect(source.hasListener, isFalse);
+    });
+  });
+}

--- a/test/features/auth/widgets/deep_link_listener_test.dart
+++ b/test/features/auth/widgets/deep_link_listener_test.dart
@@ -172,4 +172,31 @@ void main() {
 
     expect(find.textContaining('token=abc+xyz'), findsOneWidget);
   });
+
+  testWidgets('createLoginService failure shows error dialog',
+      (tester) async {
+    when(matrix.isLoggedIn).thenReturn(true);
+    when(manager.createLoginService())
+        .thenThrow(StateError('boom'));
+
+    await service.start();
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    source.emit(Uri.parse('kohera://register?server=matrix.org&token=abc'));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Create account'));
+    await tester.pumpAndSettle();
+
+    expect(find.text("Couldn't start new account"), findsOneWidget);
+    expect(find.textContaining('try the invite link again'), findsOneWidget);
+    expect(find.textContaining('add:/add-account/register?'), findsNothing);
+
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+    expect(find.text("Couldn't start new account"), findsNothing);
+    expect(service.pending, isNull);
+  });
 }

--- a/test/features/auth/widgets/deep_link_listener_test.dart
+++ b/test/features/auth/widgets/deep_link_listener_test.dart
@@ -1,0 +1,175 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kohera/core/services/client_manager.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/features/auth/services/deep_link_service.dart';
+import 'package:kohera/features/auth/widgets/deep_link_listener.dart';
+import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
+
+import '../../../widgets/login_controller_test.mocks.dart';
+
+class _FakeSource implements DeepLinkSource {
+  Uri? initial;
+  final _controller = StreamController<Uri>.broadcast(sync: true);
+
+  void emit(Uri uri) => _controller.add(uri);
+
+  @override
+  Future<Uri?> getInitialLink() async => initial;
+
+  @override
+  Stream<Uri> get uriLinkStream => _controller.stream;
+}
+
+void main() {
+  late MockClientManager manager;
+  late MockMatrixService matrix;
+  late _FakeSource source;
+  late DeepLinkService service;
+  late GoRouter router;
+
+  setUp(() {
+    manager = MockClientManager();
+    matrix = MockMatrixService();
+    source = _FakeSource();
+    service = DeepLinkService(source: source);
+
+    router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, __) =>
+              const Scaffold(body: Center(child: Text('home'))),
+        ),
+        GoRoute(
+          path: '/register',
+          builder: (_, state) => Scaffold(
+            body: Center(child: Text('register:${state.uri}')),
+          ),
+        ),
+        GoRoute(
+          path: '/add-account/register',
+          builder: (_, state) => Scaffold(
+            body: Center(child: Text('add:${state.uri}')),
+          ),
+        ),
+      ],
+    );
+  });
+
+  Widget buildApp() {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider<ClientManager>.value(value: manager),
+        ChangeNotifierProvider<MatrixService>.value(value: matrix),
+        ChangeNotifierProvider<DeepLinkService>.value(value: service),
+      ],
+      child: MaterialApp.router(
+        routerConfig: router,
+        builder: (context, child) => DeepLinkListener(
+          service: service,
+          router: router,
+          child: child ?? const SizedBox.shrink(),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('logged-out intent navigates to /register', (tester) async {
+    when(matrix.isLoggedIn).thenReturn(false);
+
+    await service.start();
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    source.emit(Uri.parse('kohera://register?server=matrix.org&token=abc'));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('register:/register?'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('server=matrix.org'), findsOneWidget);
+    expect(find.textContaining('token=abc'), findsOneWidget);
+    expect(service.pending, isNull);
+  });
+
+  testWidgets('logged-in intent shows confirm dialog', (tester) async {
+    when(matrix.isLoggedIn).thenReturn(true);
+
+    await service.start();
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    source.emit(Uri.parse('kohera://register?server=matrix.org&token=abc'));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Use this invite?'), findsOneWidget);
+    expect(find.textContaining('matrix.org'), findsWidgets);
+    expect(find.text('Create account'), findsOneWidget);
+    expect(find.text('Cancel'), findsOneWidget);
+  });
+
+  testWidgets('confirm creates pending service + navigates', (tester) async {
+    when(matrix.isLoggedIn).thenReturn(true);
+    when(manager.createLoginService())
+        .thenAnswer((_) async => MockMatrixService());
+
+    await service.start();
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    source.emit(Uri.parse('kohera://register?server=matrix.org&token=abc'));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Create account'));
+    await tester.pumpAndSettle();
+
+    verify(manager.createLoginService()).called(1);
+    expect(find.textContaining('add:/add-account/register?'), findsOneWidget);
+    expect(find.textContaining('server=matrix.org'), findsOneWidget);
+    expect(service.pending, isNull);
+  });
+
+  testWidgets('cancel dismisses dialog without navigation', (tester) async {
+    when(matrix.isLoggedIn).thenReturn(true);
+
+    await service.start();
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    source.emit(Uri.parse('kohera://register?server=matrix.org&token=abc'));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    verifyNever(manager.createLoginService());
+    expect(find.text('home'), findsOneWidget);
+    expect(service.pending, isNull);
+  });
+
+  testWidgets('token with special characters is URL-encoded on navigation',
+      (tester) async {
+    when(matrix.isLoggedIn).thenReturn(false);
+
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    source.emit(
+      Uri.parse('kohera://register?server=matrix.org&token=abc%20xyz'),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('token=abc+xyz'), findsOneWidget);
+  });
+}

--- a/test/screens/registration_screen_test.dart
+++ b/test/screens/registration_screen_test.dart
@@ -90,7 +90,10 @@ void main() {
         .thenThrow(Exception('Connection refused'));
   }
 
-  Widget buildTestWidget({String homeserver = 'matrix.org'}) {
+  Widget buildTestWidget({
+    String homeserver = 'matrix.org',
+    String? initialToken,
+  }) {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider<MatrixService>.value(value: matrixService),
@@ -100,7 +103,10 @@ void main() {
         ChangeNotifierProvider<ClientManager>.value(value: clientManager),
       ],
       child: MaterialApp(
-        home: RegistrationScreen(initialHomeserver: homeserver),
+        home: RegistrationScreen(
+          initialHomeserver: homeserver,
+          initialToken: initialToken,
+        ),
       ),
     );
   }
@@ -385,6 +391,54 @@ void main() {
 
       expect(find.text('This server does not support registration'),
           findsOneWidget,);
+    });
+
+    // ── initialToken ──────────────────────────────────────────
+
+    testWidgets('initialToken pre-fills the token field', (tester) async {
+      stubServerSupportsRegistration(
+        registrationStages: ['m.login.registration_token', 'm.login.dummy'],
+      );
+      await tester.pumpWidget(buildTestWidget(initialToken: 'abc123'));
+      await tester.pumpAndSettle();
+
+      final field = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Registration token'),
+      );
+      expect(field.controller?.text, 'abc123');
+    });
+
+    testWidgets('initialToken null leaves the token field empty',
+        (tester) async {
+      stubServerSupportsRegistration(
+        registrationStages: ['m.login.registration_token', 'm.login.dummy'],
+      );
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      final field = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Registration token'),
+      );
+      expect(field.controller?.text, '');
+    });
+
+    testWidgets('seeded token field remains editable', (tester) async {
+      stubServerSupportsRegistration(
+        registrationStages: ['m.login.registration_token', 'm.login.dummy'],
+      );
+      await tester.pumpWidget(buildTestWidget(initialToken: 'abc123'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Registration token'),
+        'overwrite',
+      );
+      await tester.pump();
+
+      final field = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Registration token'),
+      );
+      expect(field.controller?.text, 'overwrite');
     });
   });
 }

--- a/test/screens/registration_screen_test.dart
+++ b/test/screens/registration_screen_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:kohera/core/services/call_service.dart';
 import 'package:kohera/core/services/client_manager.dart';
 import 'package:kohera/core/services/matrix_service.dart';
@@ -13,6 +14,7 @@ import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
 
 import '../services/matrix_service_test.mocks.dart';
+import '../widgets/login_controller_test.mocks.dart' as login_mocks;
 
 class _FixedServiceFactory extends MatrixServiceFactory {
   _FixedServiceFactory(this._service);
@@ -439,6 +441,52 @@ void main() {
         find.widgetWithText(TextField, 'Registration token'),
       );
       expect(field.controller?.text, 'overwrite');
+    });
+
+    // ── isAddAccount ──────────────────────────────────────────
+
+    testWidgets('Sign in link goes to /add-account when isAddAccount=true',
+        (tester) async {
+      final mockManager = login_mocks.MockClientManager();
+      stubServerSupportsRegistration();
+
+      final router = GoRouter(
+        initialLocation: '/register',
+        routes: [
+          GoRoute(
+            path: '/add-account',
+            builder: (_, __) =>
+                const Scaffold(body: Center(child: Text('add-account'))),
+          ),
+          GoRoute(
+            path: '/register',
+            builder: (_, __) => RegistrationScreen(
+              initialHomeserver: 'matrix.org',
+              isAddAccount: true,
+            ),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(MultiProvider(
+        providers: [
+          ChangeNotifierProvider<MatrixService>.value(value: matrixService),
+          ChangeNotifierProvider(
+              create: (ctx) =>
+                  CallService(client: ctx.read<MatrixService>().client),),
+          ChangeNotifierProvider<ClientManager>.value(value: mockManager),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),);
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(
+        find.text('Already have an account? Sign in'),
+      );
+      await tester.tap(find.text('Already have an account? Sign in'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('add-account'), findsOneWidget);
     });
   });
 }

--- a/test/screens/registration_screen_test.dart
+++ b/test/screens/registration_screen_test.dart
@@ -488,5 +488,48 @@ void main() {
 
       expect(find.text('add-account'), findsOneWidget);
     });
+
+    testWidgets(
+        'Sign in link falls back to /login when stack is empty',
+        (tester) async {
+      final mockManager = login_mocks.MockClientManager();
+      stubServerSupportsRegistration();
+
+      final router = GoRouter(
+        initialLocation: '/register',
+        routes: [
+          GoRoute(
+            path: '/login',
+            builder: (_, __) =>
+                const Scaffold(body: Center(child: Text('login'))),
+          ),
+          GoRoute(
+            path: '/register',
+            builder: (_, __) =>
+                RegistrationScreen(initialHomeserver: 'matrix.org'),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(MultiProvider(
+        providers: [
+          ChangeNotifierProvider<MatrixService>.value(value: matrixService),
+          ChangeNotifierProvider(
+              create: (ctx) =>
+                  CallService(client: ctx.read<MatrixService>().client),),
+          ChangeNotifierProvider<ClientManager>.value(value: mockManager),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),);
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(
+        find.text('Already have an account? Sign in'),
+      );
+      await tester.tap(find.text('Already have an account? Sign in'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('login'), findsOneWidget);
+    });
   });
 }

--- a/test/screens/share_invite_screen_test.dart
+++ b/test/screens/share_invite_screen_test.dart
@@ -130,5 +130,40 @@ void main() {
         findsWidgets,
       );
     });
+
+    testWidgets('landing HTML escapes </script> to prevent tag breakout',
+        (tester) async {
+      await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Registration token'),
+        'evil</script><img>',
+      );
+      await tester.pumpAndSettle();
+
+      await tester.dragUntilVisible(
+        find.text('Landing-page HTML'),
+        find.byType(ListView),
+        const Offset(0, -200),
+      );
+
+      // The generated HTML must not contain a raw </script> sequence
+      // inside the embedded JS string literal. URL encoding of the token
+      // during Uri.toString() is the first line of defence; the
+      // </ → <\/ pass in _jsScriptSafeString is belt-and-braces.
+      final htmlSelectables = tester
+          .widgetList<SelectableText>(find.byType(SelectableText))
+          .map((w) => w.data ?? '')
+          .where((t) => t.contains('<!DOCTYPE html>'))
+          .toList();
+      expect(htmlSelectables, isNotEmpty);
+      final html = htmlSelectables.first;
+      final jsLine = html
+          .split('\n')
+          .firstWhere((l) => l.contains('window.location.replace('));
+      expect(jsLine.contains('</script>'), isFalse,
+          reason: 'embedded JS string must not contain </script>',);
+    });
   });
 }

--- a/test/screens/share_invite_screen_test.dart
+++ b/test/screens/share_invite_screen_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/features/settings/screens/share_invite_screen.dart';
+import 'package:matrix/matrix.dart';
+import 'package:matrix/src/utils/cached_stream_controller.dart';
+import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
+
+import '../services/matrix_service_test.mocks.dart';
+
+void main() {
+  late MockClient mockClient;
+  late MockFlutterSecureStorage mockStorage;
+  late MatrixService matrixService;
+
+  setUp(() {
+    mockClient = MockClient();
+    mockStorage = MockFlutterSecureStorage();
+    when(mockClient.rooms).thenReturn([]);
+    when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
+    when(mockClient.homeserver).thenReturn(Uri.parse('https://matrix.org'));
+    matrixService = MatrixService(
+      client: mockClient,
+      storage: mockStorage,
+      clientName: 'test',
+    );
+  });
+
+  Widget buildApp() {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider<MatrixService>.value(value: matrixService),
+      ],
+      child: const MaterialApp(home: ShareInviteScreen()),
+    );
+  }
+
+  group('ShareInviteScreen', () {
+    testWidgets('pre-fills homeserver from logged-in client', (tester) async {
+      await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
+
+      final field = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Homeserver'),
+      );
+      expect(field.controller?.text, 'matrix.org');
+    });
+
+    testWidgets('outputs hidden until token entered', (tester) async {
+      await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Deep link'), findsNothing);
+      expect(
+        find.textContaining('Enter a homeserver and token'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('entering token renders deep link + QR + HTML',
+        (tester) async {
+      await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Registration token'),
+        'abc123',
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Deep link'), findsOneWidget);
+      expect(find.text('QR code'), findsOneWidget);
+
+      await tester.dragUntilVisible(
+        find.text('Landing-page HTML'),
+        find.byType(ListView),
+        const Offset(0, -200),
+      );
+      expect(find.text('Landing-page HTML'), findsOneWidget);
+      expect(
+        find.textContaining('kohera://register?server=matrix.org&token=abc123'),
+        findsWidgets,
+      );
+    });
+
+    testWidgets('copy button writes deep link to clipboard', (tester) async {
+      String? copied;
+      final binding = TestWidgetsFlutterBinding.ensureInitialized();
+      binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            copied = (call.arguments as Map)['text'] as String?;
+          }
+          return null;
+        },
+      );
+
+      await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Registration token'),
+        'abc123',
+      );
+      await tester.pumpAndSettle();
+
+      final copyButton = find.widgetWithIcon(IconButton, Icons.copy).first;
+      await tester.tap(copyButton);
+      await tester.pumpAndSettle();
+
+      expect(copied, 'kohera://register?server=matrix.org&token=abc123');
+      expect(find.text('Link copied to clipboard'), findsOneWidget);
+    });
+
+    testWidgets('URL-encodes special characters in token', (tester) async {
+      await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Registration token'),
+        'abc xyz',
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('token=abc+xyz'),
+        findsWidgets,
+      );
+    });
+  });
+}

--- a/test/utils/log_scrubber_test.dart
+++ b/test/utils/log_scrubber_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/utils/log_scrubber.dart';
+
+void main() {
+  group('scrubSensitive', () {
+    test('top-level sensitive keys scrubbed', () {
+      final result = scrubSensitive({'token': 'abc', 'user': 'alice'});
+      expect(result, {'token': '***', 'user': 'alice'});
+    });
+
+    test('nested map scrubbed', () {
+      final result = scrubSensitive({
+        'auth': {'password': 'p', 'type': 'x'},
+      });
+      expect(result, {
+        'auth': {'password': '***', 'type': 'x'},
+      });
+    });
+
+    test('list of maps recursed', () {
+      final result = scrubSensitive([
+        {'token': 't'},
+        {'token': 'u'},
+      ]);
+      expect(result, [
+        {'token': '***'},
+        {'token': '***'},
+      ]);
+    });
+
+    test('unrelated keys preserved', () {
+      final input = {
+        'foo': 'bar',
+        'baz': 42,
+        'qux': [1, 2, 3],
+      };
+      expect(scrubSensitive(input), input);
+    });
+
+    test('case-insensitive match', () {
+      final result = scrubSensitive({'Token': 'x', 'PASSWORD': 'y'});
+      expect(result, {'Token': '***', 'PASSWORD': '***'});
+    });
+
+    test('all six sensitive keys hit individually', () {
+      for (final key in [
+        'token',
+        'access_token',
+        'refresh_token',
+        'nonce',
+        'password',
+        'mac',
+      ]) {
+        final result = scrubSensitive({key: 'secret'})! as Map;
+        expect(result[key], '***', reason: 'key=$key should be scrubbed');
+      }
+    });
+
+    test('empty map returns empty map', () {
+      expect(scrubSensitive(<String, dynamic>{}), isEmpty);
+    });
+
+    test('non-map top-level returned unchanged', () {
+      expect(scrubSensitive('hello'), 'hello');
+      expect(scrubSensitive(42), 42);
+      expect(scrubSensitive(null), null);
+      expect(scrubSensitive(true), true);
+    });
+
+    test('deep nesting — three levels scrubbed', () {
+      final result = scrubSensitive({
+        'outer': {
+          'middle': [
+            {'token': 'deep'},
+          ],
+        },
+      });
+      expect(result, {
+        'outer': {
+          'middle': [
+            {'token': '***'},
+          ],
+        },
+      });
+    });
+
+    test('input map not mutated', () {
+      final input = {'token': 'keep-me', 'user': 'alice'};
+      scrubSensitive(input);
+      expect(input['token'], 'keep-me');
+    });
+
+    test('exact match — substring not scrubbed', () {
+      final result = scrubSensitive({
+        'passwordless': true,
+        'my_token_count': 3,
+        'tokenizer': 'bpe',
+      });
+      expect(result, {
+        'passwordless': true,
+        'my_token_count': 3,
+        'tokenizer': 'bpe',
+      });
+    });
+
+    test('null value on sensitive key preserved', () {
+      final result = scrubSensitive({'token': null, 'user': 'alice'});
+      expect(result, {'token': null, 'user': 'alice'});
+    });
+
+    test('non-String map keys — scrubs by stringified key', () {
+      final result =
+          scrubSensitive(<dynamic, dynamic>{1: 'safe', 'token': 'x'});
+      expect(result, <dynamic, dynamic>{1: 'safe', 'token': '***'});
+    });
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <app_links/app_links_plugin_c_api.h>
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <desktop_drop/desktop_drop_plugin.h>
 #include <dynamic_color/dynamic_color_plugin_c_api.h>
@@ -26,6 +27,8 @@
 #include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  AppLinksPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
   ConnectivityPlusWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   DesktopDropPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  app_links
   connectivity_plus
   desktop_drop
   dynamic_color


### PR DESCRIPTION
## Summary

Implements the recipient side of the invite deep-link epic (#327). After this PR, a homeserver admin can hand out a registration token by URL; users tap it and land in Kohera with the token pre-filled.

Closes #330, #331, #332, #333.

### What ships

- **#330** — `/register` accepts `server` and `token` via `Uri.queryParameters`. Fallback chain: `state.extra → query → prefs → AppConfig`. `ValueKey` resets state on param change.
- **#331** — `kohera://` URI scheme wired across Android, iOS, macOS, Linux. New `DeepLinkService` (ChangeNotifier, `AppLinks`-backed, testable `DeepLinkSource` abstraction, 30s same-URI dedup, injectable clock) + `DeepLinkListener` widget. Logged-out deep links → `/register?...`; logged-in deep links → confirm dialog → `/add-account/register?...` with a pending `MatrixService`.
  - `fixup`: added error-dialog UX when `ClientManager.createLoginService()` fails mid-invite.
- **#332** — `lib/core/utils/log_scrubber.dart` recursive `scrubSensitive()` guardrail (exact, case-insensitive match on `token`, `access_token`, `refresh_token`, `nonce`, `password`, `mac`). `docs/invite-landing.md` with nginx 302, static HTML, and web-app direct-link recipes for admins.
- **#333** — **Share Invite** composer in Settings: paste a token → generate deep link, QR code, and ready-to-host landing-page HTML. No network, no storage, no Synapse coupling.
  - `fixup`: `</script>` escape in generated HTML (via `jsonEncode` + `</` → `<\/`) so a pathological token can't break out of the inline `<script>` tag.

### Not in scope (deliberately)

- Synapse admin token CRUD — dropped in the reslice (closed #328, #329). Couples Kohera to Synapse admin API; use `synapse-admin` instead.
- Android App Links / iOS Universal Links (HTTPS-backed). Custom scheme only for now.
- Landing page hosting — this PR ships docs + composer; admins host the artifact.

## Test plan

### Automated

- [x] `flutter analyze` — clean
- [x] `flutter test` — 1531 passing, 0 failing on final state
- [x] New: `test/core/routing/app_router_test.dart` — 10 cases (query params, re-nav, /add-account/register with pending service)
- [x] New: `test/features/auth/services/deep_link_service_test.dart` — 12 cases (scheme filter, trim, dedup, cold start, consume, idempotent start, dispose)
- [x] New: `test/features/auth/widgets/deep_link_listener_test.dart` — 6 cases (logged-out nav, logged-in dialog, confirm/cancel, URL-encoding, createLoginService failure)
- [x] New: `test/utils/log_scrubber_test.dart` — 13 cases (case-insensitivity, substring safety, null preservation, non-String keys, deep nesting, immutability)
- [x] New: `test/screens/share_invite_screen_test.dart` — 6 cases (homeserver pre-fill, output gating, render, clipboard, URL encoding, `</script>` escape)
- [x] Extended: `test/screens/registration_screen_test.dart` — `initialToken` group + `isAddAccount` sign-in nav
- [x] Extended: `test/e2e/settings_screen_test.dart` — `dragUntilVisible` for SECURITY after INVITES section insert

### Manual per-platform smoke

Not yet performed in this PR. Required before merge for confidence that `app_links` delivers on each OS.

- [ ] **Linux**: `flutter build linux --release` → install → `xdg-mime default io.github.quantumheart.kohera.desktop x-scheme-handler/kohera` → `xdg-open 'kohera://register?server=matrix.org&token=abc123'` → verify register screen pre-filled.
- [ ] **macOS**: `flutter build macos --release` → open the app → in another terminal, `open 'kohera://register?server=matrix.org&token=abc123'` (warm). Quit + `open 'kohera://...'` (cold).
- [ ] **Android**: `flutter run -d <device>` → `adb shell am start -a android.intent.action.VIEW -d 'kohera://register?server=matrix.org&token=abc123'`. Repeat after `adb shell am force-stop io.github.quantumheart.kohera` for cold start. Verify `singleInstance` launch mode doesn't drop intent on warm delivery; if broken, switch to `singleTask`.
- [ ] **iOS simulator**: `xcrun simctl openurl booted 'kohera://register?server=matrix.org&token=abc'`.
- [ ] **Web**: cold hit `https://<host>/#/register?server=matrix.org&token=abc` — verify GoRouter pre-fills without scheme involvement.

### UX flows to verify manually

- [ ] Logged-out + tap link → `/register` opens with homeserver + token pre-filled; submitting completes registration.
- [ ] Logged-in + tap link → "Use this invite?" dialog with server name; **Create account** → new account slot, `/add-account/register` with token pre-filled; on success, new account becomes active and lands on `/`.
- [ ] Logged-in + tap link → **Cancel** dismisses, no navigation, no snackbar.
- [ ] Same link tapped twice within 30s → second tap ignored silently.
- [ ] Invite with missing `server=` or `token=` → debug log, no UI change.
- [ ] Settings → **Share an invite** → paste a token → deep link, QR, HTML all populate; copy buttons work; snackbar confirms.
- [ ] Paste a token containing `</script>` → generated HTML contains `<\/script>` (or URL-encoded equivalent), no tag breakout.

### Security posture

- No full URI or token is logged by `DeepLinkService`, `DeepLinkListener`, or the composer.
- `log_scrubber` available for any future callsite that logs payload maps.
- Landing-page recipes discourage query-string access logging and warn that the invite URL will appear in the user's browser history.