### PR TITLE
feat: render unhandled Matrix events in timeline

### DIFF
--- a/lib/features/chat/widgets/message_bubble.dart
+++ b/lib/features/chat/widgets/message_bubble.dart
@@ -17,6 +17,7 @@ import 'package:kohera/features/chat/widgets/inline_image_preview.dart';
 import 'package:kohera/features/chat/widgets/inline_reply_preview.dart';
 import 'package:kohera/features/chat/widgets/link_preview_card.dart';
 import 'package:kohera/features/chat/widgets/linkable_text.dart';
+import 'package:kohera/features/chat/widgets/verification_request_tile.dart';
 import 'package:kohera/features/chat/widgets/video_bubble.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
 import 'package:matrix/matrix.dart';
@@ -575,30 +576,81 @@ class _MessageBubbleState extends State<MessageBubble> {
       return FileBubble(event: widget.event, isMe: widget.isMe);
     }
 
+    if (widget.event.messageType == MessageTypes.KeyVerificationRequest) {
+      return VerificationRequestTile(event: widget.event);
+    }
+
     // Check for HTML formatted body.
     final formattedBody = widget.event.formattedText;
     final hasHtml = formattedBody.isNotEmpty &&
         widget.event.content['format'] == 'org.matrix.custom.html';
 
-    final textStyle = tt.bodyLarge?.copyWith(
+    final isEmote = widget.event.messageType == MessageTypes.Emote;
+    final isServerNotice =
+        widget.event.messageType == MessageTypes.ServerNotice;
+
+    var textStyle = tt.bodyLarge?.copyWith(
       color: widget.isMe ? cs.onPrimary : cs.onSurface,
       fontSize: metrics.bodyFontSize,
       height: metrics.bodyLineHeight,
     );
 
+    if (isEmote) {
+      textStyle = textStyle?.copyWith(fontStyle: FontStyle.italic);
+    }
+    if (isServerNotice) {
+      textStyle = textStyle?.copyWith(
+        color: widget.isMe
+            ? cs.onPrimary.withValues(alpha: 0.8)
+            : cs.onSurfaceVariant,
+      );
+    }
+
     if (hasHtml) {
-      return HtmlMessageText(
-        html: formattedBody,
+      final html = isEmote
+          ? '* ${widget.event.senderFromMemoryOrFallback.calcDisplayname()} '
+              '$formattedBody'
+          : formattedBody;
+      final htmlWidget = HtmlMessageText(
+        html: html,
         style: textStyle,
         isMe: widget.isMe,
         room: widget.event.room,
       );
+      if (isServerNotice) return _wrapWithServerNoticeIcon(htmlWidget, cs);
+      return htmlWidget;
     }
 
-    return LinkableText(
-      text: bodyText,
+    final displayText = isEmote
+        ? '* ${widget.event.senderFromMemoryOrFallback.calcDisplayname()} '
+            '$bodyText'
+        : bodyText;
+    final textWidget = LinkableText(
+      text: displayText,
       style: textStyle,
       isMe: widget.isMe,
+    );
+    if (isServerNotice) return _wrapWithServerNoticeIcon(textWidget, cs);
+    return textWidget;
+  }
+
+  Widget _wrapWithServerNoticeIcon(Widget child, ColorScheme cs) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: 2, right: 6),
+          child: Icon(
+            Icons.campaign_outlined,
+            size: 16,
+            color: widget.isMe
+                ? cs.onPrimary.withValues(alpha: 0.8)
+                : cs.onSurfaceVariant,
+          ),
+        ),
+        Flexible(child: child),
+      ],
     );
   }
 

--- a/lib/features/chat/widgets/message_bubble.dart
+++ b/lib/features/chat/widgets/message_bubble.dart
@@ -576,7 +576,7 @@ class _MessageBubbleState extends State<MessageBubble> {
       return FileBubble(event: widget.event, isMe: widget.isMe);
     }
 
