### PR TITLE
fix: switch active account before sign-out to avoid login redirect

### DIFF
--- a/lib/core/services/client_manager.dart
+++ b/lib/core/services/client_manager.dart
@@ -154,6 +154,20 @@ class ClientManager extends ChangeNotifier {
 
   // ── Removing Accounts ─────────────────────────────────────────
 
+  /// Signs out of [service]. If other accounts exist, switches the active
+  /// index to another one *before* logging out so the router redirect
+  /// doesn't briefly flash the login screen.
+  Future<void> signOut(MatrixService service) async {
+    final index = _services.indexOf(service);
+    if (index == -1) return;
+    if (_services.length > 1 && index == _activeIndex) {
+      _activeIndex = index == 0 ? 1 : 0;
+      notifyListeners();
+    }
+    await service.logout();
+    await removeService(service);
+  }
+
   Future<void> removeService(MatrixService service) async {
     final index = _services.indexOf(service);
     if (index == -1) return;

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -551,8 +551,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 : null,
             onPressed: () async {
               Navigator.pop(ctx);
-              await matrix.logout();
-              await manager.removeService(matrix);
+              await manager.signOut(matrix);
             },
             child: const Text('Sign Out'),
           ),

--- a/test/services/client_manager_test.dart
+++ b/test/services/client_manager_test.dart
@@ -235,6 +235,69 @@ void main() {
     });
   });
 
+  group('signOut', () {
+    test(
+      'switches active before logging out when other accounts exist',
+      () async {
+        when(mockPrefs.getStringList('kohera_client_names'))
+            .thenReturn(['default', 'work']);
+        when(mockPrefs.setStringList(any, any)).thenAnswer((_) async => true);
+        when(mockStorage.delete(key: anyNamed('key')))
+            .thenAnswer((_) async {});
+
+        final services = <MatrixService>[];
+        final manager = ClientManager(
+          storage: mockStorage,
+          prefs: mockPrefs,
+          serviceFactory: _TestServiceFactory(trackServices: services),
+        );
+        await manager.init();
+
+        // Active is services[0] ('default'). Sign out of it.
+        final target = services[0];
+
+        // Record manager notifications: each time ClientManager notifies,
+        // capture the currently active service's logged-in state.
+        final activeLoggedSnapshots = <bool>[];
+        manager.addListener(() {
+          activeLoggedSnapshots
+              .add(manager.activeService.isLoggedIn);
+        });
+
+        await manager.signOut(target);
+
+        // Regression: active must switch *before* logout, so every
+        // notification during sign-out observes a logged-in active.
+        expect(activeLoggedSnapshots, isNotEmpty);
+        expect(activeLoggedSnapshots, everyElement(isTrue));
+
+        expect(manager.services, hasLength(1));
+        expect(manager.activeService.clientName, 'work');
+      },
+    );
+
+    test('falls through to login flow when last account signs out',
+        () async {
+      when(mockPrefs.getStringList('kohera_client_names')).thenReturn(null);
+      when(mockPrefs.setStringList(any, any)).thenAnswer((_) async => true);
+      when(mockStorage.delete(key: anyNamed('key')))
+          .thenAnswer((_) async {});
+
+      final services = <MatrixService>[];
+      final manager = ClientManager(
+        storage: mockStorage,
+        prefs: mockPrefs,
+        serviceFactory: _TestServiceFactory(trackServices: services),
+      );
+      await manager.init();
+
+      await manager.signOut(services[0]);
+
+      // Fresh default was created; it's not logged in (fresh client).
+      expect(manager.services, hasLength(1));
+    });
+  });
+
   group('hasMultipleAccounts', () {
     test('returns false with single account', () async {
       when(mockPrefs.getStringList('kohera_client_names')).thenReturn(null);


### PR DESCRIPTION
## Summary
- Root cause: `settings_screen` called `matrix.logout()` *then* `manager.removeService()`. Between the two, the router's `_ActiveMatrixListenable` saw the still-active, now-logged-out service and redirected to `/login` — even with another account available.
- Add `ClientManager.signOut(service)` that swaps the active index to another account *before* logging out, then removes the service.
- Settings sign-out now calls the new method.

Closes #289

## Test plan
- [x] `flutter test test/services/client_manager_test.dart` — new `signOut` group asserts that every `ClientManager` notification during sign-out observes a logged-in active service, and that the remaining account becomes active.
- [x] `flutter analyze` clean on touched files.
- [x] Manual: with two accounts signed in, sign out of the active one — stays in the app on the other account; no flash of the login screen.
- [x] Manual: with a single account, sign out — goes to login screen as before.