### PR TITLE
fix: gate Matrix sync on app foreground to stop iOS 0xdead10cc

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -331,9 +331,7 @@ import UserNotifications
         "roomId": roomId,
         "withVideo": isVideo ? "true" : "false",
       ]
-      plugin.showCallkitIncoming(data, fromPushKit: true) {
-        finish()
-      }
+      plugin.showCallkitIncoming(data, fromPushKit: true) {}
     } else {
       NSLog("[Kohera] PushKit: SwiftFlutterCallkitIncomingPlugin.sharedInstance nil; dropping call")
       finish()
@@ -345,8 +343,18 @@ import UserNotifications
     enriched["nativeCallId"] = nativeCallId
     enriched["callKitAlreadyShown"] = callKitShown
 
+    // Defer PushKit `completion()` until Dart acks (or we hit the safety
+    // timeout). This prevents iOS from suspending the process while the
+    // Matrix oneShotSync is still writing to sqflite — which was the cause
+    // of `0xdead10cc` watchdog kills on background launch.
+    DispatchQueue.main.asyncAfter(deadline: .now() + 20) {
+      finish()
+    }
+
     if voipChannelReady {
-      voipChannel?.invokeMethod("onVoipMessage", arguments: enriched)
+      voipChannel?.invokeMethod("onVoipMessage", arguments: enriched) { _ in
+        finish()
+      }
     } else if pendingVoipPayloads.count < AppDelegate.maxPendingPayloads {
       pendingVoipPayloads.append(enriched)
     }

--- a/lib/core/services/matrix_service.dart
+++ b/lib/core/services/matrix_service.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:kohera/core/services/session_backup.dart';
 import 'package:kohera/core/services/sub_services/auth_service.dart';
@@ -17,7 +17,7 @@ import 'package:matrix/src/utils/client_init_exception.dart';
 String koheraKey(String clientName, String suffix) =>
     'kohera_${clientName}_$suffix';
 
-class MatrixService extends ChangeNotifier {
+class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
   static String friendlyAuthError(Object e) {
     if (isNetworkError(e)) return 'Could not reach server';
     if (e is TimeoutException) return 'Connection timed out';
@@ -80,6 +80,9 @@ class MatrixService extends ChangeNotifier {
     auth.notifyListeners();
   }
 
+  @visibleForTesting
+  Future<void> activateSessionForTest() => _activateSession();
+
   bool _disposed = false;
   bool get disposed => _disposed;
 
@@ -99,6 +102,9 @@ class MatrixService extends ChangeNotifier {
 
   StreamSubscription<LoginState>? _loginStateSub;
 
+  bool _foregroundSyncStarted = false;
+  bool _lifecycleObserverRegistered = false;
+
   bool _hasSkippedSetup = false;
   bool get hasSkippedSetup => _hasSkippedSetup;
   void skipSetup() {
@@ -109,6 +115,10 @@ class MatrixService extends ChangeNotifier {
   @override
   void dispose() {
     _disposed = true;
+    if (_lifecycleObserverRegistered) {
+      WidgetsBinding.instance.removeObserver(this);
+      _lifecycleObserverRegistered = false;
+    }
     auth.removeListener(_onAuthChanged);
     auth.isLoggedIn = false;
     sync.cancelSyncSub();
@@ -118,6 +128,19 @@ class MatrixService extends ChangeNotifier {
     sync.dispose();
     unawaited(_loginStateSub?.cancel());
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.resumed:
+        _startForegroundSync();
+      case AppLifecycleState.inactive:
+      case AppLifecycleState.paused:
+      case AppLifecycleState.detached:
+      case AppLifecycleState.hidden:
+        break;
+    }
   }
 
   // ── Public API ──────────────────────────────────────────────────
@@ -230,6 +253,11 @@ class MatrixService extends ChangeNotifier {
       selection.resetSelection();
       chatBackup.resetChatBackupState();
       _hasSkippedSetup = false;
+      _foregroundSyncStarted = false;
+      if (_lifecycleObserverRegistered) {
+        WidgetsBinding.instance.removeObserver(this);
+        _lifecycleObserverRegistered = false;
+      }
     }
     notifyListeners();
   }
@@ -251,6 +279,31 @@ class MatrixService extends ChangeNotifier {
 
   Future<void> _activateSession() async {
     auth.activateRestoredSession();
+    if (!_lifecycleObserverRegistered) {
+      WidgetsBinding.instance.addObserver(this);
+      _lifecycleObserverRegistered = true;
+    }
+    if (_isAppForegrounded()) {
+      _startForegroundSync();
+    } else {
+      debugPrint(
+        '[Kohera] Session activated in background — deferring sync until '
+        'app is resumed (lifecycleState='
+        '${WidgetsBinding.instance.lifecycleState})',
+      );
+    }
+  }
+
+  bool _isAppForegrounded() =>
+      WidgetsBinding.instance.lifecycleState == AppLifecycleState.resumed;
+
+  void _startForegroundSync() {
+    if (_foregroundSyncStarted || _disposed) return;
+    _foregroundSyncStarted = true;
+    if (_lifecycleObserverRegistered) {
+      WidgetsBinding.instance.removeObserver(this);
+      _lifecycleObserverRegistered = false;
+    }
     unawaited(
       sync.startSync().catchError((Object e) {
         if (e is! TimeoutException) {

--- a/lib/core/services/sub_services/sync_service.dart
+++ b/lib/core/services/sub_services/sync_service.dart
@@ -30,6 +30,7 @@ class SyncService extends ChangeNotifier {
   }
 
   Future<void> startSync({Duration? timeout = const Duration(seconds: 30)}) async {
+    if (_syncing) return;
     _syncing = true;
     notifyListeners();
 

--- a/lib/features/notifications/services/apns_push_service.dart
+++ b/lib/features/notifications/services/apns_push_service.dart
@@ -55,7 +55,7 @@ class ApnsPushService {
         debugPrint('[Kohera] APNs registration error: $error');
       case 'onRemoteMessage':
         final payload = Map<String, dynamic>.from(call.arguments as Map);
-        unawaited(_processPushMessage(payload));
+        await _processPushMessage(payload);
       case 'onNotificationTap':
         final roomId = call.arguments as String;
         debugPrint('[Kohera] APNs notification tapped for room $roomId');
@@ -158,7 +158,11 @@ class ApnsPushService {
     if (_disposed) return;
 
     try {
-      await matrixService.client.oneShotSync();
+      await matrixService.client
+          .oneShotSync()
+          .timeout(const Duration(seconds: 20));
+    } on TimeoutException {
+      debugPrint('[Kohera] APNs oneShotSync timed out after 20s');
     } catch (e) {
       debugPrint('[Kohera] APNs push message processing error: $e');
     }

--- a/lib/features/notifications/services/ios_voip_push_service.dart
+++ b/lib/features/notifications/services/ios_voip_push_service.dart
@@ -126,7 +126,12 @@ class IosVoipPushService {
       );
 
       try {
-        await matrixService.client.oneShotSync();
+        await matrixService.client
+            .oneShotSync()
+            .timeout(const Duration(seconds: 20));
+      } on TimeoutException {
+        debugPrint('[Kohera] VoIP oneShotSync timed out after 20s');
+        return;
       } catch (e) {
         debugPrint('[Kohera] VoIP oneShotSync failed: $e');
         return;

--- a/test/screens/chat_search_test.mocks.dart
+++ b/test/screens/chat_search_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i16;
 import 'dart:ui' as _i18;
 
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i17;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -23,7 +25,7 @@ import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/models/timeline_chunk.dart' as _i13;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i19;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i15;
 
@@ -7901,6 +7903,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7923,6 +7935,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -8025,6 +8047,161 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i20.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -8511,18 +8688,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i19.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i19.SpaceParent>[],
-        returnValueForMissingStub: <_i19.SpaceParent>[],
-      ) as List<_i19.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i19.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i19.SpaceChild>[],
-        returnValueForMissingStub: <_i19.SpaceChild>[],
-      ) as List<_i19.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(

--- a/test/screens/devices_screen_test.mocks.dart
+++ b/test/screens/devices_screen_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i15;
 import 'dart:ui' as _i17;
 
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -7837,6 +7839,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7859,6 +7871,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -7961,6 +7983,161 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i5.Future<_i17.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );

--- a/test/services/chat_message_actions_test.mocks.dart
+++ b/test/services/chat_message_actions_test.mocks.dart
@@ -9,9 +9,10 @@ import 'dart:ui' as _i23;
 
 import 'package:flutter/foundation.dart' as _i15;
 import 'package:flutter/scheduler.dart' as _i17;
-import 'package:flutter/src/material/banner.dart' as _i25;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/src/material/banner.dart' as _i26;
 import 'package:flutter/src/material/scaffold.dart' as _i14;
-import 'package:flutter/src/material/snack_bar.dart' as _i24;
+import 'package:flutter/src/material/snack_bar.dart' as _i25;
 import 'package:flutter/widgets.dart' as _i16;
 import 'package:http/http.dart' as _i5;
 import 'package:kohera/core/services/matrix_service.dart' as _i22;
@@ -10999,6 +11000,16 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as bool);
 
   @override
+  _i6.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -11021,6 +11032,16 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -11126,6 +11147,161 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
         ),
         returnValueForMissingStub: null,
       );
+
+  @override
+  _i6.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i6.Future<bool>.value(false),
+        returnValueForMissingStub: _i6.Future<bool>.value(false),
+      ) as _i6.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i6.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i6.Future<bool>.value(false),
+        returnValueForMissingStub: _i6.Future<bool>.value(false),
+      ) as _i6.Future<bool>);
+
+  @override
+  _i6.Future<bool> didPushRouteInformation(
+          _i16.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i6.Future<bool>.value(false),
+        returnValueForMissingStub: _i6.Future<bool>.value(false),
+      ) as _i6.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i6.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i6.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i6.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i6.Future<_i23.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [ScaffoldMessengerState].
@@ -11176,9 +11352,9 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  _i14.ScaffoldFeatureController<_i24.SnackBar, _i24.SnackBarClosedReason>
+  _i14.ScaffoldFeatureController<_i25.SnackBar, _i25.SnackBarClosedReason>
       showSnackBar(
-    _i24.SnackBar? snackBar, {
+    _i25.SnackBar? snackBar, {
     _i16.AnimationStyle? snackBarAnimationStyle,
   }) =>
           (super.noSuchMethod(
@@ -11187,8 +11363,8 @@ class MockScaffoldMessengerState extends _i1.Mock
               [snackBar],
               {#snackBarAnimationStyle: snackBarAnimationStyle},
             ),
-            returnValue: _FakeScaffoldFeatureController_82<_i24.SnackBar,
-                _i24.SnackBarClosedReason>(
+            returnValue: _FakeScaffoldFeatureController_82<_i25.SnackBar,
+                _i25.SnackBarClosedReason>(
               this,
               Invocation.method(
                 #showSnackBar,
@@ -11197,7 +11373,7 @@ class MockScaffoldMessengerState extends _i1.Mock
               ),
             ),
             returnValueForMissingStub: _FakeScaffoldFeatureController_82<
-                _i24.SnackBar, _i24.SnackBarClosedReason>(
+                _i25.SnackBar, _i25.SnackBarClosedReason>(
               this,
               Invocation.method(
                 #showSnackBar,
@@ -11205,13 +11381,13 @@ class MockScaffoldMessengerState extends _i1.Mock
                 {#snackBarAnimationStyle: snackBarAnimationStyle},
               ),
             ),
-          ) as _i14.ScaffoldFeatureController<_i24.SnackBar,
-              _i24.SnackBarClosedReason>);
+          ) as _i14.ScaffoldFeatureController<_i25.SnackBar,
+              _i25.SnackBarClosedReason>);
 
   @override
   void removeCurrentSnackBar(
-          {_i24.SnackBarClosedReason? reason =
-              _i24.SnackBarClosedReason.remove}) =>
+          {_i25.SnackBarClosedReason? reason =
+              _i25.SnackBarClosedReason.remove}) =>
       super.noSuchMethod(
         Invocation.method(
           #removeCurrentSnackBar,
@@ -11223,8 +11399,8 @@ class MockScaffoldMessengerState extends _i1.Mock
 
   @override
   void hideCurrentSnackBar(
-          {_i24.SnackBarClosedReason? reason =
-              _i24.SnackBarClosedReason.hide}) =>
+          {_i25.SnackBarClosedReason? reason =
+              _i25.SnackBarClosedReason.hide}) =>
       super.noSuchMethod(
         Invocation.method(
           #hideCurrentSnackBar,
@@ -11244,16 +11420,16 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  _i14.ScaffoldFeatureController<_i25.MaterialBanner,
-      _i25.MaterialBannerClosedReason> showMaterialBanner(
-          _i25.MaterialBanner? materialBanner) =>
+  _i14.ScaffoldFeatureController<_i26.MaterialBanner,
+      _i26.MaterialBannerClosedReason> showMaterialBanner(
+          _i26.MaterialBanner? materialBanner) =>
       (super.noSuchMethod(
         Invocation.method(
           #showMaterialBanner,
           [materialBanner],
         ),
-        returnValue: _FakeScaffoldFeatureController_82<_i25.MaterialBanner,
-            _i25.MaterialBannerClosedReason>(
+        returnValue: _FakeScaffoldFeatureController_82<_i26.MaterialBanner,
+            _i26.MaterialBannerClosedReason>(
           this,
           Invocation.method(
             #showMaterialBanner,
@@ -11261,20 +11437,20 @@ class MockScaffoldMessengerState extends _i1.Mock
           ),
         ),
         returnValueForMissingStub: _FakeScaffoldFeatureController_82<
-            _i25.MaterialBanner, _i25.MaterialBannerClosedReason>(
+            _i26.MaterialBanner, _i26.MaterialBannerClosedReason>(
           this,
           Invocation.method(
             #showMaterialBanner,
             [materialBanner],
           ),
         ),
-      ) as _i14.ScaffoldFeatureController<_i25.MaterialBanner,
-          _i25.MaterialBannerClosedReason>);
+      ) as _i14.ScaffoldFeatureController<_i26.MaterialBanner,
+          _i26.MaterialBannerClosedReason>);
 
   @override
   void removeCurrentMaterialBanner(
-          {_i25.MaterialBannerClosedReason? reason =
-              _i25.MaterialBannerClosedReason.remove}) =>
+          {_i26.MaterialBannerClosedReason? reason =
+              _i26.MaterialBannerClosedReason.remove}) =>
       super.noSuchMethod(
         Invocation.method(
           #removeCurrentMaterialBanner,
@@ -11286,8 +11462,8 @@ class MockScaffoldMessengerState extends _i1.Mock
 
   @override
   void hideCurrentMaterialBanner(
-          {_i25.MaterialBannerClosedReason? reason =
-              _i25.MaterialBannerClosedReason.hide}) =>
+          {_i26.MaterialBannerClosedReason? reason =
+              _i26.MaterialBannerClosedReason.hide}) =>
       super.noSuchMethod(
         Invocation.method(
           #hideCurrentMaterialBanner,

--- a/test/services/ios_voip_push_service_test.mocks.dart
+++ b/test/services/ios_voip_push_service_test.mocks.dart
@@ -4,13 +4,13 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i11;
-import 'dart:typed_data' as _i19;
+import 'dart:typed_data' as _i21;
 import 'dart:ui' as _i17;
 
-import 'package:flutter/services.dart' as _i27;
-import 'package:flutter/widgets.dart' as _i28;
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
 import 'package:http/http.dart' as _i10;
-import 'package:kohera/core/services/call_service.dart' as _i20;
+import 'package:kohera/core/services/call_service.dart' as _i22;
 import 'package:kohera/core/services/matrix_service.dart' as _i13;
 import 'package:kohera/core/services/preferences_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
@@ -20,17 +20,17 @@ import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i6;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i7;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i4;
-import 'package:kohera/features/calling/models/call_participant.dart' as _i23;
-import 'package:kohera/features/calling/models/call_state.dart' as _i25;
-import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i24;
-import 'package:kohera/features/calling/services/livekit_service.dart' as _i21;
-import 'package:kohera/features/calling/services/ringtone_service.dart' as _i26;
+import 'package:kohera/features/calling/models/call_participant.dart' as _i25;
+import 'package:kohera/features/calling/models/call_state.dart' as _i27;
+import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i26;
+import 'package:kohera/features/calling/services/livekit_service.dart' as _i23;
+import 'package:kohera/features/calling/services/ringtone_service.dart' as _i28;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
 import 'package:kohera/features/notifications/services/notification_service.dart'
     as _i29;
-import 'package:livekit_client/livekit_client.dart' as _i22;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:livekit_client/livekit_client.dart' as _i24;
+import 'package:matrix/encryption.dart' as _i20;
 import 'package:matrix/matrix.dart' as _i3;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i12;
 import 'package:matrix/src/models/timeline_chunk.dart' as _i15;
@@ -1112,6 +1112,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
+  _i11.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i11.Future<void>.value(),
+        returnValueForMissingStub: _i11.Future<void>.value(),
+      ) as _i11.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -1134,6 +1144,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -1239,6 +1259,161 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
         ),
         returnValueForMissingStub: null,
       );
+
+  @override
+  _i11.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  _i11.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i11.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i11.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i11.Future<_i17.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [Client].
@@ -1259,12 +1434,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as _i3.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i20.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i20.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
+      ) as Set<_i20.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1763,34 +1938,34 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as _i9.CachedStreamController<_i3.BasicEvent>);
 
   @override
-  _i9.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i9.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_13<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_13<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_13<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i9.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i9.CachedStreamController<_i20.RoomKeyRequest>);
 
   @override
-  _i9.CachedStreamController<_i18.KeyVerification>
+  _i9.CachedStreamController<_i20.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_13<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_13<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_13<_i18.KeyVerification>(
+                _FakeCachedStreamController_13<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i9.CachedStreamController<_i18.KeyVerification>);
+          ) as _i9.CachedStreamController<_i20.KeyVerification>);
 
   @override
   _i9.CachedStreamController<_i3.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1946,7 +2121,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3419,7 +3594,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
 
   @override
   _i11.Future<Uri> uploadContent(
-    _i19.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3937,7 +4112,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Never unexpectedResponse(
     _i10.BaseResponse? response,
-    _i19.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8065,7 +8240,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
   _i11.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i19.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8092,7 +8267,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
 /// A class which mocks [CallService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCallService extends _i1.Mock implements _i20.CallService {
+class MockCallService extends _i1.Mock implements _i22.CallService {
   @override
   _i3.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -8114,7 +8289,7 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       ) as bool);
 
   @override
-  _i21.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
+  _i23.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
         Invocation.getter(#httpPostForTest),
         returnValue: (
           _i10.Client httpClient,
@@ -8136,14 +8311,14 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
           this,
           Invocation.getter(#httpPostForTest),
         )),
-      ) as _i21.HttpPostFunction);
+      ) as _i23.HttpPostFunction);
 
   @override
-  List<_i22.RemoteParticipant> get participants => (super.noSuchMethod(
+  List<_i24.RemoteParticipant> get participants => (super.noSuchMethod(
         Invocation.getter(#participants),
-        returnValue: <_i22.RemoteParticipant>[],
-        returnValueForMissingStub: <_i22.RemoteParticipant>[],
-      ) as List<_i22.RemoteParticipant>);
+        returnValue: <_i24.RemoteParticipant>[],
+        returnValueForMissingStub: <_i24.RemoteParticipant>[],
+      ) as List<_i24.RemoteParticipant>);
 
   @override
   bool get isMicEnabled => (super.noSuchMethod(
@@ -8174,14 +8349,14 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       ) as bool);
 
   @override
-  List<_i22.Participant<_i22.TrackPublication<_i22.Track>>>
+  List<_i24.Participant<_i24.TrackPublication<_i24.Track>>>
       get activeSpeakers => (super.noSuchMethod(
             Invocation.getter(#activeSpeakers),
-            returnValue: <_i22
-                .Participant<_i22.TrackPublication<_i22.Track>>>[],
-            returnValueForMissingStub: <_i22
-                .Participant<_i22.TrackPublication<_i22.Track>>>[],
-          ) as List<_i22.Participant<_i22.TrackPublication<_i22.Track>>>);
+            returnValue: <_i24
+                .Participant<_i24.TrackPublication<_i24.Track>>>[],
+            returnValueForMissingStub: <_i24
+                .Participant<_i24.TrackPublication<_i24.Track>>>[],
+          ) as List<_i24.Participant<_i24.TrackPublication<_i24.Track>>>);
 
   @override
   bool get isCallingAvailable => (super.noSuchMethod(
@@ -8191,11 +8366,11 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       ) as bool);
 
   @override
-  List<_i23.CallParticipant> get allParticipants => (super.noSuchMethod(
+  List<_i25.CallParticipant> get allParticipants => (super.noSuchMethod(
         Invocation.getter(#allParticipants),
-        returnValue: <_i23.CallParticipant>[],
-        returnValueForMissingStub: <_i23.CallParticipant>[],
-      ) as List<_i23.CallParticipant>);
+        returnValue: <_i25.CallParticipant>[],
+        returnValueForMissingStub: <_i25.CallParticipant>[],
+      ) as List<_i25.CallParticipant>);
 
   @override
   bool get isSpeakerOn => (super.noSuchMethod(
@@ -8205,12 +8380,12 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       ) as bool);
 
   @override
-  _i11.Stream<_i24.IncomingCallInfo> get incomingCallStream =>
+  _i11.Stream<_i26.IncomingCallInfo> get incomingCallStream =>
       (super.noSuchMethod(
         Invocation.getter(#incomingCallStream),
-        returnValue: _i11.Stream<_i24.IncomingCallInfo>.empty(),
-        returnValueForMissingStub: _i11.Stream<_i24.IncomingCallInfo>.empty(),
-      ) as _i11.Stream<_i24.IncomingCallInfo>);
+        returnValue: _i11.Stream<_i26.IncomingCallInfo>.empty(),
+        returnValueForMissingStub: _i11.Stream<_i26.IncomingCallInfo>.empty(),
+      ) as _i11.Stream<_i26.IncomingCallInfo>);
 
   @override
   _i11.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
@@ -8220,11 +8395,11 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       ) as _i11.Stream<String>);
 
   @override
-  _i25.KoheraCallState get callState => (super.noSuchMethod(
+  _i27.KoheraCallState get callState => (super.noSuchMethod(
         Invocation.getter(#callState),
-        returnValue: _i25.KoheraCallState.idle,
-        returnValueForMissingStub: _i25.KoheraCallState.idle,
-      ) as _i25.KoheraCallState);
+        returnValue: _i27.KoheraCallState.idle,
+        returnValueForMissingStub: _i27.KoheraCallState.idle,
+      ) as _i27.KoheraCallState);
 
   @override
   set preferencesService(_i14.PreferencesService? prefs) => super.noSuchMethod(
@@ -8236,7 +8411,7 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       );
 
   @override
-  set ringtoneService(_i26.RingtoneService? service) => super.noSuchMethod(
+  set ringtoneService(_i28.RingtoneService? service) => super.noSuchMethod(
         Invocation.setter(
           #ringtoneService,
           service,
@@ -8245,7 +8420,7 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       );
 
   @override
-  set roomFactoryForTest(_i21.LiveKitRoomFactory? factory) =>
+  set roomFactoryForTest(_i23.LiveKitRoomFactory? factory) =>
       super.noSuchMethod(
         Invocation.setter(
           #roomFactoryForTest,
@@ -8255,7 +8430,7 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       );
 
   @override
-  set httpPostForTest(_i21.HttpPostFunction? fn) => super.noSuchMethod(
+  set httpPostForTest(_i23.HttpPostFunction? fn) => super.noSuchMethod(
         Invocation.setter(
           #httpPostForTest,
           fn,
@@ -8465,7 +8640,7 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
   @override
   _i11.Future<void> initiateCall(
     String? roomId, {
-    _i24.CallType? type = _i24.CallType.voice,
+    _i26.CallType? type = _i26.CallType.voice,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8596,7 +8771,7 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       ) as _i11.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i27.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8607,7 +8782,7 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i27.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8655,7 +8830,7 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
 
   @override
   _i11.Future<bool> didPushRouteInformation(
-          _i28.RouteInformation? routeInformation) =>
+          _i19.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,

--- a/test/services/matrix_service_test.dart
+++ b/test/services/matrix_service_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/services/matrix_service.dart';
@@ -1481,6 +1482,83 @@ void main() {
 
       // Should not throw
       service.dispose();
+    });
+  });
+
+  group('_activateSession lifecycle gate', () {
+    setUpAll(TestWidgetsFlutterBinding.ensureInitialized);
+
+    test('does not start sync when app is paused', () async {
+      WidgetsBinding.instance
+          .handleAppLifecycleStateChanged(AppLifecycleState.paused);
+
+      await service.activateSessionForTest();
+
+      expect(service.sync.syncing, isFalse);
+    });
+
+    test('does not start sync when app is detached', () async {
+      WidgetsBinding.instance
+          .handleAppLifecycleStateChanged(AppLifecycleState.detached);
+
+      await service.activateSessionForTest();
+
+      expect(service.sync.syncing, isFalse);
+    });
+
+    test('starts sync when app is resumed at activation time', () async {
+      WidgetsBinding.instance
+          .handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+
+      await service.activateSessionForTest();
+
+      expect(service.sync.syncing, isTrue);
+    });
+
+    test('defers sync at boot then starts when app transitions to resumed',
+        () async {
+      WidgetsBinding.instance
+          .handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await service.activateSessionForTest();
+      expect(
+        service.sync.syncing,
+        isFalse,
+        reason: 'sync should be deferred while in background',
+      );
+
+      WidgetsBinding.instance
+          .handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+
+      expect(
+        service.sync.syncing,
+        isTrue,
+        reason: 'sync should start once app reaches foreground',
+      );
+    });
+
+    test('does not double-start across paused→resumed cycles', () async {
+      WidgetsBinding.instance
+          .handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await service.activateSessionForTest();
+      WidgetsBinding.instance
+          .handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      expect(service.sync.syncing, isTrue);
+
+      var notifyCount = 0;
+      service.sync.addListener(() => notifyCount++);
+
+      WidgetsBinding.instance
+          .handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      WidgetsBinding.instance
+          .handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+
+      expect(
+        notifyCount,
+        0,
+        reason: 'observer should be unregistered after first foreground sync; '
+            'subsequent transitions must not re-trigger startSync',
+      );
+      expect(service.sync.syncing, isTrue);
     });
   });
 }

--- a/test/services/notification_service_test.mocks.dart
+++ b/test/services/notification_service_test.mocks.dart
@@ -4,20 +4,22 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i11;
-import 'dart:typed_data' as _i17;
+import 'dart:typed_data' as _i19;
 import 'dart:ui' as _i15;
 
+import 'package:flutter/services.dart' as _i16;
+import 'package:flutter/widgets.dart' as _i17;
 import 'package:flutter_local_notifications/src/flutter_local_notifications_plugin.dart'
-    as _i20;
-import 'package:flutter_local_notifications/src/initialization_settings.dart'
-    as _i21;
-import 'package:flutter_local_notifications/src/notification_details.dart'
-    as _i23;
-import 'package:flutter_local_notifications/src/platform_specifics/android/schedule_mode.dart'
-    as _i25;
-import 'package:flutter_local_notifications/src/types.dart' as _i26;
-import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart'
     as _i22;
+import 'package:flutter_local_notifications/src/initialization_settings.dart'
+    as _i23;
+import 'package:flutter_local_notifications/src/notification_details.dart'
+    as _i25;
+import 'package:flutter_local_notifications/src/platform_specifics/android/schedule_mode.dart'
+    as _i27;
+import 'package:flutter_local_notifications/src/types.dart' as _i28;
+import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart'
+    as _i24;
 import 'package:http/http.dart' as _i10;
 import 'package:kohera/core/services/matrix_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
@@ -29,15 +31,15 @@ import 'package:kohera/core/services/sub_services/sync_service.dart' as _i7;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i4;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i18;
 import 'package:matrix/matrix.dart' as _i3;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i12;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i9;
-import 'package:matrix/src/utils/space_child.dart' as _i18;
+import 'package:matrix/src/utils/space_child.dart' as _i20;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i14;
-import 'package:timezone/timezone.dart' as _i24;
+import 'package:timezone/timezone.dart' as _i26;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -1059,6 +1061,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
+  _i11.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i11.Future<void>.value(),
+        returnValueForMissingStub: _i11.Future<void>.value(),
+      ) as _i11.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -1081,6 +1093,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i15.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -1186,6 +1208,161 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
         ),
         returnValueForMissingStub: null,
       );
+
+  @override
+  _i11.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i16.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i16.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  _i11.Future<bool> didPushRouteInformation(
+          _i17.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i15.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i15.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<_i15.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+      ) as _i11.Future<_i15.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [Client].
@@ -1206,12 +1383,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as _i3.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i18.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i18.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
+      ) as Set<_i18.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1710,34 +1887,34 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as _i9.CachedStreamController<_i3.BasicEvent>);
 
   @override
