### PR TITLE
fix: suppress mobile keyboard on room entry and scroll-back

### DIFF
--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -86,11 +86,13 @@ class _ChatScreenState extends State<ChatScreen>
     _actions = _createActions();
     _search = _createSearchController();
     _initControllers();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted && _composeFocusNode.canRequestFocus) {
-        _composeFocusNode.requestFocus();
-      }
-    });
+    if (!isTouchDevice) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && _composeFocusNode.canRequestFocus) {
+          _composeFocusNode.requestFocus();
+        }
+      });
+    }
   }
 
   @override
@@ -106,11 +108,13 @@ class _ChatScreenState extends State<ChatScreen>
       _search.dispose();
       _actions = _createActions();
       _search = _createSearchController();
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted && _composeFocusNode.canRequestFocus) {
-          _composeFocusNode.requestFocus();
-        }
-      });
+      if (!isTouchDevice) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted && _composeFocusNode.canRequestFocus) {
+            _composeFocusNode.requestFocus();
+          }
+        });
+      }
     }
   }
 
@@ -150,6 +154,10 @@ class _ChatScreenState extends State<ChatScreen>
   void _setReplyTo(Event event) {
     _compose.setReplyTo(event);
     _composeFocusNode.requestFocus();
+  }
+
+  void _dismissKeyboard() {
+    if (_composeFocusNode.hasFocus) _composeFocusNode.unfocus();
   }
 
   // ── Attachments ─────────────────────────────────────────
@@ -288,6 +296,7 @@ class _ChatScreenState extends State<ChatScreen>
             onToggleReaction: _actions.toggleReaction,
             onPin: _actions.togglePin,
             onHighlight: _search.setHighlight,
+            onScrollBack: isTouchDevice ? _dismissKeyboard : null,
           ),
         ),
         TypingIndicator(

--- a/lib/features/chat/widgets/message_list_view.dart
+++ b/lib/features/chat/widgets/message_list_view.dart
@@ -26,6 +26,7 @@ class MessageListView extends StatefulWidget {
     required this.onHighlight,
     this.initialEventId,
     this.highlightedEventId,
+    this.onScrollBack,
     super.key,
   });
 
