### PR TITLE
feat: clearer recovery-key storage UX

### DIFF
--- a/docs/recovery-key-storage.md
+++ b/docs/recovery-key-storage.md
@@ -1,0 +1,53 @@
+# Storing your recovery key safely
+
+Your recovery key is the only thing that can restore your encrypted message
+history on a new device, after a reinstall, or if you lose the device you set
+backup up on. Treat it like the master password for your messages.
+
+## What it does
+
+Your messages are encrypted end-to-end. The keys that decrypt them are
+themselves encrypted with your recovery key and stored on the server. Without
+the recovery key:
+
+- A new device cannot read your old messages.
+- Cross-device verification cannot be re-established from scratch.
+- Your message history stays encrypted forever — no one (not Kohera, not your
+  homeserver admin) can recover it for you.
+
+## Where to store it
+
+**Recommended:**
+
+- A password manager (1Password, Bitwarden, KeePass, your browser's built-in
+  manager). This is the simplest and most reliable option for most people.
+- Printed on paper, stored somewhere physically secure (a locked drawer, a
+  safe, with other important documents).
+
+**Avoid:**
+
+- Screenshots — they sync to cloud photo libraries in plaintext.
+- Unencrypted notes apps (Google Keep, Apple Notes without a per-note lock,
+  OneNote, plain `.txt` files in iCloud / Drive / Dropbox). These cache to the
+  cloud in a form your provider can read.
+- Email to yourself — your inbox is one phishing or breach away from exposing
+  the key.
+- Chat messages, including to yourself in Kohera or any other app.
+
+## "Also keep a copy on this device"
+
+When you set up backup, you can choose to cache a copy of the key in this
+device's secure storage so the app can unlock backup automatically.
+
+**This is a convenience, not a backup.** If you lose the device or wipe it,
+the cached copy is gone — that's exactly the failure mode the recovery key
+exists to protect against. Always save the key somewhere off-device too.
+
+## If you lose your key
+
+Your encrypted message history on the server stays encrypted and unreadable.
+You can sign back in and continue using Kohera, but old messages on rooms
+you've left, or on devices you no longer have, won't be recoverable.
+
+You can set up a new chat backup at any time — it will protect future
+messages, but it can't reach back and decrypt the old ones.

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -13,6 +13,7 @@ import 'package:kohera/features/calling/screens/call_pane.dart';
 import 'package:kohera/features/calling/screens/call_screen.dart';
 import 'package:kohera/features/chat/screens/chat_screen.dart';
 import 'package:kohera/features/e2ee/screens/e2ee_setup_screen.dart';
+import 'package:kohera/features/e2ee/screens/show_recovery_key_screen.dart';
 import 'package:kohera/features/home/screens/home_shell.dart';
 import 'package:kohera/features/home/widgets/inbox_screen.dart';
 import 'package:kohera/features/rooms/widgets/room_details_panel.dart';
@@ -235,6 +236,12 @@ GoRouter buildRouter(ClientManager manager) {
                     name: Routes.settingsVoiceVideo,
                     builder: (context, state) =>
                         const VoiceVideoSettingsScreen(),
+                  ),
+                  GoRoute(
+                    path: 'recovery-key',
+                    name: Routes.settingsRecoveryKey,
+                    builder: (context, state) =>
+                        const ShowRecoveryKeyScreen(),
                   ),
                 ],
               ),