-  _i9.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i9.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_13<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_13<_i18.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_13<_i18.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i9.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i9.CachedStreamController<_i18.RoomKeyRequest>);
 
   @override
-  _i9.CachedStreamController<_i16.KeyVerification>
+  _i9.CachedStreamController<_i18.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_13<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_13<_i18.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_13<_i16.KeyVerification>(
+                _FakeCachedStreamController_13<_i18.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i9.CachedStreamController<_i16.KeyVerification>);
+          ) as _i9.CachedStreamController<_i18.KeyVerification>);
 
   @override
   _i9.CachedStreamController<_i3.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1893,7 +2070,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3366,7 +3543,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
 
   @override
   _i11.Future<Uri> uploadContent(
-    _i17.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3884,7 +4061,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Never unexpectedResponse(
     _i10.BaseResponse? response,
-    _i17.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8012,7 +8189,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
   _i11.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i17.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8517,18 +8694,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i18.SpaceParent>[],
-        returnValueForMissingStub: <_i18.SpaceParent>[],
-      ) as List<_i18.SpaceParent>);
+        returnValue: <_i20.SpaceParent>[],
+        returnValueForMissingStub: <_i20.SpaceParent>[],
+      ) as List<_i20.SpaceParent>);
 
   @override
-  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i18.SpaceChild>[],
-        returnValueForMissingStub: <_i18.SpaceChild>[],
-      ) as List<_i18.SpaceChild>);
+        returnValue: <_i20.SpaceChild>[],
+        returnValueForMissingStub: <_i20.SpaceChild>[],
+      ) as List<_i20.SpaceChild>);
 
   @override
   set membership(_i3.Membership? value) => super.noSuchMethod(
@@ -9215,15 +9392,15 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as _i11.Future<void>);
 
   @override