@@ -38,6 +39,7 @@ class MessageListView extends StatefulWidget {
   final Future<void> Function(Event event, String emoji) onToggleReaction;
   final Future<void> Function(Event event) onPin;
   final void Function(String eventId) onHighlight;
+  final VoidCallback? onScrollBack;
 
   @override
   State<MessageListView> createState() => MessageListViewState();
@@ -48,6 +50,8 @@ class MessageListViewState extends State<MessageListView> {
   static const _scrollAnimationDuration = Duration(milliseconds: 400);
   static const _readMarkerDelay = Duration(seconds: 1);
 
+  static const _scrollBackDismissThreshold = 120.0;
+
   final _itemScrollCtrl = ItemScrollController();
   final _itemPosListener = ItemPositionsListener.create();
   Timeline? _timeline;
@@ -56,6 +60,8 @@ class MessageListViewState extends State<MessageListView> {
   int _initGeneration = 0;
   List<Event>? _cachedVisibleEvents;
   String? _initialFullyReadId;
+  double _scrollBackDelta = 0;
+  bool _scrollBackFired = false;
 
   Timeline? get timeline => _timeline;
 
@@ -183,6 +189,22 @@ class MessageListViewState extends State<MessageListView> {
     if (maxIndex >= _visibleEvents.length - _historyLoadThreshold && !_loadingHistory) {
       unawaited(_loadMore());
     }
+  }
+
+  bool _handleScrollNotification(ScrollNotification notification) {
+    if (widget.onScrollBack == null) return false;
+    if (notification is ScrollStartNotification) {
+      _scrollBackDelta = 0;
+      _scrollBackFired = false;
+    } else if (notification is ScrollUpdateNotification) {
+      _scrollBackDelta += notification.scrollDelta ?? 0;
+      if (!_scrollBackFired &&
+          _scrollBackDelta >= _scrollBackDismissThreshold) {
+        _scrollBackFired = true;
+        widget.onScrollBack!.call();
+      }
+    }
+    return false;
   }
 
   Future<void> _loadMore() async {
@@ -387,66 +409,69 @@ class MessageListViewState extends State<MessageListView> {
     final hasLoadingIndicator = _loadingHistory;
     final totalCount = events.length + (hasLoadingIndicator ? 1 : 0);
 
-    return ScrollablePositionedList.builder(
-      itemScrollController: _itemScrollCtrl,
-      itemPositionsListener: _itemPosListener,
-      reverse: true,
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      itemCount: totalCount,
-      itemBuilder: (context, i) {
-        if (hasLoadingIndicator && i == totalCount - 1) {
-          return const Padding(
-            padding: EdgeInsets.symmetric(vertical: 16),
-            child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
-          );
-        }
-        final event = events[i];
+    return NotificationListener<ScrollNotification>(
+      onNotification: _handleScrollNotification,
+      child: ScrollablePositionedList.builder(
+        itemScrollController: _itemScrollCtrl,
+        itemPositionsListener: _itemPosListener,
+        reverse: true,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        itemCount: totalCount,
+        itemBuilder: (context, i) {
+          if (hasLoadingIndicator && i == totalCount - 1) {
+            return const Padding(
+              padding: EdgeInsets.symmetric(vertical: 16),
+              child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+            );
+          }
+          final event = events[i];
 
-        final Widget tile;
-        if (_isCallEvent(event)) {
-          tile = CallEventTile(
-            event: event,
-            isMe: event.senderId == widget.matrix.client.userID,
-            duration: _callDuration(event),
-          );
-        } else if (_isStateEvent(event)) {
-          tile = StateEventTile(event: event);
-        } else if (event.type == EventTypes.Sticker) {
-          tile = StickerBubble(
-            event: event,
-            isMe: event.senderId == widget.matrix.client.userID,
-          );
-        } else {
-          final prevSender =
-              i + 1 < events.length ? events[i + 1].senderId : null;
-          tile = ChatMessageItem(
-            event: event,
-            isMe: event.senderId == widget.matrix.client.userID,
-            isFirst: event.senderId != prevSender,
-            isMobile: isMobile,
-            timeline: _timeline,
-            client: widget.matrix.client,
-            highlightedEventId: widget.highlightedEventId,
-            receiptMap: receiptMap,
-            onReply: widget.onReply,
-            onEdit: (event) => widget.onEdit(event, _timeline),
-            onToggleReaction: widget.onToggleReaction,
-            onPin: widget.onPin,
-            onTapReply: _navigateToEvent,
-          );
-        }
+          final Widget tile;
+          if (_isCallEvent(event)) {
+            tile = CallEventTile(
+              event: event,
+              isMe: event.senderId == widget.matrix.client.userID,
+              duration: _callDuration(event),
+            );
+          } else if (_isStateEvent(event)) {
+            tile = StateEventTile(event: event);
+          } else if (event.type == EventTypes.Sticker) {
+            tile = StickerBubble(
+              event: event,
+              isMe: event.senderId == widget.matrix.client.userID,
+            );
+          } else {
+            final prevSender =
+                i + 1 < events.length ? events[i + 1].senderId : null;
+            tile = ChatMessageItem(
+              event: event,
+              isMe: event.senderId == widget.matrix.client.userID,
+              isFirst: event.senderId != prevSender,
+              isMobile: isMobile,
+              timeline: _timeline,
+              client: widget.matrix.client,
+              highlightedEventId: widget.highlightedEventId,
+              receiptMap: receiptMap,
+              onReply: widget.onReply,
+              onEdit: (event) => widget.onEdit(event, _timeline),
+              onToggleReaction: widget.onToggleReaction,
+              onPin: widget.onPin,
+              onTapReply: _navigateToEvent,
+            );
+          }
 
-        if (_shouldShowUnreadDivider(event, i, events)) {
-          return Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              tile,
-              const UnreadDivider(),
-            ],
-          );
-        }
-        return tile;
-      },
+          if (_shouldShowUnreadDivider(event, i, events)) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                tile,
+                const UnreadDivider(),
+              ],
+            );
+          }
+          return tile;
+        },
+      ),
     );
   }
 


### PR DESCRIPTION
## Summary
- Skip compose autofocus on touch devices so entering a room does not force the on-screen keyboard open; desktop keeps autofocus.
- Dismiss the keyboard when the user scroll-backs >=120px toward older messages in the chat list; smaller scrolls leave focus intact.

## Test plan
- [x] On a touch device, open a room → keyboard stays hidden.
- [x] On desktop, open a room → compose input gets focus.
- [x] On a touch device with keyboard open, scroll up ≥120px in the message list → keyboard dismisses.
- [x] Short scrolls (<120px) leave focus and keyboard intact.