### PR TITLE
fix: refresh chat backup status after cross-device self-verification

### DIFF
--- a/lib/features/e2ee/widgets/verification_request_listener.dart
+++ b/lib/features/e2ee/widgets/verification_request_listener.dart
@@ -88,6 +88,12 @@ class _VerificationRequestListenerState
         debugPrint('[Kohera] Post-verification key recovery failed: $e');
       }
       if (!mounted) return;
+      try {
+        await matrix.chatBackup.checkChatBackupStatus();
+      } catch (e) {
+        debugPrint('[Kohera] Post-verification backup status check failed: $e');
+      }
+      if (!mounted) return;
     }
 
     _showNextPending();

--- a/test/widgets/verification_request_listener_test.dart
+++ b/test/widgets/verification_request_listener_test.dart
@@ -50,6 +50,8 @@ void main() {
     when(mockMatrix.chatBackup).thenReturn(mockChatBackup);
     when(mockChatBackup.runKeyRecovery(ssssKey: anyNamed('ssssKey')))
         .thenAnswer((_) => Future<void>.value());
+    when(mockChatBackup.checkChatBackupStatus())
+        .thenAnswer((_) => Future<void>.value());
   });
 
   Future<GoRouter> pumpListener(WidgetTester tester) async {
@@ -94,6 +96,42 @@ void main() {
 
     verify(mockChatBackup.runKeyRecovery(ssssKey: anyNamed('ssssKey')))
         .called(1);
+  });
+
+  testWidgets(
+      'self verification confirmed refreshes chat backup status '
+      '(regression for #309)', (tester) async {
+    await pumpListener(tester);
+
+    final verification = _FakeVerification(userId: selfUserId);
+    verificationStream.add(verification);
+    await tester.pump();
+
+    verification.simulateStateChange(KeyVerificationState.done);
+    await tester.pump();
+
+    await tester.tap(find.text('Done'));
+    await tester.pumpAndSettle();
+
+    verify(mockChatBackup.checkChatBackupStatus()).called(1);
+  });
+
+  testWidgets(
+      'cross-user verification confirmed does not refresh chat backup status',
+      (tester) async {
+    await pumpListener(tester);
+
+    final verification = _FakeVerification(userId: otherUserId);
+    verificationStream.add(verification);
+    await tester.pump();
+
+    verification.simulateStateChange(KeyVerificationState.done);
+    await tester.pump();
+
+    await tester.tap(find.text('Done'));
+    await tester.pumpAndSettle();
+
+    verifyNever(mockChatBackup.checkChatBackupStatus());
   });
 
   testWidgets('self verification cancelled does not trigger runKeyRecovery',


### PR DESCRIPTION
## Summary

- `VerificationRequestListener._showVerification()` ran `runKeyRecovery()` on self-verification success but never called `ChatBackupService.checkChatBackupStatus()`, so `chatBackupNeeded` stayed `true`.
- Result: after completing emoji verification initiated by another device, the "Protect your messages" banner and E2EE unlock screen stayed on screen even though crypto state was now healthy.
- Fix: after the post-verification key recovery completes, call `checkChatBackupStatus()` to re-evaluate and notify listeners.

Closes #309

## Test plan

- [x] New regression test: `self verification confirmed refreshes chat backup status (regression for #309)` — fails on unfixed code, passes with fix.
- [x] New negative test: cross-user verification does not refresh backup status (scope is self-verification only).
- [x] Existing tests in `verification_request_listener_test.dart` still pass.
- [ ] Manual: log in on two devices, run emoji verification, confirm banner/unlock screen disappear on the receiving device.