-  _i11.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
+  _i11.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i11.Future<_i19.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i11.Future<_i19.TimelineChunk?>.value(),
-      ) as _i11.Future<_i19.TimelineChunk?>);
+        returnValue: _i11.Future<_i21.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i11.Future<_i21.TimelineChunk?>.value(),
+      ) as _i11.Future<_i21.TimelineChunk?>);
 
   @override
   _i11.Future<void> postReceipt(
@@ -9749,13 +9926,13 @@ class MockRoom extends _i1.Mock implements _i3.Room {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockFlutterLocalNotificationsPlugin extends _i1.Mock
-    implements _i20.FlutterLocalNotificationsPlugin {
+    implements _i22.FlutterLocalNotificationsPlugin {
   @override
   _i11.Future<bool?> initialize({
-    required _i21.InitializationSettings? settings,
-    _i22.DidReceiveNotificationResponseCallback?
+    required _i23.InitializationSettings? settings,
+    _i24.DidReceiveNotificationResponseCallback?
         onDidReceiveNotificationResponse,
-    _i22.DidReceiveBackgroundNotificationResponseCallback?
+    _i24.DidReceiveBackgroundNotificationResponseCallback?
         onDidReceiveBackgroundNotificationResponse,
   }) =>
       (super.noSuchMethod(
@@ -9774,24 +9951,24 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
       ) as _i11.Future<bool?>);
 
   @override
-  _i11.Future<_i22.NotificationAppLaunchDetails?>
+  _i11.Future<_i24.NotificationAppLaunchDetails?>
       getNotificationAppLaunchDetails() => (super.noSuchMethod(
             Invocation.method(
               #getNotificationAppLaunchDetails,
               [],
             ),
             returnValue:
-                _i11.Future<_i22.NotificationAppLaunchDetails?>.value(),
+                _i11.Future<_i24.NotificationAppLaunchDetails?>.value(),
             returnValueForMissingStub:
-                _i11.Future<_i22.NotificationAppLaunchDetails?>.value(),
-          ) as _i11.Future<_i22.NotificationAppLaunchDetails?>);
+                _i11.Future<_i24.NotificationAppLaunchDetails?>.value(),
+          ) as _i11.Future<_i24.NotificationAppLaunchDetails?>);
 
   @override
   _i11.Future<void> show({
     required int? id,
     String? title,
     String? body,
-    _i23.NotificationDetails? notificationDetails,
+    _i25.NotificationDetails? notificationDetails,
     String? payload,
   }) =>
       (super.noSuchMethod(
@@ -9851,13 +10028,13 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
   @override
   _i11.Future<void> zonedSchedule({
     required int? id,
-    required _i24.TZDateTime? scheduledDate,
-    required _i23.NotificationDetails? notificationDetails,
-    required _i25.AndroidScheduleMode? androidScheduleMode,
+    required _i26.TZDateTime? scheduledDate,
+    required _i25.NotificationDetails? notificationDetails,
+    required _i27.AndroidScheduleMode? androidScheduleMode,
     String? title,
     String? body,
     String? payload,
-    _i26.DateTimeComponents? matchDateTimeComponents,
+    _i28.DateTimeComponents? matchDateTimeComponents,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9881,9 +10058,9 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
   @override
   _i11.Future<void> periodicallyShow({
     required int? id,
-    required _i22.RepeatInterval? repeatInterval,
-    required _i23.NotificationDetails? notificationDetails,
-    required _i25.AndroidScheduleMode? androidScheduleMode,
+    required _i24.RepeatInterval? repeatInterval,
+    required _i25.NotificationDetails? notificationDetails,
+    required _i27.AndroidScheduleMode? androidScheduleMode,
     String? title,
     String? body,
     String? payload,
@@ -9910,11 +10087,11 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
   _i11.Future<void> periodicallyShowWithDuration({
     required int? id,
     required Duration? repeatDurationInterval,
-    required _i23.NotificationDetails? notificationDetails,
+    required _i25.NotificationDetails? notificationDetails,
     String? title,
     String? body,
-    _i25.AndroidScheduleMode? androidScheduleMode =
-        _i25.AndroidScheduleMode.exact,
+    _i27.AndroidScheduleMode? androidScheduleMode =
+        _i27.AndroidScheduleMode.exact,
     String? payload,
   }) =>
       (super.noSuchMethod(
@@ -9936,31 +10113,31 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
       ) as _i11.Future<void>);
 
   @override
-  _i11.Future<List<_i22.PendingNotificationRequest>>
+  _i11.Future<List<_i24.PendingNotificationRequest>>
       pendingNotificationRequests() => (super.noSuchMethod(
             Invocation.method(
               #pendingNotificationRequests,
               [],
             ),
             returnValue:
-                _i11.Future<List<_i22.PendingNotificationRequest>>.value(
-                    <_i22.PendingNotificationRequest>[]),
+                _i11.Future<List<_i24.PendingNotificationRequest>>.value(
+                    <_i24.PendingNotificationRequest>[]),
             returnValueForMissingStub:
-                _i11.Future<List<_i22.PendingNotificationRequest>>.value(
-                    <_i22.PendingNotificationRequest>[]),
-          ) as _i11.Future<List<_i22.PendingNotificationRequest>>);
+                _i11.Future<List<_i24.PendingNotificationRequest>>.value(
+                    <_i24.PendingNotificationRequest>[]),
+          ) as _i11.Future<List<_i24.PendingNotificationRequest>>);
 
   @override
-  _i11.Future<List<_i22.ActiveNotification>> getActiveNotifications() =>
+  _i11.Future<List<_i24.ActiveNotification>> getActiveNotifications() =>
       (super.noSuchMethod(
         Invocation.method(
           #getActiveNotifications,
           [],
         ),
-        returnValue: _i11.Future<List<_i22.ActiveNotification>>.value(
-            <_i22.ActiveNotification>[]),
+        returnValue: _i11.Future<List<_i24.ActiveNotification>>.value(
+            <_i24.ActiveNotification>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i22.ActiveNotification>>.value(
-                <_i22.ActiveNotification>[]),
-      ) as _i11.Future<List<_i22.ActiveNotification>>);
+            _i11.Future<List<_i24.ActiveNotification>>.value(
+                <_i24.ActiveNotification>[]),
+      ) as _i11.Future<List<_i24.ActiveNotification>>);
 }

--- a/test/widgets/add_existing_rooms_dialog_test.mocks.dart
+++ b/test/widgets/add_existing_rooms_dialog_test.mocks.dart
@@ -4,9 +4,11 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i11;
-import 'dart:typed_data' as _i19;
+import 'dart:typed_data' as _i21;
 import 'dart:ui' as _i15;
 
+import 'package:flutter/services.dart' as _i16;
+import 'package:flutter/widgets.dart' as _i17;
 import 'package:http/http.dart' as _i10;
 import 'package:kohera/core/services/matrix_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
@@ -18,12 +20,12 @@ import 'package:kohera/core/services/sub_services/sync_service.dart' as _i7;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i4;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:matrix/encryption.dart' as _i20;
 import 'package:matrix/matrix.dart' as _i3;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i12;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i17;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i9;
-import 'package:matrix/src/utils/space_child.dart' as _i16;
+import 'package:matrix/src/utils/space_child.dart' as _i18;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i14;
 
@@ -1047,6 +1049,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
+  _i11.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i11.Future<void>.value(),
+        returnValueForMissingStub: _i11.Future<void>.value(),
+      ) as _i11.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -1069,6 +1081,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i15.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -1171,6 +1193,161 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i16.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i16.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  _i11.Future<bool> didPushRouteInformation(
+          _i17.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i15.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i15.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<_i15.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+      ) as _i11.Future<_i15.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -1657,18 +1834,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i16.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i16.SpaceParent>[],
-        returnValueForMissingStub: <_i16.SpaceParent>[],
-      ) as List<_i16.SpaceParent>);
+        returnValue: <_i18.SpaceParent>[],
+        returnValueForMissingStub: <_i18.SpaceParent>[],
+      ) as List<_i18.SpaceParent>);
 
   @override
