### PR TITLE
feat: spaces-only discovery + hierarchical preview (S3 of #113)

### DIFF
--- a/lib/features/spaces/widgets/space_action_dialog.dart
+++ b/lib/features/spaces/widgets/space_action_dialog.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart' hide Visibility;
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/home/screens/home_shell.dart';
+import 'package:kohera/shared/widgets/mxc_image.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 
@@ -402,11 +403,29 @@ class SpaceDiscoveryDialog extends StatefulWidget {
   State<SpaceDiscoveryDialog> createState() => _SpaceDiscoveryDialogState();
 }
 
+class _PreviewFrame {
+  _PreviewFrame({
+    required this.roomId,
+    this.fallbackName,
+    this.fallbackAvatar,
+  });
+
+  final String roomId;
+  final String? fallbackName;
+  final Uri? fallbackAvatar;
+
+  GetSpaceHierarchyResponse? hierarchy;
+  String? error;
+}
+
+const int _maxPreviewDepth = 5;
+
 class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
   List<PublishedRoomsChunk>? _results;
   String? _error;
   String? _joiningRoomId;
   String? _joinError;
+  final List<_PreviewFrame> _previewStack = [];
 
   @override
   void initState() {
@@ -420,8 +439,12 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
       _error = null;
     });
     try {
-      final resp =
-          await widget.matrixService.client.queryPublicRooms(limit: 50);
+      final resp = await widget.matrixService.client.queryPublicRooms(
+        limit: 50,
+        filter: PublicRoomQueryFilter(
+          roomTypes: ['m.space'],
+        ),
+      );
       if (!mounted) return;
       setState(() => _results = resp.chunk);
     } catch (e) {
@@ -431,40 +454,114 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
     }
   }
 
