### PR TITLE
feat: photo & camera picker for mobile chat attachments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What is Kohera?
 
-Kohera is a Flutter Matrix chat client. It uses the `matrix` Dart SDK for the Matrix protocol, Provider (ChangeNotifier) for state management, GoRouter for navigation, and Material You dynamic color theming. It supports E2EE, voice/video calling (LiveKit), multi-account, and runs on Linux, macOS, and web.
+Kohera is a Flutter Matrix chat client. It uses the `matrix` Dart SDK for the Matrix protocol, Provider (ChangeNotifier) for state management, GoRouter for navigation, and Material You dynamic color theming. It supports E2EE, voice/video calling (LiveKit), multi-account, and runs on Linux, macOS, Windows, web, Android, and iOS.
 
 ## How to work with this project
 

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -1,4 +1,5 @@
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform, kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:giphy_get/giphy_get.dart';
 import 'package:kohera/core/models/pending_attachment.dart';
@@ -14,6 +15,7 @@ import 'package:kohera/features/chat/services/compose_state_controller.dart';
 import 'package:kohera/features/chat/services/typing_controller.dart';
 import 'package:kohera/features/chat/services/voice_recording_controller.dart';
 import 'package:kohera/features/chat/services/voice_recording_mixin.dart';
+import 'package:kohera/features/chat/widgets/attachment_source_sheet.dart';
 import 'package:kohera/features/chat/widgets/chat_app_bar.dart';
 import 'package:kohera/features/chat/widgets/compose_bar_section.dart';
 import 'package:kohera/features/chat/widgets/desktop_drop_wrapper.dart';
@@ -21,6 +23,7 @@ import 'package:kohera/features/chat/widgets/file_send_handler.dart';
 import 'package:kohera/features/chat/widgets/gif_send_handler.dart';
 import 'package:kohera/features/chat/widgets/join_call_banner.dart';
 import 'package:kohera/features/chat/widgets/message_list_view.dart';
+import 'package:kohera/features/chat/widgets/photo_send_handler.dart';
 import 'package:kohera/features/chat/widgets/search_results_body.dart';
 import 'package:kohera/features/chat/widgets/typing_indicator.dart';
 import 'package:matrix/matrix.dart';
