### PR TITLE
Fix fun phase text not showing on call join screen

### DIFF
--- a/lib/features/calling/screens/call_screen.dart
+++ b/lib/features/calling/screens/call_screen.dart
@@ -77,7 +77,10 @@ class _CallScreenState extends State<CallScreen> {
             onCancel: callService.cancelOutgoingCall,
           ),
         KoheraCallState.ringingIncoming => CallJoiningView(displayName: widget.displayName),
-        KoheraCallState.joining => CallJoiningView(displayName: widget.displayName),
+        KoheraCallState.joining => CallJoiningView(
+            displayName: widget.displayName,
+            phase: callService.joinPhase,
+          ),
         KoheraCallState.connected => const ConnectedCallView(),
         KoheraCallState.reconnecting => const CallReconnectingView(),
         KoheraCallState.disconnecting ||


### PR DESCRIPTION
## Summary
- `CallJoiningView` in `call_screen.dart` was missing the `phase` parameter, so it always fell through to the `null` case ("Joining call…") instead of showing the randomized fun phrases added in 86a1f65.
- Passes `callService.joinPhase` to match what `call_pane.dart` already does.

## Test plan
- [x] Join a call via the mobile/single-pane layout and verify randomized phrases appear (e.g. "Cracking the mainframe…", "Spinning up the warp core…")
- [x] Confirm the wide/pane layout still shows fun phrases as before
