### PR TITLE
fix: re-fetch LiveKit well-known on TTL expiry

### DIFF
--- a/lib/features/calling/services/livekit_service.dart
+++ b/lib/features/calling/services/livekit_service.dart
@@ -698,6 +698,7 @@ class LiveKitService {
         DateTime.now().difference(_wellKnownFetchedAt!) > _wellKnownTtl) {
       _cachedLivekitServiceUrl = null;
       _wellKnownFetchedAt = null;
+      unawaited(fetchWellKnownLiveKit());
     }
     return _cachedLivekitServiceUrl;
   }
@@ -705,6 +706,11 @@ class LiveKitService {
   set cachedLivekitServiceUrlForTest(String? url) {
     _cachedLivekitServiceUrl = url;
     _wellKnownFetchedAt = url != null ? DateTime.now() : null;
+  }
+
+  @visibleForTesting
+  set wellKnownFetchedAtForTest(DateTime? when) {
+    _wellKnownFetchedAt = when;
   }
 
   Future<void> fetchWellKnownLiveKit() async {

--- a/test/services/livekit_service_test.dart
+++ b/test/services/livekit_service_test.dart
@@ -874,6 +874,38 @@ void main() {
       service.cachedLivekitServiceUrlForTest = null;
       expect(service.cachedLivekitServiceUrl, isNull);
     });
+
+    test(
+        'expired cache triggers background re-fetch (regression for #347)',
+        () async {
+      when(mockClient.getWellknown()).thenAnswer((_) async =>
+          DiscoveryInformation(
+            mHomeserver: HomeserverInformation(
+                baseUrl: Uri.parse('https://example.com'),),
+            additionalProperties: {
+              'org.matrix.msc4143.rtc_foci': [
+                {
+                  'type': 'livekit',
+                  'livekit_service_url': 'https://lk.example.com',
+                },
+              ],
+            },
+          ),);
+
+      service.cachedLivekitServiceUrlForTest = 'https://stale.example.com';
+      service.wellKnownFetchedAtForTest =
+          DateTime.now().subtract(const Duration(hours: 2));
+
+      final readback = service.cachedLivekitServiceUrl;
+      expect(readback, isNull,
+          reason: 'expired cache should null out on read',);
+
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      verify(mockClient.getWellknown()).called(1);
+      expect(service.cachedLivekitServiceUrl, 'https://lk.example.com');
+    });
   });
 
   // ── LiveKit events ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `LiveKitService.cachedLivekitServiceUrl` (`lib/features/calling/services/livekit_service.dart:695`) self-invalidated after the 1h well-known TTL but nothing re-fetched.
- `CallService.isCallingAvailable` reads that getter; once null, the headset quick-start button in `room_tile.dart:443` disappeared for non-DM tiles until app restart.
- Fix: kick off `unawaited(fetchWellKnownLiveKit())` in the same expiry branch that nulls the cache. Existing `_onChanged()` on successful fetch notifies listeners so the UI picks up the refreshed URL.
- Added `@visibleForTesting` setter `wellKnownFetchedAtForTest` to age the cache deterministically in tests.

Closes #347

## Test plan

- [x] New regression test `expired cache triggers background re-fetch (regression for #347)` — fails when the `unawaited(...)` call is removed, passes with it.
- [x] All 73 tests in `livekit_service_test.dart` pass.
- [x] Manual: leave app running >1h on a homeserver that publishes `org.matrix.msc4143.rtc_foci`; confirm headset icon still visible on non-DM room tiles without restart.