--- a/lib/core/routing/route_names.dart
+++ b/lib/core/routing/route_names.dart
@@ -12,6 +12,7 @@ abstract class Routes {
   static const settingsNotifications = 'settings-notifications';
   static const settingsDevices = 'settings-devices';
   static const settingsVoiceVideo = 'settings-voice-video';
+  static const settingsRecoveryKey = 'settings-recovery-key';
   static const inbox = 'inbox';
   static const spaceDetails = 'space-details';
   static const call = 'call';

--- a/lib/features/e2ee/screens/e2ee_setup_screen.dart
+++ b/lib/features/e2ee/screens/e2ee_setup_screen.dart
@@ -9,6 +9,10 @@ import 'package:kohera/features/e2ee/widgets/bootstrap_controller.dart';
 import 'package:kohera/features/e2ee/widgets/key_verification_inline.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+const String _recoveryKeyDocsUrl =
+    'https://github.com/Quantumheart/Kohera/blob/main/docs/recovery-key-storage.md';
 
 // ── Screen-local steps (outside bootstrap lifecycle) ───────────
 
@@ -118,6 +122,38 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
       _matrixService.uia.completeUiaWithPassword(request, password);
     } else {
       request.cancel();
+    }
+  }
+
+  // ── Confirm key saved ─────────────────────────────────────────
+
+  Future<void> _confirmKeyStoredAndAdvance() async {
+    final controller = _controller;
+    if (controller == null) return;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Have you saved your recovery key?'),
+        content: const Text(
+          'If you lose this key, your encrypted messages cannot be '
+          "recovered. Make sure it's stored somewhere you'll still have "
+          'access to if you lose this device.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Not yet'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text("I've saved it"),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) {
+      controller.confirmNewSsss();
     }
   }
 
@@ -326,7 +362,7 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
             ),
             FilledButton(
               onPressed: !controller.generatingKey && controller.canConfirmNewKey
-                  ? controller.confirmNewSsss
+                  ? _confirmKeyStoredAndAdvance
                   : null,
               child: const Text('Next'),
             ),
