### PR TITLE
feat: make message text selectable

### DIFF
--- a/lib/features/chat/widgets/message_bubble.dart
+++ b/lib/features/chat/widgets/message_bubble.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/utils/platform_info.dart';
@@ -195,9 +196,12 @@ class _MessageBubbleState extends State<MessageBubble> {
         onExit: (_) {
           if (!_quickReactOpen.value) _hovering.value = false;
         },
-        child: GestureDetector(
-          onSecondaryTapUp: (details) =>
-              _openContextMenu(details.globalPosition),
+        child: Listener(
+          onPointerDown: (event) {
+            if (event.buttons == kSecondaryMouseButton) {
+              _openContextMenu(event.position);
+            }
+          },
           child: bubble,
         ),
       );

--- a/lib/features/chat/widgets/message_bubble_content.dart
+++ b/lib/features/chat/widgets/message_bubble_content.dart
@@ -57,48 +57,50 @@ class MessageBubbleContent extends StatelessWidget {
         (displayEvent.messageType == MessageTypes.Text ||
             displayEvent.messageType == MessageTypes.Notice);
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        if (replyEventId != null)
-          Padding(
-            padding: const EdgeInsets.only(bottom: 4),
-            child: InlineReplyPreview(
-              event: event,
-              timeline: timeline,
-              isMe: isMe,
-              onTap: onTapReply,
-            ),
-          ),
-        if (!isMe && isFirst)
-          Padding(
-            padding: EdgeInsets.only(bottom: metrics.senderNameBottomPad),
-            child: Text(
-              event.senderFromMemoryOrFallback.displayName ?? event.senderId,
-              style: tt.bodyMedium?.copyWith(
-                fontWeight: FontWeight.w600,
-                fontSize: metrics.senderNameFontSize,
-                color: senderColor(event.senderId, cs),
+    return SelectionArea(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (replyEventId != null)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: InlineReplyPreview(
+                event: event,
+                timeline: timeline,
+                isMe: isMe,
+                onTap: onTapReply,
               ),
             ),
+          if (!isMe && isFirst)
+            Padding(
+              padding: EdgeInsets.only(bottom: metrics.senderNameBottomPad),
+              child: Text(
+                event.senderFromMemoryOrFallback.displayName ?? event.senderId,
+                style: tt.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                  fontSize: metrics.senderNameFontSize,
+                  color: senderColor(event.senderId, cs),
+                ),
+              ),
+            ),
+          MessageBubbleBody(
+            event: event,
+            displayEvent: displayEvent,
+            bodyText: bodyText,
+            isMe: isMe,
+            metrics: metrics,
           ),
-        MessageBubbleBody(
-          event: event,
-          displayEvent: displayEvent,
-          bodyText: bodyText,
-          isMe: isMe,
-          metrics: metrics,
-        ),
-        if (isTextMessage)
-          MessageBubbleLinkPreview(bodyText: bodyText, isMe: isMe),
-        MessageBubbleTimestamp(
-          event: event,
-          isMe: isMe,
-          isPinned: isPinned,
-          isEdited: isEdited,
-          metrics: metrics,
-        ),
-      ],
+          if (isTextMessage)
+            MessageBubbleLinkPreview(bodyText: bodyText, isMe: isMe),
+          MessageBubbleTimestamp(
+            event: event,
+            isMe: isMe,
+            isPinned: isPinned,
+            isEdited: isEdited,
+            metrics: metrics,
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- Wrap `MessageBubbleContent` in `SelectionArea` so body, sender name, reply preview, file name, and timestamp are mouse-selectable/copyable.
- Placed inside `SwipeableMessage`/`LongPressWrapper` so mobile swipe-to-reply and long-press actions stay intact.

## Test plan
- [x] Desktop: drag-select text across a message bubble, copy, paste elsewhere.
- [x] Desktop: select across sender name, reply preview, timestamp.
- [x] Mobile: swipe-to-reply still triggers.
- [x] Mobile: long-press menu still opens.