-  List<_i16.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i16.SpaceChild>[],
-        returnValueForMissingStub: <_i16.SpaceChild>[],
-      ) as List<_i16.SpaceChild>);
+        returnValue: <_i18.SpaceChild>[],
+        returnValueForMissingStub: <_i18.SpaceChild>[],
+      ) as List<_i18.SpaceChild>);
 
   @override
   set membership(_i3.Membership? value) => super.noSuchMethod(
@@ -2355,15 +2532,15 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as _i11.Future<void>);
 
   @override
-  _i11.Future<_i17.TimelineChunk?> getEventContext(String? eventId) =>
+  _i11.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i11.Future<_i17.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i11.Future<_i17.TimelineChunk?>.value(),
-      ) as _i11.Future<_i17.TimelineChunk?>);
+        returnValue: _i11.Future<_i19.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i11.Future<_i19.TimelineChunk?>.value(),
+      ) as _i11.Future<_i19.TimelineChunk?>);
 
   @override
   _i11.Future<void> postReceipt(
@@ -2903,12 +3080,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as _i3.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i20.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i20.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
+      ) as Set<_i20.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3407,34 +3584,34 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as _i9.CachedStreamController<_i3.BasicEvent>);
 
   @override
-  _i9.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i9.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_8<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i9.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i9.CachedStreamController<_i20.RoomKeyRequest>);
 
   @override
-  _i9.CachedStreamController<_i18.KeyVerification>
+  _i9.CachedStreamController<_i20.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_8<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_8<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_8<_i18.KeyVerification>(
+                _FakeCachedStreamController_8<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i9.CachedStreamController<_i18.KeyVerification>);
+          ) as _i9.CachedStreamController<_i20.KeyVerification>);
 
   @override
   _i9.CachedStreamController<_i3.UiaRequest<dynamic>> get onUiaRequest =>
@@ -3590,7 +3767,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -5063,7 +5240,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
 
   @override
   _i11.Future<Uri> uploadContent(
-    _i19.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5581,7 +5758,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Never unexpectedResponse(
     _i10.BaseResponse? response,
-    _i19.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9709,7 +9886,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
   _i11.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i19.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>

--- a/test/widgets/add_room_to_space_dialog_test.mocks.dart
+++ b/test/widgets/add_room_to_space_dialog_test.mocks.dart
@@ -4,9 +4,11 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i11;
-import 'dart:typed_data' as _i19;
+import 'dart:typed_data' as _i21;
 import 'dart:ui' as _i15;
 
+import 'package:flutter/services.dart' as _i16;
+import 'package:flutter/widgets.dart' as _i17;
 import 'package:http/http.dart' as _i10;
 import 'package:kohera/core/services/matrix_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
@@ -18,12 +20,12 @@ import 'package:kohera/core/services/sub_services/sync_service.dart' as _i7;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i4;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:matrix/encryption.dart' as _i20;
 import 'package:matrix/matrix.dart' as _i3;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i12;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i17;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i9;
-import 'package:matrix/src/utils/space_child.dart' as _i16;
+import 'package:matrix/src/utils/space_child.dart' as _i18;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i14;
 
@@ -1047,6 +1049,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
+  _i11.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i11.Future<void>.value(),
+        returnValueForMissingStub: _i11.Future<void>.value(),
+      ) as _i11.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -1069,6 +1081,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i15.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -1171,6 +1193,161 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i16.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i16.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  _i11.Future<bool> didPushRouteInformation(
+          _i17.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i15.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i15.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<_i15.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+      ) as _i11.Future<_i15.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -1657,18 +1834,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i16.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i16.SpaceParent>[],
-        returnValueForMissingStub: <_i16.SpaceParent>[],
-      ) as List<_i16.SpaceParent>);
+        returnValue: <_i18.SpaceParent>[],
+        returnValueForMissingStub: <_i18.SpaceParent>[],
+      ) as List<_i18.SpaceParent>);
 
   @override
-  List<_i16.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i16.SpaceChild>[],
-        returnValueForMissingStub: <_i16.SpaceChild>[],
-      ) as List<_i16.SpaceChild>);
+        returnValue: <_i18.SpaceChild>[],
+        returnValueForMissingStub: <_i18.SpaceChild>[],
+      ) as List<_i18.SpaceChild>);
 
   @override
   set membership(_i3.Membership? value) => super.noSuchMethod(
@@ -2355,15 +2532,15 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as _i11.Future<void>);
 
   @override
-  _i11.Future<_i17.TimelineChunk?> getEventContext(String? eventId) =>
+  _i11.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i11.Future<_i17.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i11.Future<_i17.TimelineChunk?>.value(),
-      ) as _i11.Future<_i17.TimelineChunk?>);
+        returnValue: _i11.Future<_i19.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i11.Future<_i19.TimelineChunk?>.value(),
+      ) as _i11.Future<_i19.TimelineChunk?>);
 
   @override
   _i11.Future<void> postReceipt(
@@ -2903,12 +3080,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as _i3.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i20.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i20.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
+      ) as Set<_i20.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3407,34 +3584,34 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as _i9.CachedStreamController<_i3.BasicEvent>);
 
   @override
-  _i9.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i9.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_8<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i9.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i9.CachedStreamController<_i20.RoomKeyRequest>);
 
   @override
-  _i9.CachedStreamController<_i18.KeyVerification>
+  _i9.CachedStreamController<_i20.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_8<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_8<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_8<_i18.KeyVerification>(
+                _FakeCachedStreamController_8<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i9.CachedStreamController<_i18.KeyVerification>);
+          ) as _i9.CachedStreamController<_i20.KeyVerification>);
 
   @override
   _i9.CachedStreamController<_i3.UiaRequest<dynamic>> get onUiaRequest =>
@@ -3590,7 +3767,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -5063,7 +5240,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
 
   @override
   _i11.Future<Uri> uploadContent(
-    _i19.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5581,7 +5758,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Never unexpectedResponse(
     _i10.BaseResponse? response,
-    _i19.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9709,7 +9886,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
   _i11.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i19.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>

--- a/test/widgets/bootstrap_controller_test.mocks.dart
+++ b/test/widgets/bootstrap_controller_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i18;
 import 'dart:ui' as _i20;
 
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i19;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -7942,6 +7944,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7964,6 +7976,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -8066,6 +8088,161 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i22.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i5.Future<_i20.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );

--- a/test/widgets/bootstrap_driver_test.mocks.dart
+++ b/test/widgets/bootstrap_driver_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i18;
 import 'dart:ui' as _i20;
 
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i19;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -7931,6 +7933,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7953,6 +7965,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -8055,6 +8077,161 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i22.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i5.Future<_i20.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );

--- a/test/widgets/chat/message_actions_test.mocks.dart
+++ b/test/widgets/chat/message_actions_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i16;
 import 'dart:ui' as _i18;
 
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i17;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -23,7 +25,7 @@ import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/models/timeline_chunk.dart' as _i13;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i19;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i15;
 
@@ -7921,6 +7923,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7943,6 +7955,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -8045,6 +8067,161 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i20.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -8531,18 +8708,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i19.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i19.SpaceParent>[],
-        returnValueForMissingStub: <_i19.SpaceParent>[],
-      ) as List<_i19.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i19.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i19.SpaceChild>[],
-        returnValueForMissingStub: <_i19.SpaceChild>[],
-      ) as List<_i19.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(

--- a/test/widgets/chat/pinned_messages_test.mocks.dart
+++ b/test/widgets/chat/pinned_messages_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i16;
 import 'dart:ui' as _i18;
 
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i17;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -23,7 +25,7 @@ import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/models/timeline_chunk.dart' as _i13;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i19;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i15;
 
@@ -7921,6 +7923,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7943,6 +7955,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -8045,6 +8067,161 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i20.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -8531,18 +8708,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i19.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i19.SpaceParent>[],
-        returnValueForMissingStub: <_i19.SpaceParent>[],
-      ) as List<_i19.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i19.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i19.SpaceChild>[],
-        returnValueForMissingStub: <_i19.SpaceChild>[],
-      ) as List<_i19.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(

--- a/test/widgets/create_subspace_dialog_test.mocks.dart
+++ b/test/widgets/create_subspace_dialog_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i15;
 import 'dart:ui' as _i17;
 
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -21,9 +23,9 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
 import 'package:matrix/encryption.dart' as _i13;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i18;
+import 'package:matrix/src/utils/space_child.dart' as _i20;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i14;
 
@@ -7880,6 +7882,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7902,6 +7914,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -8004,6 +8026,161 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i5.Future<_i17.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -8490,18 +8667,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i18.SpaceParent>[],
-        returnValueForMissingStub: <_i18.SpaceParent>[],
-      ) as List<_i18.SpaceParent>);
+        returnValue: <_i20.SpaceParent>[],
+        returnValueForMissingStub: <_i20.SpaceParent>[],
+      ) as List<_i20.SpaceParent>);
 
   @override