@@ -164,6 +167,46 @@ class _ChatScreenState extends State<ChatScreen>
 
   void _addAttachment(PendingAttachment attachment) {
     _showAttachmentError(_compose.addAttachment(attachment));
+  }
+
+  Future<void> _handleAttachPressed() async {
+    final isMobileTouch = !kIsWeb &&
+        (defaultTargetPlatform == TargetPlatform.iOS ||
+            defaultTargetPlatform == TargetPlatform.android);
+
+    if (!isMobileTouch) {
+      final attachment = await pickFileAsAttachment();
+      if (attachment != null && mounted) _addAttachment(attachment);
+      return;
+    }
+
+    final source = await showAttachmentSourceSheet(context);
+    if (source == null || !mounted) return;
+
+    switch (source) {
+      case AttachmentSource.file:
+        final attachment = await pickFileAsAttachment();
+        if (attachment != null && mounted) _addAttachment(attachment);
+      case AttachmentSource.camera:
+        final attachment = await takePhotoWithCamera();
+        if (attachment != null && mounted) _addAttachment(attachment);
+      case AttachmentSource.gallery:
+        final remaining = ComposeStateController.maxAttachments -
+            _compose.pendingAttachments.value.length;
+        if (remaining <= 0) {
+          _showAttachmentError(AddAttachmentResult.tooMany);
+          return;
+        }
+        final picked = await pickMediaFromGallery(limit: remaining);
+        if (!mounted) return;
+        for (final attachment in picked) {
+          final result = _compose.addAttachment(attachment);
+          if (result != AddAttachmentResult.ok) {
+            _showAttachmentError(result);
+            break;
+          }
+        }
+    }
   }
 
   Future<void> _handlePasteImage() async {
@@ -312,10 +355,7 @@ class _ChatScreenState extends State<ChatScreen>
           onSend: _actions.send,
           onCancelReply: _compose.cancelReply,
           onCancelEdit: () => _compose.cancelEdit(_msgCtrl),
-          onAttach: () async {
-            final attachment = await pickFileAsAttachment();
-            if (attachment != null && mounted) _addAttachment(attachment);
-          },
+          onAttach: _handleAttachPressed,
           onGif: AppConfig.isInitialized && AppConfig.instance.giphyEnabled
               ? () async {
                   final gif = await GiphyGet.getGif(

--- a/lib/features/chat/widgets/attachment_source_sheet.dart
+++ b/lib/features/chat/widgets/attachment_source_sheet.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+enum AttachmentSource { gallery, camera, file }
+
+Future<AttachmentSource?> showAttachmentSourceSheet(BuildContext context) {
+  return showModalBottomSheet<AttachmentSource>(
+    context: context,
+    showDragHandle: true,
+    builder: (sheetContext) {
+      return SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.photo_library_outlined),
+              title: const Text('Photo or Video'),
+              onTap: () => Navigator.pop(sheetContext, AttachmentSource.gallery),
+            ),
+            ListTile(
+              leading: const Icon(Icons.camera_alt_outlined),
+              title: const Text('Take Photo'),
+              onTap: () => Navigator.pop(sheetContext, AttachmentSource.camera),
+            ),
+            ListTile(
+              leading: const Icon(Icons.folder_outlined),
+              title: const Text('File'),
+              onTap: () => Navigator.pop(sheetContext, AttachmentSource.file),
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
+      );
+    },
+  );
+}

--- a/lib/features/chat/widgets/photo_send_handler.dart
+++ b/lib/features/chat/widgets/photo_send_handler.dart
@@ -1,0 +1,44 @@
+import 'package:image_picker/image_picker.dart';
+import 'package:kohera/core/models/pending_attachment.dart';
+
+// coverage:ignore-start
+
+Future<List<PendingAttachment>> pickMediaFromGallery({required int limit}) async {
+  if (limit <= 0) return const [];
+  final picker = ImagePicker();
+  final picked = await picker.pickMultipleMedia(limit: limit);
+  if (picked.isEmpty) return const [];
+
+  final attachments = <PendingAttachment>[];
+  for (final xfile in picked) {
+    final bytes = await xfile.readAsBytes();
+    final name = xfile.name.isNotEmpty ? xfile.name : _fallbackName(xfile.path);
+    attachments.add(PendingAttachment.fromBytes(bytes: bytes, name: name));
+  }
+  return attachments;
+}
+
+Future<PendingAttachment?> takePhotoWithCamera() async {
+  final picker = ImagePicker();
+  final xfile = await picker.pickImage(source: ImageSource.camera);
+  if (xfile == null) return null;
+  final bytes = await xfile.readAsBytes();
+  final name = xfile.name.isNotEmpty ? xfile.name : _cameraFilename();
+  return PendingAttachment.fromBytes(bytes: bytes, name: name);
+}
+
+String _cameraFilename() {
+  final now = DateTime.now();
+  String two(int n) => n.toString().padLeft(2, '0');
+  final ts =
+      '${now.year}${two(now.month)}${two(now.day)}_${two(now.hour)}${two(now.minute)}${two(now.second)}';
+  return 'camera_$ts.jpg';
+}
+
+String _fallbackName(String path) {
+  final slash = path.lastIndexOf('/');
+  if (slash >= 0 && slash < path.length - 1) return path.substring(slash + 1);
+  return _cameraFilename();
+}
+
+// coverage:ignore-end


### PR DESCRIPTION
## Summary
- On iOS/Android, tapping **+** in the chat compose bar now opens a Material 3 bottom sheet offering **Photo or Video**, **Take Photo**, and **File**.
- Gallery uses `ImagePicker.pickMultipleMedia` capped at remaining attachment slots; camera uses `pickImage(source: camera)` with a synthesized `camera_YYYYMMDD_HHMMSS.jpg` filename when `XFile.name` is empty.
- Desktop and web keep the existing direct-to-file-picker behavior — drag-and-drop and paste flows are unchanged.
- Reuses the existing `_addAttachment` → `ComposeStateController.addAttachment` pipeline so the 10-attachment / 25 MB limits still apply.

Closes #316.

## Test plan
- [x] `flutter analyze` clean
- [x] Android: tap **+** → sheet appears; gallery multi-select adds N attachments; camera capture adds one; file path still works
- [x] Android: with 9 attachments pending, gallery is limited to 1 more; >25 MB shows "File exceeds 25 MB limit"
- [x] iOS: same checks; verify first gallery/camera tap shows the photo-library/camera permission prompts
- [x] Linux & web: **+** still goes straight to the file picker (no sheet)