### PR TITLE
feat: sort inbox room groups by most-recent notification

### DIFF
--- a/lib/features/notifications/services/inbox_controller.dart
+++ b/lib/features/notifications/services/inbox_controller.dart
@@ -371,31 +371,25 @@ class InboxController extends ChangeNotifier {
       map[n.roomId]!.add(n);
     }
 
-    final groups = <NotificationGroup>[];
-    for (final roomId in order) {
+    final insertionIndex = <String, int>{
+      for (var i = 0; i < order.length; i++) order[i]: i,
+    };
+    int maxTs(String roomId) =>
+        map[roomId]!.map((n) => n.ts).reduce((a, b) => a > b ? a : b);
+    order.sort((a, b) {
+      final cmp = maxTs(b).compareTo(maxTs(a));
+      if (cmp != 0) return cmp;
+      return insertionIndex[a]!.compareTo(insertionIndex[b]!);
+    });
+
+    return order.map((roomId) {
       final room = _client.getRoomById(roomId);
-      groups.add(NotificationGroup(
+      return NotificationGroup(
         roomId: roomId,
         roomName: room?.getLocalizedDisplayname() ?? roomId,
         notifications: map[roomId]!,
-      ),);
-    }
-
-    final indexed = <(int, NotificationGroup)>[
-      for (var i = 0; i < groups.length; i++) (i, groups[i]),
-    ];
-    indexed.sort((a, b) {
-      final aMax = a.$2.notifications
-          .map((n) => n.ts)
-          .reduce((x, y) => x > y ? x : y);
-      final bMax = b.$2.notifications
-          .map((n) => n.ts)
-          .reduce((x, y) => x > y ? x : y);
-      final cmp = bMax.compareTo(aMax);
-      if (cmp != 0) return cmp;
-      return a.$1.compareTo(b.$1);
-    });
-    return [for (final entry in indexed) entry.$2];
+      );
+    }).toList();
   }
 
   @override

--- a/lib/features/notifications/services/inbox_controller.dart
+++ b/lib/features/notifications/services/inbox_controller.dart
@@ -371,14 +371,31 @@ class InboxController extends ChangeNotifier {
       map[n.roomId]!.add(n);
     }
 
-    return order.map((roomId) {
+    final groups = <NotificationGroup>[];
+    for (final roomId in order) {
       final room = _client.getRoomById(roomId);
-      return NotificationGroup(
+      groups.add(NotificationGroup(
         roomId: roomId,
         roomName: room?.getLocalizedDisplayname() ?? roomId,
         notifications: map[roomId]!,
-      );
-    }).toList();
+      ),);
+    }
+
+    final indexed = <(int, NotificationGroup)>[
+      for (var i = 0; i < groups.length; i++) (i, groups[i]),
+    ];
+    indexed.sort((a, b) {
+      final aMax = a.$2.notifications
+          .map((n) => n.ts)
+          .reduce((x, y) => x > y ? x : y);
+      final bMax = b.$2.notifications
+          .map((n) => n.ts)
+          .reduce((x, y) => x > y ? x : y);
+      final cmp = bMax.compareTo(aMax);
+      if (cmp != 0) return cmp;
+      return a.$1.compareTo(b.$1);
+    });
+    return [for (final entry in indexed) entry.$2];
   }
 
   @override

--- a/test/services/inbox_controller_test.dart
+++ b/test/services/inbox_controller_test.dart
@@ -159,7 +159,7 @@ void main() {
         limit: anyNamed('limit'),
         only: anyNamed('only'),
       ),).thenAnswer((_) async => _makeResponse([
-            _makeNotification(eventId: 'e1', roomId: '!old:x', ts: 1000),
+            _makeNotification(eventId: 'e1', roomId: '!old:x'),
             _makeNotification(eventId: 'e2', roomId: '!new:x', ts: 3000),
             _makeNotification(eventId: 'e3', roomId: '!mid:x', ts: 2000),
           ]),);

--- a/test/services/inbox_controller_test.dart
+++ b/test/services/inbox_controller_test.dart
@@ -153,6 +153,24 @@ void main() {
       expect(controller.error, contains('network'));
       expect(controller.grouped, isEmpty);
     });
+
+    test('orders groups by most-recent notification descending', () async {
+      when(mockClient.getNotifications(
+        limit: anyNamed('limit'),
+        only: anyNamed('only'),
+      ),).thenAnswer((_) async => _makeResponse([
+            _makeNotification(eventId: 'e1', roomId: '!old:x', ts: 1000),
+            _makeNotification(eventId: 'e2', roomId: '!new:x', ts: 3000),
+            _makeNotification(eventId: 'e3', roomId: '!mid:x', ts: 2000),
+          ]),);
+
+      await controller.fetch();
+
+      expect(
+        controller.grouped.map((g) => g.roomId).toList(),
+        ['!new:x', '!mid:x', '!old:x'],
+      );
+    });
   });
 
   // ── setFilter() ─────────────────────────────────────────────


### PR DESCRIPTION
Groups previously appeared in fetch order (oldest-first), burying the
most active conversations. Now they surface by max notification
timestamp descending, with a stable insertion-index tiebreaker so equal
timestamps keep their original order.

https://claude.ai/code/session_01Jq3fdh7YiLkA8CPPuSsdoE