-  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i18.SpaceChild>[],
-        returnValueForMissingStub: <_i18.SpaceChild>[],
-      ) as List<_i18.SpaceChild>);
+        returnValue: <_i20.SpaceChild>[],
+        returnValueForMissingStub: <_i20.SpaceChild>[],
+      ) as List<_i20.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9188,15 +9365,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i19.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i19.TimelineChunk?>.value(),
-      ) as _i5.Future<_i19.TimelineChunk?>);
+        returnValue: _i5.Future<_i21.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i21.TimelineChunk?>.value(),
+      ) as _i5.Future<_i21.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(

--- a/test/widgets/homeserver_controller_test.mocks.dart
+++ b/test/widgets/homeserver_controller_test.mocks.dart
@@ -6,6 +6,8 @@
 import 'dart:async' as _i12;
 import 'dart:ui' as _i13;
 
+import 'package:flutter/services.dart' as _i14;
+import 'package:flutter/widgets.dart' as _i15;
 import 'package:kohera/core/models/server_auth_capabilities.dart' as _i9;
 import 'package:kohera/core/services/matrix_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
@@ -320,6 +322,16 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       ) as bool);
 
   @override
+  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -342,6 +354,16 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i13.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -444,6 +466,161 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i14.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i14.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
+
+  @override
+  _i12.Future<bool> didPushRouteInformation(
+          _i15.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i13.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i13.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i12.Future<_i13.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i12.Future<_i13.AppExitResponse>.value(_i13.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i12.Future<_i13.AppExitResponse>.value(_i13.AppExitResponse.exit),
+      ) as _i12.Future<_i13.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );

--- a/test/widgets/invite_dialog_test.mocks.dart
+++ b/test/widgets/invite_dialog_test.mocks.dart
@@ -4,9 +4,11 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i11;
-import 'dart:typed_data' as _i19;
+import 'dart:typed_data' as _i21;
 import 'dart:ui' as _i15;
 
+import 'package:flutter/services.dart' as _i16;
+import 'package:flutter/widgets.dart' as _i17;
 import 'package:http/http.dart' as _i10;
 import 'package:kohera/core/services/matrix_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
@@ -18,12 +20,12 @@ import 'package:kohera/core/services/sub_services/sync_service.dart' as _i7;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i4;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:matrix/encryption.dart' as _i20;
 import 'package:matrix/matrix.dart' as _i3;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i12;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i17;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i9;
-import 'package:matrix/src/utils/space_child.dart' as _i16;
+import 'package:matrix/src/utils/space_child.dart' as _i18;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i14;
 
@@ -1047,6 +1049,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
+  _i11.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i11.Future<void>.value(),
+        returnValueForMissingStub: _i11.Future<void>.value(),
+      ) as _i11.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -1069,6 +1081,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i15.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -1171,6 +1193,161 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i16.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i16.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  _i11.Future<bool> didPushRouteInformation(
+          _i17.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i15.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i15.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<_i15.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+      ) as _i11.Future<_i15.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -1657,18 +1834,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i16.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i16.SpaceParent>[],
-        returnValueForMissingStub: <_i16.SpaceParent>[],
-      ) as List<_i16.SpaceParent>);
+        returnValue: <_i18.SpaceParent>[],
+        returnValueForMissingStub: <_i18.SpaceParent>[],
+      ) as List<_i18.SpaceParent>);
 
   @override
-  List<_i16.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i16.SpaceChild>[],
-        returnValueForMissingStub: <_i16.SpaceChild>[],
-      ) as List<_i16.SpaceChild>);
+        returnValue: <_i18.SpaceChild>[],
+        returnValueForMissingStub: <_i18.SpaceChild>[],
+      ) as List<_i18.SpaceChild>);
 
   @override
   set membership(_i3.Membership? value) => super.noSuchMethod(
@@ -2355,15 +2532,15 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as _i11.Future<void>);
 
   @override
-  _i11.Future<_i17.TimelineChunk?> getEventContext(String? eventId) =>
+  _i11.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i11.Future<_i17.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i11.Future<_i17.TimelineChunk?>.value(),
-      ) as _i11.Future<_i17.TimelineChunk?>);
+        returnValue: _i11.Future<_i19.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i11.Future<_i19.TimelineChunk?>.value(),
+      ) as _i11.Future<_i19.TimelineChunk?>);
 
   @override
   _i11.Future<void> postReceipt(
@@ -2903,12 +3080,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as _i3.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i20.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i20.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
+      ) as Set<_i20.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3407,34 +3584,34 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as _i9.CachedStreamController<_i3.BasicEvent>);
 
   @override
-  _i9.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i9.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_8<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i9.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i9.CachedStreamController<_i20.RoomKeyRequest>);
 
   @override
-  _i9.CachedStreamController<_i18.KeyVerification>
+  _i9.CachedStreamController<_i20.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_8<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_8<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_8<_i18.KeyVerification>(
+                _FakeCachedStreamController_8<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i9.CachedStreamController<_i18.KeyVerification>);
+          ) as _i9.CachedStreamController<_i20.KeyVerification>);
 
   @override
   _i9.CachedStreamController<_i3.UiaRequest<dynamic>> get onUiaRequest =>
@@ -3590,7 +3767,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -5063,7 +5240,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
 
   @override
   _i11.Future<Uri> uploadContent(
-    _i19.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5581,7 +5758,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Never unexpectedResponse(
     _i10.BaseResponse? response,
-    _i19.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9709,7 +9886,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
   _i11.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i19.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>

--- a/test/widgets/invite_tile_test.mocks.dart
+++ b/test/widgets/invite_tile_test.mocks.dart
@@ -4,9 +4,11 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i11;
-import 'dart:typed_data' as _i19;
+import 'dart:typed_data' as _i21;
 import 'dart:ui' as _i15;
 
+import 'package:flutter/services.dart' as _i16;
+import 'package:flutter/widgets.dart' as _i17;
 import 'package:http/http.dart' as _i10;
 import 'package:kohera/core/services/matrix_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
@@ -18,12 +20,12 @@ import 'package:kohera/core/services/sub_services/sync_service.dart' as _i7;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i4;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:matrix/encryption.dart' as _i20;
 import 'package:matrix/matrix.dart' as _i3;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i12;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i17;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i9;
-import 'package:matrix/src/utils/space_child.dart' as _i16;
+import 'package:matrix/src/utils/space_child.dart' as _i18;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i14;
 
@@ -1047,6 +1049,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
+  _i11.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i11.Future<void>.value(),
+        returnValueForMissingStub: _i11.Future<void>.value(),
+      ) as _i11.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -1069,6 +1081,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i15.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -1171,6 +1193,161 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i16.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i16.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  _i11.Future<bool> didPushRouteInformation(
+          _i17.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i15.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i15.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<_i15.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+      ) as _i11.Future<_i15.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -1657,18 +1834,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i16.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i16.SpaceParent>[],
-        returnValueForMissingStub: <_i16.SpaceParent>[],
-      ) as List<_i16.SpaceParent>);
+        returnValue: <_i18.SpaceParent>[],
+        returnValueForMissingStub: <_i18.SpaceParent>[],
+      ) as List<_i18.SpaceParent>);
 
   @override
-  List<_i16.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i16.SpaceChild>[],
-        returnValueForMissingStub: <_i16.SpaceChild>[],
-      ) as List<_i16.SpaceChild>);
+        returnValue: <_i18.SpaceChild>[],
+        returnValueForMissingStub: <_i18.SpaceChild>[],
+      ) as List<_i18.SpaceChild>);
 
   @override
   set membership(_i3.Membership? value) => super.noSuchMethod(
@@ -2355,15 +2532,15 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as _i11.Future<void>);
 
   @override
-  _i11.Future<_i17.TimelineChunk?> getEventContext(String? eventId) =>
+  _i11.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i11.Future<_i17.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i11.Future<_i17.TimelineChunk?>.value(),
-      ) as _i11.Future<_i17.TimelineChunk?>);
+        returnValue: _i11.Future<_i19.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i11.Future<_i19.TimelineChunk?>.value(),
+      ) as _i11.Future<_i19.TimelineChunk?>);
 
   @override
   _i11.Future<void> postReceipt(
@@ -2903,12 +3080,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as _i3.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i20.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i20.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
+      ) as Set<_i20.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3407,34 +3584,34 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as _i9.CachedStreamController<_i3.BasicEvent>);
 
   @override
-  _i9.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i9.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_8<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i9.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i9.CachedStreamController<_i20.RoomKeyRequest>);
 
   @override
-  _i9.CachedStreamController<_i18.KeyVerification>
+  _i9.CachedStreamController<_i20.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_8<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_8<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_8<_i18.KeyVerification>(
+                _FakeCachedStreamController_8<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i9.CachedStreamController<_i18.KeyVerification>);
+          ) as _i9.CachedStreamController<_i20.KeyVerification>);
 
   @override
   _i9.CachedStreamController<_i3.UiaRequest<dynamic>> get onUiaRequest =>
@@ -3590,7 +3767,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -5063,7 +5240,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
 
   @override
   _i11.Future<Uri> uploadContent(
-    _i19.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5581,7 +5758,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Never unexpectedResponse(
     _i10.BaseResponse? response,
-    _i19.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9709,7 +9886,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
   _i11.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i19.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>

--- a/test/widgets/login_controller_test.mocks.dart
+++ b/test/widgets/login_controller_test.mocks.dart
@@ -4,12 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i12;
-import 'dart:typed_data' as _i19;
+import 'dart:typed_data' as _i21;
 import 'dart:ui' as _i16;
 
+import 'package:flutter/services.dart' as _i17;
+import 'package:flutter/widgets.dart' as _i18;
 import 'package:http/http.dart' as _i11;
 import 'package:kohera/core/models/server_auth_capabilities.dart' as _i14;
-import 'package:kohera/core/services/client_manager.dart' as _i17;
+import 'package:kohera/core/services/client_manager.dart' as _i19;
 import 'package:kohera/core/services/matrix_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
@@ -20,7 +22,7 @@ import 'package:kohera/core/services/sub_services/sync_service.dart' as _i7;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i4;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:matrix/encryption.dart' as _i20;
 import 'package:matrix/matrix.dart' as _i3;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i13;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i10;
@@ -1027,6 +1029,16 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       ) as bool);
 
   @override
+  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -1049,6 +1061,16 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i16.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -1154,12 +1176,167 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
         ),
         returnValueForMissingStub: null,
       );
+
+  @override
+  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i17.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i17.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
+
+  @override
+  _i12.Future<bool> didPushRouteInformation(
+          _i18.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i16.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i16.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i12.Future<_i16.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
+      ) as _i12.Future<_i16.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [ClientManager].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockClientManager extends _i1.Mock implements _i17.ClientManager {
+class MockClientManager extends _i1.Mock implements _i19.ClientManager {
   @override
   List<_i9.MatrixService> get services => (super.noSuchMethod(
         Invocation.getter(#services),
@@ -1348,12 +1525,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as _i3.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i20.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i20.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
+      ) as Set<_i20.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1852,34 +2029,34 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as _i10.CachedStreamController<_i3.BasicEvent>);
 
   @override
-  _i10.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i10.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_14<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_14<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_14<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i10.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i10.CachedStreamController<_i20.RoomKeyRequest>);
 
   @override
-  _i10.CachedStreamController<_i18.KeyVerification>
+  _i10.CachedStreamController<_i20.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_14<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_14<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_14<_i18.KeyVerification>(
+                _FakeCachedStreamController_14<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i10.CachedStreamController<_i18.KeyVerification>);
+          ) as _i10.CachedStreamController<_i20.KeyVerification>);
 
   @override
   _i10.CachedStreamController<_i3.UiaRequest<dynamic>> get onUiaRequest =>
