### PR TITLE
feat: threads (MSC3440) — Slice C: thread-aware read markers + polish

### DIFF
--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -191,6 +191,10 @@ class _ChatScreenState extends State<ChatScreen>
     setState(() => _activeThreadEventId = null);
   }
 
+  void _onTimelineChanged() {
+    if (mounted) setState(() {});
+  }
+
   void _openThreadList() {
     if (_isDesktop) {
       setState(() {
@@ -415,6 +419,7 @@ class _ChatScreenState extends State<ChatScreen>
             onScrollBack: isTouchDevice ? _dismissKeyboard : null,
             onOpenThread: _openThread,
             onReplyInThread: _replyInThread,
+            onTimelineChanged: _onTimelineChanged,
           ),
         ),
         TypingIndicator(

--- a/lib/features/chat/screens/thread_list_screen.dart
+++ b/lib/features/chat/screens/thread_list_screen.dart
@@ -2,9 +2,9 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/features/chat/services/thread_roots_service.dart';
 import 'package:kohera/features/chat/services/thread_summary.dart';
 import 'package:kohera/features/chat/widgets/thread_list_tile.dart';
-import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 
 class ThreadListScreen extends StatefulWidget {
@@ -24,69 +24,52 @@ class ThreadListScreen extends StatefulWidget {
 }
 
 class _ThreadListScreenState extends State<ThreadListScreen> {
-  Timeline? _timeline;
+  List<ThreadSummary>? _summaries;
   StreamSubscription<dynamic>? _syncSub;
-  bool _backfilling = false;
+  bool _loading = true;
+  String? _error;
 
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) => _init());
+    WidgetsBinding.instance.addPostFrameCallback((_) => _refresh());
   }
 
-  Future<void> _init() async {
+  Future<void> _refresh() async {
     if (!mounted) return;
     final matrix = context.read<MatrixService>();
     final room = matrix.client.getRoomById(widget.roomId);
-    if (room == null) return;
-    final timeline = await room.getTimeline(
-      onUpdate: () {
-        if (mounted) setState(() {});
-      },
-    );
-    if (!mounted) {
-      timeline.cancelSubscriptions();
+    if (room == null) {
+      if (mounted) setState(() => _loading = false);
       return;
     }
-    setState(() => _timeline = timeline);
-    _syncSub = matrix.client.onSync.stream.listen((_) {
-      if (mounted) setState(() {});
-    });
-    unawaited(_backfillUntilThreadsFound(timeline, room, matrix));
-  }
-
-  Future<void> _backfillUntilThreadsFound(
-    Timeline timeline,
-    Room room,
-    MatrixService matrix,
-  ) async {
-    if (_backfilling) return;
-    _backfilling = true;
     try {
-      const maxRounds = 10;
-      var rounds = 0;
-      while (mounted && rounds < maxRounds && timeline.canRequestHistory) {
-        final summaries = deriveThreadSummaries(
-          timeline: timeline,
-          room: room,
-          myUserId: matrix.client.userID ?? '',
-        );
-        if (summaries.isNotEmpty) break;
-        rounds++;
-        await timeline.requestHistory();
-      }
+      final summaries = await fetchThreadSummaries(
+        client: matrix.client,
+        room: room,
+      );
+      if (!mounted) return;
+      setState(() {
+        _summaries = summaries;
+        _loading = false;
+        _error = null;
+      });
+      _syncSub ??= matrix.client.onSync.stream.listen((_) {
+        if (mounted) unawaited(_refresh());
+      });
     } catch (e) {
-      debugPrint('[Kohera] Thread list backfill error: $e');
-    } finally {
-      _backfilling = false;
-      if (mounted) setState(() {});
+      debugPrint('[Kohera] Thread roots fetch error: $e');
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = e.toString();
+      });
     }
   }
 
   @override
   void dispose() {
     unawaited(_syncSub?.cancel() ?? Future.value());
-    _timeline?.cancelSubscriptions();
     super.dispose();
   }
 
@@ -103,73 +86,98 @@ class _ThreadListScreenState extends State<ThreadListScreen> {
       );
     }
 
-    final timeline = _timeline;
-    if (timeline == null) {
-      return Scaffold(
-        appBar: AppBar(title: const Text('Threads')),
-        body: const Center(child: CircularProgressIndicator()),
+    final summaries = _summaries;
+    final Widget body;
+    if (_loading && summaries == null) {
+      body = const Center(child: CircularProgressIndicator());
+    } else if (_error != null && (summaries == null || summaries.isEmpty)) {
+      body = _buildError(context);
+    } else if (summaries == null || summaries.isEmpty) {
+      body = _buildEmpty(context);
+    } else {
+      body = ListView.separated(
+        itemCount: summaries.length,
+        separatorBuilder: (_, __) => const Divider(height: 1),
+        itemBuilder: (context, i) {
+          final s = summaries[i];
+          return ThreadListTile(
+            summary: s,
+            onTap: () => widget.onOpenThread(s.root.eventId),
+          );
+        },
       );
     }
-
-    final summaries = deriveThreadSummaries(
-      timeline: timeline,
-      room: room,
-      myUserId: matrix.client.userID ?? '',
-    );
 
     return Scaffold(
       appBar: AppBar(
         leading: widget.onClose != null
             ? IconButton(
                 icon: const Icon(Icons.close),
+                tooltip: 'Close threads',
                 onPressed: widget.onClose,
               )
             : null,
         title: const Text('Threads'),
       ),
-      body: summaries.isEmpty
-          ? (_backfilling
-              ? const Center(child: CircularProgressIndicator())
-              : _buildEmpty(context))
-          : ListView.separated(
-              itemCount: summaries.length,
-              separatorBuilder: (_, __) => const Divider(height: 1),
-              itemBuilder: (context, i) {
-                final s = summaries[i];
-                return ThreadListTile(
-                  summary: s,
-                  onTap: () => widget.onOpenThread(s.root.eventId),
-                );
-              },
-            ),
+      body: RefreshIndicator(
+        onRefresh: _refresh,
+        child: body,
+      ),
     );
   }
 
   Widget _buildEmpty(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(Icons.forum_outlined,
-              size: 48, color: cs.onSurfaceVariant.withValues(alpha: 0.4),),
-          const SizedBox(height: 12),
-          Text(
+    return ListView(
+      children: [
+        const SizedBox(height: 80),
+        Icon(Icons.forum_outlined,
+            size: 48, color: cs.onSurfaceVariant.withValues(alpha: 0.4),),
+        const SizedBox(height: 12),
+        Center(
+          child: Text(
             'No threads yet',
             style: tt.titleMedium?.copyWith(
               color: cs.onSurfaceVariant.withValues(alpha: 0.7),
             ),
           ),
-          const SizedBox(height: 4),
-          Text(
+        ),
+        const SizedBox(height: 4),
+        Center(
+          child: Text(
             'Start one from any message → Reply in thread',
             style: tt.bodySmall?.copyWith(
               color: cs.onSurfaceVariant.withValues(alpha: 0.5),
             ),
           ),
-        ],
-      ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildError(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+    return ListView(
+      children: [
+        const SizedBox(height: 80),
+        Icon(Icons.error_outline, size: 48, color: cs.error),
+        const SizedBox(height: 12),
+        Center(
+          child: Text(
+            'Could not load threads',
+            style: tt.titleMedium?.copyWith(color: cs.error),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Center(
+          child: TextButton(
+            onPressed: _refresh,
+            child: const Text('Retry'),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/chat/screens/thread_list_screen.dart
+++ b/lib/features/chat/screens/thread_list_screen.dart
@@ -26,6 +26,7 @@ class ThreadListScreen extends StatefulWidget {
 class _ThreadListScreenState extends State<ThreadListScreen> {
   Timeline? _timeline;
   StreamSubscription<dynamic>? _syncSub;
+  bool _backfilling = false;
 
   @override
   void initState() {
@@ -51,6 +52,35 @@ class _ThreadListScreenState extends State<ThreadListScreen> {
     _syncSub = matrix.client.onSync.stream.listen((_) {
       if (mounted) setState(() {});
     });
+    unawaited(_backfillUntilThreadsFound(timeline, room, matrix));
+  }
+
+  Future<void> _backfillUntilThreadsFound(
+    Timeline timeline,
+    Room room,
+    MatrixService matrix,
+  ) async {
+    if (_backfilling) return;
+    _backfilling = true;
+    try {
+      const maxRounds = 10;
+      var rounds = 0;
+      while (mounted && rounds < maxRounds && timeline.canRequestHistory) {
+        final summaries = deriveThreadSummaries(
+          timeline: timeline,
+          room: room,
+          myUserId: matrix.client.userID ?? '',
+        );
+        if (summaries.isNotEmpty) break;
+        rounds++;
+        await timeline.requestHistory();
+      }
+    } catch (e) {
+      debugPrint('[Kohera] Thread list backfill error: $e');
+    } finally {
+      _backfilling = false;
+      if (mounted) setState(() {});
+    }
   }
 
   @override
@@ -98,7 +128,9 @@ class _ThreadListScreenState extends State<ThreadListScreen> {
         title: const Text('Threads'),
       ),
       body: summaries.isEmpty
-          ? _buildEmpty(context)
+          ? (_backfilling
+              ? const Center(child: CircularProgressIndicator())
+              : _buildEmpty(context))
           : ListView.separated(
               itemCount: summaries.length,
               separatorBuilder: (_, __) => const Divider(height: 1),

--- a/lib/features/chat/screens/thread_screen.dart
+++ b/lib/features/chat/screens/thread_screen.dart
@@ -75,7 +75,11 @@ class _ThreadScreenState extends State<ThreadScreen> {
       });
     } catch (e) {
       debugPrint('[Kohera] Thread root load failed: $e');
-      if (mounted) setState(() => _loadingRoot = false);
+      if (!mounted) return;
+      setState(() => _loadingRoot = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Could not load thread')),
+      );
     }
   }
 
@@ -134,6 +138,7 @@ class _ThreadScreenState extends State<ThreadScreen> {
         leading: widget.onClose != null
             ? IconButton(
                 icon: const Icon(Icons.close),
+                tooltip: 'Close thread',
                 onPressed: widget.onClose,
               )
             : null,
@@ -150,6 +155,7 @@ class _ThreadScreenState extends State<ThreadScreen> {
               matrix: matrix,
               threadRootEventId: widget.threadRootEventId,
               initialEventId: widget.threadRootEventId,
+              emptyText: 'No replies yet.\nStart the conversation.',
               onReply: _compose.setReplyTo,
               onEdit: (event, timeline) =>
                   _compose.setEditEvent(event, timeline, _msgCtrl),

--- a/lib/features/chat/services/thread_roots_service.dart
+++ b/lib/features/chat/services/thread_roots_service.dart
@@ -11,7 +11,10 @@ Future<List<ThreadSummary>> fetchThreadSummaries({
 
   final summaries = <ThreadSummary>[];
   for (final raw in response.chunk) {
-    final root = Event.fromMatrixEvent(raw, room);
+    final root = await _decryptIfNeeded(
+      client,
+      Event.fromMatrixEvent(raw, room),
+    );
     final children = await _fetchChildren(client, room, root.eventId);
     summaries.add(
       ThreadSummary(
@@ -40,8 +43,26 @@ Future<List<Event>> _fetchChildren(
     RelationshipTypes.thread,
     limit: 100,
   );
-  return relations.chunk
-      .map((m) => Event.fromMatrixEvent(m, room))
-      .toList()
-    ..sort((a, b) => a.originServerTs.compareTo(b.originServerTs));
+  final events = <Event>[];
+  for (final raw in relations.chunk) {
+    events.add(
+      await _decryptIfNeeded(client, Event.fromMatrixEvent(raw, room)),
+    );
+  }
+  events.sort((a, b) => a.originServerTs.compareTo(b.originServerTs));
+  return events;
+}
+
+Future<Event> _decryptIfNeeded(Client client, Event event) async {
+  if (event.type != EventTypes.Encrypted) return event;
+  final encryption = client.encryption;
+  if (encryption == null) return event;
+  try {
+    final decrypted = await encryption
+        .decryptRoomEvent(event)
+        .timeout(const Duration(seconds: 3));
+    return decrypted;
+  } catch (_) {
+    return event;
+  }
 }

--- a/lib/features/chat/services/thread_roots_service.dart
+++ b/lib/features/chat/services/thread_roots_service.dart
@@ -1,0 +1,47 @@
+import 'package:kohera/features/chat/services/thread_summary.dart';
+import 'package:matrix/matrix.dart';
+
+Future<List<ThreadSummary>> fetchThreadSummaries({
+  required Client client,
+  required Room room,
+  int limit = 50,
+}) async {
+  final myUserId = client.userID ?? '';
+  final response = await client.getThreadRoots(room.id, limit: limit);
+
+  final summaries = <ThreadSummary>[];
+  for (final raw in response.chunk) {
+    final root = Event.fromMatrixEvent(raw, room);
+    final children = await _fetchChildren(client, room, root.eventId);
+    summaries.add(
+      ThreadSummary(
+        root: root,
+        children: children,
+        unreadCount: unreadCountFromChildren(
+          rootEventId: root.eventId,
+          children: children,
+          room: room,
+          myUserId: myUserId,
+        ),
+      ),
+    );
+  }
+  return summaries;
+}
+
+Future<List<Event>> _fetchChildren(
+  Client client,
+  Room room,
+  String rootEventId,
+) async {
+  final relations = await client.getRelatingEventsWithRelType(
+    room.id,
+    rootEventId,
+    RelationshipTypes.thread,
+    limit: 100,
+  );
+  return relations.chunk
+      .map((m) => Event.fromMatrixEvent(m, room))
+      .toList()
+    ..sort((a, b) => a.originServerTs.compareTo(b.originServerTs));
+}

--- a/lib/features/chat/services/thread_summary.dart
+++ b/lib/features/chat/services/thread_summary.dart
@@ -38,7 +38,7 @@ List<ThreadSummary> deriveThreadSummaries({
       ThreadSummary(
         root: event,
         children: children,
-        unreadCount: _unreadCountFor(
+        unreadCount: unreadCountFromChildren(
           rootEventId: event.eventId,
           children: children,
           room: room,
@@ -51,7 +51,7 @@ List<ThreadSummary> deriveThreadSummaries({
   return summaries;
 }
 
-int _unreadCountFor({
+int unreadCountFromChildren({
   required String rootEventId,
   required List<Event> children,
   required Room room,
@@ -81,7 +81,7 @@ int threadUnreadCountFor({
   }
   final children =
       root.aggregatedEvents(timeline, RelationshipTypes.thread).toList();
-  return _unreadCountFor(
+  return unreadCountFromChildren(
     rootEventId: root.eventId,
     children: children,
     room: room,

--- a/lib/features/chat/widgets/message_list_view.dart
+++ b/lib/features/chat/widgets/message_list_view.dart
@@ -31,6 +31,7 @@ class MessageListView extends StatefulWidget {
     this.onReplyInThread,
     this.onOpenThread,
     this.emptyText,
+    this.onTimelineChanged,
     super.key,
   });
 
@@ -48,6 +49,7 @@ class MessageListView extends StatefulWidget {
   final void Function(Event event)? onReplyInThread;
   final void Function(Event event)? onOpenThread;
   final String? emptyText;
+  final VoidCallback? onTimelineChanged;
 
   @override
   State<MessageListView> createState() => MessageListViewState();
@@ -108,11 +110,13 @@ class MessageListViewState extends State<MessageListView> {
           _cachedVisibleEvents = null;
           setState(() {});
         }
+        widget.onTimelineChanged?.call();
         _markAsRead();
       },
     );
     if (gen != _initGeneration) return;
     if (mounted) setState(() {});
+    widget.onTimelineChanged?.call();
     _markAsRead();
     _requestMissingKeys();
     if (widget.initialEventId != null) _jumpToEvent(widget.initialEventId!);

--- a/lib/features/chat/widgets/message_list_view.dart
+++ b/lib/features/chat/widgets/message_list_view.dart
@@ -30,6 +30,7 @@ class MessageListView extends StatefulWidget {
     this.threadRootEventId,
     this.onReplyInThread,
     this.onOpenThread,
+    this.emptyText,
     super.key,
   });
 
@@ -46,6 +47,7 @@ class MessageListView extends StatefulWidget {
   final VoidCallback? onScrollBack;
   final void Function(Event event)? onReplyInThread;
   final void Function(Event event)? onOpenThread;
+  final String? emptyText;
 
   @override
   State<MessageListView> createState() => MessageListViewState();
@@ -197,21 +199,45 @@ class MessageListViewState extends State<MessageListView> {
   }
 
   void _markAsRead() {
-    if (widget.threadRootEventId != null) return;
     _readMarkerTimer?.cancel();
     _readMarkerTimer = Timer(_readMarkerDelay, () async {
       if (!mounted) return;
-      final lastEvent = widget.room.lastEvent;
-      if (lastEvent != null && widget.room.notificationCount > 0) {
+      final client = widget.matrix.client;
+      final threadRootId = widget.threadRootEventId;
+
+      if (threadRootId != null) {
+        final visible = _visibleEvents;
+        if (visible.isEmpty) return;
+        final lastThreadEvent = visible.first;
         try {
-          final sendPublic = context.read<PreferencesService>().readReceipts;
-          await widget.room.setReadMarker(
-            lastEvent.eventId,
-            mRead: sendPublic ? lastEvent.eventId : null,
+          await client.postReceipt(
+            widget.room.id,
+            ReceiptType.mRead,
+            lastThreadEvent.eventId,
+            threadId: threadRootId,
           );
         } catch (e) {
-          debugPrint('[Kohera] Failed to mark as read: $e');
+          debugPrint('[Kohera] Failed to mark thread as read: $e');
         }
+        return;
+      }
+
+      final lastEvent = widget.room.lastEvent;
+      if (lastEvent == null || widget.room.notificationCount == 0) return;
+      try {
+        final sendPublic = context.read<PreferencesService>().readReceipts;
+        await widget.room.setReadMarker(
+          lastEvent.eventId,
+          mRead: sendPublic ? lastEvent.eventId : null,
+        );
+        await client.postReceipt(
+          widget.room.id,
+          ReceiptType.mRead,
+          lastEvent.eventId,
+          threadId: 'main',
+        );
+      } catch (e) {
+        debugPrint('[Kohera] Failed to mark as read: $e');
       }
     });
   }
@@ -430,7 +456,7 @@ class MessageListViewState extends State<MessageListView> {
       final tt = Theme.of(context).textTheme;
       return Center(
         child: Text(
-          'No messages yet.\nSay hello!',
+          widget.emptyText ?? 'No messages yet.\nSay hello!',
           textAlign: TextAlign.center,
           style: tt.bodyMedium?.copyWith(
             color: cs.onSurfaceVariant.withValues(alpha: 0.5),
@@ -442,7 +468,11 @@ class MessageListViewState extends State<MessageListView> {
     final isMobile = isTouchDevice;
     final showReceipts = context.watch<PreferencesService>().readReceipts;
     final receiptMap = showReceipts
-        ? buildReceiptMap(widget.room, widget.matrix.client.userID)
+        ? buildReceiptMap(
+            widget.room,
+            widget.matrix.client.userID,
+            threadRootId: widget.threadRootEventId,
+          )
         : <String, List<Receipt>>{};
     final hasLoadingIndicator = _loadingHistory;
     final totalCount = events.length + (hasLoadingIndicator ? 1 : 0);

--- a/lib/features/chat/widgets/read_receipts.dart
+++ b/lib/features/chat/widgets/read_receipts.dart
@@ -11,7 +11,11 @@ import 'package:matrix/matrix.dart';
 /// Iterates [room.receiptState.global.otherUsers] (and optionally
 /// mainThread) once, so cost is O(N) where N = number of users with
 /// receipts, rather than O(N×M) if we queried per-event.
-Map<String, List<Receipt>> buildReceiptMap(Room room, String? myUserId) {
+Map<String, List<Receipt>> buildReceiptMap(
+  Room room,
+  String? myUserId, {
+  String? threadRootId,
+}) {
   final map = <String, List<Receipt>>{};
   final seen = <String>{};
 
@@ -26,6 +30,12 @@ Map<String, List<Receipt>> buildReceiptMap(Room room, String? myUserId) {
       final receipt = Receipt(user, data.timestamp);
       (map[data.eventId] ??= []).add(receipt);
     }
+  }
+
+  if (threadRootId != null) {
+    final threadState = room.receiptState.byThread[threadRootId];
+    if (threadState != null) addReceipts(threadState.otherUsers);
+    return map;
   }
 
   addReceipts(room.receiptState.global.otherUsers);

--- a/lib/features/chat/widgets/thread_indicator_chip.dart
+++ b/lib/features/chat/widgets/thread_indicator_chip.dart
@@ -32,7 +32,12 @@ class ThreadIndicatorChip extends StatelessWidget {
         left: isMe ? 0 : 4,
         right: isMe ? 4 : 0,
       ),
-      child: MouseRegion(
+      child: Semantics(
+        button: true,
+        label: unreadCount > 0
+            ? 'View thread, $label, $unreadCount unread'
+            : 'View thread, $label',
+        child: MouseRegion(
         cursor: SystemMouseCursors.click,
         child: InkWell(
         onTap: onTap,
@@ -72,6 +77,7 @@ class ThreadIndicatorChip extends StatelessWidget {
             ],
           ),
         ),
+      ),
       ),
       ),
     );

--- a/lib/features/chat/widgets/thread_list_tile.dart
+++ b/lib/features/chat/widgets/thread_list_tile.dart
@@ -32,7 +32,15 @@ class ThreadListTile extends StatelessWidget {
             : stripReplyFallback(lastReply.body).trim());
     final hasUnread = summary.unreadCount > 0;
 
-    return MouseRegion(
+    final previewLabel = preview.isEmpty ? 'Thread' : preview;
+    final semanticsLabel = hasUnread
+        ? 'Open thread: $previewLabel, ${summary.unreadCount} unread'
+        : 'Open thread: $previewLabel';
+
+    return Semantics(
+      button: true,
+      label: semanticsLabel,
+      child: MouseRegion(
       cursor: SystemMouseCursors.click,
       child: InkWell(
         mouseCursor: SystemMouseCursors.click,
@@ -118,6 +126,7 @@ class ThreadListTile extends StatelessWidget {
             ],
           ),
         ),
+      ),
       ),
     );
   }

--- a/lib/features/rooms/widgets/room_tile.dart
+++ b/lib/features/rooms/widgets/room_tile.dart
@@ -317,13 +317,28 @@ class _RoomTileState extends State<RoomTile> {
         ),
       );
     }
-    return Text(
+    final isThreadReply =
+        lastEvent?.relationshipType == RelationshipTypes.thread;
+    final previewText = Text(
       _lastMessagePreview(lastEvent, userId),
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
       style: tt.bodyMedium?.copyWith(
         color: cs.onSurfaceVariant.withValues(alpha: 0.7),
       ),
+    );
+    if (!isThreadReply) return previewText;
+    return Row(
+      children: [
+        Icon(Icons.forum_outlined, size: 12, color: cs.primary),
+        const SizedBox(width: 4),
+        Text(
+          'in thread',
+          style: tt.labelSmall?.copyWith(color: cs.primary, fontSize: 10),
+        ),
+        const SizedBox(width: 6),
+        Expanded(child: previewText),
+      ],
     );
   }
 

--- a/test/widgets/chat/read_receipts_test.dart
+++ b/test/widgets/chat/read_receipts_test.dart
@@ -29,6 +29,7 @@ MockUser _makeUser(String id, String? displayName, {Uri? avatarUrl}) {
 MockRoom _makeRoom({
   required Map<String, LatestReceiptStateData> globalOtherUsers,
   required Map<String, MockUser> userMap, Map<String, LatestReceiptStateData>? mainThreadOtherUsers,
+  Map<String, Map<String, LatestReceiptStateData>>? byThreadOtherUsers,
 }) {
   final room = MockRoom();
 
@@ -49,9 +50,22 @@ MockRoom _makeRoom({
     );
   }
 
+  final byThread = <String, LatestReceiptStateForTimeline>{};
+  if (byThreadOtherUsers != null) {
+    for (final entry in byThreadOtherUsers.entries) {
+      byThread[entry.key] = LatestReceiptStateForTimeline(
+        ownPrivate: null,
+        ownPublic: null,
+        latestOwnReceipt: null,
+        otherUsers: entry.value,
+      );
+    }
+  }
+
   when(room.receiptState).thenReturn(LatestReceiptState(
     global: global,
     mainThread: mainThread,
+    byThread: byThread,
   ),);
 
   for (final entry in userMap.entries) {
@@ -132,6 +146,59 @@ void main() {
         allReceipts.where((r) => r.user.id == '@alice:example.com').length,
         1,
       );
+    });
+
+    test('threadRootId scopes receipts to byThread only', () {
+      final alice = _makeUser('@alice:example.com', 'Alice');
+      final bob = _makeUser('@bob:example.com', 'Bob');
+
+      final room = _makeRoom(
+        globalOtherUsers: {
+          '@alice:example.com': LatestReceiptStateData(r'$global1', 1000),
+        },
+        mainThreadOtherUsers: {
+          '@alice:example.com': LatestReceiptStateData(r'$main1', 1500),
+        },
+        byThreadOtherUsers: {
+          r'$root': {
+            '@bob:example.com': LatestReceiptStateData(r'$thread1', 2000),
+          },
+        },
+        userMap: {
+          '@alice:example.com': alice,
+          '@bob:example.com': bob,
+        },
+      );
+
+      final map = buildReceiptMap(
+        room,
+        '@me:example.com',
+        threadRootId: r'$root',
+      );
+
+      expect(map.containsKey(r'$thread1'), isTrue);
+      expect(map[r'$thread1']!.single.user.id, '@bob:example.com');
+      expect(map.containsKey(r'$global1'), isFalse);
+      expect(map.containsKey(r'$main1'), isFalse);
+    });
+
+    test('threadRootId with no matching thread returns empty', () {
+      final room = _makeRoom(
+        globalOtherUsers: {
+          '@alice:example.com': LatestReceiptStateData(r'$evt1', 1000),
+        },
+        userMap: {
+          '@alice:example.com': _makeUser('@alice:example.com', 'Alice'),
+        },
+      );
+
+      final map = buildReceiptMap(
+        room,
+        '@me:example.com',
+        threadRootId: r'$missing',
+      );
+
+      expect(map, isEmpty);
     });
 
     test('returns empty map for room with no receipts', () {


### PR DESCRIPTION
Closes #383.

## Summary

Slice C of the threads epic — thread-aware read markers, polish, plus several follow-ups discovered while testing.

### Read markers
- `MessageListView` posts `client.postReceipt(roomId, mRead, eventId, threadId: rootId)` when viewing a thread panel.
- Main timeline now also tags receipts with `thread_id: 'main'` so `room.receiptState.byThread` / `mainThread` split populates correctly.
- `buildReceiptMap` accepts optional `threadRootId` to scope receipt avatars to the thread's own readers in the thread panel.

### Thread list
- `ThreadListScreen` loads roots via the `/_matrix/client/v1/rooms/{roomId}/threads` endpoint (`client.getThreadRoots`) — server returns roots ordered by latest activity regardless of local timeline window, so older threads now appear.
- Children fetched per root via `client.getRelatingEventsWithRelType(roomId, rootId, 'm.thread')`.
- Pull-to-refresh; error state with retry; refetch on sync.
- New `lib/features/chat/services/thread_roots_service.dart` (`fetchThreadSummaries`).
- `thread_summary._unreadCountFor` exposed as `unreadCountFromChildren` for reuse.

### Polish
- `ThreadScreen` shows a SnackBar on root load failure; close button gets a tooltip; new `MessageListView.emptyText` powers a "No replies yet" empty state.
- Semantics labels on `ThreadIndicatorChip` and `ThreadListTile` (button + unread count).
- Threads icon in chat app bar appears as soon as timeline is ready (new `MessageListView.onTimelineChanged` callback) — was previously delayed because parent didn't rebuild on internal `setState`.
- Room tile preview tags thread-reply lastEvents with a forum icon + "in thread" label so users can spot when the latest activity isn't in the main panel.

## Test plan

- [x] `flutter test test/widgets/chat/ test/services/thread_summary_test.dart test/services/inbox_controller_test.dart` — all green
- [x] `flutter build linux --debug` — clean
- [x] New unit tests in `read_receipts_test.dart` cover thread-scoped `buildReceiptMap`
- [x] Manual: open thread panel from app bar; verify older threads appear; receive a reply on another client and confirm badge clears within ~2s; verify main timeline unread independent of thread reads; receipt avatars in panel scope to thread readers; room tile shows "in thread" prefix when latest event is a thread reply.