### PR TITLE
fix: await sync round-trip after favourite toggle

### DIFF
--- a/lib/features/rooms/widgets/room_details_panel.dart
+++ b/lib/features/rooms/widgets/room_details_panel.dart
@@ -95,7 +95,11 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
   });
 
   Future<void> _toggleFavourite(Room room) => _run('favourite', () async {
-    await room.setFavourite(!room.isFavourite);
+    final target = !room.isFavourite;
+    await room.setFavourite(target);
+    await room.client.onSync.stream
+        .firstWhere((_) => room.isFavourite == target)
+        .timeout(const Duration(seconds: 5), onTimeout: () => SyncUpdate(nextBatch: ''));
   });
 
   Future<void> _showInviteDialog(Room room) async {


### PR DESCRIPTION
## Summary
- Star icon and Pinned section showed stale state after toggling favourite — required a second tap before UI caught up.
- Root cause: `room.setFavourite` POSTs the `m.favourite` tag but local `tags` map only refreshes on next `/sync`. The action's setState fired before sync arrived.
- Fix: after `setFavourite`, await the next `onSync` where `room.isFavourite` matches the target (5s timeout fallback).

## Test plan
- [ ] Tap star in room details → star fills immediately, no second tap needed
- [ ] Back to room list → room appears under Pinned
- [ ] Tap star again → star clears, room leaves Pinned
- [ ] Toggle on slow connection (>2s sync) → still resolves within 5s timeout