### PR TITLE
fix: clear MatrixRTC membership when declining incoming call

### DIFF
--- a/lib/core/services/call_service.dart
+++ b/lib/core/services/call_service.dart
@@ -661,9 +661,22 @@ class CallService extends ChangeNotifier with WidgetsBindingObserver {
   void declineCall() {
     if (_callState != KoheraCallState.ringingIncoming) return;
 
+    final roomId = _ringing.incomingCall?.roomId;
+
     _ringing.stopRinging();
     _ringing.resetIncomingCall();
     _incomingCallerStateKey = null;
+
+    if (roomId != null) {
+      unawaited(
+        _rtcMembership.removeMembershipEvent(roomId).catchError(
+          (Object e) => debugPrint(
+            '[Kohera] Failed to remove membership on decline: $e',
+          ),
+        ),
+      );
+    }
+
     _setCallState(KoheraCallState.idle);
   }
 

--- a/test/services/call_service_test.dart
+++ b/test/services/call_service_test.dart
@@ -496,6 +496,52 @@ void main() {
       expect(service.callState, KoheraCallState.idle);
     });
 
+    test('declineCall removes RTC membership for incoming roomId', () async {
+      when(mockClient.setRoomStateWithKey(any, any, any, any))
+          .thenAnswer((_) async => 'event_id');
+
+      service.handlePushCallInvite(
+        roomId: '!room:example.com',
+        callId: 'call1',
+        callerName: 'Alice',
+        isVideo: false,
+        callKitAlreadyShown: true,
+      );
+      expect(service.callState, KoheraCallState.ringingIncoming);
+
+      service.declineCall();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(service.callState, KoheraCallState.idle);
+      verify(
+        mockClient.setRoomStateWithKey(
+          '!room:example.com',
+          'org.matrix.msc3401.call.member',
+          '_@user:example.com_DEVICE1_m.call',
+          <String, dynamic>{},
+        ),
+      ).called(1);
+    });
+
+    test('acceptCall joins and reaches connected', () async {
+      setupLiveKitMocks();
+      setupMockRoom();
+
+      service.handlePushCallInvite(
+        roomId: '!room:example.com',
+        callId: 'call1',
+        callerName: 'Alice',
+        isVideo: false,
+        callKitAlreadyShown: true,
+      );
+      expect(service.callState, KoheraCallState.ringingIncoming);
+
+      await service.acceptCall();
+
+      expect(service.callState, KoheraCallState.connected);
+      expect(service.activeCallRoomId, '!room:example.com');
+    });
+
     test('cancelOutgoingCall resets state', () {
       service.cancelOutgoingCall();
       expect(service.callState, KoheraCallState.idle);


### PR DESCRIPTION
declineCall() reset local ringing state but never removed the callee's
m.call.member state event, leaving the caller ringing for up to ~30s
until ringPhase expiry instead of hanging up immediately. Mirror the
cancelOutgoingCall() pattern: capture the incoming roomId before
resetIncomingCall() clears it, then fire removeMembershipEvent.

Also adds the previously-missing accept-flow test (accept -> joinCall
-> connected) noted as a gap during the #319 review.

Closes #352