@@ -450,8 +486,34 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
           ),
           const SizedBox(height: 16),
           const Text(
-            'Store this key somewhere safe \u2014 a password manager, '
-            'printed copy, or secure note.',
+            'Save this key in a password manager, or print it and store '
+            'the paper somewhere safe.',
+          ),
+          const SizedBox(height: 8),
+          Text(
+            "Don't save it in screenshots, unencrypted notes apps, or chat "
+            'messages. If you lose this key, your message history is gone '
+            "\u2014 we can't recover it for you.",
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: cs.error,
+                ),
+          ),
+          const SizedBox(height: 4),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton.icon(
+              onPressed: () => unawaited(launchUrl(
+                Uri.parse(_recoveryKeyDocsUrl),
+                mode: LaunchMode.externalApplication,
+              ),),
+              icon: const Icon(Icons.open_in_new, size: 16),
+              label: const Text('Learn more about safe storage'),
+              style: TextButton.styleFrom(
+                padding: EdgeInsets.zero,
+                minimumSize: Size.zero,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+            ),
           ),
           const SizedBox(height: 16),
           Container(
@@ -489,7 +551,12 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
           CheckboxListTile(
             value: controller.saveToDevice,
             onChanged: (v) => controller.setSaveToDevice(v ?? false),
-            title: const Text('Save to device'),
+            title: const Text('Also keep a copy on this device'),
+            subtitle: Text(
+              'Convenient for unlocking on this device. This is not a '
+              'backup — if you lose the device, this copy is gone too.',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
             controlAffinity: ListTileControlAffinity.leading,
             contentPadding: EdgeInsets.zero,
             mouseCursor: SystemMouseCursors.click,
@@ -525,7 +592,12 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
           CheckboxListTile(
             value: controller?.saveToDevice ?? false,
             onChanged: (v) => controller?.setSaveToDevice(v ?? false),
-            title: const Text('Save to device'),
+            title: const Text('Also keep a copy on this device'),
+            subtitle: Text(
+              'Convenient for unlocking on this device. This is not a '
+              'backup — if you lose the device, this copy is gone too.',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
             controlAffinity: ListTileControlAffinity.leading,
             contentPadding: EdgeInsets.zero,
             mouseCursor: SystemMouseCursors.click,

--- a/lib/features/e2ee/screens/show_recovery_key_screen.dart
+++ b/lib/features/e2ee/screens/show_recovery_key_screen.dart
@@ -1,0 +1,178 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+const String _recoveryKeyDocsUrl =
+    'https://github.com/Quantumheart/Kohera/blob/main/docs/recovery-key-storage.md';
+
+class ShowRecoveryKeyScreen extends StatefulWidget {
+  const ShowRecoveryKeyScreen({super.key});
+
+  @override
+  State<ShowRecoveryKeyScreen> createState() => _ShowRecoveryKeyScreenState();
+}
+
+class _ShowRecoveryKeyScreenState extends State<ShowRecoveryKeyScreen> {
+  Future<String?>? _keyFuture;
+  bool _copied = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _keyFuture =
+        context.read<MatrixService>().chatBackup.getStoredRecoveryKey();
+  }
+
+  Future<void> _openDocs() async {
+    await launchUrl(
+      Uri.parse(_recoveryKeyDocsUrl),
+      mode: LaunchMode.externalApplication,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Recovery key')),
+      body: SafeArea(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 480),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+              child: FutureBuilder<String?>(
+                future: _keyFuture,
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState != ConnectionState.done) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+                  final key = snapshot.data;
+                  if (key == null || key.isEmpty) {
+                    return _buildNoKey();
+                  }
+                  return _buildKey(key);
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildKey(String key) {
+    final cs = Theme.of(context).colorScheme;
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Your recovery key',
+            style: Theme.of(context).textTheme.headlineSmall,
+          ),
+          const SizedBox(height: 16),
+          const Text(
+            'Save this key in a password manager, or print it and store '
+            'the paper somewhere safe.',
+          ),
+          const SizedBox(height: 8),
+          Text(
+            "Don't save it in screenshots, unencrypted notes apps, or chat "
+            'messages. If you lose this key, your message history is gone '
+            "— we can't recover it for you.",
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: cs.error,
+                ),
+          ),
+          const SizedBox(height: 4),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton.icon(
+              onPressed: () => unawaited(_openDocs()),
+              icon: const Icon(Icons.open_in_new, size: 16),
+              label: const Text('Learn more about safe storage'),
+              style: TextButton.styleFrom(
+                padding: EdgeInsets.zero,
+                minimumSize: Size.zero,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: cs.surfaceContainerHighest,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: SelectableText(
+              key,
+              style: const TextStyle(fontFamily: 'monospace', fontSize: 14),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: TextButton.icon(
+              onPressed: _copied
+                  ? null
+                  : () {
+                      unawaited(
+                        Clipboard.setData(ClipboardData(text: key)),
+                      );
+                      setState(() => _copied = true);
+                    },
+              icon: Icon(_copied ? Icons.check : Icons.copy, size: 18),
+              label: Text(_copied ? 'Copied' : 'Copy'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNoKey() {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.key_off_outlined,
+            size: 64,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'No recovery key on this device',
+            style: Theme.of(context).textTheme.titleMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            "There's no recovery key stored on this device. If you saved "
+            'your key elsewhere when you set up backup, you can still use '
+            'it. Otherwise, set up chat backup again to generate a new key.',
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 24),
+          FilledButton(
+            onPressed: () => context.go('/e2ee-setup'),
+            child: const Text('Set up chat backup'),
+          ),
+          const SizedBox(height: 8),
+          TextButton.icon(
+            onPressed: () => unawaited(_openDocs()),
+            icon: const Icon(Icons.open_in_new, size: 16),
+            label: const Text('Learn more about safe storage'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -431,6 +431,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 ),
                 const Divider(height: 1, indent: 56),
                 _SettingsTile(
+                  icon: Icons.vpn_key_outlined,
+                  title: 'Show recovery key',
+                  subtitle: 'View the copy stored on this device',
+                  onTap: () =>
+                      context.pushOrGo(Routes.settingsRecoveryKey),
+                ),
+                const Divider(height: 1, indent: 56),
+                _SettingsTile(
                   icon: Icons.devices_rounded,
                   title: 'Devices',
                   subtitle: 'Manage your devices',


### PR DESCRIPTION
Replace the vague "secure note" guidance with concrete recommendations
(password manager / printed paper) and an explicit warning against
unsafe stores (screenshots, unencrypted notes apps, chat messages).
Add a confirmation dialog before advancing past the key screen so a
quick click can't strand a user without the key. Relabel "Save to
device" to "Also keep a copy on this device" with a subtitle that
clarifies it's a cache, not a backup.

Add a Settings entry to view the on-device copy of the recovery key
after setup, with the same guidance and warnings; if no copy is
cached, the screen explains why and routes back to setup.

Add docs/recovery-key-storage.md and link "Learn more about safe
storage" from both the setup screen and the new view-key screen.

https://claude.ai/code/session_01KNo6xdsafWwKXLGJeMmdvg