### PR TITLE
feat: join spaces from discovery list (S2 of #113)

### DIFF
--- a/lib/features/home/widgets/mobile_space_drawer.dart
+++ b/lib/features/home/widgets/mobile_space_drawer.dart
@@ -110,6 +110,17 @@ class MobileSpaceDrawer extends StatelessWidget {
                 unawaited(JoinSpaceDialog.show(context, matrixService: matrix));
               },
             ),
+            ListTile(
+              leading: Icon(Icons.travel_explore, color: cs.primary),
+              title: const Text('Explore spaces'),
+              onTap: () {
+                final matrix = context.read<MatrixService>();
+                Navigator.of(context).pop();
+                unawaited(
+                  SpaceDiscoveryDialog.show(context, matrixService: matrix),
+                );
+              },
+            ),
           ],
         ),
       ),

--- a/lib/features/spaces/widgets/space_action_dialog.dart
+++ b/lib/features/spaces/widgets/space_action_dialog.dart
@@ -556,22 +556,27 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
       );
     }
 
-    return AlertDialog(
-      title: const Text('Explore spaces'),
-      insetPadding: isWide
-          ? const EdgeInsets.symmetric(horizontal: 40, vertical: 24)
-          : const EdgeInsets.all(12),
-      content: SizedBox(
-        width: isWide ? 480 : size.width,
-        height: isWide ? 520 : size.height * 0.75,
-        child: body,
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(context),
-          child: const Text('Close'),
+    final isJoiningAny = _joiningRoomId != null;
+
+    return PopScope(
+      canPop: !isJoiningAny,
+      child: AlertDialog(
+        title: const Text('Explore spaces'),
+        insetPadding: isWide
+            ? const EdgeInsets.symmetric(horizontal: 40, vertical: 24)
+            : const EdgeInsets.all(12),
+        content: SizedBox(
+          width: isWide ? 480 : size.width,
+          height: isWide ? 520 : size.height * 0.75,
+          child: body,
         ),
-      ],
+        actions: [
+          TextButton(
+            onPressed: isJoiningAny ? null : () => Navigator.pop(context),
+            child: const Text('Close'),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/spaces/widgets/space_action_dialog.dart
+++ b/lib/features/spaces/widgets/space_action_dialog.dart
@@ -525,7 +525,7 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
               chunk.roomId;
           final isJoining = _joiningRoomId == chunk.roomId;
           return ListTile(
-            enabled: _joiningRoomId == null,
+            enabled: _joiningRoomId == null || isJoining,
             title: Text(title, maxLines: 1, overflow: TextOverflow.ellipsis),
             subtitle: Text('${chunk.numJoinedMembers} members'),
             trailing: isJoining

--- a/lib/features/spaces/widgets/space_action_dialog.dart
+++ b/lib/features/spaces/widgets/space_action_dialog.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart' hide Visibility;
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
+import 'package:kohera/features/home/screens/home_shell.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 
@@ -404,6 +405,8 @@ class SpaceDiscoveryDialog extends StatefulWidget {
 class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
   List<PublishedRoomsChunk>? _results;
   String? _error;
+  String? _joiningRoomId;
+  String? _joinError;
 
   @override
   void initState() {
@@ -428,9 +431,55 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
     }
   }
 
+  List<String>? _viaFor(PublishedRoomsChunk chunk) {
+    final alias = chunk.canonicalAlias;
+    if (alias != null) {
+      final idx = alias.indexOf(':');
+      if (idx != -1 && idx < alias.length - 1) {
+        return [alias.substring(idx + 1)];
+      }
+    }
+    return null;
+  }
+
+  Future<void> _join(PublishedRoomsChunk chunk) async {
+    if (_joiningRoomId != null) return;
+    final client = widget.matrixService.client;
+    final target = chunk.canonicalAlias ?? chunk.roomId;
+    final via = _viaFor(chunk);
+
+    setState(() {
+      _joiningRoomId = chunk.roomId;
+      _joinError = null;
+    });
+
+    try {
+      final roomId = await client.joinRoom(target, via: via);
+      await client
+          .waitForRoomInSync(roomId, join: true)
+          .timeout(const Duration(seconds: 30));
+
+      if (!mounted) return;
+      final room = client.getRoomById(roomId);
+      if (room != null && room.isSpace) {
+        context.read<SelectionService>().selectSpace(roomId);
+      }
+      Navigator.pop(context);
+    } catch (e) {
+      debugPrint('[Kohera] Space discovery join failed: $e');
+      if (!mounted) return;
+      setState(() {
+        _joinError = MatrixService.friendlyAuthError(e);
+        _joiningRoomId = null;
+      });
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
+    final size = MediaQuery.sizeOf(context);
+    final isWide = size.width >= HomeShell.wideBreakpoint;
 
     Widget body;
     if (_error != null) {
@@ -467,27 +516,54 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
         ),
       );
     } else {
-      body = ListView.builder(
+      final list = ListView.builder(
         itemCount: _results!.length,
         itemBuilder: (context, i) {
           final chunk = _results![i];
           final title = chunk.name ??
               chunk.canonicalAlias ??
               chunk.roomId;
+          final isJoining = _joiningRoomId == chunk.roomId;
           return ListTile(
+            enabled: _joiningRoomId == null,
             title: Text(title, maxLines: 1, overflow: TextOverflow.ellipsis),
             subtitle: Text('${chunk.numJoinedMembers} members'),
-            onTap: () => Navigator.pop(context),
+            trailing: isJoining
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : null,
+            onTap: () => _join(chunk),
           );
         },
+      );
+
+      body = Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (_joinError != null)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Text(
+                _joinError!,
+                style: TextStyle(color: cs.error),
+              ),
+            ),
+          Expanded(child: list),
+        ],
       );
     }
 
     return AlertDialog(
       title: const Text('Explore spaces'),
+      insetPadding: isWide
+          ? const EdgeInsets.symmetric(horizontal: 40, vertical: 24)
+          : const EdgeInsets.all(12),
       content: SizedBox(
-        width: 480,
-        height: 520,
+        width: isWide ? 480 : size.width,
+        height: isWide ? 520 : size.height * 0.75,
         child: body,
       ),
       actions: [


### PR DESCRIPTION
## Summary
- Wires `SpaceDiscoveryDialog` row taps to `client.joinRoom`, using the chunk's `canonicalAlias` when present (with `via` parsed from the alias domain) and falling back to `roomId`. Awaits `waitForRoomInSync`, calls `SelectionService.selectSpace` if the joined room is a space, then pops.
- Per-row spinner while joining; single in-flight join lock; inline error banner via `MatrixService.friendlyAuthError` keeps the dialog open on failure.
- `PopScope` + disabled Close button block dismiss mid-join so background joins can't complete silently after the user cancels.
- Adapts the dialog to narrow widths via `HomeShell.wideBreakpoint` — S1 hardcoded 480×520 which overflowed on phone-sized viewports.
- Adds an "Explore spaces" tile to `MobileSpaceDrawer` next to Create/Join space, since the space rail (and its `+` menu) is only mounted in `WideLayout` — without this, mobile users had no way to reach the dialog.

Closes #358. Refs #113.

## Out of scope (future slices)
S3 `m.space` filter + preview, S4 pagination, S5 search, S6 cross-server, S7 persisted server list.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter run -d linux`, `+` rail menu → Explore spaces → tap a public room → row spinner → dialog closes → room appears in inbox
- [x] Tap a public space (e.g. `#community:matrix.org`) → space becomes selected on the rail
- [x] Tap a federated entry (alias on a non-local server) → joins successfully via parsed `via`
- [ ] Force network failure mid-join → inline red error appears, dialog stays open, other rows tappable
- [x] Try to dismiss while joining (Close button, barrier tap, back) → blocked until join settles
- [x] Resize window below 720 px → dialog fills width with 12 px insets; row spinner and error banner readable
- [x] On a narrow build (or simulated phone), open hamburger drawer on Inbox/Chats → "Explore spaces" tile opens the same dialog