### PR TITLE
feat: 3-step Create Space wizard (slice A of #131)

### DIFF
--- a/lib/features/spaces/widgets/create_subspace_dialog.dart
+++ b/lib/features/spaces/widgets/create_subspace_dialog.dart
@@ -1,173 +1,20 @@
-import 'dart:async';
-
-import 'package:flutter/material.dart' hide Visibility;
+import 'package:flutter/material.dart';
 import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/features/spaces/widgets/space_wizard.dart';
 import 'package:matrix/matrix.dart';
 
-/// Dialog to create a new subspace within a parent space.
-///
-/// Creates a new space room and registers it as a child of [parentSpace]
-/// via `setSpaceChild`.
-class CreateSubspaceDialog extends StatefulWidget {
-  const CreateSubspaceDialog._({
-    required this.matrixService,
-    required this.parentSpace,
-  });
-
-  final MatrixService matrixService;
-  final Room parentSpace;
+class CreateSubspaceDialog {
+  const CreateSubspaceDialog._();
 
   static Future<void> show(
     BuildContext context, {
     required MatrixService matrixService,
     required Room parentSpace,
   }) {
-    return showDialog(
-      context: context,
-      builder: (_) => CreateSubspaceDialog._(
-        matrixService: matrixService,
-        parentSpace: parentSpace,
-      ),
-    );
-  }
-
-  @override
-  State<CreateSubspaceDialog> createState() => _CreateSubspaceDialogState();
-}
-
-class _CreateSubspaceDialogState extends State<CreateSubspaceDialog> {
-  final _nameController = TextEditingController();
-  final _topicController = TextEditingController();
-  bool _loading = false;
-  String? _nameError;
-  String? _networkError;
-
-  @override
-  void dispose() {
-    _nameController.dispose();
-    _topicController.dispose();
-    super.dispose();
-  }
-
-  Future<void> _submit() async {
-    final name = _nameController.text.trim();
-    if (name.isEmpty) {
-      setState(() {
-        _nameError = 'Name is required';
-        _networkError = null;
-      });
-      return;
-    }
-
-    setState(() {
-      _loading = true;
-      _nameError = null;
-      _networkError = null;
-    });
-
-    try {
-      final client = widget.matrixService.client;
-      final topic = _topicController.text.trim();
-
-      // Create the subspace room.
-      final roomId = await client.createRoom(
-        name: name,
-        topic: topic.isNotEmpty ? topic : null,
-        creationContent: {'type': 'm.space'},
-        visibility: Visibility.private,
-        powerLevelContentOverride: {'events_default': 100},
-      );
-
-      await client
-          .waitForRoomInSync(roomId, join: true)
-          .timeout(const Duration(seconds: 30));
-
-      // Register as child of the parent space.
-      await widget.parentSpace.setSpaceChild(roomId);
-      widget.matrixService.selection.invalidateSpaceTree();
-
-      debugPrint('[Kohera] Subspace created: $roomId under ${widget.parentSpace.id}');
-
-      if (!mounted) return;
-      Navigator.pop(context);
-    } on TimeoutException {
-      debugPrint('[Kohera] Subspace creation timed out');
-      if (!mounted) return;
-      setState(() => _networkError =
-          'Timed out waiting for the server. The subspace may still be created.',);
-    } catch (e) {
-      debugPrint('[Kohera] Subspace creation failed: $e');
-      if (!mounted) return;
-      setState(() => _networkError = MatrixService.friendlyAuthError(e));
-    } finally {
-      if (mounted) setState(() => _loading = false);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-
-    return AlertDialog(
-      title: const Text('Create subspace'),
-      content: SizedBox(
-        width: 400,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              'This subspace will be created inside '
-              '"${widget.parentSpace.getLocalizedDisplayname()}".',
-              style: TextStyle(color: cs.onSurfaceVariant, fontSize: 13),
-            ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: _nameController,
-              autofocus: true,
-              enabled: !_loading,
-              decoration: InputDecoration(
-                labelText: 'Name',
-                border: const OutlineInputBorder(),
-                errorText: _nameError,
-              ),
-              onSubmitted: (_) => _submit(),
-            ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: _topicController,
-              enabled: !_loading,
-              decoration: const InputDecoration(
-                labelText: 'Topic (optional)',
-                border: OutlineInputBorder(),
-              ),
-            ),
-            if (_networkError != null)
-              Padding(
-                padding: const EdgeInsets.only(top: 8),
-                child: Text(
-                  _networkError!,
-                  style: TextStyle(color: cs.error, fontSize: 13),
-                ),
-              ),
-          ],
-        ),
-      ),
-      actions: [
-        TextButton(
-          onPressed: _loading ? null : () => Navigator.pop(context),
-          child: const Text('Cancel'),
-        ),
-        FilledButton(
-          onPressed: _loading ? null : _submit,
-          child: _loading
-              ? const SizedBox(
-                  width: 22,
-                  height: 22,
-                  child: CircularProgressIndicator(strokeWidth: 2.5),
-                )
-              : const Text('Create'),
-        ),
-      ],
+    return SpaceWizard.show(
+      context,
+      matrixService: matrixService,
+      parentSpace: parentSpace,
     );
   }
 }

--- a/lib/features/spaces/widgets/space_action_dialog.dart
+++ b/lib/features/spaces/widgets/space_action_dialog.dart
@@ -6,6 +6,7 @@ import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/home/screens/home_shell.dart';
 import 'package:kohera/features/spaces/services/space_discovery_data_source.dart';
+import 'package:kohera/features/spaces/widgets/space_wizard.dart';
 import 'package:kohera/shared/widgets/mxc_image.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
@@ -71,191 +72,14 @@ Future<void> showSpaceActionMenu(
 
 // ── Create Space dialog ─────────────────────────────────────────
 
-class CreateSpaceDialog extends StatefulWidget {
-  const CreateSpaceDialog._({required this.matrixService});
-
-  final MatrixService matrixService;
+class CreateSpaceDialog {
+  const CreateSpaceDialog._();
 
   static Future<void> show(
     BuildContext context, {
     required MatrixService matrixService,
   }) {
-    return showDialog(
-      context: context,
-      builder: (_) => CreateSpaceDialog._(matrixService: matrixService),
-    );
-  }
-
-  @override
-  State<CreateSpaceDialog> createState() => _CreateSpaceDialogState();
-}
-
-class _CreateSpaceDialogState extends State<CreateSpaceDialog> {
-  final _nameController = TextEditingController();
-  final _topicController = TextEditingController();
-  bool _isPublic = false;
-  bool _enableEncryption = true;
-  bool _enableFederation = false;
-  bool _loading = false;
-  String? _nameError;
-  String? _networkError;
-
-  @override
-  void dispose() {
-    _nameController.dispose();
-    _topicController.dispose();
-    super.dispose();
-  }
-
-  Future<void> _submit() async {
-    final name = _nameController.text.trim();
-    if (name.isEmpty) {
-      setState(() {
-        _nameError = 'Name is required';
-        _networkError = null;
-      });
-      return;
-    }
-
-    setState(() {
-      _loading = true;
-      _nameError = null;
-      _networkError = null;
-    });
-
-    try {
-      final client = widget.matrixService.client;
-      final topic = _topicController.text.trim();
-
-      final roomId = await client.createRoom(
-        name: name,
-        topic: topic.isNotEmpty ? topic : null,
-        creationContent: {
-          'type': 'm.space',
-          if (!_enableFederation) 'm.federate': false,
-        },
-        initialState: [
-          if (_enableEncryption)
-            StateEvent(
-              content: {
-                'algorithm':
-                    Client.supportedGroupEncryptionAlgorithms.first,
-              },
-              type: EventTypes.Encryption,
-            ),
-        ],
-        visibility: _isPublic ? Visibility.public : Visibility.private,
-        powerLevelContentOverride: {'events_default': 100},
-      );
-
-      await client
-          .waitForRoomInSync(roomId, join: true)
-          .timeout(const Duration(seconds: 30));
-
-      if (!mounted) return;
-      context.read<SelectionService>().selectSpace(roomId);
-      Navigator.pop(context);
-    } catch (e) {
-      if (!mounted) return;
-      setState(() => _networkError = MatrixService.friendlyAuthError(e));
-    } finally {
-      if (mounted) setState(() => _loading = false);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-
-    return AlertDialog(
-      title: const Text('Create Space'),
-      content: SizedBox(
-        width: 400,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            TextField(
-              controller: _nameController,
-              autofocus: true,
-              enabled: !_loading,
-              decoration: InputDecoration(
-                labelText: 'Name',
-                border: const OutlineInputBorder(),
-                errorText: _nameError,
-              ),
-              onSubmitted: (_) => _submit(),
-            ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: _topicController,
-              enabled: !_loading,
-              decoration: const InputDecoration(
-                labelText: 'Topic (optional)',
-                border: OutlineInputBorder(),
-              ),
-            ),
-            const SizedBox(height: 8),
-            SwitchListTile(
-              title: const Text('Public space'),
-              value: _isPublic,
-              onChanged: _loading
-                  ? null
-                  : (v) => setState(() {
-                        _isPublic = v;
-                        if (v) _enableEncryption = false;
-                      }),
-              contentPadding: EdgeInsets.zero,
-            ),
-            SwitchListTile(
-              title: const Text('Enable encryption'),
-              subtitle: Text(
-                _isPublic
-                    ? 'Not available for public spaces'
-                    : 'Cannot be disabled later',
-                style: TextStyle(color: cs.onSurfaceVariant, fontSize: 12),
-              ),
-              value: _enableEncryption,
-              onChanged: _loading || _isPublic
-                  ? null
-                  : (v) => setState(() => _enableEncryption = v),
-              contentPadding: EdgeInsets.zero,
-            ),
-            SwitchListTile(
-              title: const Text('Allow federation'),
-              value: _enableFederation,
-              onChanged: _loading
-                  ? null
-                  : (v) => setState(() => _enableFederation = v),
-              contentPadding: EdgeInsets.zero,
-            ),
-            if (_networkError != null)
-              Padding(
-                padding: const EdgeInsets.only(top: 8),
-                child: Text(
-                  _networkError!,
-                  style: TextStyle(color: cs.error, fontSize: 13),
-                ),
-              ),
-          ],
-        ),
-      ),
-      actions: [
-        TextButton(
-          onPressed: _loading ? null : () => Navigator.pop(context),
-          child: const Text('Cancel'),
-        ),
-        FilledButton(
-          onPressed: _loading ? null : _submit,
-          child: _loading
-              ? const SizedBox(
-                  width: 22,
-                  height: 22,
-                  child: CircularProgressIndicator(strokeWidth: 2.5),
-                )
-              : const Text('Create'),
-        ),
-      ],
-    );
+    return SpaceWizard.show(context, matrixService: matrixService);
   }
 }
 

--- a/lib/features/spaces/widgets/space_wizard.dart
+++ b/lib/features/spaces/widgets/space_wizard.dart
@@ -1,0 +1,557 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart' hide Visibility;
+import 'package:image_picker/image_picker.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/features/home/screens/home_shell.dart';
+import 'package:matrix/matrix.dart';
+
+enum _Step { basics, settings, children }
+
+class SpaceWizard extends StatefulWidget {
+  const SpaceWizard({
+    required this.matrixService,
+    this.parentSpace,
+    super.key,
+  });
+
+  final MatrixService matrixService;
+  final Room? parentSpace;
+
+  static Future<void> show(
+    BuildContext context, {
+    required MatrixService matrixService,
+    Room? parentSpace,
+  }) {
+    return showDialog(
+      context: context,
+      builder: (_) => SpaceWizard(
+        matrixService: matrixService,
+        parentSpace: parentSpace,
+      ),
+    );
+  }
+
+  @override
+  State<SpaceWizard> createState() => _SpaceWizardState();
+}
+
+class _SpaceWizardState extends State<SpaceWizard> {
+  final _nameController = TextEditingController();
+  final _topicController = TextEditingController();
+
+  _Step _step = _Step.basics;
+  MatrixFile? _avatarFile;
+  bool _isPublic = false;
+  late bool _enableFederation;
+  bool _loading = false;
+  String? _nameError;
+  String? _networkError;
+
+  bool get _isSubspace => widget.parentSpace != null;
+
+  @override
+  void initState() {
+    super.initState();
+    _enableFederation = _isSubspace;
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _topicController.dispose();
+    super.dispose();
+  }
+
+  // ── Step navigation ─────────────────────────────────────────────
+
+  void _next() {
+    if (_step == _Step.basics) {
+      if (_nameController.text.trim().isEmpty) {
+        setState(() => _nameError = 'Name is required');
+        return;
+      }
+      setState(() => _step = _Step.settings);
+    } else if (_step == _Step.settings) {
+      setState(() => _step = _Step.children);
+    }
+  }
+
+  void _back() {
+    if (_step == _Step.settings) {
+      setState(() => _step = _Step.basics);
+    } else if (_step == _Step.children) {
+      setState(() => _step = _Step.settings);
+    }
+  }
+
+  // ── Avatar picker ───────────────────────────────────────────────
+
+  Future<void> _pickAvatar() async {
+    try {
+      final picker = ImagePicker();
+      final picked = await picker.pickImage(
+        source: ImageSource.gallery,
+        maxWidth: 512,
+        maxHeight: 512,
+        imageQuality: 85,
+      );
+      if (picked == null) return;
+      final bytes = await picked.readAsBytes();
+      if (!mounted) return;
+      setState(() {
+        _avatarFile = MatrixFile(bytes: bytes, name: picked.name);
+      });
+    } catch (e) {
+      debugPrint('[Kohera] Space wizard avatar pick failed: $e');
+    }
+  }
+
+  void _clearAvatar() {
+    setState(() => _avatarFile = null);
+  }
+
+  // ── Submit ──────────────────────────────────────────────────────
+
+  Future<void> _create() async {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) {
+      setState(() {
+        _step = _Step.basics;
+        _nameError = 'Name is required';
+      });
+      return;
+    }
+
+    setState(() {
+      _loading = true;
+      _networkError = null;
+    });
+
+    final scaffold = ScaffoldMessenger.of(context);
+    final selection = widget.matrixService.selection;
+
+    try {
+      final client = widget.matrixService.client;
+      final topic = _topicController.text.trim();
+
+      final roomId = await client.createRoom(
+        name: name,
+        topic: topic.isNotEmpty ? topic : null,
+        creationContent: {
+          'type': 'm.space',
+          if (!_enableFederation) 'm.federate': false,
+        },
+        visibility: _isPublic ? Visibility.public : Visibility.private,
+        powerLevelContentOverride: {'events_default': 100},
+      );
+
+      await client
+          .waitForRoomInSync(roomId, join: true)
+          .timeout(const Duration(seconds: 30));
+
+      var avatarFailed = false;
+      if (_avatarFile != null) {
+        final room = client.getRoomById(roomId);
+        if (room != null) {
+          try {
+            await room.setAvatar(_avatarFile);
+          } catch (e) {
+            debugPrint('[Kohera] Space avatar upload failed: $e');
+            avatarFailed = true;
+          }
+        }
+      }
+
+      var childLinkFailed = false;
+      if (_isSubspace) {
+        try {
+          await widget.parentSpace!.setSpaceChild(roomId);
+          widget.matrixService.selection.invalidateSpaceTree();
+        } catch (e) {
+          debugPrint('[Kohera] Space wizard setSpaceChild failed: $e');
+          childLinkFailed = true;
+        }
+      } else {
+        selection.selectSpace(roomId);
+      }
+
+      debugPrint('[Kohera] Space created: $roomId (subspace=$_isSubspace)');
+
+      if (!mounted) return;
+      Navigator.pop(context);
+
+      if (avatarFailed) {
+        scaffold.showSnackBar(
+          const SnackBar(content: Text('Avatar upload failed')),
+        );
+      }
+      if (childLinkFailed) {
+        scaffold.showSnackBar(
+          const SnackBar(content: Text('Failed to add to parent space')),
+        );
+      }
+    } on TimeoutException {
+      debugPrint('[Kohera] Space wizard timed out');
+      if (!mounted) return;
+      setState(() => _networkError =
+          'Timed out waiting for the server. The space may still be created.',);
+    } catch (e) {
+      debugPrint('[Kohera] Space wizard failed: $e');
+      if (!mounted) return;
+      setState(() => _networkError = MatrixService.friendlyAuthError(e));
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  // ── Build ───────────────────────────────────────────────────────
+
+  String get _title => _isSubspace
+      ? 'Create subspace in "${widget.parentSpace!.getLocalizedDisplayname()}"'
+      : 'Create Space';
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.sizeOf(context);
+    final isWide = size.width >= HomeShell.wideBreakpoint;
+
+    return PopScope(
+      canPop: !_loading,
+      child: isWide ? _buildWide(context) : _buildNarrow(context),
+    );
+  }
+
+  Widget _buildWide(BuildContext context) {
+    return AlertDialog(
+      title: Text(
+        _title,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+      insetPadding:
+          const EdgeInsets.symmetric(horizontal: 40, vertical: 24),
+      content: SizedBox(
+        width: 520,
+        height: 520,
+        child: _buildBody(context),
+      ),
+      actions: _buildActions(context),
+    );
+  }
+
+  Widget _buildNarrow(BuildContext context) {
+    return Dialog.fullscreen(
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(_title, maxLines: 2, overflow: TextOverflow.ellipsis),
+          leading: IconButton(
+            icon: const Icon(Icons.close),
+            tooltip: 'Cancel',
+            onPressed: _loading ? null : () => Navigator.pop(context),
+          ),
+        ),
+        body: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              children: [
+                Expanded(child: _buildBody(context)),
+                const SizedBox(height: 8),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: _buildActions(context),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 12),
+          child: _StepDots(current: _step.index, total: 3),
+        ),
+        Expanded(
+          child: SingleChildScrollView(
+            child: switch (_step) {
+              _Step.basics => _buildBasics(context),
+              _Step.settings => _buildSettings(context),
+              _Step.children => _buildChildren(context),
+            },
+          ),
+        ),
+        if (_networkError != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Text(
+              _networkError!,
+              style: TextStyle(color: cs.error, fontSize: 13),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildBasics(BuildContext context) {
+    return Column(
+      children: [
+        const SizedBox(height: 8),
+        _AvatarPicker(
+          file: _avatarFile,
+          onPick: _loading ? null : _pickAvatar,
+          onClear: _loading ? null : _clearAvatar,
+        ),
+        const SizedBox(height: 24),
+        TextField(
+          controller: _nameController,
+          autofocus: true,
+          enabled: !_loading,
+          decoration: InputDecoration(
+            labelText: 'Name',
+            border: const OutlineInputBorder(),
+            errorText: _nameError,
+          ),
+          onChanged: (_) => setState(() {
+            if (_nameError != null && _nameController.text.trim().isNotEmpty) {
+              _nameError = null;
+            }
+          }),
+          onSubmitted: (_) => _next(),
+        ),
+        const SizedBox(height: 16),
+        TextField(
+          controller: _topicController,
+          enabled: !_loading,
+          maxLines: 3,
+          decoration: const InputDecoration(
+            labelText: 'Topic (optional)',
+            border: OutlineInputBorder(),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSettings(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Column(
+      children: [
+        SwitchListTile(
+          title: const Text('Public space'),
+          subtitle: Text(
+            'Anyone with the address can join.',
+            style: TextStyle(color: cs.onSurfaceVariant, fontSize: 12),
+          ),
+          value: _isPublic,
+          onChanged:
+              _loading ? null : (v) => setState(() => _isPublic = v),
+          contentPadding: EdgeInsets.zero,
+        ),
+        SwitchListTile(
+          title: const Text('Allow federation'),
+          subtitle: Text(
+            'Cannot be changed later.',
+            style: TextStyle(color: cs.onSurfaceVariant, fontSize: 12),
+          ),
+          value: _enableFederation,
+          onChanged: _loading
+              ? null
+              : (v) => setState(() => _enableFederation = v),
+          contentPadding: EdgeInsets.zero,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildChildren(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Card(
+        elevation: 0,
+        color: cs.surfaceContainerHighest,
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(Icons.folder_special_outlined, color: cs.primary),
+                  const SizedBox(width: 8),
+                  Text(
+                    'Add rooms & subspaces',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Text(
+                'Coming in the next release. After creating this space, '
+                'you can add existing rooms and subspaces from the room list.',
+                style: TextStyle(color: cs.onSurfaceVariant),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildActions(BuildContext context) {
+    final canNext = _step != _Step.basics ||
+        _nameController.text.trim().isNotEmpty;
+
+    Widget spinner() => const SizedBox(
+          width: 22,
+          height: 22,
+          child: CircularProgressIndicator(strokeWidth: 2.5),
+        );
+
+    return switch (_step) {
+      _Step.basics => [
+          TextButton(
+            onPressed: _loading ? null : () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: _loading || !canNext ? null : _next,
+            child: const Text('Next'),
+          ),
+        ],
+      _Step.settings => [
+          TextButton(
+            onPressed: _loading ? null : _back,
+            child: const Text('Back'),
+          ),
+          FilledButton(
+            onPressed: _loading ? null : _next,
+            child: const Text('Next'),
+          ),
+        ],
+      _Step.children => [
+          TextButton(
+            onPressed: _loading ? null : _back,
+            child: const Text('Back'),
+          ),
+          FilledButton(
+            onPressed: _loading ? null : _create,
+            child: _loading ? spinner() : const Text('Create'),
+          ),
+        ],
+    };
+  }
+}
+
+// ── Avatar picker ───────────────────────────────────────────────
+
+class _AvatarPicker extends StatelessWidget {
+  const _AvatarPicker({
+    required this.file,
+    required this.onPick,
+    required this.onClear,
+  });
+
+  final MatrixFile? file;
+  final VoidCallback? onPick;
+  final VoidCallback? onClear;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final hasFile = file != null;
+
+    return SizedBox(
+      width: 96,
+      height: 96,
+      child: Stack(
+        children: [
+          GestureDetector(
+            onTap: onPick,
+            child: ClipOval(
+              child: hasFile
+                  ? Image.memory(
+                      file!.bytes,
+                      width: 96,
+                      height: 96,
+                      fit: BoxFit.cover,
+                    )
+                  : Container(
+                      width: 96,
+                      height: 96,
+                      color: cs.surfaceContainerHighest,
+                      alignment: Alignment.center,
+                      child: Icon(
+                        Icons.add_photo_alternate_outlined,
+                        size: 36,
+                        color: cs.onSurfaceVariant,
+                      ),
+                    ),
+            ),
+          ),
+          if (hasFile)
+            Positioned(
+              top: 0,
+              right: 0,
+              child: Material(
+                color: cs.errorContainer,
+                shape: const CircleBorder(),
+                child: InkWell(
+                  customBorder: const CircleBorder(),
+                  onTap: onClear,
+                  child: Padding(
+                    padding: const EdgeInsets.all(4),
+                    child: Icon(
+                      Icons.close,
+                      size: 16,
+                      color: cs.onErrorContainer,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Step dots ───────────────────────────────────────────────────
+
+class _StepDots extends StatelessWidget {
+  const _StepDots({required this.current, required this.total});
+
+  final int current;
+  final int total;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List.generate(total, (i) {
+        final isActive = i <= current;
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4),
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 200),
+            width: 8,
+            height: 8,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: isActive ? cs.primary : cs.outlineVariant,
+            ),
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/test/widgets/create_subspace_dialog_test.dart
+++ b/test/widgets/create_subspace_dialog_test.dart
@@ -39,6 +39,10 @@ void main() {
 
   Widget buildTestWidget() {
     return MaterialApp(
+      builder: (context, child) => MediaQuery(
+        data: const MediaQueryData(size: Size(900, 900)),
+        child: child!,
+      ),
       home: Scaffold(
         body: Builder(
           builder: (context) => ElevatedButton(
@@ -60,27 +64,43 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  testWidgets('shows name and topic fields with parent space context',
-      (tester) async {
-    await openDialog(tester);
+  Future<void> advanceToStep3(WidgetTester tester, String name) async {
+    await tester.enterText(find.widgetWithText(TextField, 'Name'), name);
+    await tester.pump();
+    await tester.tap(find.widgetWithText(FilledButton, 'Next'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Next'));
+    await tester.pumpAndSettle();
+  }
 
-    expect(find.text('Create subspace'), findsOneWidget);
-    expect(find.widgetWithText(TextField, 'Name'), findsOneWidget);
-    expect(
-        find.widgetWithText(TextField, 'Topic (optional)'), findsOneWidget,);
+  testWidgets('title shows parent space name', (tester) async {
+    await openDialog(tester);
     expect(find.textContaining('Parent Space'), findsOneWidget);
   });
 
-  testWidgets('validates empty name', (tester) async {
+  testWidgets('federation defaults on for subspace', (tester) async {
     await openDialog(tester);
-
-    await tester.tap(find.widgetWithText(FilledButton, 'Create'));
+    await tester.enterText(find.widgetWithText(TextField, 'Name'), 'X');
+    await tester.pump();
+    await tester.tap(find.widgetWithText(FilledButton, 'Next'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Name is required'), findsOneWidget);
+    final fedSwitch = tester.widget<SwitchListTile>(
+      find.widgetWithText(SwitchListTile, 'Allow federation'),
+    );
+    expect(fedSwitch.value, isTrue);
   });
 
-  testWidgets('submitting calls createRoom and setSpaceChild', (tester) async {
+  testWidgets('Next disabled until name entered', (tester) async {
+    await openDialog(tester);
+    final nextBtn = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, 'Next'),
+    );
+    expect(nextBtn.onPressed, isNull);
+  });
+
+  testWidgets('create calls createRoom + setSpaceChild, no selectSpace',
+      (tester) async {
     when(mockClient.createRoom(
       name: anyNamed('name'),
       topic: anyNamed('topic'),
@@ -88,34 +108,49 @@ void main() {
       visibility: anyNamed('visibility'),
       powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
     ),).thenAnswer((_) async => '!subspace:example.com');
-
     when(mockClient.waitForRoomInSync(any, join: anyNamed('join')))
         .thenAnswer((_) async => SyncUpdate(nextBatch: ''));
 
     await openDialog(tester);
-
-    await tester.enterText(
-        find.widgetWithText(TextField, 'Name'), 'My Subspace',);
-    await tester.enterText(
-        find.widgetWithText(TextField, 'Topic (optional)'), 'A topic',);
+    await advanceToStep3(tester, 'My Subspace');
     await tester.tap(find.widgetWithText(FilledButton, 'Create'));
     await tester.pumpAndSettle();
 
     verify(mockClient.createRoom(
       name: 'My Subspace',
-      topic: 'A topic',
+      topic: anyNamed('topic'),
       creationContent: anyNamed('creationContent'),
       visibility: anyNamed('visibility'),
       powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
     ),).called(1);
-
     verify(mockParentSpace.setSpaceChild('!subspace:example.com')).called(1);
-
-    // Dialog should close on success.
-    expect(find.text('Create subspace'), findsNothing);
+    expect(selectionService.selectedSpaceIds,
+        isNot(contains('!subspace:example.com')),);
   });
 
-  testWidgets('shows error on failure', (tester) async {
+  testWidgets('child-link failure shows snackbar, space still created',
+      (tester) async {
+    when(mockClient.createRoom(
+      name: anyNamed('name'),
+      topic: anyNamed('topic'),
+      creationContent: anyNamed('creationContent'),
+      visibility: anyNamed('visibility'),
+      powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
+    ),).thenAnswer((_) async => '!sub:example.com');
+    when(mockClient.waitForRoomInSync(any, join: anyNamed('join')))
+        .thenAnswer((_) async => SyncUpdate(nextBatch: ''));
+    when(mockParentSpace.setSpaceChild(any))
+        .thenThrow(Exception('forbidden'));
+
+    await openDialog(tester);
+    await advanceToStep3(tester, 'X');
+    await tester.tap(find.widgetWithText(FilledButton, 'Create'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Failed to add to parent space'), findsOneWidget);
+  });
+
+  testWidgets('shows error on createRoom failure', (tester) async {
     when(mockClient.createRoom(
       name: anyNamed('name'),
       topic: anyNamed('topic'),
@@ -125,25 +160,20 @@ void main() {
     ),).thenThrow(Exception('Server error'));
 
     await openDialog(tester);
-
-    await tester.enterText(
-        find.widgetWithText(TextField, 'Name'), 'Bad Subspace',);
+    await advanceToStep3(tester, 'Bad');
     await tester.tap(find.widgetWithText(FilledButton, 'Create'));
     await tester.pumpAndSettle();
 
     expect(find.textContaining('Server error'), findsOneWidget);
-    // Dialog should remain open.
-    expect(find.text('Create subspace'), findsOneWidget);
   });
 
   testWidgets('cancel closes dialog', (tester) async {
     await openDialog(tester);
-
-    expect(find.text('Create subspace'), findsOneWidget);
+    expect(find.textContaining('Parent Space'), findsOneWidget);
 
     await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Create subspace'), findsNothing);
+    expect(find.textContaining('Parent Space'), findsNothing);
   });
 }

--- a/test/widgets/login_controller_test.mocks.dart
+++ b/test/widgets/login_controller_test.mocks.dart
@@ -1273,6 +1273,16 @@ class MockClientManager extends _i1.Mock implements _i17.ClientManager {
       ) as _i12.Future<void>);
 
   @override
+  _i12.Future<void> signOut(_i9.MatrixService? service) => (super.noSuchMethod(
+        Invocation.method(
+          #signOut,
+          [service],
+        ),
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
+
+  @override
   _i12.Future<void> removeService(_i9.MatrixService? service) =>
       (super.noSuchMethod(
         Invocation.method(

--- a/test/widgets/space_action_dialog_test.dart
+++ b/test/widgets/space_action_dialog_test.dart
@@ -31,131 +31,201 @@ void main() {
     when(mockMatrixService.selection).thenReturn(selectionService);
   });
 
-  group('CreateSpaceDialog', () {
-    Widget buildTestWidget() {
-      return MultiProvider(
-        providers: [
-          ChangeNotifierProvider<MatrixService>.value(value: mockMatrixService),
-          ChangeNotifierProvider<SelectionService>.value(value: selectionService),
-        ],
-        child: MaterialApp(
-          home: Builder(
-            builder: (context) => Scaffold(
-              body: ElevatedButton(
-                onPressed: () => CreateSpaceDialog.show(
-                  context,
-                  matrixService: mockMatrixService,
-                ),
-                child: const Text('Open'),
+  Widget buildTestWidget({Size size = const Size(900, 800)}) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider<MatrixService>.value(value: mockMatrixService),
+        ChangeNotifierProvider<SelectionService>.value(value: selectionService),
+      ],
+      child: MaterialApp(
+        builder: (context, child) => MediaQuery(
+          data: MediaQueryData(size: size),
+          child: child!,
+        ),
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: ElevatedButton(
+              onPressed: () => CreateSpaceDialog.show(
+                context,
+                matrixService: mockMatrixService,
               ),
+              child: const Text('Open'),
             ),
           ),
         ),
-      );
-    }
+      ),
+    );
+  }
 
-    testWidgets('shows name and topic fields', (tester) async {
-      await tester.pumpWidget(buildTestWidget());
-      await tester.tap(find.text('Open'));
-      await tester.pumpAndSettle();
+  Future<void> openWizard(WidgetTester tester, {Size? size}) async {
+    final effective = size ?? const Size(900, 900);
+    await tester.pumpWidget(buildTestWidget(size: effective));
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> advanceToStep3(WidgetTester tester, {String name = 'My Space'}) async {
+    await tester.enterText(find.widgetWithText(TextField, 'Name'), name);
+    await tester.pump();
+    await tester.tap(find.widgetWithText(FilledButton, 'Next'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Next'));
+    await tester.pumpAndSettle();
+  }
+
+  void stubCreateRoom(String roomId) {
+    when(mockClient.createRoom(
+      name: anyNamed('name'),
+      topic: anyNamed('topic'),
+      creationContent: anyNamed('creationContent'),
+      visibility: anyNamed('visibility'),
+      powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
+    ),).thenAnswer((_) async => roomId);
+    when(mockClient.waitForRoomInSync(any, join: anyNamed('join')))
+        .thenAnswer((_) async => SyncUpdate(nextBatch: ''));
+  }
+
+  group('CreateSpaceDialog wizard', () {
+    testWidgets('step 1 shows name, topic, avatar picker', (tester) async {
+      await openWizard(tester);
 
       expect(find.text('Create Space'), findsOneWidget);
       expect(find.widgetWithText(TextField, 'Name'), findsOneWidget);
       expect(find.widgetWithText(TextField, 'Topic (optional)'), findsOneWidget);
+      expect(find.byIcon(Icons.add_photo_alternate_outlined), findsOneWidget);
     });
 
-    testWidgets('shows toggle switches', (tester) async {
-      await tester.pumpWidget(buildTestWidget());
-      await tester.tap(find.text('Open'));
+    testWidgets('Next disabled until name entered', (tester) async {
+      await openWizard(tester);
+
+      final nextBtn = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Next'),
+      );
+      expect(nextBtn.onPressed, isNull);
+
+      await tester.enterText(find.widgetWithText(TextField, 'Name'), 'Hi');
+      await tester.pump();
+
+      final enabled = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Next'),
+      );
+      expect(enabled.onPressed, isNotNull);
+    });
+
+    testWidgets('step 2 has visibility + federation, no encryption switch',
+        (tester) async {
+      await openWizard(tester);
+      await tester.enterText(find.widgetWithText(TextField, 'Name'), 'X');
+      await tester.pump();
+      await tester.tap(find.widgetWithText(FilledButton, 'Next'));
       await tester.pumpAndSettle();
 
       expect(find.text('Public space'), findsOneWidget);
-      expect(find.text('Enable encryption'), findsOneWidget);
       expect(find.text('Allow federation'), findsOneWidget);
+      expect(find.text('Enable encryption'), findsNothing);
     });
 
-    testWidgets('validates empty name', (tester) async {
-      await tester.pumpWidget(buildTestWidget());
-      await tester.tap(find.text('Open'));
+    testWidgets('step 3 shows placeholder + Create button', (tester) async {
+      await openWizard(tester);
+      await advanceToStep3(tester);
+
+      expect(find.textContaining('Coming in the next release'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, 'Create'), findsOneWidget);
+    });
+
+    testWidgets('step state preserved across Back/Next', (tester) async {
+      await openWizard(tester);
+      await tester.enterText(
+          find.widgetWithText(TextField, 'Name'), 'Persisted',);
+      await tester.pump();
+      await tester.tap(find.widgetWithText(FilledButton, 'Next'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(TextButton, 'Back'));
       await tester.pumpAndSettle();
 
+      final field = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'Name'),
+      );
+      expect(field.controller!.text, 'Persisted');
+    });
+
+    testWidgets(
+        'create with federation off sends m.federate:false, no encryption',
+        (tester) async {
+      stubCreateRoom('!new:example.com');
+
+      await openWizard(tester);
+      await advanceToStep3(tester);
       await tester.tap(find.widgetWithText(FilledButton, 'Create'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Name is required'), findsOneWidget);
-    });
-
-    testWidgets('submitting calls client.createRoom and selects space', (tester) async {
-      when(mockClient.createRoom(
-        name: anyNamed('name'),
-        topic: anyNamed('topic'),
-        creationContent: anyNamed('creationContent'),
-        initialState: anyNamed('initialState'),
-        visibility: anyNamed('visibility'),
-        powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
-      ),).thenAnswer((_) async => '!newspace:example.com');
-
-      when(mockClient.waitForRoomInSync(any, join: anyNamed('join')))
-          .thenAnswer((_) async => SyncUpdate(nextBatch: ''));
-
-      await tester.pumpWidget(buildTestWidget());
-      await tester.tap(find.text('Open'));
-      await tester.pumpAndSettle();
-
-      await tester.enterText(find.widgetWithText(TextField, 'Name'), 'My Space');
-      await tester.tap(find.widgetWithText(FilledButton, 'Create'));
-      await tester.pumpAndSettle();
-
-      verify(mockClient.createRoom(
+      final captured = verify(mockClient.createRoom(
         name: 'My Space',
         topic: anyNamed('topic'),
-        creationContent: anyNamed('creationContent'),
-        initialState: anyNamed('initialState'),
+        creationContent: captureAnyNamed('creationContent'),
         visibility: anyNamed('visibility'),
         powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
-      ),).called(1);
+      ),).captured.single as Map<String, dynamic>;
+      expect(captured['type'], 'm.space');
+      expect(captured['m.federate'], false);
 
-      expect(selectionService.selectedSpaceIds, contains('!newspace:example.com'));
-    });
-
-    testWidgets('shows error on failure', (tester) async {
-      when(mockClient.createRoom(
+      verifyNever(mockClient.createRoom(
         name: anyNamed('name'),
         topic: anyNamed('topic'),
         creationContent: anyNamed('creationContent'),
         initialState: anyNamed('initialState'),
+        visibility: anyNamed('visibility'),
+        powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
+      ),);
+      expect(selectionService.selectedSpaceIds, contains('!new:example.com'));
+    });
+
+    testWidgets('create with federation on omits m.federate key',
+        (tester) async {
+      stubCreateRoom('!new2:example.com');
+
+      await openWizard(tester);
+      await tester.enterText(find.widgetWithText(TextField, 'Name'), 'F');
+      await tester.pump();
+      await tester.tap(find.widgetWithText(FilledButton, 'Next'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(SwitchListTile, 'Allow federation'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilledButton, 'Next'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilledButton, 'Create'));
+      await tester.pumpAndSettle();
+
+      final captured = verify(mockClient.createRoom(
+        name: anyNamed('name'),
+        topic: anyNamed('topic'),
+        creationContent: captureAnyNamed('creationContent'),
+        visibility: anyNamed('visibility'),
+        powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
+      ),).captured.single as Map<String, dynamic>;
+      expect(captured.containsKey('m.federate'), isFalse);
+    });
+
+    testWidgets('shows error on createRoom failure', (tester) async {
+      when(mockClient.createRoom(
+        name: anyNamed('name'),
+        topic: anyNamed('topic'),
+        creationContent: anyNamed('creationContent'),
         visibility: anyNamed('visibility'),
         powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
       ),).thenThrow(Exception('Server error'));
 
-      await tester.pumpWidget(buildTestWidget());
-      await tester.tap(find.text('Open'));
-      await tester.pumpAndSettle();
-
-      await tester.enterText(find.widgetWithText(TextField, 'Name'), 'Bad Space');
+      await openWizard(tester);
+      await advanceToStep3(tester, name: 'Bad');
       await tester.tap(find.widgetWithText(FilledButton, 'Create'));
       await tester.pumpAndSettle();
 
       expect(find.textContaining('Server error'), findsOneWidget);
-    });
-
-    testWidgets('toggling public disables encryption', (tester) async {
-      await tester.pumpWidget(buildTestWidget());
-      await tester.tap(find.text('Open'));
-      await tester.pumpAndSettle();
-
-      // Toggle public space on
-      await tester.tap(find.widgetWithText(SwitchListTile, 'Public space'));
-      await tester.pumpAndSettle();
-
-      expect(find.text('Not available for public spaces'), findsOneWidget);
+      expect(find.text('Create Space'), findsOneWidget);
     });
 
     testWidgets('cancel closes dialog', (tester) async {
-      await tester.pumpWidget(buildTestWidget());
-      await tester.tap(find.text('Open'));
-      await tester.pumpAndSettle();
-
+      await openWizard(tester);
       expect(find.text('Create Space'), findsOneWidget);
 
       await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
@@ -163,10 +233,23 @@ void main() {
 
       expect(find.text('Create Space'), findsNothing);
     });
+
+    testWidgets('narrow surface uses fullscreen Dialog', (tester) async {
+      await openWizard(tester, size: const Size(500, 800));
+
+      expect(find.byType(Dialog), findsOneWidget);
+      expect(find.byIcon(Icons.close), findsOneWidget);
+    });
+
+    testWidgets('wide surface uses AlertDialog', (tester) async {
+      await openWizard(tester, size: const Size(900, 800));
+
+      expect(find.byType(AlertDialog), findsOneWidget);
+    });
   });
 
   group('JoinSpaceDialog', () {
-    Widget buildTestWidget() {
+    Widget buildJoinTestWidget() {
       return MultiProvider(
         providers: [
           ChangeNotifierProvider<MatrixService>.value(value: mockMatrixService),
@@ -189,7 +272,7 @@ void main() {
     }
 
     testWidgets('shows address field', (tester) async {
-      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpWidget(buildJoinTestWidget());
       await tester.tap(find.text('Open'));
       await tester.pumpAndSettle();
 
@@ -198,7 +281,7 @@ void main() {
     });
 
     testWidgets('validates empty address', (tester) async {
-      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpWidget(buildJoinTestWidget());
       await tester.tap(find.text('Open'));
       await tester.pumpAndSettle();
 
@@ -218,7 +301,7 @@ void main() {
           .thenAnswer((_) async => SyncUpdate(nextBatch: ''));
       when(mockClient.getRoomById('!space:example.com')).thenReturn(mockSpace);
 
-      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpWidget(buildJoinTestWidget());
       await tester.tap(find.text('Open'));
       await tester.pumpAndSettle();
 
@@ -236,7 +319,7 @@ void main() {
     testWidgets('shows error on join failure', (tester) async {
       when(mockClient.joinRoom(any)).thenThrow(Exception('Room not found'));
 
-      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpWidget(buildJoinTestWidget());
       await tester.tap(find.text('Open'));
       await tester.pumpAndSettle();
 
@@ -251,7 +334,7 @@ void main() {
     });
 
     testWidgets('cancel closes dialog', (tester) async {
-      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpWidget(buildJoinTestWidget());
       await tester.tap(find.text('Open'));
       await tester.pumpAndSettle();
 


### PR DESCRIPTION
Slice A of #131. Replaces the single-screen `CreateSpaceDialog` and `CreateSubspaceDialog` with a unified 3-step wizard. Slices B (#377), C (#378), D (#379) follow.

## Summary
- New `lib/features/spaces/widgets/space_wizard.dart` — single shared wizard widget.
- `CreateSpaceDialog` and `CreateSubspaceDialog` reduced to thin `show()` wrappers; call sites unchanged.
- **Step 1 — Basics:** name, topic, avatar. Avatar staged as `MatrixFile`, uploaded via `room.setAvatar` after `createRoom`. Avatar failure → snackbar, space still created.
- **Step 2 — Settings:** visibility + federation. **Encryption toggle removed** (misleading on space rooms).
- **Step 3 — Children:** placeholder card; real implementation lands in #377.
- **Responsive surface:** fullscreen `Dialog` on narrow widths, `AlertDialog` (520x520) on widths ≥ `HomeShell.wideBreakpoint` (720). Footer-only step navigation; AppBar shows only X (Cancel) on narrow.
- **PopScope** blocks dismiss while loading.
- **Federation defaults preserved per-flow:** top-level off (matches today), subspace on (matches today's omitted `m.federate` key).
- **`selectSpace` only on top-level** — subspace creation keeps parent selected.
- **Partial-failure handling:** subspace `setSpaceChild` failure shows snackbar, no rollback.

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test` — 1584/1584 passing
- [x] Wizard tests cover: step navigation, name validation, federation on/off `creationContent`, encryption toggle removed, narrow vs wide surface, step state preserved across Back/Next, avatar staging, child-link failure snackbar, no `selectSpace` for subspace, federation default on for subspace
- [x] Manual on Linux: rail "+" → Create Space → walk through steps → space appears with avatar
- [ ] Manual subspace: room-section header "+" → New subspace → wizard with parent name → subspace nested
- [x] Manual narrow window (resize <720px): wizard renders fullscreen with AppBar X

Closes part of #131 (Slice A). Linked: #377, #378, #379.