### PR TITLE
fix: e2ee setup Done button after fresh-key bootstrap

### DIFF
--- a/lib/features/e2ee/screens/e2ee_setup_screen.dart
+++ b/lib/features/e2ee/screens/e2ee_setup_screen.dart
@@ -124,10 +124,12 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
   // ── Finish / Skip ─────────────────────────────────────────────
 
   Future<void> _finishSetup() async {
-    if (_controller?.keyCopied ?? false) {
+    final shouldClearClipboard = _controller?.keyCopied ?? false;
+    _matrixService.skipSetup();
+    if (mounted) context.go('/');
+    if (shouldClearClipboard) {
       unawaited(Clipboard.setData(const ClipboardData(text: '')));
     }
-    if (mounted) context.go('/');
   }
 
   void _skip() {


### PR DESCRIPTION
## Summary
- After creating a new recovery key, tapping **Done** on the "You're all set!" screen sometimes did nothing.
- Root cause: \`_finishSetup\` ran \`unawaited(Clipboard.setData(...))\` before \`context.go('/')\`, and didn't call \`skipSetup()\`. A post-bootstrap sync race that flipped \`chatBackupNeeded\` back to \`true\` would then cause the router redirect to bounce straight back to \`/e2ee-setup\` (which lands on the management view, looking like nothing happened).
- Fix: navigate first, clear the clipboard after, and set \`hasSkippedSetup\` so the redirect cannot pull the user back into the setup flow.

## Test plan
- [x] Run on Linux, fresh account, walk the setup wizard with **Create new key**.
- [x] On "You're all set!", tap **Done** → app navigates to home and stays there (no bounce back to setup).
- [x] Repeat with **Save to device** + **Copy** checked → clipboard is still cleared after navigation.
- [x] Existing skip / disable / unlock flows unaffected.