@@ -2035,7 +2212,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3508,7 +3685,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
 
   @override
   _i12.Future<Uri> uploadContent(
-    _i19.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -4026,7 +4203,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Never unexpectedResponse(
     _i11.BaseResponse? response,
-    _i19.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8154,7 +8331,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
   _i12.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i19.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>

--- a/test/widgets/message_reply_test.mocks.dart
+++ b/test/widgets/message_reply_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i16;
 import 'dart:ui' as _i18;
 
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i17;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -23,7 +25,7 @@ import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/models/timeline_chunk.dart' as _i13;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i19;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i15;
 
@@ -7921,6 +7923,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7943,6 +7955,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -8045,6 +8067,161 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i20.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -8531,18 +8708,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i19.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i19.SpaceParent>[],
-        returnValueForMissingStub: <_i19.SpaceParent>[],
-      ) as List<_i19.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i19.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i19.SpaceChild>[],
-        returnValueForMissingStub: <_i19.SpaceChild>[],
-      ) as List<_i19.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(

--- a/test/widgets/new_dm_dialog_test.mocks.dart
+++ b/test/widgets/new_dm_dialog_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i15;
 import 'dart:ui' as _i17;
 
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -21,9 +23,9 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
 import 'package:matrix/encryption.dart' as _i13;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i18;
+import 'package:matrix/src/utils/space_child.dart' as _i20;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i14;
 
@@ -7880,6 +7882,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7902,6 +7914,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -8004,6 +8026,161 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i5.Future<_i17.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -8490,18 +8667,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i18.SpaceParent>[],
-        returnValueForMissingStub: <_i18.SpaceParent>[],
-      ) as List<_i18.SpaceParent>);
+        returnValue: <_i20.SpaceParent>[],
+        returnValueForMissingStub: <_i20.SpaceParent>[],
+      ) as List<_i20.SpaceParent>);
 
   @override
-  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i18.SpaceChild>[],
-        returnValueForMissingStub: <_i18.SpaceChild>[],
-      ) as List<_i18.SpaceChild>);
+        returnValue: <_i20.SpaceChild>[],
+        returnValueForMissingStub: <_i20.SpaceChild>[],
+      ) as List<_i20.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9188,15 +9365,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i19.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i19.TimelineChunk?>.value(),
-      ) as _i5.Future<_i19.TimelineChunk?>);
+        returnValue: _i5.Future<_i21.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i21.TimelineChunk?>.value(),
+      ) as _i5.Future<_i21.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(

--- a/test/widgets/new_room_dialog_test.mocks.dart
+++ b/test/widgets/new_room_dialog_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i15;
 import 'dart:ui' as _i17;
 
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -7837,6 +7839,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7859,6 +7871,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -7961,6 +7983,161 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i5.Future<_i17.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );

--- a/test/widgets/recovery_key_handler_test.mocks.dart
+++ b/test/widgets/recovery_key_handler_test.mocks.dart
@@ -4,9 +4,11 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i12;
-import 'dart:typed_data' as _i20;
+import 'dart:typed_data' as _i22;
 import 'dart:ui' as _i19;
 
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i11;
 import 'package:kohera/core/services/matrix_service.dart' as _i17;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
@@ -1109,6 +1111,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
+  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -1131,6 +1143,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -1233,6 +1255,161 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
+
+  @override
+  _i12.Future<bool> didPushRouteInformation(
+          _i21.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i12.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i12.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i12.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i12.Future<_i19.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -1730,7 +1907,7 @@ class MockOpenSSSS extends _i1.Mock implements _i9.OpenSSSS {
       ) as bool);
 
   @override
-  set privateKey(_i20.Uint8List? value) => super.noSuchMethod(
+  set privateKey(_i22.Uint8List? value) => super.noSuchMethod(
         Invocation.setter(
           #privateKey,
           value,
@@ -1761,7 +1938,7 @@ class MockOpenSSSS extends _i1.Mock implements _i9.OpenSSSS {
       ) as _i12.Future<void>);
 
   @override
-  _i12.Future<void> setPrivateKey(_i20.Uint8List? key) => (super.noSuchMethod(
+  _i12.Future<void> setPrivateKey(_i22.Uint8List? key) => (super.noSuchMethod(
         Invocation.method(
           #setPrivateKey,
           [key],
@@ -4017,7 +4194,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
 
   @override
   _i12.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i22.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -4535,7 +4712,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Never unexpectedResponse(
     _i11.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i22.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8663,7 +8840,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
   _i12.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i22.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>

--- a/test/widgets/registration_controller_test.mocks.dart
+++ b/test/widgets/registration_controller_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i16;
 import 'dart:ui' as _i18;
 
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/models/server_auth_capabilities.dart' as _i13;
 import 'package:kohera/core/services/matrix_service.dart' as _i17;
@@ -7849,6 +7851,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7871,6 +7883,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -7973,6 +7995,161 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i20.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );

--- a/test/widgets/room_context_menu_test.mocks.dart
+++ b/test/widgets/room_context_menu_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i15;
 import 'dart:ui' as _i17;
 
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -21,9 +23,9 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
 import 'package:matrix/encryption.dart' as _i13;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i18;
+import 'package:matrix/src/utils/space_child.dart' as _i20;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i14;
 
@@ -7880,6 +7882,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7902,6 +7914,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -8004,6 +8026,161 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i5.Future<_i17.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -8490,18 +8667,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i18.SpaceParent>[],
-        returnValueForMissingStub: <_i18.SpaceParent>[],
-      ) as List<_i18.SpaceParent>);
+        returnValue: <_i20.SpaceParent>[],
+        returnValueForMissingStub: <_i20.SpaceParent>[],
+      ) as List<_i20.SpaceParent>);
 
   @override
-  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i18.SpaceChild>[],
-        returnValueForMissingStub: <_i18.SpaceChild>[],
-      ) as List<_i18.SpaceChild>);
+        returnValue: <_i20.SpaceChild>[],
+        returnValueForMissingStub: <_i20.SpaceChild>[],
+      ) as List<_i20.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9188,15 +9365,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i19.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i19.TimelineChunk?>.value(),
-      ) as _i5.Future<_i19.TimelineChunk?>);
+        returnValue: _i5.Future<_i21.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i21.TimelineChunk?>.value(),
+      ) as _i5.Future<_i21.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(

--- a/test/widgets/room_details_panel_test.mocks.dart
+++ b/test/widgets/room_details_panel_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i15;
 import 'dart:ui' as _i17;
 
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -21,9 +23,9 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
 import 'package:matrix/encryption.dart' as _i13;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i18;
+import 'package:matrix/src/utils/space_child.dart' as _i20;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i14;
 
@@ -7880,6 +7882,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7902,6 +7914,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -8004,6 +8026,161 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i5.Future<_i17.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -8490,18 +8667,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i18.SpaceParent>[],
-        returnValueForMissingStub: <_i18.SpaceParent>[],
-      ) as List<_i18.SpaceParent>);
+        returnValue: <_i20.SpaceParent>[],
+        returnValueForMissingStub: <_i20.SpaceParent>[],
+      ) as List<_i20.SpaceParent>);
 
   @override
-  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i18.SpaceChild>[],
-        returnValueForMissingStub: <_i18.SpaceChild>[],
-      ) as List<_i18.SpaceChild>);
+        returnValue: <_i20.SpaceChild>[],
+        returnValueForMissingStub: <_i20.SpaceChild>[],
+      ) as List<_i20.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9188,15 +9365,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i19.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i19.TimelineChunk?>.value(),
-      ) as _i5.Future<_i19.TimelineChunk?>);
+        returnValue: _i5.Future<_i21.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i21.TimelineChunk?>.value(),
+      ) as _i5.Future<_i21.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(

--- a/test/widgets/room_members_section_test.mocks.dart
+++ b/test/widgets/room_members_section_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i15;
 import 'dart:ui' as _i17;
 
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -21,9 +23,9 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
 import 'package:matrix/encryption.dart' as _i13;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i18;
+import 'package:matrix/src/utils/space_child.dart' as _i20;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i14;
 
@@ -7890,6 +7892,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7912,6 +7924,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -8014,6 +8036,161 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i5.Future<_i17.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -8500,18 +8677,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i18.SpaceParent>[],
-        returnValueForMissingStub: <_i18.SpaceParent>[],
-      ) as List<_i18.SpaceParent>);
+        returnValue: <_i20.SpaceParent>[],
+        returnValueForMissingStub: <_i20.SpaceParent>[],
+      ) as List<_i20.SpaceParent>);
 
   @override
-  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i18.SpaceChild>[],
-        returnValueForMissingStub: <_i18.SpaceChild>[],
-      ) as List<_i18.SpaceChild>);
+        returnValue: <_i20.SpaceChild>[],
+        returnValueForMissingStub: <_i20.SpaceChild>[],
+      ) as List<_i20.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9198,15 +9375,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i19.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i19.TimelineChunk?>.value(),
-      ) as _i5.Future<_i19.TimelineChunk?>);
+        returnValue: _i5.Future<_i21.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i21.TimelineChunk?>.value(),
+      ) as _i5.Future<_i21.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(

--- a/test/widgets/room_section_header_test.mocks.dart
+++ b/test/widgets/room_section_header_test.mocks.dart
@@ -7,10 +7,12 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i16;
 import 'dart:ui' as _i18;
 
-import 'package:flutter/material.dart' as _i20;
+import 'package:flutter/material.dart' as _i22;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i17;
-import 'package:kohera/core/services/preferences_service.dart' as _i19;
+import 'package:kohera/core/services/preferences_service.dart' as _i21;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i9;
@@ -24,9 +26,9 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
 import 'package:matrix/encryption.dart' as _i14;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/src/utils/space_child.dart' as _i23;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i15;
 
@@ -7893,6 +7895,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7915,6 +7927,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -8020,33 +8042,188 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
         ),
         returnValueForMissingStub: null,
       );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i20.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [PreferencesService].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockPreferencesService extends _i1.Mock
