### PR TITLE
fix: support UIA fallback for OAuth/SSO cross-signing upload

### DIFF
--- a/lib/core/services/sub_services/uia_service.dart
+++ b/lib/core/services/sub_services/uia_service.dart
@@ -57,9 +57,29 @@ class UiaService {
           ),
         );
       default:
-        debugPrint('[Kohera] UIA: unsupported stage $stage, cancelling');
-        uiaRequest.cancel();
+        debugPrint(
+          '[Kohera] UIA: stage $stage requires fallback, forwarding to UI',
+        );
+        _uiaController.add(uiaRequest);
     }
+  }
+
+  /// Completes a UIA stage that was authenticated via the homeserver's
+  /// `/auth/<type>/fallback/web` flow. The browser-completed session is
+  /// re-submitted with only `{ session, type }`; the server recognises the
+  /// stage as already satisfied.
+  void completeUiaFallback(UiaRequest<dynamic> request) {
+    final stage =
+        request.nextStages.isNotEmpty ? request.nextStages.first : null;
+    if (stage == null) return;
+    unawaited(
+      request.completeStage(
+        AuthenticationData(
+          type: stage,
+          session: request.session,
+        ),
+      ),
+    );
   }
 
   void completeUiaWithPassword(UiaRequest<dynamic> request, String password) {

--- a/lib/features/e2ee/screens/e2ee_setup_screen.dart
+++ b/lib/features/e2ee/screens/e2ee_setup_screen.dart
@@ -9,6 +9,7 @@ import 'package:kohera/features/e2ee/widgets/bootstrap_controller.dart';
 import 'package:kohera/features/e2ee/widgets/key_verification_inline.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 // ── Screen-local steps (outside bootstrap lifecycle) ───────────
 
@@ -85,6 +86,20 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
   Future<void> _showUiaPasswordPrompt(UiaRequest<dynamic> request) async {
     if (!mounted || _uiaPromptShowing) return;
     _uiaPromptShowing = true;
+    final stage =
+        request.nextStages.isNotEmpty ? request.nextStages.first : '';
+    try {
+      if (stage == AuthenticationTypes.password) {
+        await _runPasswordPrompt(request);
+      } else {
+        await _runFallbackPrompt(request, stage);
+      }
+    } finally {
+      _uiaPromptShowing = false;
+    }
+  }
+
+  Future<void> _runPasswordPrompt(UiaRequest<dynamic> request) async {
     var passwordValue = '';
     final password = await showDialog<String>(
       context: context,
@@ -113,9 +128,76 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
         ],
       ),
     );
-    _uiaPromptShowing = false;
     if (password != null && password.isNotEmpty) {
       _matrixService.uia.completeUiaWithPassword(request, password);
+    } else {
+      request.cancel();
+    }
+  }
+
+  Future<void> _runFallbackPrompt(
+    UiaRequest<dynamic> request,
+    String stage,
+  ) async {
+    final homeserver = _matrixService.client.homeserver;
+    if (homeserver == null) {
+      request.cancel();
+      return;
+    }
+    final fallbackUrl = Uri.parse(
+      '$homeserver/_matrix/client/v3/auth/$stage/fallback/web'
+      '?session=${Uri.encodeQueryComponent(request.session ?? '')}',
+    );
+    var browserOpened = false;
+    final completed = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setLocal) => AlertDialog(
+          title: const Text('Authentication required'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Your homeserver requires you to authenticate in a browser '
+                'to continue (stage: $stage).',
+              ),
+              const SizedBox(height: 12),
+              const Text(
+                '1. Open the authentication page in your browser.\n'
+                '2. Complete the prompts there.\n'
+                '3. Return here and tap Continue.',
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () async {
+                final ok = await launchUrl(
+                  fallbackUrl,
+                  mode: LaunchMode.externalApplication,
+                );
+                if (ok) setLocal(() => browserOpened = true);
+              },
+              child: const Text('Open in browser'),
+            ),
+            FilledButton(
+              onPressed: browserOpened
+                  ? () => Navigator.pop(ctx, true)
+                  : null,
+              child: const Text('Continue'),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (completed == true) {
+      _matrixService.uia.completeUiaFallback(request);
     } else {
       request.cancel();
     }


### PR DESCRIPTION
## Summary
- Homeservers running MAS (matrix.org) or other OIDC backends now emit non-password UIA stages (e.g. \`m.oauth\`) when uploading cross-signing keys. \`UiaService\` cancelled anything that wasn't \`m.login.password\` / \`m.login.dummy\`, which made every bootstrap fail mid-flow with \`Error setting up cross signing - Request has been canceled\` and left users unable to enable chat backup.
- Forward unknown stages to the UI instead of cancelling. Add \`UiaService.completeUiaFallback(request)\` that resubmits \`{ session, type }\` after the user completes the homeserver's \`/_matrix/client/v3/auth/<type>/fallback/web\` flow in a browser.
- New fallback dialog in the e2ee setup screen: explains the situation, has an "Open in browser" button (uses \`url_launcher\`), gates the **Continue** button until the URL is launched, and cancels the request on dismiss. Password stages still use the existing inline dialog.

## Test plan
- [ ] Linux build, account on a MAS-fronted homeserver (matrix.org). Wipe + recreate backup → fallback dialog appears, browser opens, complete OIDC consent, click **Continue** → bootstrap finishes and chat backup is enabled.
- [ ] Account on a classic password-UIA homeserver → existing password dialog still appears and works.
- [ ] Cancel the fallback dialog → bootstrap reports error cleanly, no retry storm.

Refs the OAuth/MAS UIA migration on matrix.org.