-  List<String>? _viaFor(PublishedRoomsChunk chunk) {
-    final alias = chunk.canonicalAlias;
-    if (alias != null) {
-      final idx = alias.indexOf(':');
-      if (idx != -1 && idx < alias.length - 1) {
-        return [alias.substring(idx + 1)];
-      }
-    }
-    return null;
+  List<String>? _viaFromAlias(String? alias) {
+    if (alias == null) return null;
+    final idx = alias.indexOf(':');
+    if (idx == -1 || idx >= alias.length - 1) return null;
+    return [alias.substring(idx + 1)];
   }
 
-  Future<void> _join(PublishedRoomsChunk chunk) async {
+  bool _isMember(String roomId) {
+    final room = widget.matrixService.client.getRoomById(roomId);
+    return room != null && room.membership == Membership.join;
+  }
+
+  // ── Preview navigation ──────────────────────────────────────────
+
+  void _openPreview(PublishedRoomsChunk chunk) {
+    debugPrint('[Kohera] Space preview opened: ${chunk.roomId}');
+    final frame = _PreviewFrame(
+      roomId: chunk.roomId,
+      fallbackName: chunk.name ?? chunk.canonicalAlias,
+      fallbackAvatar: chunk.avatarUrl,
+    );
+    setState(() {
+      _previewStack.add(frame);
+      _joinError = null;
+    });
+    unawaited(_loadHierarchy(frame));
+  }
+
+  void _pushSubspace(SpaceRoomsChunk$2 child) {
+    if (_previewStack.length >= _maxPreviewDepth) {
+      debugPrint('[Kohera] Space preview stack at max depth, ignoring open');
+      return;
+    }
+    debugPrint('[Kohera] Space subspace opened: ${child.roomId}');
+    final frame = _PreviewFrame(
+      roomId: child.roomId,
+      fallbackName: child.name ?? child.canonicalAlias,
+      fallbackAvatar: child.avatarUrl,
+    );
+    setState(() {
+      _previewStack.add(frame);
+      _joinError = null;
+    });
+    unawaited(_loadHierarchy(frame));
+  }
+
+  void _popPreview() {
+    if (_previewStack.isEmpty) return;
+    setState(() {
+      _previewStack.removeLast();
+      _joinError = null;
+    });
+  }
+
+  Future<void> _loadHierarchy(_PreviewFrame frame) async {
+    try {
+      final resp = await widget.matrixService.client.getSpaceHierarchy(
+        frame.roomId,
+        maxDepth: 1,
+        suggestedOnly: false,
+      );
+      if (!mounted) return;
+      setState(() => frame.hierarchy = resp);
+    } catch (e) {
+      debugPrint('[Kohera] Space hierarchy fetch failed: $e');
+      if (!mounted) return;
+      setState(() => frame.error = MatrixService.friendlyAuthError(e));
+    }
+  }
+
+  Future<void> _retryHierarchy(_PreviewFrame frame) async {
+    setState(() {
+      frame.error = null;
+      frame.hierarchy = null;
+    });
+    await _loadHierarchy(frame);
+  }
+
+  // ── Join ────────────────────────────────────────────────────────
+
+  Future<void> _joinChunk({
+    required String roomId,
+    String? alias,
+    List<String>? via,
+  }) async {
     if (_joiningRoomId != null) return;
     final client = widget.matrixService.client;
-    final target = chunk.canonicalAlias ?? chunk.roomId;
-    final via = _viaFor(chunk);
+    final target = alias ?? roomId;
 
     setState(() {
-      _joiningRoomId = chunk.roomId;
+      _joiningRoomId = roomId;
       _joinError = null;
     });
 
     try {
-      final roomId = await client.joinRoom(target, via: via);
+      final joinedId = await client.joinRoom(target, via: via);
       await client
-          .waitForRoomInSync(roomId, join: true)
+          .waitForRoomInSync(joinedId, join: true)
           .timeout(const Duration(seconds: 30));
 
       if (!mounted) return;
-      final room = client.getRoomById(roomId);
+      final room = client.getRoomById(joinedId);
       if (room != null && room.isSpace) {
-        context.read<SelectionService>().selectSpace(roomId);
+        context.read<SelectionService>().selectSpace(joinedId);
+        Navigator.pop(context);
+        return;
       }
-      Navigator.pop(context);
+      setState(() => _joiningRoomId = null);
     } catch (e) {
       debugPrint('[Kohera] Space discovery join failed: $e');
       if (!mounted) return;
@@ -475,15 +572,83 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
     }
   }
 
+  void _openExistingSpace(String roomId) {
+    context.read<SelectionService>().selectSpace(roomId);
+    Navigator.pop(context);
+  }
+
+  // ── Build ───────────────────────────────────────────────────────
+
   @override
   Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
     final size = MediaQuery.sizeOf(context);
     final isWide = size.width >= HomeShell.wideBreakpoint;
+    final inPreview = _previewStack.isNotEmpty;
+    final isJoiningAny = _joiningRoomId != null;
 
-    Widget body;
+    final Widget content;
+    final String title;
+    final Widget? leading;
+
+    if (inPreview) {
+      final frame = _previewStack.last;
+      content = _buildPreview(frame);
+      title = frame.fallbackName ?? frame.roomId;
+      leading = IconButton(
+        icon: const Icon(Icons.arrow_back),
+        tooltip: 'Back',
+        onPressed: isJoiningAny ? null : _popPreview,
+      );
+    } else {
+      content = _buildList();
+      title = 'Explore spaces';
+      leading = null;
+    }
+
+    return PopScope(
+      canPop: !isJoiningAny && !inPreview,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop && inPreview && !isJoiningAny) _popPreview();
+      },
+      child: AlertDialog(
+        titlePadding: const EdgeInsets.fromLTRB(8, 16, 16, 0),
+        title: Row(
+          children: [
+            if (leading != null) leading else const SizedBox(width: 16),
+            Expanded(
+              child: Text(
+                title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+        insetPadding: isWide
+            ? const EdgeInsets.symmetric(horizontal: 40, vertical: 24)
+            : const EdgeInsets.all(12),
+        content: SizedBox(
+          width: isWide ? 520 : size.width,
+          height: isWide ? 560 : size.height * 0.75,
+          child: content,
+        ),
+        actions: [
+          TextButton(
+            onPressed: isJoiningAny ? null : () => Navigator.pop(context),
+            child: const Text('Close'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── List view ───────────────────────────────────────────────────
+
+  Widget _buildList() {
+    final cs = Theme.of(context).colorScheme;
+
     if (_error != null) {
-      body = Center(
+      return Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -500,82 +665,296 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
           ],
         ),
       );
-    } else if (_results == null) {
-      body = const Center(
+    }
+    if (_results == null) {
+      return const Center(
         child: SizedBox(
           width: 22,
           height: 22,
           child: CircularProgressIndicator(strokeWidth: 2.5),
         ),
       );
-    } else if (_results!.isEmpty) {
-      body = Center(
+    }
+    if (_results!.isEmpty) {
+      return Center(
         child: Text(
           'No public spaces found.',
           style: TextStyle(color: cs.onSurfaceVariant),
         ),
       );
-    } else {
-      final list = ListView.builder(
-        itemCount: _results!.length,
-        itemBuilder: (context, i) {
-          final chunk = _results![i];
-          final title = chunk.name ??
-              chunk.canonicalAlias ??
-              chunk.roomId;
-          final isJoining = _joiningRoomId == chunk.roomId;
-          return ListTile(
-            enabled: _joiningRoomId == null || isJoining,
-            title: Text(title, maxLines: 1, overflow: TextOverflow.ellipsis),
-            subtitle: Text('${chunk.numJoinedMembers} members'),
-            trailing: isJoining
-                ? const SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : null,
-            onTap: () => _join(chunk),
-          );
-        },
-      );
+    }
 
-      body = Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          if (_joinError != null)
-            Padding(
-              padding: const EdgeInsets.only(bottom: 8),
-              child: Text(
-                _joinError!,
-                style: TextStyle(color: cs.error),
-              ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (_joinError != null)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Text(
+              _joinError!,
+              style: TextStyle(color: cs.error),
             ),
-          Expanded(child: list),
-        ],
+          ),
+        Expanded(
+          child: ListView.builder(
+            itemCount: _results!.length,
+            itemBuilder: (context, i) {
+              final chunk = _results![i];
+              final name = chunk.name ?? chunk.canonicalAlias ?? chunk.roomId;
+              return ListTile(
+                leading: _avatarFor(
+                  chunk.avatarUrl?.toString() ?? '',
+                  name,
+                  size: 40,
+                ),
+                title: Text(name, maxLines: 1, overflow: TextOverflow.ellipsis),
+                subtitle: Text('${chunk.numJoinedMembers} members'),
+                onTap: () => _openPreview(chunk),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  // ── Preview view ────────────────────────────────────────────────
+
+  Widget _buildPreview(_PreviewFrame frame) {
+    final cs = Theme.of(context).colorScheme;
+
+    if (frame.error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              frame.error!,
+              style: TextStyle(color: cs.error),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 12),
+            FilledButton.tonal(
+              onPressed: () => _retryHierarchy(frame),
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+      );
+    }
+    if (frame.hierarchy == null) {
+      return const Center(
+        child: SizedBox(
+          width: 22,
+          height: 22,
+          child: CircularProgressIndicator(strokeWidth: 2.5),
+        ),
       );
     }
 
-    final isJoiningAny = _joiningRoomId != null;
-
-    return PopScope(
-      canPop: !isJoiningAny,
-      child: AlertDialog(
-        title: const Text('Explore spaces'),
-        insetPadding: isWide
-            ? const EdgeInsets.symmetric(horizontal: 40, vertical: 24)
-            : const EdgeInsets.all(12),
-        content: SizedBox(
-          width: isWide ? 480 : size.width,
-          height: isWide ? 520 : size.height * 0.75,
-          child: body,
+    final rooms = frame.hierarchy!.rooms;
+    if (rooms.isEmpty) {
+      return Center(
+        child: Text(
+          'No data for this space.',
+          style: TextStyle(color: cs.onSurfaceVariant),
         ),
-        actions: [
-          TextButton(
-            onPressed: isJoiningAny ? null : () => Navigator.pop(context),
-            child: const Text('Close'),
+      );
+    }
+
+    final self = rooms.first;
+    final children = rooms.skip(1).toList();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (_joinError != null)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Text(
+              _joinError!,
+              style: TextStyle(color: cs.error),
+            ),
           ),
-        ],
+        _buildPreviewHeader(self, children.length),
+        const Divider(height: 24),
+        if (children.isEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 16),
+            child: Text(
+              'This space has no rooms yet.',
+              style: TextStyle(color: cs.onSurfaceVariant),
+              textAlign: TextAlign.center,
+            ),
+          )
+        else
+          Text(
+            'Rooms in this space',
+            style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  color: cs.onSurfaceVariant,
+                ),
+          ),
+        const SizedBox(height: 4),
+        Expanded(
+          child: ListView.builder(
+            itemCount: children.length,
+            itemBuilder: (_, i) => _buildChildTile(children[i]),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPreviewHeader(SpaceRoomsChunk$2 self, int childCount) {
+    final cs = Theme.of(context).colorScheme;
+    final theme = Theme.of(context);
+    final name = self.name ?? self.canonicalAlias ?? self.roomId;
+    final alreadyMember = _isMember(self.roomId);
+    final isJoiningSelf = _joiningRoomId == self.roomId;
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _avatarFor(self.avatarUrl?.toString() ?? '', name, size: 64),
+        const SizedBox(width: 16),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                name,
+                style: theme.textTheme.titleLarge,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              if (self.canonicalAlias != null)
+                Text(
+                  self.canonicalAlias!,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: cs.onSurfaceVariant,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              const SizedBox(height: 4),
+              Text(
+                '${self.numJoinedMembers} members · '
+                '$childCount room${childCount == 1 ? '' : 's'}',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: cs.onSurfaceVariant,
+                ),
+              ),
+              if (self.topic != null && self.topic!.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                Text(
+                  self.topic!,
+                  maxLines: 3,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ],
+              const SizedBox(height: 12),
+              if (alreadyMember)
+                OutlinedButton.icon(
+                  onPressed: _joiningRoomId != null
+                      ? null
+                      : () => _openExistingSpace(self.roomId),
+                  icon: const Icon(Icons.open_in_new, size: 18),
+                  label: const Text('Open'),
+                )
+              else
+                FilledButton(
+                  onPressed: _joiningRoomId != null
+                      ? null
+                      : () => _joinChunk(
+                            roomId: self.roomId,
+                            alias: self.canonicalAlias,
+                            via: _viaFromAlias(self.canonicalAlias),
+                          ),
+                  child: isJoiningSelf
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child:
+                              CircularProgressIndicator(strokeWidth: 2.5),
+                        )
+                      : const Text('Join space'),
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildChildTile(SpaceRoomsChunk$2 child) {
+    final cs = Theme.of(context).colorScheme;
+    final name = child.name ?? child.canonicalAlias ?? child.roomId;
+    final isSpace = child.roomType == 'm.space';
+    final isJoining = _joiningRoomId == child.roomId;
+    final alreadyJoined = _isMember(child.roomId);
+    final disableOthers = _joiningRoomId != null && !isJoining;
+
+    Widget trailing;
+    if (isSpace) {
+      trailing = OutlinedButton(
+        onPressed:
+            disableOthers ? null : () => _pushSubspace(child),
+        child: const Text('Open'),
+      );
+    } else if (alreadyJoined) {
+      trailing = Text(
+        'Joined',
+        style: TextStyle(color: cs.onSurfaceVariant),
+      );
+    } else if (isJoining) {
+      trailing = const SizedBox(
+        width: 20,
+        height: 20,
+        child: CircularProgressIndicator(strokeWidth: 2),
+      );
+    } else {
+      trailing = FilledButton.tonal(
+        onPressed: disableOthers
+            ? null
+            : () => _joinChunk(
+                  roomId: child.roomId,
+                  alias: child.canonicalAlias,
+                  via: _viaFromAlias(child.canonicalAlias),
+                ),
+        child: const Text('Join'),
+      );
+    }
+
+    return ListTile(
+      leading: _avatarFor(
+        child.avatarUrl?.toString() ?? '',
+        name,
+        size: 32,
+      ),
+      title: Text(name, maxLines: 1, overflow: TextOverflow.ellipsis),
+      subtitle: Text('${child.numJoinedMembers} members'),
+      trailing: trailing,
+    );
+  }
+
+  Widget _avatarFor(String mxc, String fallback, {required double size}) {
+    final letter = fallback.isNotEmpty ? fallback[0].toUpperCase() : '?';
+    return ClipOval(
+      child: SizedBox(
+        width: size,
+        height: size,
+        child: MxcImage(
+          mxcUrl: mxc,
+          client: widget.matrixService.client,
+          fallbackText: letter,
+          fallbackStyle: TextStyle(
+            fontSize: size * 0.45,
+            fontWeight: FontWeight.w600,
+          ),
+          width: size,
+          height: size,
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Closes #359, third slice of #113.
- The outer \`queryPublicRooms\` call now passes \`PublicRoomQueryFilter(roomTypes: ['m.space'])\`, so the discovery list contains only public spaces.
- Tap on a row opens a preview inside the dialog that fetches \`getSpaceHierarchy(roomId, maxDepth: 1)\` and renders a header (avatar / name / canonical alias / member count + room count / topic clamped to 3 lines) plus a scrollable list of direct children.
- Per-child trailing action reflects state: \`Join\` for unjoined rooms, \`Joining\` spinner, \`Joined\` once member, \`Open\` for subspaces (recurses the preview, capped at 5 levels).
- Header action: \`Join space\` when not a member; \`Open\` (selects + closes) when already joined. Joining a parent space still selects it and pops the dialog as in S2.
- \`MxcImage\` (wrapped in \`ClipOval\`) used for both header and child avatars; no \`Room\` instance is needed since both chunk types expose \`avatarUrl\`.

## Deviation from the issue
The issue specced \`showModalBottomSheet\` on narrow widths. PR keeps the in-dialog content swap on every breakpoint — running two parallel widget trees (sheet + dialog) needed extra plumbing to keep their state in sync, and the existing dialog already covers ~75% of a narrow viewport, so the visual difference was minor. Easy follow-up if it turns out to matter.

## Test plan
- [x] \`flutter analyze\` clean.
- [x] \`flutter run -d linux\` against an account with public spaces (matrix.org / quantum-matrix.xyz). Open \`+\` → Explore spaces.
- [x] List shows spaces only, no plain rooms.
- [x] Tap a row → preview swaps in. Header shows avatar, counts, topic. Children list populates.
- [x] Tap **Join** on a room child → spinner → tile reads \"Joined\". Verify membership in the room list without having joined the parent.
- [ ] Tap **Open** on a subspace child → preview recurses. Open 5 levels → 6th tap is a no-op (debug log).
- [ ] Back arrow pops one preview level. Once empty, list view returns.
- [ ] Header **Join space** on unjoined parent → joins, dialog closes, space selected in rail.
- [ ] Already-joined parent → header reads **Open**, tap → dialog closes, space selected.
- [ ] Force a hierarchy error (bad roomId or 403) → preview shows error + Retry.

Refs #113.