### PR TITLE
ci: build iOS release on macos-26 for iOS 26 SDK

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
 
   build-ios:
     needs: analyze-and-test
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # v2


### PR DESCRIPTION
## Summary
- TestFlight is rejecting our IPAs because they're not built against the iOS 26 SDK.
- The `macos-latest` runner image still ships Xcode 16; switch `build-ios` to `macos-26`, which preinstalls Xcode 26.
- `build-macos` is left on `macos-latest` since the rejection was iOS-specific.

## Test plan
- [x] Trigger the release workflow and confirm `build-ios` runs on `macos-26` with Xcode 26 selected.
- [ ] Verify the resulting IPA is accepted by TestFlight.