### PR TITLE
feat: paginate space discovery list (S4 of #113)

### DIFF
--- a/lib/features/spaces/services/space_discovery_data_source.dart
+++ b/lib/features/spaces/services/space_discovery_data_source.dart
@@ -1,0 +1,443 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:matrix/matrix.dart';
+
+abstract class SpaceDiscoveryDataSource {
+  Future<QueryPublicRoomsResponse> queryPublicRooms({
+    int? limit,
+    String? since,
+    String? server,
+    PublicRoomQueryFilter? filter,
+  });
+
+  Future<GetSpaceHierarchyResponse> getSpaceHierarchy(
+    String roomId, {
+    int? maxDepth,
+    bool? suggestedOnly,
+  });
+
+  /// Joins [roomIdOrAlias] and waits until the resulting room is in the
+  /// local sync. Returns the joined room id.
+  Future<String> joinRoom(String roomIdOrAlias, {List<String>? via});
+
+  /// True if the user is already a `join` member of [roomId].
+  bool isMember(String roomId);
+
+  /// True when [roomId] resolves to a space (room type `m.space`). Used
+  /// by the dialog after a join to decide whether to select the space
+  /// and pop, or remain in the preview.
+  bool isSpace(String roomId);
+}
+
+class LiveSpaceDiscoveryDataSource implements SpaceDiscoveryDataSource {
+  LiveSpaceDiscoveryDataSource(this._client);
+
+  final Client _client;
+
+  @override
+  Future<QueryPublicRoomsResponse> queryPublicRooms({
+    int? limit,
+    String? since,
+    String? server,
+    PublicRoomQueryFilter? filter,
+  }) {
+    return _client.queryPublicRooms(
+      limit: limit,
+      since: since,
+      server: server,
+      filter: filter,
+    );
+  }
+
+  @override
+  Future<GetSpaceHierarchyResponse> getSpaceHierarchy(
+    String roomId, {
+    int? maxDepth,
+    bool? suggestedOnly,
+  }) {
+    return _client.getSpaceHierarchy(
+      roomId,
+      maxDepth: maxDepth,
+      suggestedOnly: suggestedOnly,
+    );
+  }
+
+  @override
+  Future<String> joinRoom(String roomIdOrAlias, {List<String>? via}) async {
+    final joinedId = await _client.joinRoom(roomIdOrAlias, via: via);
+    await _client
+        .waitForRoomInSync(joinedId, join: true)
+        .timeout(const Duration(seconds: 30));
+    return joinedId;
+  }
+
+  @override
+  bool isMember(String roomId) {
+    final room = _client.getRoomById(roomId);
+    return room != null && room.membership == Membership.join;
+  }
+
+  @override
+  bool isSpace(String roomId) =>
+      _client.getRoomById(roomId)?.isSpace ?? false;
+}
+
+// ── Fake fixture ────────────────────────────────────────────────
+
+class FakeSpaceDiscoveryDataSource implements SpaceDiscoveryDataSource {
+  FakeSpaceDiscoveryDataSource({
+    this.delay = const Duration(milliseconds: 400),
+    this.failHierarchyForRoomId = '!fake-broken:example.org',
+  });
+
+  final Duration delay;
+  final String failHierarchyForRoomId;
+  final Set<String> _joined = {};
+
+  static final List<PublishedRoomsChunk> _allSpaces = _generateSpaces();
+  static final Map<String, GetSpaceHierarchyResponse> _hierarchies =
+      _generateHierarchies();
+  static final Set<String> _spaceIds = {
+    ..._allSpaces.map((c) => c.roomId),
+    '!fake-subspace-tech:example.org',
+    '!fake-subspace-deep:example.org',
+  };
+
+  @override
+  Future<QueryPublicRoomsResponse> queryPublicRooms({
+    int? limit,
+    String? since,
+    String? server,
+    PublicRoomQueryFilter? filter,
+  }) async {
+    await Future<void>.delayed(delay);
+    final pageSize = limit ?? 20;
+    final start = since == null ? 0 : int.tryParse(since) ?? 0;
+    final end = math.min(start + pageSize, _allSpaces.length);
+    final chunk = _allSpaces.sublist(start, end);
+    final nextBatch = end < _allSpaces.length ? end.toString() : null;
+    return QueryPublicRoomsResponse(
+      chunk: chunk,
+      nextBatch: nextBatch,
+      totalRoomCountEstimate: _allSpaces.length,
+    );
+  }
+
+  @override
+  Future<GetSpaceHierarchyResponse> getSpaceHierarchy(
+    String roomId, {
+    int? maxDepth,
+    bool? suggestedOnly,
+  }) async {
+    await Future<void>.delayed(delay);
+    if (roomId == failHierarchyForRoomId) {
+      throw Exception('Fake hierarchy failure for $roomId');
+    }
+    final hit = _hierarchies[roomId];
+    if (hit != null) return hit;
+    return _hierarchyForUnknownSpace(roomId);
+  }
+
+  // ── Fixture generation ───────────────────────────────────────
+
+  static List<PublishedRoomsChunk> _generateSpaces() {
+    const themes = [
+      ['Quantum HQ', 'Default home for quantum-matrix users.'],
+      ['Linux', 'All things Linux: distros, kernels, tooling.'],
+      ['Self-Hosted', 'Run your own services. Helpful tips and rants.'],
+      ['Flutter Devs', 'Cross-platform UI talk, package showcases.'],
+      ['Homelab', 'Racks, hypervisors, weird DIY networking.'],
+      ['Photography', 'Gear, technique, critique.'],
+      ['Music Lounge', 'Sharing what we listen to.'],
+      ['Cooking', 'Recipes, kitchen disasters, sourdough.'],
+      ['Books', 'Fiction, nonfiction, recommendations.'],
+      ['Movies & TV', null],
+      ['Gaming', 'Discussion across platforms and genres.'],
+      ['Indie Web', 'Personal sites, RSS, the open web.'],
+      ['Privacy', 'Threat models, OPSEC, tooling.'],
+      ['Cycling', 'Routes, mechanicals, n+1.'],
+      ['Coffee', null],
+      ['Open Source', 'Contributing, maintaining, governance.'],
+      ['News & Current Events', 'Mostly civil discussion.'],
+      ['Travel', 'Trip reports and planning.'],
+      ['Languages', 'Polyglots and learners.'],
+      ['Dev Tools', 'Editors, terminals, CLIs.'],
+      ['Astro', null],
+      ['Fediverse', 'Mastodon, Lemmy, the rest.'],
+      ['Crypto', 'Cryptography, not coins.'],
+      ['Math', 'From arithmetic to algebraic topology.'],
+      ['Birding', 'eBird logs, field marks.'],
+      ['Woodworking', null],
+      ['3D Printing', 'Prints, slicers, filament.'],
+      ['DIY Electronics', 'Hand-soldered fun.'],
+      ['Mech Keyboards', 'Switches, layouts, group buys.'],
+      ['Retro Gaming', null],
+      ['Movies (Foreign)', 'World cinema appreciation.'],
+      ['Whisky', 'Tasting notes and bottle hunts.'],
+      ['Tea', null],
+      ['Hiking', 'Trails and trip reports.'],
+      ['Climbing', 'Routes, gyms, gear.'],
+      ['Running', 'Training plans and race reports.'],
+      ['Yoga', null],
+      ['Stoicism', 'Practical philosophy.'],
+      ['Productivity', 'Systems and habits.'],
+      ['Note-taking', 'Org, Obsidian, Logseq, paper.'],
+      ['Esoteric Programming', null],
+      ['Functional Programming', 'Haskell, OCaml, Rust folks too.'],
+      ['Rust', 'Systems programming with rustc.'],
+      ['Go', 'Goroutines, channels, build tags.'],
+      ['Zig', null],
+      ['Game Dev', 'Engines, art, design.'],
+      ['Pixel Art', 'Aseprite, palettes, animation.'],
+      ['Synthesizers', 'Modular, soft, vintage.'],
+      ['Electronic Music', null],
+      ['Classical Music', 'Performances, recordings, scores.'],
+      ['Jazz', 'Standards and adventurous corners.'],
+      ['Plants', 'Houseplants and gardens.'],
+      ['Aquariums', 'Freshwater, planted, reef.'],
+      ['Star Trek', null],
+      ['Star Wars', null],
+      ['Anime', 'Currently airing and classics.'],
+      ['Tabletop RPG', 'D&D, indie systems, GM advice.'],
+      ['Board Games', 'Heavy euros to filler.'],
+      ['Puzzle Hunts', null],
+      ['Math Puzzles', 'Riddles and Olympiad problems.'],
+    ];
+    final rng = math.Random(42);
+    return [
+      for (var i = 0; i < themes.length; i++)
+        PublishedRoomsChunk(
+          guestCanJoin: false,
+          numJoinedMembers: 5 + rng.nextInt(11000),
+          roomId: '!fake-space-$i:example.org',
+          worldReadable: true,
+          name: themes[i][0],
+          topic: themes[i][1],
+          canonicalAlias:
+              '#${themes[i][0]!.toLowerCase().replaceAll(RegExp('[^a-z0-9]+'), '-')}'
+              ':example.org',
+          roomType: 'm.space',
+        ),
+    ];
+  }
+
+  static Map<String, GetSpaceHierarchyResponse> _generateHierarchies() {
+    final out = <String, GetSpaceHierarchyResponse>{};
+
+    SpaceRoomsChunk$2 chunk({
+      required String roomId,
+      required String name,
+      String? topic,
+      int members = 50,
+      String? roomType,
+      String? alias,
+    }) {
+      return SpaceRoomsChunk$2(
+        guestCanJoin: false,
+        numJoinedMembers: members,
+        roomId: roomId,
+        worldReadable: true,
+        childrenState: const [],
+        name: name,
+        topic: topic,
+        canonicalAlias: alias,
+        roomType: roomType,
+      );
+    }
+
+    // Quantum HQ — rich hierarchy with a subspace.
+    out['!fake-space-0:example.org'] = GetSpaceHierarchyResponse(
+      rooms: [
+        chunk(
+          roomId: '!fake-space-0:example.org',
+          name: 'Quantum HQ',
+          topic: 'Default home for quantum-matrix users.',
+          members: 1247,
+          roomType: 'm.space',
+          alias: '#quantum-hq:example.org',
+        ),
+        chunk(
+          roomId: '!fake-room-lounge:example.org',
+          name: 'lounge',
+          topic: 'Casual hangout.',
+          members: 412,
+          alias: '#lounge:example.org',
+        ),
+        chunk(
+          roomId: '!fake-room-offtopic:example.org',
+          name: 'offtopic',
+          members: 138,
+          alias: '#offtopic:example.org',
+        ),
+        chunk(
+          roomId: '!fake-room-devtalk:example.org',
+          name: 'dev-talk',
+          topic: 'Technical chatter.',
+          members: 201,
+          alias: '#dev-talk:example.org',
+        ),
+        chunk(
+          roomId: '!fake-subspace-tech:example.org',
+          name: 'Tech',
+          topic: 'Subspace for technical rooms.',
+          members: 320,
+          roomType: 'm.space',
+          alias: '#tech:example.org',
+        ),
+        chunk(
+          roomId: '!fake-room-announcements:example.org',
+          name: 'announcements',
+          members: 87,
+          alias: '#announcements:example.org',
+        ),
+      ],
+    );
+
+    // Tech subspace under Quantum HQ.
+    out['!fake-subspace-tech:example.org'] = GetSpaceHierarchyResponse(
+      rooms: [
+        chunk(
+          roomId: '!fake-subspace-tech:example.org',
+          name: 'Tech',
+          topic: 'Subspace for technical rooms.',
+          members: 320,
+          roomType: 'm.space',
+          alias: '#tech:example.org',
+        ),
+        chunk(
+          roomId: '!fake-room-linux-tech:example.org',
+          name: 'linux',
+          members: 144,
+          alias: '#linux-tech:example.org',
+        ),
+        chunk(
+          roomId: '!fake-room-homelab:example.org',
+          name: 'homelab',
+          members: 98,
+          alias: '#homelab-tech:example.org',
+        ),
+        chunk(
+          roomId: '!fake-subspace-deep:example.org',
+          name: 'Deep dive',
+          topic: 'Nested subspace for testing recursion.',
+          members: 12,
+          roomType: 'm.space',
+          alias: '#deep:example.org',
+        ),
+      ],
+    );
+
+    // Deep nested subspace.
+    out['!fake-subspace-deep:example.org'] = GetSpaceHierarchyResponse(
+      rooms: [
+        chunk(
+          roomId: '!fake-subspace-deep:example.org',
+          name: 'Deep dive',
+          topic: 'Nested subspace for testing recursion.',
+          members: 12,
+          roomType: 'm.space',
+          alias: '#deep:example.org',
+        ),
+        chunk(
+          roomId: '!fake-room-deeper:example.org',
+          name: 'deeper',
+          members: 4,
+          alias: '#deeper:example.org',
+        ),
+      ],
+    );
+
+    // Empty space — preview shows "No rooms yet".
+    out['!fake-space-9:example.org'] = GetSpaceHierarchyResponse(
+      rooms: [
+        chunk(
+          roomId: '!fake-space-9:example.org',
+          name: 'Movies & TV',
+          members: 88,
+          roomType: 'm.space',
+          alias: '#movies-tv:example.org',
+        ),
+      ],
+    );
+
+    return out;
+  }
+
+  @override
+  Future<String> joinRoom(String roomIdOrAlias, {List<String>? via}) async {
+    await Future<void>.delayed(delay);
+    var id = roomIdOrAlias;
+    if (id.startsWith('#')) {
+      final match = _allSpaces.firstWhere(
+        (s) => s.canonicalAlias == id,
+        orElse: () => _allSpaces.first,
+      );
+      id = match.roomId;
+    }
+    _joined.add(id);
+    return id;
+  }
+
+  @override
+  bool isMember(String roomId) => _joined.contains(roomId);
+
+  @override
+  bool isSpace(String roomId) => _spaceIds.contains(roomId);
+
+  GetSpaceHierarchyResponse _hierarchyForUnknownSpace(String roomId) {
+    final spaceMatch = _allSpaces.firstWhere(
+      (s) => s.roomId == roomId,
+      orElse: () => _allSpaces.first,
+    );
+    return GetSpaceHierarchyResponse(
+      rooms: [
+        SpaceRoomsChunk$2(
+          guestCanJoin: false,
+          numJoinedMembers: spaceMatch.numJoinedMembers,
+          roomId: spaceMatch.roomId,
+          worldReadable: true,
+          childrenState: const [],
+          name: spaceMatch.name,
+          topic: spaceMatch.topic,
+          canonicalAlias: spaceMatch.canonicalAlias,
+          roomType: 'm.space',
+        ),
+        SpaceRoomsChunk$2(
+          guestCanJoin: false,
+          numJoinedMembers: 64,
+          roomId: '!fake-room-${roomId.hashCode}-a:example.org',
+          worldReadable: true,
+          childrenState: const [],
+          name: 'general',
+        ),
+        SpaceRoomsChunk$2(
+          guestCanJoin: false,
+          numJoinedMembers: 21,
+          roomId: '!fake-room-${roomId.hashCode}-b:example.org',
+          worldReadable: true,
+          childrenState: const [],
+          name: 'meta',
+        ),
+      ],
+    );
+  }
+}
+
+// ── Selector ────────────────────────────────────────────────────
+
+/// Build-time flag. Run with
+/// `flutter run --dart-define=KOHERA_FAKE_DISCOVERY=true` to swap the
+/// live Matrix client for canned data.
+const bool kFakeSpaceDiscovery = bool.fromEnvironment(
+  'KOHERA_FAKE_DISCOVERY',
+);
+
+SpaceDiscoveryDataSource defaultSpaceDiscoveryDataSource(Client client) {
+  if (kFakeSpaceDiscovery) {
+    debugPrint('[Kohera] SpaceDiscovery: using fake data source');
+    return FakeSpaceDiscoveryDataSource();
+  }
+  return LiveSpaceDiscoveryDataSource(client);
+}

--- a/lib/features/spaces/widgets/space_action_dialog.dart
+++ b/lib/features/spaces/widgets/space_action_dialog.dart
@@ -421,11 +421,18 @@ class _PreviewFrame {
 const int _maxPreviewDepth = 5;
 
 class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
+  static const int _pageSize = 50;
+
   List<PublishedRoomsChunk>? _results;
   String? _error;
   String? _joiningRoomId;
   String? _joinError;
   final List<_PreviewFrame> _previewStack = [];
+
+  String? _nextBatch;
+  bool _loadingMore = false;
+  String? _paginationError;
+  final Set<String> _seenRoomIds = {};
 
   @override
   void initState() {
@@ -437,20 +444,93 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
     setState(() {
       _results = null;
       _error = null;
+      _nextBatch = null;
+      _paginationError = null;
+      _seenRoomIds.clear();
     });
     try {
       final resp = await widget.matrixService.client.queryPublicRooms(
-        limit: 50,
+        limit: _pageSize,
         filter: PublicRoomQueryFilter(
           roomTypes: ['m.space'],
         ),
       );
       if (!mounted) return;
-      setState(() => _results = resp.chunk);
+      final unique = resp.chunk.where((c) => _seenRoomIds.add(c.roomId)).toList();
+      setState(() {
+        _results = unique;
+        _nextBatch = resp.nextBatch;
+      });
     } catch (e) {
       debugPrint('[Kohera] Space discovery load failed: $e');
       if (!mounted) return;
       setState(() => _error = MatrixService.friendlyAuthError(e));
+    }
+  }
+
+  bool get _hasSentinel => _nextBatch != null || _paginationError != null;
+
+  Widget _buildSentinel() {
+    final cs = Theme.of(context).colorScheme;
+    if (_paginationError != null) {
+      return Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            Text(
+              _paginationError!,
+              style: TextStyle(color: cs.error),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            FilledButton.tonal(
+              onPressed: _loadMore,
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+      );
+    }
+    return const Padding(
+      padding: EdgeInsets.symmetric(vertical: 16),
+      child: Center(
+        child: SizedBox(
+          width: 22,
+          height: 22,
+          child: CircularProgressIndicator(strokeWidth: 2.5),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _loadMore() async {
+    if (_loadingMore || _nextBatch == null || _results == null) return;
+    setState(() {
+      _loadingMore = true;
+      _paginationError = null;
+    });
+    try {
+      final resp = await widget.matrixService.client.queryPublicRooms(
+        limit: _pageSize,
+        since: _nextBatch,
+        filter: PublicRoomQueryFilter(
+          roomTypes: ['m.space'],
+        ),
+      );
+      if (!mounted) return;
+      final additions = resp.chunk.where((c) => _seenRoomIds.add(c.roomId)).toList();
+      setState(() {
+        _results!.addAll(additions);
+        _nextBatch = resp.nextBatch;
+        _loadingMore = false;
+      });
+    } catch (e) {
+      debugPrint('[Kohera] Space discovery pagination failed: $e');
+      if (!mounted) return;
+      setState(() {
+        _paginationError = MatrixService.friendlyAuthError(e);
+        _loadingMore = false;
+      });
     }
   }
 
@@ -696,22 +776,34 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
             ),
           ),
         Expanded(
-          child: ListView.builder(
-            itemCount: _results!.length,
-            itemBuilder: (context, i) {
-              final chunk = _results![i];
-              final name = chunk.name ?? chunk.canonicalAlias ?? chunk.roomId;
-              return ListTile(
-                leading: _avatarFor(
-                  chunk.avatarUrl?.toString() ?? '',
-                  name,
-                  size: 40,
-                ),
-                title: Text(name, maxLines: 1, overflow: TextOverflow.ellipsis),
-                subtitle: Text('${chunk.numJoinedMembers} members'),
-                onTap: () => _openPreview(chunk),
-              );
+          child: NotificationListener<ScrollNotification>(
+            onNotification: (notification) {
+              if (notification.metrics.pixels >=
+                  notification.metrics.maxScrollExtent - 200) {
+                unawaited(_loadMore());
+              }
+              return false;
             },
+            child: ListView.builder(
+              itemCount: _results!.length + (_hasSentinel ? 1 : 0),
+              itemBuilder: (context, i) {
+                if (i == _results!.length) return _buildSentinel();
+                final chunk = _results![i];
+                final name =
+                    chunk.name ?? chunk.canonicalAlias ?? chunk.roomId;
+                return ListTile(
+                  leading: _avatarFor(
+                    chunk.avatarUrl?.toString() ?? '',
+                    name,
+                    size: 40,
+                  ),
+                  title:
+                      Text(name, maxLines: 1, overflow: TextOverflow.ellipsis),
+                  subtitle: Text('${chunk.numJoinedMembers} members'),
+                  onTap: () => _openPreview(chunk),
+                );
+              },
+            ),
           ),
         ),
       ],

--- a/lib/features/spaces/widgets/space_action_dialog.dart
+++ b/lib/features/spaces/widgets/space_action_dialog.dart
@@ -1035,7 +1035,29 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
   }
 
   Widget _avatarFor(String mxc, String fallback, {required double size}) {
+    final cs = Theme.of(context).colorScheme;
     final letter = fallback.isNotEmpty ? fallback[0].toUpperCase() : '?';
+
+    final placeholder = Container(
+      width: size,
+      height: size,
+      alignment: Alignment.center,
+      color: cs.surfaceContainerHighest,
+      child: Text(
+        letter,
+        style: TextStyle(
+          fontSize: size * 0.45,
+          fontWeight: FontWeight.w600,
+          color: cs.onSurfaceVariant,
+          height: 1,
+        ),
+      ),
+    );
+
+    if (mxc.isEmpty) {
+      return ClipOval(child: placeholder);
+    }
+
     return ClipOval(
       child: SizedBox(
         width: size,
@@ -1047,6 +1069,8 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
           fallbackStyle: TextStyle(
             fontSize: size * 0.45,
             fontWeight: FontWeight.w600,
+            color: cs.onSurfaceVariant,
+            height: 1,
           ),
           width: size,
           height: size,

--- a/lib/features/spaces/widgets/space_action_dialog.dart
+++ b/lib/features/spaces/widgets/space_action_dialog.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart' hide Visibility;
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/home/screens/home_shell.dart';
+import 'package:kohera/features/spaces/services/space_discovery_data_source.dart';
 import 'package:kohera/shared/widgets/mxc_image.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
@@ -385,17 +386,27 @@ class _JoinSpaceDialogState extends State<JoinSpaceDialog> {
 // ── Space Discovery dialog ──────────────────────────────────────
 
 class SpaceDiscoveryDialog extends StatefulWidget {
-  const SpaceDiscoveryDialog._({required this.matrixService});
+  const SpaceDiscoveryDialog._({
+    required this.matrixService,
+    required this.dataSource,
+  });
 
   final MatrixService matrixService;
+  final SpaceDiscoveryDataSource dataSource;
 
   static Future<void> show(
     BuildContext context, {
     required MatrixService matrixService,
+    SpaceDiscoveryDataSource? dataSource,
   }) {
+    final ds = dataSource ??
+        defaultSpaceDiscoveryDataSource(matrixService.client);
     return showDialog(
       context: context,
-      builder: (_) => SpaceDiscoveryDialog._(matrixService: matrixService),
+      builder: (_) => SpaceDiscoveryDialog._(
+        matrixService: matrixService,
+        dataSource: ds,
+      ),
     );
   }
 
@@ -449,7 +460,7 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
       _seenRoomIds.clear();
     });
     try {
-      final resp = await widget.matrixService.client.queryPublicRooms(
+      final resp = await widget.dataSource.queryPublicRooms(
         limit: _pageSize,
         filter: PublicRoomQueryFilter(
           roomTypes: ['m.space'],
@@ -510,7 +521,7 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
       _paginationError = null;
     });
     try {
-      final resp = await widget.matrixService.client.queryPublicRooms(
+      final resp = await widget.dataSource.queryPublicRooms(
         limit: _pageSize,
         since: _nextBatch,
         filter: PublicRoomQueryFilter(
@@ -541,10 +552,7 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
     return [alias.substring(idx + 1)];
   }
 
-  bool _isMember(String roomId) {
-    final room = widget.matrixService.client.getRoomById(roomId);
-    return room != null && room.membership == Membership.join;
-  }
+  bool _isMember(String roomId) => widget.dataSource.isMember(roomId);
 
   // ── Preview navigation ──────────────────────────────────────────
 
@@ -590,7 +598,7 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
 
   Future<void> _loadHierarchy(_PreviewFrame frame) async {
     try {
-      final resp = await widget.matrixService.client.getSpaceHierarchy(
+      final resp = await widget.dataSource.getSpaceHierarchy(
         frame.roomId,
         maxDepth: 1,
         suggestedOnly: false,
@@ -620,7 +628,6 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
     List<String>? via,
   }) async {
     if (_joiningRoomId != null) return;
-    final client = widget.matrixService.client;
     final target = alias ?? roomId;
 
     setState(() {
@@ -629,14 +636,11 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
     });
 
     try {
-      final joinedId = await client.joinRoom(target, via: via);
-      await client
-          .waitForRoomInSync(joinedId, join: true)
-          .timeout(const Duration(seconds: 30));
+      final joinedId =
+          await widget.dataSource.joinRoom(target, via: via);
 
       if (!mounted) return;
-      final room = client.getRoomById(joinedId);
-      if (room != null && room.isSpace) {
+      if (widget.dataSource.isSpace(joinedId)) {
         context.read<SelectionService>().selectSpace(joinedId);
         Navigator.pop(context);
         return;


### PR DESCRIPTION
## Summary
- Closes #360, fourth slice of #113.
- **Stacked on top of #365 (S3).** Merge S3 first; this PR's base is \`feat/space-discovery-s3\`. Once S3 lands the base will rebase down to \`master\` and the diff will read as ~110 lines.
- Track \`resp.nextBatch\` and append further pages as the user scrolls within 200px of the bottom. A loading sentinel renders at the end while a page is in flight; on failure the sentinel becomes an inline error with a **Retry** button, leaving the already-fetched rows intact.
- Pagination cursor and seen-room set live on the dialog state, so re-opening the dialog spawns a fresh \`_SpaceDiscoveryDialogState\` and pagination restarts from page 1 automatically.
- Defensive dedup via \`_seenRoomIds\` covers the (rare) case where overlap shows up across pages.

## Test plan
- [x] \`flutter analyze\` clean.
- [x] \`flutter run -d linux\` against a homeserver with >50 public spaces (matrix.org). Open \`+\` → Explore spaces.
- [x] Scroll near the bottom → spinner sentinel appears, next page appends seamlessly.
- [x] Reach the end (server returns \`nextBatch == null\`) → sentinel disappears, no perpetual spinner.
- [x] Toggle airplane mode mid-scroll → sentinel becomes inline error + Retry. Tap Retry online → continues.
- [x] Close + reopen the dialog → list starts from page 1 again.
- [x] Open a space preview, back out → list scroll position persists, no duplicate fetches.

Refs #113.