-    implements _i19.PreferencesService {
+    implements _i21.PreferencesService {
   @override
-  _i19.MessageDensity get messageDensity => (super.noSuchMethod(
+  _i21.MessageDensity get messageDensity => (super.noSuchMethod(
         Invocation.getter(#messageDensity),
-        returnValue: _i19.MessageDensity.compact,
-        returnValueForMissingStub: _i19.MessageDensity.compact,
-      ) as _i19.MessageDensity);
+        returnValue: _i21.MessageDensity.compact,
+        returnValueForMissingStub: _i21.MessageDensity.compact,
+      ) as _i21.MessageDensity);
 
   @override
-  _i19.MobileTab get lastMobileTab => (super.noSuchMethod(
+  _i21.MobileTab get lastMobileTab => (super.noSuchMethod(
         Invocation.getter(#lastMobileTab),
-        returnValue: _i19.MobileTab.inbox,
-        returnValueForMissingStub: _i19.MobileTab.inbox,
-      ) as _i19.MobileTab);
+        returnValue: _i21.MobileTab.inbox,
+        returnValueForMissingStub: _i21.MobileTab.inbox,
+      ) as _i21.MobileTab);
 
   @override
-  _i20.ThemeMode get themeMode => (super.noSuchMethod(
+  _i22.ThemeMode get themeMode => (super.noSuchMethod(
         Invocation.getter(#themeMode),
-        returnValue: _i20.ThemeMode.system,
-        returnValueForMissingStub: _i20.ThemeMode.system,
-      ) as _i20.ThemeMode);
+        returnValue: _i22.ThemeMode.system,
+        returnValueForMissingStub: _i22.ThemeMode.system,
+      ) as _i22.ThemeMode);
 
   @override
   String get themeModeLabel => (super.noSuchMethod(
@@ -8075,11 +8252,11 @@ class MockPreferencesService extends _i1.Mock
       ) as _i13.CustomTheme);
 
   @override
-  _i20.ThemeMode get customThemeMode => (super.noSuchMethod(
+  _i22.ThemeMode get customThemeMode => (super.noSuchMethod(
         Invocation.getter(#customThemeMode),
-        returnValue: _i20.ThemeMode.system,
-        returnValueForMissingStub: _i20.ThemeMode.system,
-      ) as _i20.ThemeMode);
+        returnValue: _i22.ThemeMode.system,
+        returnValueForMissingStub: _i22.ThemeMode.system,
+      ) as _i22.ThemeMode);
 
   @override
   Set<String> get collapsedSpaceSections => (super.noSuchMethod(
@@ -8110,11 +8287,11 @@ class MockPreferencesService extends _i1.Mock
       ) as double);
 
   @override
-  _i19.NotificationLevel get notificationLevel => (super.noSuchMethod(
+  _i21.NotificationLevel get notificationLevel => (super.noSuchMethod(
         Invocation.getter(#notificationLevel),
-        returnValue: _i19.NotificationLevel.all,
-        returnValueForMissingStub: _i19.NotificationLevel.all,
-      ) as _i19.NotificationLevel);
+        returnValue: _i21.NotificationLevel.all,
+        returnValueForMissingStub: _i21.NotificationLevel.all,
+      ) as _i21.NotificationLevel);
 
   @override
   String get notificationLevelLabel => (super.noSuchMethod(
@@ -8277,11 +8454,11 @@ class MockPreferencesService extends _i1.Mock
       ) as bool);
 
   @override
-  _i19.AudioQuality get audioQuality => (super.noSuchMethod(
+  _i21.AudioQuality get audioQuality => (super.noSuchMethod(
         Invocation.getter(#audioQuality),
-        returnValue: _i19.AudioQuality.speech,
-        returnValueForMissingStub: _i19.AudioQuality.speech,
-      ) as _i19.AudioQuality);
+        returnValue: _i21.AudioQuality.speech,
+        returnValueForMissingStub: _i21.AudioQuality.speech,
+      ) as _i21.AudioQuality);
 
   @override
   bool get highPassFilter => (super.noSuchMethod(
@@ -8325,7 +8502,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setMessageDensity(_i19.MessageDensity? density) =>
+  _i5.Future<void> setMessageDensity(_i21.MessageDensity? density) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMessageDensity,
@@ -8336,7 +8513,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setLastMobileTab(_i19.MobileTab? tab) => (super.noSuchMethod(
+  _i5.Future<void> setLastMobileTab(_i21.MobileTab? tab) => (super.noSuchMethod(
         Invocation.method(
           #setLastMobileTab,
           [tab],
@@ -8346,7 +8523,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setThemeMode(_i20.ThemeMode? mode) => (super.noSuchMethod(
+  _i5.Future<void> setThemeMode(_i22.ThemeMode? mode) => (super.noSuchMethod(
         Invocation.method(
           #setThemeMode,
           [mode],
@@ -8377,7 +8554,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setCustomThemeMode(_i20.ThemeMode? mode) =>
+  _i5.Future<void> setCustomThemeMode(_i22.ThemeMode? mode) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCustomThemeMode,
@@ -8429,7 +8606,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setNotificationLevel(_i19.NotificationLevel? level) =>
+  _i5.Future<void> setNotificationLevel(_i21.NotificationLevel? level) =>
       (super.noSuchMethod(
         Invocation.method(
           #setNotificationLevel,
@@ -8708,7 +8885,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setAudioQuality(_i19.AudioQuality? quality) =>
+  _i5.Future<void> setAudioQuality(_i21.AudioQuality? quality) =>
       (super.noSuchMethod(
         Invocation.method(
           #setAudioQuality,
@@ -9256,18 +9433,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i23.SpaceParent>[],
+        returnValueForMissingStub: <_i23.SpaceParent>[],
+      ) as List<_i23.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i23.SpaceChild>[],
+        returnValueForMissingStub: <_i23.SpaceChild>[],
+      ) as List<_i23.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9954,15 +10131,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i22.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i22.TimelineChunk?>.value(),
-      ) as _i5.Future<_i22.TimelineChunk?>);
+        returnValue: _i5.Future<_i24.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i24.TimelineChunk?>.value(),
+      ) as _i5.Future<_i24.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(

--- a/test/widgets/room_tile_test.mocks.dart
+++ b/test/widgets/room_tile_test.mocks.dart
@@ -4,15 +4,15 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i11;
-import 'dart:typed_data' as _i19;
+import 'dart:typed_data' as _i21;
 import 'dart:ui' as _i15;
 
-import 'package:flutter/services.dart' as _i28;
-import 'package:flutter/widgets.dart' as _i29;
+import 'package:flutter/services.dart' as _i16;
+import 'package:flutter/widgets.dart' as _i17;
 import 'package:http/http.dart' as _i10;
-import 'package:kohera/core/services/call_service.dart' as _i20;
+import 'package:kohera/core/services/call_service.dart' as _i22;
 import 'package:kohera/core/services/matrix_service.dart' as _i13;
-import 'package:kohera/core/services/preferences_service.dart' as _i26;
+import 'package:kohera/core/services/preferences_service.dart' as _i28;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i5;
@@ -20,20 +20,20 @@ import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i6;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i7;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i4;
-import 'package:kohera/features/calling/models/call_participant.dart' as _i23;
-import 'package:kohera/features/calling/models/call_state.dart' as _i25;
-import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i24;
-import 'package:kohera/features/calling/services/livekit_service.dart' as _i21;
-import 'package:kohera/features/calling/services/ringtone_service.dart' as _i27;
+import 'package:kohera/features/calling/models/call_participant.dart' as _i25;
+import 'package:kohera/features/calling/models/call_state.dart' as _i27;
+import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i26;
+import 'package:kohera/features/calling/services/livekit_service.dart' as _i23;
+import 'package:kohera/features/calling/services/ringtone_service.dart' as _i29;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
-import 'package:livekit_client/livekit_client.dart' as _i22;
-import 'package:matrix/encryption.dart' as _i18;
+import 'package:livekit_client/livekit_client.dart' as _i24;
+import 'package:matrix/encryption.dart' as _i20;
 import 'package:matrix/matrix.dart' as _i3;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i12;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i17;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i9;
-import 'package:matrix/src/utils/space_child.dart' as _i16;
+import 'package:matrix/src/utils/space_child.dart' as _i18;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i14;
 
@@ -1097,6 +1097,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
+  _i11.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i11.Future<void>.value(),
+        returnValueForMissingStub: _i11.Future<void>.value(),
+      ) as _i11.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -1119,6 +1129,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i15.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -1221,6 +1241,161 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i16.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i16.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  _i11.Future<bool> didPushRouteInformation(
+          _i17.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i11.Future<bool>.value(false),
+        returnValueForMissingStub: _i11.Future<bool>.value(false),
+      ) as _i11.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i15.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i15.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i11.Future<_i15.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+      ) as _i11.Future<_i15.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -1707,18 +1882,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i16.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i16.SpaceParent>[],
-        returnValueForMissingStub: <_i16.SpaceParent>[],
-      ) as List<_i16.SpaceParent>);
+        returnValue: <_i18.SpaceParent>[],
+        returnValueForMissingStub: <_i18.SpaceParent>[],
+      ) as List<_i18.SpaceParent>);
 
   @override
-  List<_i16.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i16.SpaceChild>[],
-        returnValueForMissingStub: <_i16.SpaceChild>[],
-      ) as List<_i16.SpaceChild>);
+        returnValue: <_i18.SpaceChild>[],
+        returnValueForMissingStub: <_i18.SpaceChild>[],
+      ) as List<_i18.SpaceChild>);
 
   @override
   set membership(_i3.Membership? value) => super.noSuchMethod(
@@ -2405,15 +2580,15 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as _i11.Future<void>);
 
   @override
-  _i11.Future<_i17.TimelineChunk?> getEventContext(String? eventId) =>
+  _i11.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i11.Future<_i17.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i11.Future<_i17.TimelineChunk?>.value(),
-      ) as _i11.Future<_i17.TimelineChunk?>);
+        returnValue: _i11.Future<_i19.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i11.Future<_i19.TimelineChunk?>.value(),
+      ) as _i11.Future<_i19.TimelineChunk?>);
 
   @override
   _i11.Future<void> postReceipt(
@@ -2953,12 +3128,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as _i3.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i20.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i20.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
+      ) as Set<_i20.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3457,34 +3632,34 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as _i9.CachedStreamController<_i3.BasicEvent>);
 
   @override
-  _i9.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i9.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_8<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i9.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i9.CachedStreamController<_i20.RoomKeyRequest>);
 
   @override
-  _i9.CachedStreamController<_i18.KeyVerification>
+  _i9.CachedStreamController<_i20.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_8<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_8<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_8<_i18.KeyVerification>(
+                _FakeCachedStreamController_8<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i9.CachedStreamController<_i18.KeyVerification>);
+          ) as _i9.CachedStreamController<_i20.KeyVerification>);
 
   @override
   _i9.CachedStreamController<_i3.UiaRequest<dynamic>> get onUiaRequest =>
@@ -3640,7 +3815,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -5113,7 +5288,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
 
   @override
   _i11.Future<Uri> uploadContent(
-    _i19.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5631,7 +5806,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Never unexpectedResponse(
     _i10.BaseResponse? response,
-    _i19.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9759,7 +9934,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
   _i11.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i19.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -10373,7 +10548,7 @@ class MockEvent extends _i1.Mock implements _i3.Event {
   @override
   _i11.Future<_i3.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i11.Future<_i19.Uint8List> Function(Uri)? downloadCallback,
+    _i11.Future<_i21.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -11034,7 +11209,7 @@ class MockUser extends _i1.Mock implements _i3.User {
 /// A class which mocks [CallService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCallService extends _i1.Mock implements _i20.CallService {
+class MockCallService extends _i1.Mock implements _i22.CallService {
   @override
   _i3.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -11056,7 +11231,7 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       ) as bool);
 
   @override
-  _i21.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
+  _i23.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
         Invocation.getter(#httpPostForTest),
         returnValue: (
           _i10.Client httpClient,
@@ -11078,14 +11253,14 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
           this,
           Invocation.getter(#httpPostForTest),
         )),
-      ) as _i21.HttpPostFunction);
+      ) as _i23.HttpPostFunction);
 
   @override
-  List<_i22.RemoteParticipant> get participants => (super.noSuchMethod(
+  List<_i24.RemoteParticipant> get participants => (super.noSuchMethod(
         Invocation.getter(#participants),
-        returnValue: <_i22.RemoteParticipant>[],
-        returnValueForMissingStub: <_i22.RemoteParticipant>[],
-      ) as List<_i22.RemoteParticipant>);
+        returnValue: <_i24.RemoteParticipant>[],
+        returnValueForMissingStub: <_i24.RemoteParticipant>[],
+      ) as List<_i24.RemoteParticipant>);
 
   @override
   bool get isMicEnabled => (super.noSuchMethod(
@@ -11116,14 +11291,14 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       ) as bool);
 
   @override
-  List<_i22.Participant<_i22.TrackPublication<_i22.Track>>>
+  List<_i24.Participant<_i24.TrackPublication<_i24.Track>>>
       get activeSpeakers => (super.noSuchMethod(
             Invocation.getter(#activeSpeakers),
-            returnValue: <_i22
-                .Participant<_i22.TrackPublication<_i22.Track>>>[],
-            returnValueForMissingStub: <_i22
-                .Participant<_i22.TrackPublication<_i22.Track>>>[],
-          ) as List<_i22.Participant<_i22.TrackPublication<_i22.Track>>>);
+            returnValue: <_i24
+                .Participant<_i24.TrackPublication<_i24.Track>>>[],
+            returnValueForMissingStub: <_i24
+                .Participant<_i24.TrackPublication<_i24.Track>>>[],
+          ) as List<_i24.Participant<_i24.TrackPublication<_i24.Track>>>);
 
   @override
   bool get isCallingAvailable => (super.noSuchMethod(
@@ -11133,11 +11308,11 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       ) as bool);
 
   @override
-  List<_i23.CallParticipant> get allParticipants => (super.noSuchMethod(
+  List<_i25.CallParticipant> get allParticipants => (super.noSuchMethod(
         Invocation.getter(#allParticipants),
-        returnValue: <_i23.CallParticipant>[],
-        returnValueForMissingStub: <_i23.CallParticipant>[],
-      ) as List<_i23.CallParticipant>);
+        returnValue: <_i25.CallParticipant>[],
+        returnValueForMissingStub: <_i25.CallParticipant>[],
+      ) as List<_i25.CallParticipant>);
 
   @override
   bool get isSpeakerOn => (super.noSuchMethod(
@@ -11147,12 +11322,12 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       ) as bool);
 
   @override
-  _i11.Stream<_i24.IncomingCallInfo> get incomingCallStream =>
+  _i11.Stream<_i26.IncomingCallInfo> get incomingCallStream =>
       (super.noSuchMethod(
         Invocation.getter(#incomingCallStream),
-        returnValue: _i11.Stream<_i24.IncomingCallInfo>.empty(),
-        returnValueForMissingStub: _i11.Stream<_i24.IncomingCallInfo>.empty(),
-      ) as _i11.Stream<_i24.IncomingCallInfo>);
+        returnValue: _i11.Stream<_i26.IncomingCallInfo>.empty(),
+        returnValueForMissingStub: _i11.Stream<_i26.IncomingCallInfo>.empty(),
+      ) as _i11.Stream<_i26.IncomingCallInfo>);
 
   @override
   _i11.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
@@ -11162,14 +11337,14 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       ) as _i11.Stream<String>);
 
   @override
-  _i25.KoheraCallState get callState => (super.noSuchMethod(
+  _i27.KoheraCallState get callState => (super.noSuchMethod(
         Invocation.getter(#callState),
-        returnValue: _i25.KoheraCallState.idle,
-        returnValueForMissingStub: _i25.KoheraCallState.idle,
-      ) as _i25.KoheraCallState);
+        returnValue: _i27.KoheraCallState.idle,
+        returnValueForMissingStub: _i27.KoheraCallState.idle,
+      ) as _i27.KoheraCallState);
 
   @override
-  set preferencesService(_i26.PreferencesService? prefs) => super.noSuchMethod(
+  set preferencesService(_i28.PreferencesService? prefs) => super.noSuchMethod(
         Invocation.setter(
           #preferencesService,
           prefs,
@@ -11178,7 +11353,7 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       );
 
   @override
-  set ringtoneService(_i27.RingtoneService? service) => super.noSuchMethod(
+  set ringtoneService(_i29.RingtoneService? service) => super.noSuchMethod(
         Invocation.setter(
           #ringtoneService,
           service,
@@ -11187,7 +11362,7 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       );
 
   @override
-  set roomFactoryForTest(_i21.LiveKitRoomFactory? factory) =>
+  set roomFactoryForTest(_i23.LiveKitRoomFactory? factory) =>
       super.noSuchMethod(
         Invocation.setter(
           #roomFactoryForTest,
@@ -11197,7 +11372,7 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       );
 
   @override
-  set httpPostForTest(_i21.HttpPostFunction? fn) => super.noSuchMethod(
+  set httpPostForTest(_i23.HttpPostFunction? fn) => super.noSuchMethod(
         Invocation.setter(
           #httpPostForTest,
           fn,
@@ -11407,7 +11582,7 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
   @override
   _i11.Future<void> initiateCall(
     String? roomId, {
-    _i24.CallType? type = _i24.CallType.voice,
+    _i26.CallType? type = _i26.CallType.voice,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -11538,7 +11713,7 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       ) as _i11.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i28.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i16.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -11549,7 +11724,7 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i28.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i16.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -11597,7 +11772,7 @@ class MockCallService extends _i1.Mock implements _i20.CallService {
 
   @override
   _i11.Future<bool> didPushRouteInformation(
-          _i29.RouteInformation? routeInformation) =>
+          _i17.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,

--- a/test/widgets/space_action_dialog_test.mocks.dart
+++ b/test/widgets/space_action_dialog_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i15;
 import 'dart:ui' as _i17;
 
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -21,9 +23,9 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
 import 'package:matrix/encryption.dart' as _i13;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i18;
+import 'package:matrix/src/utils/space_child.dart' as _i20;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i14;
 
@@ -7880,6 +7882,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7902,6 +7914,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -8004,6 +8026,161 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i5.Future<_i17.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -8490,18 +8667,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i18.SpaceParent>[],
-        returnValueForMissingStub: <_i18.SpaceParent>[],
-      ) as List<_i18.SpaceParent>);
+        returnValue: <_i20.SpaceParent>[],
+        returnValueForMissingStub: <_i20.SpaceParent>[],
+      ) as List<_i20.SpaceParent>);
 
   @override
-  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i18.SpaceChild>[],
-        returnValueForMissingStub: <_i18.SpaceChild>[],
-      ) as List<_i18.SpaceChild>);
+        returnValue: <_i20.SpaceChild>[],
+        returnValueForMissingStub: <_i20.SpaceChild>[],
+      ) as List<_i20.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9188,15 +9365,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i19.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i19.TimelineChunk?>.value(),
-      ) as _i5.Future<_i19.TimelineChunk?>);
+        returnValue: _i5.Future<_i21.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i21.TimelineChunk?>.value(),
+      ) as _i5.Future<_i21.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(

--- a/test/widgets/space_context_menu_test.mocks.dart
+++ b/test/widgets/space_context_menu_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i15;
 import 'dart:ui' as _i17;
 
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -21,9 +23,9 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
 import 'package:matrix/encryption.dart' as _i13;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i18;
+import 'package:matrix/src/utils/space_child.dart' as _i20;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i14;
 
@@ -7910,6 +7912,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7932,6 +7944,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -8034,6 +8056,161 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i5.Future<_i17.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -8520,18 +8697,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i18.SpaceParent>[],
-        returnValueForMissingStub: <_i18.SpaceParent>[],
-      ) as List<_i18.SpaceParent>);
+        returnValue: <_i20.SpaceParent>[],
+        returnValueForMissingStub: <_i20.SpaceParent>[],
+      ) as List<_i20.SpaceParent>);
 
   @override