-    if (widget.event.messageType == MessageTypes.KeyVerificationRequest) {
+    if (widget.event.messageType == EventTypes.KeyVerificationRequest) {
       return VerificationRequestTile(event: widget.event);
     }
 
@@ -586,8 +586,7 @@ class _MessageBubbleState extends State<MessageBubble> {
         widget.event.content['format'] == 'org.matrix.custom.html';
 
     final isEmote = widget.event.messageType == MessageTypes.Emote;
-    final isServerNotice =
-        widget.event.messageType == MessageTypes.ServerNotice;
+    final isServerNotice = widget.event.messageType == 'm.server_notice';
 
     var textStyle = tt.bodyLarge?.copyWith(
       color: widget.isMe ? cs.onPrimary : cs.onSurface,
@@ -608,7 +607,7 @@ class _MessageBubbleState extends State<MessageBubble> {
 
     if (hasHtml) {
       final html = isEmote
-          ? '* ${widget.event.senderFromMemoryOrFallback.calcDisplayname()} '
+          ? '* ${_escapeHtml(widget.event.senderFromMemoryOrFallback.calcDisplayname())} '
               '$formattedBody'
           : formattedBody;
       final htmlWidget = HtmlMessageText(
@@ -633,6 +632,13 @@ class _MessageBubbleState extends State<MessageBubble> {
     if (isServerNotice) return _wrapWithServerNoticeIcon(textWidget, cs);
     return textWidget;
   }
+
+  static String _escapeHtml(String input) => input
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#39;');
 
   Widget _wrapWithServerNoticeIcon(Widget child, ColorScheme cs) {
     return Row(

--- a/lib/features/chat/widgets/message_list_view.dart
+++ b/lib/features/chat/widgets/message_list_view.dart
@@ -8,6 +8,9 @@ import 'package:kohera/features/calling/models/call_constants.dart';
 import 'package:kohera/features/chat/widgets/call_event_tile.dart';
 import 'package:kohera/features/chat/widgets/chat_message_item.dart';
 import 'package:kohera/features/chat/widgets/read_receipts.dart';
+import 'package:kohera/features/chat/widgets/state_event_tile.dart';
+import 'package:kohera/features/chat/widgets/sticker_bubble.dart';
+import 'package:kohera/features/chat/widgets/unread_divider.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
@@ -52,6 +55,7 @@ class MessageListViewState extends State<MessageListView> {
   Timer? _readMarkerTimer;
   int _initGeneration = 0;
   List<Event>? _cachedVisibleEvents;
+  String? _initialFullyReadId;
 
   Timeline? get timeline => _timeline;
 
@@ -78,6 +82,9 @@ class MessageListViewState extends State<MessageListView> {
 
   Future<void> _initTimeline() async {
     final gen = ++_initGeneration;
+    final snapshotFullyRead = widget.room.fullyRead;
+    _initialFullyReadId =
+        snapshotFullyRead.isNotEmpty ? snapshotFullyRead : null;
     _timeline = await widget.room.getTimeline(
       eventContextId: widget.initialEventId,
       onUpdate: () {
@@ -141,7 +148,9 @@ class MessageListViewState extends State<MessageListView> {
             ((e.type == EventTypes.Message || e.type == EventTypes.Encrypted) &&
                 e.relationshipType != RelationshipTypes.edit &&
                 !_isCallMemberEvent(e)) ||
-            callEventTypes.contains(e.type),)
+            callEventTypes.contains(e.type) ||
+            _isStateEvent(e) ||
+            e.type == EventTypes.Sticker,)
         .toList();
     return _cachedVisibleEvents!;
   }
@@ -274,6 +283,37 @@ class MessageListViewState extends State<MessageListView> {
 
   static bool _isCallEvent(Event event) => callEventTypes.contains(event.type);
 
+  static bool _isStateEvent(Event event) {
+    if (event.type == EventTypes.RoomName ||
+        event.type == EventTypes.RoomTopic ||
+        event.type == EventTypes.RoomAvatar ||
+        event.type == EventTypes.RoomTombstone) {
+      return true;
+    }
+    if (event.type == EventTypes.RoomMember) {
+      return !_isNoOpMemberEvent(event);
+    }
+    return false;
+  }
+
+  static bool _isNoOpMemberEvent(Event event) {
+    final prev = event.prevContent;
+    if (prev == null) return false;
+    final curr = event.content;
+    final prevMembership = prev.tryGet<String>('membership');
+    final currMembership = curr.tryGet<String>('membership');
+    if (prevMembership != currMembership) return false;
+    if (prev.tryGet<String>('displayname') !=
+        curr.tryGet<String>('displayname')) {
+      return false;
+    }
+    if (prev.tryGet<String>('avatar_url') !=
+        curr.tryGet<String>('avatar_url')) {
+      return false;
+    }
+    return true;
+  }
+
   static bool _isCallMemberEvent(Event event) =>
       event.type == kCallMember ||
       event.type == kCallMemberMsc ||
@@ -361,30 +401,64 @@ class MessageListViewState extends State<MessageListView> {
           );
         }
         final event = events[i];
+
+        final Widget tile;
         if (_isCallEvent(event)) {
-          return CallEventTile(
+          tile = CallEventTile(
             event: event,
             isMe: event.senderId == widget.matrix.client.userID,
             duration: _callDuration(event),
           );
+        } else if (_isStateEvent(event)) {
+          tile = StateEventTile(event: event);
+        } else if (event.type == EventTypes.Sticker) {
+          tile = StickerBubble(
+            event: event,
+            isMe: event.senderId == widget.matrix.client.userID,
+          );
+        } else {
+          final prevSender =
+              i + 1 < events.length ? events[i + 1].senderId : null;
+          tile = ChatMessageItem(
+            event: event,
+            isMe: event.senderId == widget.matrix.client.userID,
+            isFirst: event.senderId != prevSender,
+            isMobile: isMobile,
+            timeline: _timeline,
+            client: widget.matrix.client,
+            highlightedEventId: widget.highlightedEventId,
+            receiptMap: receiptMap,
+            onReply: widget.onReply,
+            onEdit: (event) => widget.onEdit(event, _timeline),
+            onToggleReaction: widget.onToggleReaction,
+            onPin: widget.onPin,
+            onTapReply: _navigateToEvent,
+          );
         }
-        final prevSender = i + 1 < events.length ? events[i + 1].senderId : null;
-        return ChatMessageItem(
-          event: event,
-          isMe: event.senderId == widget.matrix.client.userID,
-          isFirst: event.senderId != prevSender,
-          isMobile: isMobile,
-          timeline: _timeline,
-          client: widget.matrix.client,
-          highlightedEventId: widget.highlightedEventId,
-          receiptMap: receiptMap,
-          onReply: widget.onReply,
-          onEdit: (event) => widget.onEdit(event, _timeline),
-          onToggleReaction: widget.onToggleReaction,
-          onPin: widget.onPin,
-          onTapReply: _navigateToEvent,
-        );
+
+        if (_shouldShowUnreadDivider(event, i, events)) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              tile,
+              const UnreadDivider(),
+            ],
+          );
+        }
+        return tile;
       },
     );
+  }
+
+  bool _shouldShowUnreadDivider(
+    Event event,
+    int index,
+    List<Event> events,
+  ) {
+    final markerId = _initialFullyReadId;
+    if (markerId == null) return false;
+    if (event.eventId != markerId) return false;
+    if (index == 0) return false;
+    return true;
   }
 }

--- a/lib/features/chat/widgets/state_event_tile.dart
+++ b/lib/features/chat/widgets/state_event_tile.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kohera/core/routing/route_names.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/core/utils/time_format.dart';
+import 'package:matrix/matrix.dart';
+import 'package:provider/provider.dart';
+
+class StateEventTile extends StatelessWidget {
+  const StateEventTile({required this.event, super.key});
+
+  final Event event;
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+    final cs = Theme.of(context).colorScheme;
+    final (icon, text) = _resolve();
+    final isTombstone = event.type == EventTypes.RoomTombstone;
+
+    Widget content = Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: cs.surfaceContainerHighest.withValues(alpha: 0.5),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: cs.onSurfaceVariant),
+          const SizedBox(width: 6),
+          Flexible(
+            child: Text(
+              text,
+              style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            formatMessageTime(event.originServerTs),
+            style: tt.bodySmall?.copyWith(
+              fontSize: 11,
+              color: cs.onSurfaceVariant.withValues(alpha: 0.5),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (isTombstone) {
+      content = InkWell(
+        onTap: () => _onTombstoneTap(context),
+        borderRadius: BorderRadius.circular(16),
+        child: content,
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 12),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [content],
+      ),
+    );
+  }
+
+  Future<void> _onTombstoneTap(BuildContext context) async {
+    final replacement =
+        event.content.tryGet<String>('replacement_room');
+    if (replacement == null || replacement.isEmpty) return;
+
+    final matrix = context.read<MatrixService>();
+    final scaffold = ScaffoldMessenger.of(context);
+    final router = GoRouter.of(context);
+
+    try {
+      final existing = matrix.client.getRoomById(replacement);
+      if (existing == null) {
+        await matrix.client.joinRoom(replacement);
+      }
+      router.goNamed(Routes.room, pathParameters: {'roomId': replacement});
+    } catch (e) {
+      debugPrint('[Kohera] Failed to open replacement room: $e');
+      scaffold.showSnackBar(
+        const SnackBar(content: Text('Could not open the upgraded room')),
+      );
+    }
+  }
+
+  (IconData, String) _resolve() {
+    final sender = event.senderFromMemoryOrFallback.calcDisplayname();
+
+    switch (event.type) {
+      case EventTypes.RoomMember:
+        return _resolveMember(sender);
+
+      case EventTypes.RoomName:
+        final name = event.content.tryGet<String>('name') ?? '';
+        return (
+          Icons.edit_outlined,
+          name.isEmpty
+              ? '$sender removed the room name'
+              : "$sender changed the room name to '$name'",
+        );
+
+      case EventTypes.RoomTopic:
+        final topic = event.content.tryGet<String>('topic') ?? '';
+        return (
+          Icons.edit_outlined,
+          topic.isEmpty
+              ? '$sender removed the room topic'
+              : "$sender changed the topic to '$topic'",
+        );
+
+      case EventTypes.RoomAvatar:
+        return (Icons.image_outlined, '$sender changed the room avatar');
+
+      case EventTypes.RoomTombstone:
+        final body = event.content.tryGet<String>('body');
+        final suffix = (body != null && body.isNotEmpty) ? ' $body' : '';
+        return (
+          Icons.upgrade_rounded,
+          'This room has been upgraded.$suffix Tap to open the new room.',
+        );
+
+      default:
+        return (Icons.info_outline, 'Room updated');
+    }
+  }
+
+  (IconData, String) _resolveMember(String sender) {
+    final membership = event.content.tryGet<String>('membership');
+    final prevMembership = event.prevContent?.tryGet<String>('membership');
+    final target = event.stateKey;
+    final targetUser = target != null
+        ? event.room.unsafeGetUserFromMemoryOrFallback(target)
+        : null;
+    final targetName = targetUser?.calcDisplayname() ?? target ?? 'Someone';
+    final reason = event.content.tryGet<String>('reason');
+
+    switch (membership) {
+      case 'invite':
+        return (
+          Icons.person_add_alt_1_outlined,
+          '$targetName was invited by $sender',
+        );
+      case 'join':
+        if (prevMembership == 'join') {
+          final prevDisplay = event.prevContent?.tryGet<String>('displayname');
+          final newDisplay = event.content.tryGet<String>('displayname');
+          if (prevDisplay != newDisplay) {
+            return (
+              Icons.badge_outlined,
+              newDisplay == null || newDisplay.isEmpty
+                  ? '$targetName removed their display name'
+                  : "$targetName changed their display name to '$newDisplay'",
+            );
+          }
+          final prevAvatar = event.prevContent?.tryGet<String>('avatar_url');
+          final newAvatar = event.content.tryGet<String>('avatar_url');
+          if (prevAvatar != newAvatar) {
+            return (
+              Icons.image_outlined,
+              '$targetName changed their avatar',
+            );
+          }
+          return (Icons.login_rounded, '$targetName updated their profile');
+        }
+        return (Icons.login_rounded, '$targetName joined');
+      case 'leave':
+        if (target == event.senderId) {
+          if (prevMembership == 'invite') {
+            return (
+              Icons.cancel_outlined,
+              '$targetName rejected the invitation',
+            );
+          }
+          return (Icons.logout_rounded, '$targetName left');
+        }
+        final reasonSuffix =
+            (reason != null && reason.isNotEmpty) ? ' ($reason)' : '';
+        return (
+          Icons.person_remove_outlined,
+          '$targetName was kicked by $sender$reasonSuffix',
+        );
+      case 'ban':
+        final reasonSuffix =
+            (reason != null && reason.isNotEmpty) ? ' ($reason)' : '';
+        return (
+          Icons.block_rounded,
+          '$targetName was banned by $sender$reasonSuffix',
+        );
+      case 'knock':
+        return (
+          Icons.front_hand_outlined,
+          '$targetName requested to join',
+        );
+      default:
+        return (Icons.info_outline, 'Membership changed');
+    }
+  }
+}

--- a/lib/features/chat/widgets/sticker_bubble.dart
+++ b/lib/features/chat/widgets/sticker_bubble.dart
@@ -1,0 +1,126 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:kohera/core/utils/media_auth.dart';
+import 'package:matrix/matrix.dart';
+
+// coverage:ignore-start
+
+class StickerBubble extends StatefulWidget {
+  const StickerBubble({
+    required this.event,
+    required this.isMe,
+    super.key,
+  });
+
+  final Event event;
+  final bool isMe;
+
+  @override
+  State<StickerBubble> createState() => _StickerBubbleState();
+}
+
+class _StickerBubbleState extends State<StickerBubble> {
+  static const double _maxSize = 180;
+
+  Uint8List? _imageBytes;
+  String? _imageUrl;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_loadSticker());
+  }
+
+  @override
+  void didUpdateWidget(StickerBubble old) {
+    super.didUpdateWidget(old);
+    if (old.event.eventId != widget.event.eventId) {
+      _imageBytes = null;
+      _imageUrl = null;
+      _loading = true;
+      unawaited(_loadSticker());
+    }
+  }
+
+  Future<void> _loadSticker() async {
+    try {
+      if (widget.event.isAttachmentEncrypted) {
+        final file = await widget.event.downloadAndDecryptAttachment();
+        if (mounted) {
+          setState(() {
+            _imageBytes = file.bytes;
+            _loading = false;
+          });
+        }
+      } else {
+        final uri = await widget.event.getAttachmentUri(
+          width: _maxSize.toInt() * 2,
+          height: _maxSize.toInt() * 2,
+        );
+        if (mounted) {
+          setState(() {
+            _imageUrl = uri?.toString();
+            _loading = false;
+          });
+        }
+      }
+    } catch (e) {
+      debugPrint('[Kohera] Sticker load failed: $e');
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final body = widget.event.content.tryGet<String>('body') ?? '';
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 12),
+      child: Row(
+        mainAxisAlignment:
+            widget.isMe ? MainAxisAlignment.end : MainAxisAlignment.start,
+        children: [
+          ConstrainedBox(
+            constraints: const BoxConstraints(
+              maxHeight: _maxSize,
+              maxWidth: _maxSize,
+            ),
+            child: _loading
+                ? const SizedBox(
+                    width: 80,
+                    height: 80,
+                    child: Center(
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                  )
+                : _imageBytes != null
+                    ? Image.memory(
+                        _imageBytes!,
+                        fit: BoxFit.contain,
+                        semanticLabel: body,
+                      )
+                    : _imageUrl != null
+                        ? Image.network(
+                            _imageUrl!,
+                            fit: BoxFit.contain,
+                            semanticLabel: body,
+                            headers: mediaAuthHeaders(
+                              widget.event.room.client,
+                              _imageUrl!,
+                            ),
+                            errorBuilder: (_, __, ___) => const Icon(
+                              Icons.broken_image_outlined,
+                              size: 48,
+                            ),
+                          )
+                        : const Icon(Icons.broken_image_outlined, size: 48),
+          ),
+        ],
+      ),
+    );
+  }
+}
+// coverage:ignore-end

--- a/lib/features/chat/widgets/unread_divider.dart
+++ b/lib/features/chat/widgets/unread_divider.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+class UnreadDivider extends StatelessWidget {
+  const UnreadDivider({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+      child: Row(
+        children: [
+          Expanded(
+            child: Container(height: 1, color: cs.primary.withValues(alpha: 0.5)),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Text(
+              'New messages',
+              style: tt.labelSmall?.copyWith(
+                color: cs.primary,
+                fontWeight: FontWeight.w600,
+                letterSpacing: 0.5,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Container(height: 1, color: cs.primary.withValues(alpha: 0.5)),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/chat/widgets/verification_request_tile.dart
+++ b/lib/features/chat/widgets/verification_request_tile.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:matrix/matrix.dart';
+
+class VerificationRequestTile extends StatelessWidget {
+  const VerificationRequestTile({required this.event, super.key});
+
+  final Event event;
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+    final cs = Theme.of(context).colorScheme;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(Icons.verified_user_outlined, size: 16, color: cs.primary),
+        const SizedBox(width: 6),
+        Flexible(
+          child: Text(
+            'Requested verification',
+            style: tt.bodyMedium?.copyWith(
+              color: cs.onSurfaceVariant,
+              fontStyle: FontStyle.italic,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/widgets/room_section_header_test.mocks.dart
+++ b/test/widgets/room_section_header_test.mocks.dart
@@ -8000,6 +8000,13 @@ class MockPreferencesService extends _i1.Mock
       ) as _i18.MessageDensity);
 
   @override
+  _i18.MobileTab get lastMobileTab => (super.noSuchMethod(
+        Invocation.getter(#lastMobileTab),
+        returnValue: _i18.MobileTab.inbox,
+        returnValueForMissingStub: _i18.MobileTab.inbox,
+      ) as _i18.MobileTab);
+
+  @override
   _i19.ThemeMode get themeMode => (super.noSuchMethod(
         Invocation.getter(#themeMode),
         returnValue: _i19.ThemeMode.system,
@@ -8151,6 +8158,13 @@ class MockPreferencesService extends _i1.Mock
       ) as bool);
 
   @override
+  bool get apnsPushEnabled => (super.noSuchMethod(
+        Invocation.getter(#apnsPushEnabled),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   bool get autoMuteOnJoin => (super.noSuchMethod(
         Invocation.getter(#autoMuteOnJoin),
         returnValue: false,
@@ -8274,6 +8288,16 @@ class MockPreferencesService extends _i1.Mock
         Invocation.method(
           #setMessageDensity,
           [density],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLastMobileTab(_i18.MobileTab? tab) => (super.noSuchMethod(
+        Invocation.method(
+          #setLastMobileTab,
+          [tab],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
@@ -8495,6 +8519,16 @@ class MockPreferencesService extends _i1.Mock
   _i5.Future<void> setWebPushEnabled(bool? value) => (super.noSuchMethod(
         Invocation.method(
           #setWebPushEnabled,
+          [value],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setApnsPushEnabled(bool? value) => (super.noSuchMethod(
+        Invocation.method(
+          #setApnsPushEnabled,
           [value],
         ),
         returnValue: _i5.Future<void>.value(),

--- a/test/widgets/room_tile_test.mocks.dart
+++ b/test/widgets/room_tile_test.mocks.dart
@@ -22,11 +22,9 @@ import 'package:kohera/core/services/sub_services/sync_service.dart' as _i6;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i3;
 import 'package:kohera/features/calling/models/call_participant.dart' as _i22;
 import 'package:kohera/features/calling/models/call_state.dart' as _i24;
-import 'package:kohera/features/calling/models/incoming_call_info.dart'
-    as _i23;
+import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i23;
 import 'package:kohera/features/calling/services/livekit_service.dart' as _i20;
-import 'package:kohera/features/calling/services/ringtone_service.dart'
-    as _i26;
+import 'package:kohera/features/calling/services/ringtone_service.dart' as _i26;
 import 'package:livekit_client/livekit_client.dart' as _i21;
 import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;


### PR DESCRIPTION
## Summary
- Tier 1 msgtypes in `MessageBubble`: `m.emote` (italic + HTML-escaped sender prefix), `m.server_notice` (warning icon wrap), `m.key.verification.request` (interactive tile)
- Tier 2 event types via new `StateEventTile` / `StickerBubble` / `UnreadDivider` in `MessageListView`: member transitions, room name/topic/avatar changes, `m.room.tombstone` (taps to join + route to replacement), stickers (encryption-aware), "New messages" divider anchored to `room.fullyRead` snapshot
- No-op `m.room.member` profile-unchanged events filtered out to avoid timeline spam

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test` — 1480 passing
- [ ] Manual: emote renders italic with sender, escapes `<script>` display names
- [ ] Manual: server notice shows warning icon
- [ ] Manual: verification request tile appears for incoming SAS requests
- [ ] Manual: tombstone tile joins + routes to replacement room
- [ ] Manual: sticker decrypts in E2EE rooms
- [ ] Manual: unread divider appears above first unread on room open