-  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i18.SpaceChild>[],
-        returnValueForMissingStub: <_i18.SpaceChild>[],
-      ) as List<_i18.SpaceChild>);
+        returnValue: <_i20.SpaceChild>[],
+        returnValueForMissingStub: <_i20.SpaceChild>[],
+      ) as List<_i20.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9218,15 +9395,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i19.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i19.TimelineChunk?>.value(),
-      ) as _i5.Future<_i19.TimelineChunk?>);
+        returnValue: _i5.Future<_i21.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i21.TimelineChunk?>.value(),
+      ) as _i5.Future<_i21.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(

--- a/test/widgets/space_details_panel_test.mocks.dart
+++ b/test/widgets/space_details_panel_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i15;
 import 'dart:ui' as _i17;
 
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -21,9 +23,9 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
 import 'package:matrix/encryption.dart' as _i13;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i18;
+import 'package:matrix/src/utils/space_child.dart' as _i20;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i14;
 
@@ -7880,6 +7882,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7902,6 +7914,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -8004,6 +8026,161 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i5.Future<_i17.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -8490,18 +8667,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i18.SpaceParent>[],
-        returnValueForMissingStub: <_i18.SpaceParent>[],
-      ) as List<_i18.SpaceParent>);
+        returnValue: <_i20.SpaceParent>[],
+        returnValueForMissingStub: <_i20.SpaceParent>[],
+      ) as List<_i20.SpaceParent>);
 
   @override
-  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i18.SpaceChild>[],
-        returnValueForMissingStub: <_i18.SpaceChild>[],
-      ) as List<_i18.SpaceChild>);
+        returnValue: <_i20.SpaceChild>[],
+        returnValueForMissingStub: <_i20.SpaceChild>[],
+      ) as List<_i20.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9188,15 +9365,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i19.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i19.TimelineChunk?>.value(),
-      ) as _i5.Future<_i19.TimelineChunk?>);
+        returnValue: _i5.Future<_i21.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i21.TimelineChunk?>.value(),
+      ) as _i5.Future<_i21.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(

--- a/test/widgets/space_discovery_search_test.mocks.dart
+++ b/test/widgets/space_discovery_search_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i15;
 import 'dart:ui' as _i17;
 
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -7837,6 +7839,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7859,6 +7871,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -7961,6 +7983,161 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i5.Future<_i17.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );

--- a/test/widgets/space_discovery_server_test.mocks.dart
+++ b/test/widgets/space_discovery_server_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i15;
 import 'dart:ui' as _i17;
 
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -7837,6 +7839,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7859,6 +7871,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -7961,6 +7983,161 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i5.Future<_i17.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );

--- a/test/widgets/space_discovery_servers_edit_test.mocks.dart
+++ b/test/widgets/space_discovery_servers_edit_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i15;
 import 'dart:ui' as _i17;
 
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -7837,6 +7839,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7859,6 +7871,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -7961,6 +7983,161 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i5.Future<_i17.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );

--- a/test/widgets/verification_request_listener_test.mocks.dart
+++ b/test/widgets/verification_request_listener_test.mocks.dart
@@ -7,6 +7,8 @@ import 'dart:async' as _i5;
 import 'dart:typed_data' as _i15;
 import 'dart:ui' as _i17;
 
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
 import 'package:http/http.dart' as _i4;
 import 'package:kohera/core/services/matrix_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
@@ -7837,6 +7839,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
           #notifyListeners,
@@ -7859,6 +7871,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #dispose,
           [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
         ),
         returnValueForMissingStub: null,
       );
@@ -7961,6 +7983,161 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
         Invocation.method(
           #removeListener,
           [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i5.Future<_i17.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
         ),
         returnValueForMissingStub: null,
       );


### PR DESCRIPTION
## Summary

- iOS was killing the app with `RUNNINGBOARD 0xdead10cc` (SQLite lock held through suspend) on background launches from VoIP/silent pushes — confirmed across two TestFlight crash reports (build 1.0.0 (22) and (23)). `MatrixService._activateSession` was firing an unawaited streaming sync at boot regardless of app state, and the PushKit `completion()` was being invoked the moment CallKit was shown, letting iOS suspend the process while sqflite was mid-transaction.
- Three layers of fix: lifecycle-gate boot sync, timeout per-push `oneShotSync`, and defer iOS push `completion()` until Dart acks.
- Adds 5 regression tests for the lifecycle gate; full suite (1602 tests) green.

## Changes

- `lib/core/services/matrix_service.dart` — `WidgetsBindingObserver` mixin; observer registered in `_activateSession`; `sync.startSync` only fires when app is `AppLifecycleState.resumed` (or becomes resumed). `_foregroundSyncStarted` flag for idempotency; cleanup on dispose and logout.
- `lib/core/services/sub_services/sync_service.dart` — early-out in `startSync` when already syncing (was creating duplicate stream subs and stacked completers).
- `lib/features/notifications/services/apns_push_service.dart` — handler now `await`s `_processPushMessage` so iOS's `invokeMethod` result callback fires after the sync writes; `oneShotSync` wrapped in a 20s timeout.
- `lib/features/notifications/services/ios_voip_push_service.dart` — `oneShotSync` wrapped in a 20s timeout.
- `ios/Runner/AppDelegate.swift` — VoIP `finish()` moved out of `showCallkitIncoming` callback and into the `voipChannel.invokeMethod` result callback, with a 20s `DispatchQueue.asyncAfter` safety net mirroring the existing APNs pattern. CallKit's strike rule remains satisfied because `showCallkitIncoming(... fromPushKit: true)` reports the call before completion is deferred.

## Test plan

- [x] `flutter test` — 1602/1602 pass (66 prior `matrix_service_test` cases + 5 new lifecycle-gate cases)
- [x] Lifecycle gate covered: paused/detached → no sync; resumed → sync; deferred boot → sync on resume; idempotent across paused↔resumed cycles
- [x] Manual TestFlight smoke (build 24): force-quit, trigger VoIP push from a second account, decline without opening, repeat 5–10×; expect zero `0xdead10cc` reports
- [x] Repeat with a silent APNs message-notification push
- [x] Foreground the app after a deferred boot and confirm sync starts on `resumed`
- [ ] Watch TestFlight crash dashboard for 48 h post-rollout

Local `flutter analyze` could not run (Linux `fs.inotify.max_user_instances` limit crashes the analysis server) — please run in CI.