### PR TITLE
feat: thread-aware inbox parity (slice D, #390)

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -193,9 +193,11 @@ GoRouter buildRouter(ClientManager manager) {
                     builder: (context, state) {
                       final roomId = state.pathParameters['roomId']!;
                       final eventId = state.pathParameters['eventId']!;
+                      final initialReplyEventId = state.extra as String?;
                       return ThreadScreen(
                         roomId: roomId,
                         threadRootEventId: eventId,
+                        initialReplyEventId: initialReplyEventId,
                         key: ValueKey('thread-$roomId-$eventId'),
                       );
                     },

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -193,11 +193,9 @@ GoRouter buildRouter(ClientManager manager) {
                     builder: (context, state) {
                       final roomId = state.pathParameters['roomId']!;
                       final eventId = state.pathParameters['eventId']!;
-                      final initialReplyEventId = state.extra as String?;
                       return ThreadScreen(
                         roomId: roomId,
                         threadRootEventId: eventId,
-                        initialReplyEventId: initialReplyEventId,
                         key: ValueKey('thread-$roomId-$eventId'),
                       );
                     },

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -60,7 +60,7 @@ class ChatScreen extends StatefulWidget {
 class _ChatScreenState extends State<ChatScreen>
     with VoiceRecordingMixin<ChatScreen> {
   final _msgCtrl = TextEditingController();
-  final _composeFocusNode = FocusNode();
+  final _composeFocusNode = FocusNode(debugLabel: 'chat-compose');
   final _messageListKey = GlobalKey<MessageListViewState>();
 
   // ── Compose state ───────────────────────────────────────
@@ -92,7 +92,7 @@ class _ChatScreenState extends State<ChatScreen>
   // ── Search ─────────────────────────────────────────────
   late ChatSearchController _search;
   final _searchCtrl = TextEditingController();
-  final _searchFocusNode = FocusNode();
+  final _searchFocusNode = FocusNode(debugLabel: 'chat-search');
 
   @override
   void initState() {
@@ -100,13 +100,6 @@ class _ChatScreenState extends State<ChatScreen>
     _actions = _createActions();
     _search = _createSearchController();
     _initControllers();
-    if (!isTouchDevice) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted && _composeFocusNode.canRequestFocus) {
-          _composeFocusNode.requestFocus();
-        }
-      });
-    }
   }
 
   @override
@@ -122,13 +115,6 @@ class _ChatScreenState extends State<ChatScreen>
       _search.dispose();
       _actions = _createActions();
       _search = _createSearchController();
-      if (!isTouchDevice) {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (mounted && _composeFocusNode.canRequestFocus) {
-            _composeFocusNode.requestFocus();
-          }
-        });
-      }
     }
   }
 

--- a/lib/features/chat/screens/thread_screen.dart
+++ b/lib/features/chat/screens/thread_screen.dart
@@ -182,7 +182,7 @@ class _ThreadScreenState extends State<ThreadScreen> {
       );
     }
 
-    if (_loadingRoot) {
+    if (_loadingRoot || !_focusReady) {
       return Scaffold(
         appBar: AppBar(title: const Text('Thread')),
         body: const Center(child: CircularProgressIndicator()),
@@ -221,8 +221,7 @@ class _ThreadScreenState extends State<ThreadScreen> {
               onHighlight: (_) {},
             ),
           ),
-          if (_focusReady)
-            ComposeBarSection(
+          ComposeBarSection(
               replyNotifier: _compose.replyNotifier,
               editNotifier: _compose.editNotifier,
               pendingAttachments: _compose.pendingAttachments,

--- a/lib/features/chat/screens/thread_screen.dart
+++ b/lib/features/chat/screens/thread_screen.dart
@@ -6,9 +6,11 @@ import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/chat/services/chat_message_actions.dart';
 import 'package:kohera/features/chat/services/compose_state_controller.dart';
+import 'package:kohera/features/chat/services/thread_roots_service.dart';
 import 'package:kohera/features/chat/widgets/compose_bar_section.dart';
 import 'package:kohera/features/chat/widgets/file_send_handler.dart';
 import 'package:kohera/features/chat/widgets/message_list_view.dart';
+import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 
 class ThreadScreen extends StatefulWidget {
@@ -36,6 +38,9 @@ class _ThreadScreenState extends State<ThreadScreen> {
   late ChatMessageActions _actions;
   bool _loadingRoot = true;
   bool _focusReady = false;
+  bool _loadingMoreReplies = false;
+  List<Event> _threadReplies = const [];
+  String? _repliesNextBatch;
 
   @override
   void initState() {
@@ -67,10 +72,18 @@ class _ThreadScreenState extends State<ThreadScreen> {
       return;
     }
     try {
+      final client = context.read<MatrixService>().client;
       final root = await room.getEventById(widget.threadRootEventId);
+      final page = await fetchThreadChildrenPage(
+        client,
+        room,
+        widget.threadRootEventId,
+      );
       if (!mounted) return;
       setState(() {
         _loadingRoot = false;
+        _threadReplies = page.events;
+        _repliesNextBatch = page.nextBatch;
         if (root != null) _compose.setThreadRoot(root);
       });
       _scheduleFocusReady();
@@ -82,6 +95,40 @@ class _ThreadScreenState extends State<ThreadScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Could not load thread')),
       );
+    }
+  }
+
+  Future<void> _loadMoreReplies() async {
+    if (_loadingMoreReplies) return;
+    final from = _repliesNextBatch;
+    if (from == null) return;
+    final room = context
+        .read<MatrixService>()
+        .client
+        .getRoomById(widget.roomId);
+    if (room == null) return;
+    setState(() => _loadingMoreReplies = true);
+    try {
+      final page = await fetchThreadChildrenPage(
+        context.read<MatrixService>().client,
+        room,
+        widget.threadRootEventId,
+        from: from,
+      );
+      if (!mounted) return;
+      final seen = _threadReplies.map((e) => e.eventId).toSet();
+      final merged = [
+        ..._threadReplies,
+        ...page.events.where((e) => seen.add(e.eventId)),
+      ];
+      setState(() {
+        _threadReplies = merged;
+        _repliesNextBatch = page.nextBatch;
+      });
+    } catch (e) {
+      debugPrint('[Kohera] Thread reply pagination failed: $e');
+    } finally {
+      if (mounted) setState(() => _loadingMoreReplies = false);
     }
   }
 
@@ -162,6 +209,9 @@ class _ThreadScreenState extends State<ThreadScreen> {
               matrix: matrix,
               threadRootEventId: widget.threadRootEventId,
               initialEventId: widget.threadRootEventId,
+              extraEvents: _threadReplies,
+              extraLoading: _loadingMoreReplies,
+              onLoadMoreExtra: () => unawaited(_loadMoreReplies()),
               emptyText: 'No replies yet.\nStart the conversation.',
               onReply: _compose.setReplyTo,
               onEdit: (event, timeline) =>

--- a/lib/features/chat/screens/thread_screen.dart
+++ b/lib/features/chat/screens/thread_screen.dart
@@ -17,13 +17,11 @@ class ThreadScreen extends StatefulWidget {
     required this.threadRootEventId,
     super.key,
     this.onClose,
-    this.initialReplyEventId,
   });
 
   final String roomId;
   final String threadRootEventId;
   final VoidCallback? onClose;
-  final String? initialReplyEventId;
 
   @override
   State<ThreadScreen> createState() => _ThreadScreenState();
@@ -163,8 +161,7 @@ class _ThreadScreenState extends State<ThreadScreen> {
               room: room,
               matrix: matrix,
               threadRootEventId: widget.threadRootEventId,
-              initialEventId:
-                  widget.initialReplyEventId ?? widget.threadRootEventId,
+              initialEventId: widget.threadRootEventId,
               emptyText: 'No replies yet.\nStart the conversation.',
               onReply: _compose.setReplyTo,
               onEdit: (event, timeline) =>

--- a/lib/features/chat/screens/thread_screen.dart
+++ b/lib/features/chat/screens/thread_screen.dart
@@ -31,7 +31,7 @@ class ThreadScreen extends StatefulWidget {
 
 class _ThreadScreenState extends State<ThreadScreen> {
   final _msgCtrl = TextEditingController();
-  final _focusNode = FocusNode();
+  final _focusNode = FocusNode(canRequestFocus: false);
   final _messageListKey = GlobalKey<MessageListViewState>();
   final _compose = ComposeStateController();
 
@@ -136,6 +136,10 @@ class _ThreadScreenState extends State<ThreadScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || _focusReady) return;
       setState(() => _focusReady = true);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _focusNode.canRequestFocus = true;
+      });
     });
   }
 

--- a/lib/features/chat/screens/thread_screen.dart
+++ b/lib/features/chat/screens/thread_screen.dart
@@ -153,9 +153,7 @@ class _ThreadScreenState extends State<ThreadScreen> {
             : null,
         title: const Text('Thread'),
       ),
-      body: ExcludeFocus(
-        excluding: !_focusReady,
-        child: Column(
+      body: Column(
         children: [
           Expanded(
             child: MessageListView(
@@ -173,24 +171,24 @@ class _ThreadScreenState extends State<ThreadScreen> {
               onHighlight: (_) {},
             ),
           ),
-          ComposeBarSection(
-            replyNotifier: _compose.replyNotifier,
-            editNotifier: _compose.editNotifier,
-            pendingAttachments: _compose.pendingAttachments,
-            controller: _msgCtrl,
-            onSend: _actions.send,
-            onCancelReply: _compose.cancelReply,
-            onCancelEdit: () => _compose.cancelEdit(_msgCtrl),
-            onAttach: _handleAttach,
-            uploadNotifier: _compose.uploadNotifier,
-            room: room,
-            joinedRooms: context.read<SelectionService>().rooms,
-            focusNode: _focusNode,
-            onRemoveAttachment: _compose.removeAttachment,
-            onClearAttachments: _compose.clearAttachments,
-          ),
+          if (_focusReady)
+            ComposeBarSection(
+              replyNotifier: _compose.replyNotifier,
+              editNotifier: _compose.editNotifier,
+              pendingAttachments: _compose.pendingAttachments,
+              controller: _msgCtrl,
+              onSend: _actions.send,
+              onCancelReply: _compose.cancelReply,
+              onCancelEdit: () => _compose.cancelEdit(_msgCtrl),
+              onAttach: _handleAttach,
+              uploadNotifier: _compose.uploadNotifier,
+              room: room,
+              joinedRooms: context.read<SelectionService>().rooms,
+              focusNode: _focusNode,
+              onRemoveAttachment: _compose.removeAttachment,
+              onClearAttachments: _compose.clearAttachments,
+            ),
         ],
-      ),
       ),
     );
   }

--- a/lib/features/chat/screens/thread_screen.dart
+++ b/lib/features/chat/screens/thread_screen.dart
@@ -17,11 +17,13 @@ class ThreadScreen extends StatefulWidget {
     required this.threadRootEventId,
     super.key,
     this.onClose,
+    this.initialReplyEventId,
   });
 
   final String roomId;
   final String threadRootEventId;
   final VoidCallback? onClose;
+  final String? initialReplyEventId;
 
   @override
   State<ThreadScreen> createState() => _ThreadScreenState();
@@ -161,7 +163,8 @@ class _ThreadScreenState extends State<ThreadScreen> {
               room: room,
               matrix: matrix,
               threadRootEventId: widget.threadRootEventId,
-              initialEventId: widget.threadRootEventId,
+              initialEventId:
+                  widget.initialReplyEventId ?? widget.threadRootEventId,
               emptyText: 'No replies yet.\nStart the conversation.',
               onReply: _compose.setReplyTo,
               onEdit: (event, timeline) =>

--- a/lib/features/chat/screens/thread_screen.dart
+++ b/lib/features/chat/screens/thread_screen.dart
@@ -182,7 +182,7 @@ class _ThreadScreenState extends State<ThreadScreen> {
       );
     }
 
-    if (_loadingRoot || !_focusReady) {
+    if (_loadingRoot) {
       return Scaffold(
         appBar: AppBar(title: const Text('Thread')),
         body: const Center(child: CircularProgressIndicator()),
@@ -221,7 +221,8 @@ class _ThreadScreenState extends State<ThreadScreen> {
               onHighlight: (_) {},
             ),
           ),
-          ComposeBarSection(
+          if (_focusReady)
+            ComposeBarSection(
               replyNotifier: _compose.replyNotifier,
               editNotifier: _compose.editNotifier,
               pendingAttachments: _compose.pendingAttachments,

--- a/lib/features/chat/screens/thread_screen.dart
+++ b/lib/features/chat/screens/thread_screen.dart
@@ -40,7 +40,14 @@ class _ThreadScreenState extends State<ThreadScreen> {
   bool _focusReady = false;
   bool _loadingMoreReplies = false;
   List<Event> _threadReplies = const [];
+  Event? _threadRootEvent;
   String? _repliesNextBatch;
+
+  List<Event> get _seedEvents {
+    final root = _threadRootEvent;
+    if (root == null) return _threadReplies;
+    return [root, ..._threadReplies];
+  }
 
   @override
   void initState() {
@@ -83,6 +90,7 @@ class _ThreadScreenState extends State<ThreadScreen> {
       setState(() {
         _loadingRoot = false;
         _threadReplies = page.events;
+        _threadRootEvent = root;
         _repliesNextBatch = page.nextBatch;
         if (root != null) _compose.setThreadRoot(root);
       });
@@ -208,8 +216,7 @@ class _ThreadScreenState extends State<ThreadScreen> {
               room: room,
               matrix: matrix,
               threadRootEventId: widget.threadRootEventId,
-              initialEventId: widget.threadRootEventId,
-              extraEvents: _threadReplies,
+              extraEvents: _seedEvents,
               extraLoading: _loadingMoreReplies,
               onLoadMoreExtra: () => unawaited(_loadMoreReplies()),
               emptyText: 'No replies yet.\nStart the conversation.',

--- a/lib/features/chat/screens/thread_screen.dart
+++ b/lib/features/chat/screens/thread_screen.dart
@@ -52,7 +52,6 @@ class _ThreadScreenState extends State<ThreadScreen> {
     );
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      setState(() => _focusReady = true);
       unawaited(_loadRoot());
     });
   }
@@ -64,6 +63,7 @@ class _ThreadScreenState extends State<ThreadScreen> {
         .getRoomById(widget.roomId);
     if (room == null) {
       if (mounted) setState(() => _loadingRoot = false);
+      _scheduleFocusReady();
       return;
     }
     try {
@@ -73,14 +73,23 @@ class _ThreadScreenState extends State<ThreadScreen> {
         _loadingRoot = false;
         if (root != null) _compose.setThreadRoot(root);
       });
+      _scheduleFocusReady();
     } catch (e) {
       debugPrint('[Kohera] Thread root load failed: $e');
       if (!mounted) return;
       setState(() => _loadingRoot = false);
+      _scheduleFocusReady();
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Could not load thread')),
       );
     }
+  }
+
+  void _scheduleFocusReady() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _focusReady) return;
+      setState(() => _focusReady = true);
+    });
   }
 
   void _addAttachment(PendingAttachment attachment) {

--- a/lib/features/chat/screens/thread_screen.dart
+++ b/lib/features/chat/screens/thread_screen.dart
@@ -31,7 +31,7 @@ class ThreadScreen extends StatefulWidget {
 
 class _ThreadScreenState extends State<ThreadScreen> {
   final _msgCtrl = TextEditingController();
-  final _focusNode = FocusNode(canRequestFocus: false);
+  final _focusNode = FocusNode(debugLabel: 'thread-compose');
   final _messageListKey = GlobalKey<MessageListViewState>();
   final _compose = ComposeStateController();
 
@@ -136,10 +136,6 @@ class _ThreadScreenState extends State<ThreadScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || _focusReady) return;
       setState(() => _focusReady = true);
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) return;
-        _focusNode.canRequestFocus = true;
-      });
     });
   }
 

--- a/lib/features/chat/services/thread_roots_service.dart
+++ b/lib/features/chat/services/thread_roots_service.dart
@@ -15,7 +15,7 @@ Future<List<ThreadSummary>> fetchThreadSummaries({
       client,
       Event.fromMatrixEvent(raw, room),
     );
-    final children = await _fetchChildren(client, room, root.eventId);
+    final children = await fetchThreadChildren(client, room, root.eventId);
     summaries.add(
       ThreadSummary(
         root: root,
@@ -32,16 +32,26 @@ Future<List<ThreadSummary>> fetchThreadSummaries({
   return summaries;
 }
 
-Future<List<Event>> _fetchChildren(
+class ThreadChildrenPage {
+  ThreadChildrenPage({required this.events, this.nextBatch});
+
+  final List<Event> events;
+  final String? nextBatch;
+}
+
+Future<ThreadChildrenPage> fetchThreadChildrenPage(
   Client client,
   Room room,
-  String rootEventId,
-) async {
+  String rootEventId, {
+  String? from,
+  int limit = 100,
+}) async {
   final relations = await client.getRelatingEventsWithRelType(
     room.id,
     rootEventId,
     RelationshipTypes.thread,
-    limit: 100,
+    limit: limit,
+    from: from,
   );
   final events = <Event>[];
   for (final raw in relations.chunk) {
@@ -50,7 +60,16 @@ Future<List<Event>> _fetchChildren(
     );
   }
   events.sort((a, b) => a.originServerTs.compareTo(b.originServerTs));
-  return events;
+  return ThreadChildrenPage(events: events, nextBatch: relations.nextBatch);
+}
+
+Future<List<Event>> fetchThreadChildren(
+  Client client,
+  Room room,
+  String rootEventId,
+) async {
+  final page = await fetchThreadChildrenPage(client, room, rootEventId);
+  return page.events;
 }
 
 Future<Event> _decryptIfNeeded(Client client, Event event) async {

--- a/lib/features/chat/widgets/chat_app_bar.dart
+++ b/lib/features/chat/widgets/chat_app_bar.dart
@@ -81,7 +81,7 @@ class ChatAppBar extends StatelessWidget implements PreferredSizeWidget {
         },
       ),
       actions: [
-        if (room.pinnedEventIds.isNotEmpty && onPinnedEvent != null)
+        if (!isNarrow && room.pinnedEventIds.isNotEmpty && onPinnedEvent != null)
           Builder(
             builder: (buttonContext) => IconButton(
               mouseCursor: SystemMouseCursors.click,
@@ -99,7 +99,7 @@ class ChatAppBar extends StatelessWidget implements PreferredSizeWidget {
           ),
         if (context.select<CallService, bool>((s) => s.isCallingAvailable))
           _CallButton(room: room),
-        if (onShowThreads != null)
+        if (!isNarrow && onShowThreads != null)
           IconButton(
             mouseCursor: SystemMouseCursors.click,
             tooltip: 'Threads',
@@ -116,19 +116,72 @@ class ChatAppBar extends StatelessWidget implements PreferredSizeWidget {
           icon: const Icon(Icons.search_rounded),
           onPressed: onSearch,
         ),
-        IconButton(
-          mouseCursor: SystemMouseCursors.click,
-          icon: const Icon(Icons.more_vert_rounded),
-          onPressed: () {
-            if (onShowDetails != null) {
-              onShowDetails!();
-            } else {
-              context.pushOrGo(
-                Routes.roomDetails,
-                pathParameters: {'roomId': room.id},
-              );
-            }
-          },
+        Builder(
+          builder: (buttonContext) => PopupMenuButton<_ChatMenuAction>(
+            icon: const Icon(Icons.more_vert_rounded),
+            tooltip: 'More',
+            onSelected: (action) {
+              switch (action) {
+                case _ChatMenuAction.pinned:
+                  if (onPinnedEvent != null) {
+                    showPinnedMessagesPopup(
+                      buttonContext,
+                      room,
+                      onTap: onPinnedEvent!,
+                    );
+                  }
+                case _ChatMenuAction.threads:
+                  onShowThreads?.call();
+                case _ChatMenuAction.details:
+                  if (onShowDetails != null) {
+                    onShowDetails!();
+                  } else {
+                    context.pushOrGo(
+                      Routes.roomDetails,
+                      pathParameters: {'roomId': room.id},
+                    );
+                  }
+              }
+            },
+            itemBuilder: (context) => [
+              if (isNarrow &&
+                  room.pinnedEventIds.isNotEmpty &&
+                  onPinnedEvent != null)
+                PopupMenuItem(
+                  value: _ChatMenuAction.pinned,
+                  child: ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    leading: Badge.count(
+                      count: room.pinnedEventIds.length,
+                      child: const Icon(Icons.push_pin_rounded),
+                    ),
+                    title: const Text('Pinned messages'),
+                  ),
+                ),
+              if (isNarrow && onShowThreads != null)
+                PopupMenuItem(
+                  value: _ChatMenuAction.threads,
+                  child: ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    leading: threadUnreadCount > 0
+                        ? Badge.count(
+                            count: threadUnreadCount,
+                            child: const Icon(Icons.forum_outlined),
+                          )
+                        : const Icon(Icons.forum_outlined),
+                    title: const Text('Threads'),
+                  ),
+                ),
+              const PopupMenuItem(
+                value: _ChatMenuAction.details,
+                child: ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: Icon(Icons.info_outline_rounded),
+                  title: Text('Room details'),
+                ),
+              ),
+            ],
+          ),
         ),
       ],
     );
@@ -297,3 +350,5 @@ class ChatSearchAppBar extends StatelessWidget implements PreferredSizeWidget {
     );
   }
 }
+
+enum _ChatMenuAction { pinned, threads, details }

--- a/lib/features/chat/widgets/message_list_view.dart
+++ b/lib/features/chat/widgets/message_list_view.dart
@@ -32,6 +32,9 @@ class MessageListView extends StatefulWidget {
     this.onOpenThread,
     this.emptyText,
     this.onTimelineChanged,
+    this.extraEvents,
+    this.onLoadMoreExtra,
+    this.extraLoading = false,
     super.key,
   });
 
@@ -50,6 +53,9 @@ class MessageListView extends StatefulWidget {
   final void Function(Event event)? onOpenThread;
   final String? emptyText;
   final VoidCallback? onTimelineChanged;
+  final List<Event>? extraEvents;
+  final VoidCallback? onLoadMoreExtra;
+  final bool extraLoading;
 
   @override
   State<MessageListView> createState() => MessageListViewState();
@@ -92,6 +98,8 @@ class MessageListViewState extends State<MessageListView> {
       _cachedVisibleEvents = null;
       unawaited(_initTimeline());
     } else if (oldWidget.threadRootEventId != widget.threadRootEventId) {
+      _cachedVisibleEvents = null;
+    } else if (!identical(oldWidget.extraEvents, widget.extraEvents)) {
       _cachedVisibleEvents = null;
     }
   }
@@ -176,10 +184,26 @@ class MessageListViewState extends State<MessageListView> {
 
   List<Event> get _visibleEvents {
     if (_cachedVisibleEvents != null) return _cachedVisibleEvents!;
-    final events = _timeline?.events;
-    if (events == null) return [];
+    final timelineEvents = _timeline?.events;
+    if (timelineEvents == null) return [];
     final threadRootId = widget.threadRootEventId;
-    _cachedVisibleEvents = events
+    final extra = widget.extraEvents;
+    final Iterable<Event> source;
+    if (extra != null && extra.isNotEmpty) {
+      final seen = <String>{};
+      final merged = <Event>[];
+      for (final e in timelineEvents) {
+        if (seen.add(e.eventId)) merged.add(e);
+      }
+      for (final e in extra) {
+        if (seen.add(e.eventId)) merged.add(e);
+      }
+      merged.sort((a, b) => b.originServerTs.compareTo(a.originServerTs));
+      source = merged;
+    } else {
+      source = timelineEvents;
+    }
+    _cachedVisibleEvents = source
         .where((e) =>
             (((e.type == EventTypes.Message ||
                             e.type == EventTypes.Encrypted) &&
@@ -249,13 +273,15 @@ class MessageListViewState extends State<MessageListView> {
   // ── Scroll & history ───────────────────────────────────
 
   void _onScroll() {
-    if (widget.threadRootEventId != null) return;
     final positions = _itemPosListener.itemPositions.value;
     if (positions.isEmpty) return;
     final maxIndex = positions.map((p) => p.index).reduce((a, b) => a > b ? a : b);
-    if (maxIndex >= _visibleEvents.length - _historyLoadThreshold && !_loadingHistory) {
-      unawaited(_loadMore());
+    if (maxIndex < _visibleEvents.length - _historyLoadThreshold) return;
+    if (widget.threadRootEventId != null) {
+      if (!widget.extraLoading) widget.onLoadMoreExtra?.call();
+      return;
     }
+    if (!_loadingHistory) unawaited(_loadMore());
   }
 
   bool _handleScrollNotification(ScrollNotification notification) {
@@ -478,7 +504,7 @@ class MessageListViewState extends State<MessageListView> {
             threadRootId: widget.threadRootEventId,
           )
         : <String, List<Receipt>>{};
-    final hasLoadingIndicator = _loadingHistory;
+    final hasLoadingIndicator = _loadingHistory || widget.extraLoading;
     final totalCount = events.length + (hasLoadingIndicator ? 1 : 0);
 
     return NotificationListener<ScrollNotification>(

--- a/lib/features/chat/widgets/message_list_view.dart
+++ b/lib/features/chat/widgets/message_list_view.dart
@@ -250,18 +250,20 @@ class MessageListViewState extends State<MessageListView> {
         return;
       }
 
-      final lastEvent = widget.room.lastEvent;
-      if (lastEvent == null || widget.room.notificationCount == 0) return;
+      if (widget.room.notificationCount == 0) return;
+      final visible = _visibleEvents;
+      final lastMainEvent = visible.isNotEmpty ? visible.first : null;
+      if (lastMainEvent == null) return;
       try {
         final sendPublic = context.read<PreferencesService>().readReceipts;
         await widget.room.setReadMarker(
-          lastEvent.eventId,
-          mRead: sendPublic ? lastEvent.eventId : null,
+          lastMainEvent.eventId,
+          mRead: sendPublic ? lastMainEvent.eventId : null,
         );
         await client.postReceipt(
           widget.room.id,
           ReceiptType.mRead,
-          lastEvent.eventId,
+          lastMainEvent.eventId,
           threadId: 'main',
         );
       } catch (e) {

--- a/lib/features/home/widgets/inbox_screen.dart
+++ b/lib/features/home/widgets/inbox_screen.dart
@@ -87,6 +87,10 @@ class _InboxScreenState extends State<InboxScreen> {
                   value: InboxFilter.mentions,
                   label: Text(InboxText.filterMentions),
                 ),
+                const ButtonSegment(
+                  value: InboxFilter.threads,
+                  label: Text(InboxText.filterThreads),
+                ),
                 ButtonSegment(
                   value: InboxFilter.invitations,
                   label: Text(
@@ -233,20 +237,36 @@ class _NotificationGroupTile extends StatelessWidget {
                   IconButton(
                     icon: const Icon(Icons.open_in_new_rounded, size: 20),
                     tooltip: InboxText.tooltipOpen,
-                    onPressed: () => context.goNamed(
-                      Routes.room,
-                      pathParameters: {'roomId': group.roomId},
-                    ),
+                    onPressed: () {
+                      final singleThread = group.subGroups.length == 1
+                          ? group.subGroups.first.threadRootId
+                          : null;
+                      if (singleThread != null) {
+                        context.goNamed(
+                          Routes.roomThread,
+                          pathParameters: {
+                            'roomId': group.roomId,
+                            'eventId': singleThread,
+                          },
+                        );
+                      } else {
+                        context.goNamed(
+                          Routes.room,
+                          pathParameters: {'roomId': group.roomId},
+                        );
+                      }
+                    },
                     visualDensity: VisualDensity.compact,
                   ),
                 ],
               ),
             ),
 
-            // ── Individual notifications ──
-            for (final notification in group.notifications)
-              _NotificationTile(
-                notification: notification,
+            // ── Sub-groups (per-thread + main) ──
+            for (final sub in group.subGroups)
+              _SubGroupSection(
+                roomId: group.roomId,
+                subGroup: sub,
                 client: client,
               ),
           ],
@@ -256,15 +276,111 @@ class _NotificationGroupTile extends StatelessWidget {
   }
 }
 
+// ── Sub-group section (per-thread or main timeline) ──────────
+class _SubGroupSection extends StatefulWidget {
+  const _SubGroupSection({
+    required this.roomId,
+    required this.subGroup,
+    required this.client,
+  });
+
+  final String roomId;
+  final ThreadSubGroup subGroup;
+  final matrix_sdk.Client client;
+
+  @override
+  State<_SubGroupSection> createState() => _SubGroupSectionState();
+}
+
+class _SubGroupSectionState extends State<_SubGroupSection> {
+  static final Map<String, String> _rootPreviewCache = {};
+  String? _rootPreview;
+
+  @override
+  void initState() {
+    super.initState();
+    final id = widget.subGroup.threadRootId;
+    if (id != null) {
+      _rootPreview = _rootPreviewCache[id];
+      if (_rootPreview == null) unawaited(_loadRoot(id));
+    }
+  }
+
+  Future<void> _loadRoot(String eventId) async {
+    final room = widget.client.getRoomById(widget.roomId);
+    if (room == null) return;
+    try {
+      final event = await room.getEventById(eventId);
+      if (event == null || !mounted) return;
+      final body = stripReplyFallback(event.body).trim();
+      if (body.isEmpty) return;
+      final truncated = body.length > 80 ? '${body.substring(0, 80)}…' : body;
+      final preview = InboxText.inReplyTo(truncated);
+      _rootPreviewCache[eventId] = preview;
+      if (mounted) setState(() => _rootPreview = preview);
+    } catch (_) {}
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+    final threadRootId = widget.subGroup.threadRootId;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (threadRootId != null)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(14, 6, 12, 2),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(Icons.forum_outlined, size: 14, color: cs.primary),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    _rootPreview ?? InboxText.inThread,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: tt.labelSmall?.copyWith(
+                      color: cs.primary,
+                      fontStyle: FontStyle.italic,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  InboxText.threadCount(widget.subGroup.notifications.length),
+                  style: tt.labelSmall?.copyWith(
+                    color: cs.onSurfaceVariant.withValues(alpha: 0.7),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        for (final notification in widget.subGroup.notifications)
+          _NotificationTile(
+            notification: notification,
+            client: widget.client,
+            threadRootId: threadRootId,
+          ),
+      ],
+    );
+  }
+}
+
 // ── Individual notification tile ─────────────────────────────
 class _NotificationTile extends StatelessWidget {
   const _NotificationTile({
     required this.notification,
     required this.client,
+    required this.threadRootId,
   });
 
   final matrix_sdk.Notification notification;
   final matrix_sdk.Client client;
+  final String? threadRootId;
 
   @override
   Widget build(BuildContext context) {
@@ -278,20 +394,21 @@ class _NotificationTile extends StatelessWidget {
         room?.unsafeGetUserFromMemoryOrFallback(senderId).calcDisplayname() ??
             senderId;
 
+    final controller = context.read<InboxController>();
     final body = _extractBody(context, event);
     final ts = DateTime.fromMillisecondsSinceEpoch(notification.ts);
-    final threadRootId =
-        context.read<InboxController>().threadRootIdFor(notification);
+    final isMention = controller.isMention(notification);
 
     return InkWell(
       mouseCursor: SystemMouseCursors.click,
       onTap: () {
-        if (threadRootId != null) {
+        final tid = threadRootId;
+        if (tid != null) {
           context.goNamed(
             Routes.roomThread,
             pathParameters: {
               'roomId': notification.roomId,
-              'eventId': threadRootId,
+              'eventId': tid,
             },
           );
         } else {
@@ -339,15 +456,18 @@ class _NotificationTile extends StatelessWidget {
                         ),
                       ),
                     ),
-                    if (threadRootId != null) ...[
-                      Icon(Icons.forum_outlined,
+                    if (isMention) ...[
+                      Icon(Icons.alternate_email_rounded,
                           size: 12, color: cs.primary,),
-                      const SizedBox(width: 4),
+                      const SizedBox(width: 2),
                       Text(
-                        InboxText.inThread,
+                        threadRootId != null
+                            ? InboxText.mentionInThread
+                            : InboxText.mention,
                         style: tt.labelSmall?.copyWith(
                           color: cs.primary,
                           fontSize: 10,
+                          fontWeight: FontWeight.w600,
                         ),
                       ),
                       const SizedBox(width: 6),

--- a/lib/features/home/widgets/inbox_screen.dart
+++ b/lib/features/home/widgets/inbox_screen.dart
@@ -411,6 +411,7 @@ class _NotificationTile extends StatelessWidget {
               'roomId': notification.roomId,
               'eventId': tid,
             },
+            extra: notification.event.eventId,
           );
         } else {
           context.goNamed(

--- a/lib/features/home/widgets/inbox_screen.dart
+++ b/lib/features/home/widgets/inbox_screen.dart
@@ -411,7 +411,6 @@ class _NotificationTile extends StatelessWidget {
               'roomId': notification.roomId,
               'eventId': tid,
             },
-            extra: notification.event.eventId,
           );
         } else {
           context.goNamed(

--- a/lib/features/home/widgets/inbox_screen.dart
+++ b/lib/features/home/widgets/inbox_screen.dart
@@ -238,7 +238,6 @@ class _NotificationGroupTile extends StatelessWidget {
                     icon: const Icon(Icons.open_in_new_rounded, size: 20),
                     tooltip: InboxText.tooltipOpen,
                     onPressed: () {
-                      FocusManager.instance.primaryFocus?.unfocus();
                       final singleThread = group.subGroups.length == 1
                           ? group.subGroups.first.threadRootId
                           : null;
@@ -402,8 +401,8 @@ class _NotificationTile extends StatelessWidget {
 
     return InkWell(
       mouseCursor: SystemMouseCursors.click,
+      canRequestFocus: false,
       onTap: () {
-        FocusManager.instance.primaryFocus?.unfocus();
         final tid = threadRootId;
         if (tid != null) {
           context.goNamed(

--- a/lib/features/home/widgets/inbox_screen.dart
+++ b/lib/features/home/widgets/inbox_screen.dart
@@ -238,6 +238,7 @@ class _NotificationGroupTile extends StatelessWidget {
                     icon: const Icon(Icons.open_in_new_rounded, size: 20),
                     tooltip: InboxText.tooltipOpen,
                     onPressed: () {
+                      FocusManager.instance.primaryFocus?.unfocus();
                       final singleThread = group.subGroups.length == 1
                           ? group.subGroups.first.threadRootId
                           : null;
@@ -402,6 +403,7 @@ class _NotificationTile extends StatelessWidget {
     return InkWell(
       mouseCursor: SystemMouseCursors.click,
       onTap: () {
+        FocusManager.instance.primaryFocus?.unfocus();
         final tid = threadRootId;
         if (tid != null) {
           context.goNamed(

--- a/lib/features/home/widgets/wide_layout.dart
+++ b/lib/features/home/widgets/wide_layout.dart
@@ -126,7 +126,9 @@ class _WideLayoutState extends State<WideLayout> {
         name == Routes.settingsRecoveryKey ||
         name == Routes.spaces ||
         name == Routes.spaceDetails ||
-        name == Routes.inbox) {
+        name == Routes.inbox ||
+        name == Routes.roomThread ||
+        name == Routes.roomThreads) {
       return widget.routerChild;
     }
 

--- a/lib/features/notifications/models/notification_constants.dart
+++ b/lib/features/notifications/models/notification_constants.dart
@@ -53,6 +53,7 @@ abstract class InboxText {
   static const title = 'Inbox';
   static const filterAll = 'All';
   static const filterMentions = 'Mentions';
+  static const filterThreads = 'Threads';
   static const filterInvitations = 'Invites';
   static const noNotifications = 'No notifications';
   static const failedToLoad = 'Failed to load notifications';
@@ -68,6 +69,12 @@ abstract class InboxText {
   static const mediaFile = '📎 File';
   static const loadMore = 'Load more';
   static const inThread = 'in thread';
+  static const mentionInThread = '@you in thread';
+  static const mention = '@you';
+
+  static String inReplyTo(String body) => 'In reply to "$body"';
+  static String threadCount(int count) =>
+      count == 1 ? '1 reply' : '$count replies';
 
   static String invitationsWithCount(int count) => 'Invites ($count)';
 }

--- a/lib/features/notifications/services/inbox_controller.dart
+++ b/lib/features/notifications/services/inbox_controller.dart
@@ -72,10 +72,12 @@ class InboxController extends ChangeNotifier {
   InboxFilter _filter = InboxFilter.all;
   InboxFilter get filter => _filter;
 
-  Timer? _pollTimer;
+  StreamSubscription<matrix_sdk.SyncUpdate>? _syncSub;
+  Timer? _debounce;
   int _pollingRefCount = 0;
   bool _markingAsRead = false;
   bool _tokenExpired = false;
+  static const _debounceDelay = Duration(milliseconds: 750);
 
   int _fetchGeneration = 0;
   int _cachedUnreadCount = 0;
@@ -131,6 +133,7 @@ class InboxController extends ChangeNotifier {
       if (_isTokenExpired(e)) {
         _tokenExpired = true;
         _isLoading = false;
+        _unbindSync();
         return;
       }
       _error = e.toString();
@@ -198,58 +201,65 @@ class InboxController extends ChangeNotifier {
     unawaited(fetch().catchError((Object e) => debugPrint('[Kohera] Inbox fetch error: $e')));
   }
 
-  // ── Polling ────────────────────────────────────────────────
+  // ── Sync-driven invalidation ───────────────────────────────
 
   void startPolling() {
     _pollingRefCount++;
     if (_pollingRefCount == 1) {
-      _pollTimer?.cancel();
-      _pollTimer = Timer.periodic(
-        const Duration(seconds: 7),
-        (_) => _pollOnce(),
-      );
+      _bindSync();
     }
   }
 
   void stopPolling() {
     _pollingRefCount = (_pollingRefCount - 1).clamp(0, 999);
     if (_pollingRefCount == 0) {
-      _pollTimer?.cancel();
-      _pollTimer = null;
+      _unbindSync();
     }
   }
 
-  Future<void> _pollOnce() async {
-    if (_isLoading || _markingAsRead || _tokenExpired) return;
-    try {
-      final response = await _client.getNotifications(limit: 30);
-      if (_disposed) return;
+  void _bindSync() {
+    final existing = _syncSub;
+    if (existing != null) unawaited(existing.cancel());
+    _syncSub = _client.onSync.stream.listen(_onSync);
+  }
 
-      final freshIds = <String>{};
-      for (final n in response.notifications) {
-        freshIds.add(n.event.eventId);
-      }
+  void _unbindSync() {
+    unawaited(_syncSub?.cancel() ?? Future.value());
+    _syncSub = null;
+    _debounce?.cancel();
+    _debounce = null;
+  }
 
-      final all = <matrix_sdk.Notification>[...response.notifications];
-      for (final group in _grouped) {
-        for (final n in group.notifications) {
-          if (!freshIds.contains(n.event.eventId)) {
-            all.add(n);
+  void _onSync(matrix_sdk.SyncUpdate update) {
+    if (_disposed || _tokenExpired) return;
+    if (!_shouldInvalidate(update)) return;
+    _debounce?.cancel();
+    _debounce = Timer(_debounceDelay, () {
+      if (_disposed || _tokenExpired) return;
+      if (_isLoading || _markingAsRead) return;
+      unawaited(fetch());
+    });
+  }
+
+  bool _shouldInvalidate(matrix_sdk.SyncUpdate update) {
+    final rooms = update.rooms;
+    if (rooms == null) return false;
+    final joins = rooms.join;
+    if (joins != null) {
+      for (final entry in joins.values) {
+        final timelineEvents = entry.timeline?.events;
+        if (timelineEvents != null && timelineEvents.isNotEmpty) return true;
+        final ephemeral = entry.ephemeral;
+        if (ephemeral != null) {
+          for (final ev in ephemeral) {
+            if (ev.type == 'm.receipt') return true;
           }
         }
       }
-      _grouped = await _groupByRoom(all);
-      _updateUnreadCount();
-      _error = null;
-      _nextToken ??= response.nextToken;
-      if (!_disposed) notifyListeners();
-    } catch (e) {
-      if (_isTokenExpired(e)) {
-        _tokenExpired = true;
-        return;
-      }
-      debugPrint('[Kohera] Inbox poll error: $e');
     }
+    if (rooms.invite != null && rooms.invite!.isNotEmpty) return true;
+    if (rooms.leave != null && rooms.leave!.isNotEmpty) return true;
+    return false;
   }
 
   // ── Mark as read ───────────────────────────────────────────
@@ -308,10 +318,10 @@ class InboxController extends ChangeNotifier {
             threadId: entry.key,
           ),
       ]);
-      await fetch();
     } catch (e) {
       if (_isTokenExpired(e)) {
         _tokenExpired = true;
+        _unbindSync();
         _markingAsRead = false;
         return;
       }
@@ -327,6 +337,8 @@ class InboxController extends ChangeNotifier {
   void updateClient(Client newClient) {
     _tokenExpired = false;
     if (identical(_client, newClient)) return;
+    final wasActive = _pollingRefCount > 0;
+    _unbindSync();
     _client = newClient;
     _grouped = [];
     _decryptedContent.clear();
@@ -334,7 +346,7 @@ class InboxController extends ChangeNotifier {
     _isLoading = false;
     _error = null;
     _updateUnreadCount();
-    stopPolling();
+    if (wasActive) _bindSync();
     if (!_disposed) notifyListeners();
     unawaited(fetch().catchError((Object e) => debugPrint('[Kohera] Inbox fetch error: $e')));
   }
@@ -468,7 +480,7 @@ class InboxController extends ChangeNotifier {
   @override
   void dispose() {
     _disposed = true;
-    stopPolling();
+    _unbindSync();
     super.dispose();
   }
 }

--- a/lib/features/notifications/services/inbox_controller.dart
+++ b/lib/features/notifications/services/inbox_controller.dart
@@ -27,18 +27,30 @@ bool _isLetter(int c) =>
     (c >= 0x41 && c <= 0x5A) || (c >= 0x61 && c <= 0x7A);
 
 // ── Filter enum ──────────────────────────────────────────────
-enum InboxFilter { all, mentions, invitations }
+enum InboxFilter { all, mentions, threads, invitations }
 
 // ── Grouped notification model ───────────────────────────────
+class ThreadSubGroup {
+  final String? threadRootId;
+  final List<matrix_sdk.Notification> notifications;
+
+  const ThreadSubGroup({
+    required this.threadRootId,
+    required this.notifications,
+  });
+}
+
 class NotificationGroup {
   final String roomId;
   final String roomName;
   final List<matrix_sdk.Notification> notifications;
+  final List<ThreadSubGroup> subGroups;
 
   const NotificationGroup({
     required this.roomId,
     required this.roomName,
     required this.notifications,
+    required this.subGroups,
   });
 }
 
@@ -278,18 +290,24 @@ class InboxController extends ChangeNotifier {
     unawaited(ApnsPushService.clearBadge());
     if (!_disposed) notifyListeners();
 
+    final maxThreadTs = perThread.values.fold<int>(
+      -1,
+      (acc, e) => e.ts > acc ? e.ts : acc,
+    );
+    final shouldPostMain = mainEventId != null && mainTs >= maxThreadTs;
+
     try {
-      if (mainEventId != null) {
-        await room.setReadMarker(mainEventId, mRead: mainEventId);
-      }
-      for (final entry in perThread.entries) {
-        await _client.postReceipt(
-          roomId,
-          matrix_sdk.ReceiptType.mRead,
-          entry.value.eventId,
-          threadId: entry.key,
-        );
-      }
+      await Future.wait([
+        if (shouldPostMain)
+          room.setReadMarker(mainEventId, mRead: mainEventId),
+        for (final entry in perThread.entries)
+          _client.postReceipt(
+            roomId,
+            matrix_sdk.ReceiptType.mRead,
+            entry.value.eventId,
+            threadId: entry.key,
+          ),
+      ]);
       await fetch();
     } catch (e) {
       if (_isTokenExpired(e)) {
@@ -328,7 +346,7 @@ class InboxController extends ChangeNotifier {
 
   // ── Mention detection ──────────────────────────────────────
 
-  bool _isMention(matrix_sdk.Notification n) {
+  bool isMention(matrix_sdk.Notification n) {
     final userId = _client.userID;
     if (userId == null) return false;
 
@@ -390,7 +408,10 @@ class InboxController extends ChangeNotifier {
       final room = _client.getRoomById(n.roomId);
       if (room == null || room.membership != Membership.join) continue;
       await _tryDecrypt(n);
-      if (_filter == InboxFilter.mentions && !_isMention(n)) continue;
+      if (_filter == InboxFilter.mentions && !isMention(n)) continue;
+      if (_filter == InboxFilter.threads && threadRootIdFor(n) == null) {
+        continue;
+      }
       map.putIfAbsent(n.roomId, () {
         order.add(n.roomId);
         return [];
@@ -411,12 +432,37 @@ class InboxController extends ChangeNotifier {
 
     return order.map((roomId) {
       final room = _client.getRoomById(roomId);
+      final notifications = map[roomId]!;
       return NotificationGroup(
         roomId: roomId,
         roomName: room?.getLocalizedDisplayname() ?? roomId,
-        notifications: map[roomId]!,
+        notifications: notifications,
+        subGroups: _buildSubGroups(notifications),
       );
     }).toList();
+  }
+
+  List<ThreadSubGroup> _buildSubGroups(
+    List<matrix_sdk.Notification> notifications,
+  ) {
+    const mainKey = '__main__';
+    final buckets = <String, List<matrix_sdk.Notification>>{};
+    final order = <String>[];
+    for (final n in notifications) {
+      final key = threadRootIdFor(n) ?? mainKey;
+      if (!buckets.containsKey(key)) order.add(key);
+      buckets.putIfAbsent(key, () => []).add(n);
+    }
+    int maxTs(String k) =>
+        buckets[k]!.map((n) => n.ts).reduce((a, b) => a > b ? a : b);
+    order.sort((a, b) => maxTs(b).compareTo(maxTs(a)));
+    return [
+      for (final key in order)
+        ThreadSubGroup(
+          threadRootId: key == mainKey ? null : key,
+          notifications: buckets[key]!,
+        ),
+    ];
   }
 
   @override

--- a/lib/features/rooms/widgets/room_list.dart
+++ b/lib/features/rooms/widgets/room_list.dart
@@ -28,7 +28,7 @@ class RoomList extends StatefulWidget {
 class _RoomListState extends State<RoomList>
     with TickerProviderStateMixin {
   final _searchCtrl = TextEditingController();
-  final _searchFocus = FocusNode();
+  final _searchFocus = FocusNode(debugLabel: 'roomlist-search');
   String _query = '';
   bool _searchOpen = false;
   late final AnimationController _searchAnimCtrl;

--- a/test/services/inbox_controller_test.dart
+++ b/test/services/inbox_controller_test.dart
@@ -825,4 +825,215 @@ void main() {
       expect(controller.grouped, hasLength(2));
     });
   });
+
+  // ── Thread sub-grouping ───────────────────────────────────
+  Map<String, Object?> threadContent(String rootId) => {
+        'body': 'reply',
+        'msgtype': 'm.text',
+        'm.relates_to': {
+          'rel_type': 'm.thread',
+          'event_id': rootId,
+        },
+      };
+
+  group('thread sub-grouping', () {
+    test('two threads in one room produce two sub-groups + main', () async {
+      when(mockClient.getNotifications(
+        limit: anyNamed('limit'),
+        only: anyNamed('only'),
+      ),).thenAnswer((_) async => _makeResponse([
+            _makeNotification(eventId: 'm1', roomId: '!r1:x'),
+            _makeNotification(
+              eventId: 't1a',
+              roomId: '!r1:x',
+              ts: 2000,
+              content: threadContent(r'$rootA'),
+            ),
+            _makeNotification(
+              eventId: 't1b',
+              roomId: '!r1:x',
+              ts: 2500,
+              content: threadContent(r'$rootA'),
+            ),
+            _makeNotification(
+              eventId: 't2',
+              roomId: '!r1:x',
+              ts: 3000,
+              content: threadContent(r'$rootB'),
+            ),
+          ]),);
+
+      await controller.fetch();
+
+      expect(controller.grouped, hasLength(1));
+      final subs = controller.grouped[0].subGroups;
+      expect(subs, hasLength(3));
+      expect(subs[0].threadRootId, r'$rootB');
+      expect(subs[0].notifications, hasLength(1));
+      expect(subs[1].threadRootId, r'$rootA');
+      expect(subs[1].notifications, hasLength(2));
+      expect(subs[2].threadRootId, isNull);
+      expect(subs[2].notifications, hasLength(1));
+    });
+
+    test('main-only room yields single null-keyed sub-group', () async {
+      when(mockClient.getNotifications(
+        limit: anyNamed('limit'),
+        only: anyNamed('only'),
+      ),).thenAnswer((_) async => _makeResponse([
+            _makeNotification(eventId: 'e1', roomId: '!r1:x'),
+            _makeNotification(eventId: 'e2', roomId: '!r1:x', ts: 2000),
+          ]),);
+
+      await controller.fetch();
+
+      final subs = controller.grouped[0].subGroups;
+      expect(subs, hasLength(1));
+      expect(subs[0].threadRootId, isNull);
+      expect(subs[0].notifications, hasLength(2));
+    });
+  });
+
+  // ── threads filter ────────────────────────────────────────
+  group('threads filter', () {
+    test('excludes non-thread notifications', () async {
+      when(mockClient.getNotifications(
+        limit: anyNamed('limit'),
+        only: anyNamed('only'),
+      ),).thenAnswer((_) async => _makeResponse([
+            _makeNotification(eventId: 'm1', roomId: '!r1:x'),
+            _makeNotification(
+              eventId: 't1',
+              roomId: '!r1:x',
+              ts: 2000,
+              content: threadContent(r'$root'),
+            ),
+            _makeNotification(eventId: 'm2', roomId: '!r2:x'),
+          ]),);
+
+      controller.setFilter(InboxFilter.threads);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.grouped, hasLength(1));
+      expect(controller.grouped[0].roomId, '!r1:x');
+      expect(controller.grouped[0].notifications, hasLength(1));
+      expect(controller.grouped[0].notifications[0].event.eventId, 't1');
+    });
+  });
+
+  // ── markRoomAsRead parallel + stale main ─────────────────
+  group('markRoomAsRead() parallelization', () {
+    test('per-thread receipts dispatched in parallel (not sequential)',
+        () async {
+      final mockRoom = MockRoom();
+      when(mockRoom.membership).thenReturn(Membership.join);
+      when(mockRoom.lastEvent).thenReturn(null);
+      when(mockRoom.setReadMarker(any, mRead: anyNamed('mRead')))
+          .thenAnswer((_) async {});
+      when(mockClient.getRoomById('!r1:x')).thenReturn(mockRoom);
+
+      final completers = <String, Completer<void>>{
+        r'$rA': Completer<void>(),
+        r'$rB': Completer<void>(),
+      };
+      when(mockClient.postReceipt(
+        any,
+        any,
+        any,
+        threadId: anyNamed('threadId'),
+      ),).thenAnswer((inv) {
+        final tid = inv.namedArguments[#threadId] as String;
+        return completers[tid]!.future;
+      });
+
+      when(mockClient.getNotifications(
+        limit: anyNamed('limit'),
+        only: anyNamed('only'),
+      ),).thenAnswer((_) async => _makeResponse([
+            _makeNotification(
+              eventId: 'tA',
+              roomId: '!r1:x',
+              ts: 2000,
+              content: threadContent(r'$rA'),
+            ),
+            _makeNotification(
+              eventId: 'tB',
+              roomId: '!r1:x',
+              ts: 3000,
+              content: threadContent(r'$rB'),
+            ),
+          ]),);
+
+      await controller.fetch();
+      final markFuture = controller.markRoomAsRead('!r1:x');
+
+      // Let microtasks drain so both postReceipt calls are issued.
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      // Both receipts in flight before either completes => parallel.
+      verify(mockClient.postReceipt('!r1:x', any, 'tA',
+              threadId: r'$rA',),).called(1);
+      verify(mockClient.postReceipt('!r1:x', any, 'tB',
+              threadId: r'$rB',),).called(1);
+
+      completers[r'$rA']!.complete();
+      completers[r'$rB']!.complete();
+      await markFuture;
+    });
+
+    test('skips main receipt when thread reply is newer', () async {
+      final mockRoom = MockRoom();
+      when(mockRoom.membership).thenReturn(Membership.join);
+      when(mockRoom.lastEvent).thenReturn(null);
+      when(mockRoom.setReadMarker(any, mRead: anyNamed('mRead')))
+          .thenAnswer((_) async {});
+      when(mockClient.postReceipt(any, any, any,
+              threadId: anyNamed('threadId'),),)
+          .thenAnswer((_) async {});
+      when(mockClient.getRoomById('!r1:x')).thenReturn(mockRoom);
+
+      when(mockClient.getNotifications(
+        limit: anyNamed('limit'),
+        only: anyNamed('only'),
+      ),).thenAnswer((_) async => _makeResponse([
+            _makeNotification(eventId: 'm-old', roomId: '!r1:x'),
+            _makeNotification(
+              eventId: 't-new',
+              roomId: '!r1:x',
+              ts: 5000,
+              content: threadContent(r'$root'),
+            ),
+          ]),);
+
+      await controller.fetch();
+      await controller.markRoomAsRead('!r1:x');
+
+      verifyNever(mockRoom.setReadMarker(any, mRead: anyNamed('mRead')));
+      verify(mockClient.postReceipt('!r1:x', any, 't-new',
+              threadId: r'$root',),).called(1);
+    });
+
+    test('posts main receipt when no threads present', () async {
+      final mockRoom = MockRoom();
+      when(mockRoom.membership).thenReturn(Membership.join);
+      when(mockRoom.lastEvent).thenReturn(null);
+      when(mockRoom.setReadMarker(any, mRead: anyNamed('mRead')))
+          .thenAnswer((_) async {});
+      when(mockClient.getRoomById('!r1:x')).thenReturn(mockRoom);
+
+      when(mockClient.getNotifications(
+        limit: anyNamed('limit'),
+        only: anyNamed('only'),
+      ),).thenAnswer((_) async => _makeResponse([
+            _makeNotification(eventId: 'e1', roomId: '!r1:x'),
+          ]),);
+
+      await controller.fetch();
+      await controller.markRoomAsRead('!r1:x');
+
+      verify(mockRoom.setReadMarker('e1', mRead: 'e1')).called(1);
+    });
+  });
 }

--- a/test/services/inbox_controller_test.dart
+++ b/test/services/inbox_controller_test.dart
@@ -358,7 +358,7 @@ void main() {
 
   // ── Sync-stream invalidation ──────────────────────────────
 
-  SyncUpdate _syncWithTimelineEvent(String roomId) {
+  SyncUpdate syncWithTimelineEvent(String roomId) {
     final ev = MatrixEvent(
       type: 'm.room.message',
       content: const {'body': 'hi', 'msgtype': 'm.text'},
@@ -379,7 +379,7 @@ void main() {
     );
   }
 
-  SyncUpdate _syncTypingOnly(String roomId) {
+  SyncUpdate syncTypingOnly(String roomId) {
     return SyncUpdate(
       nextBatch: 'tok',
       rooms: RoomsUpdate(
@@ -407,7 +407,7 @@ void main() {
         // Initial fetch is NOT triggered by startPolling (caller does it).
         clearInteractions(mockClient);
 
-        syncCtl.add(_syncWithTimelineEvent('!r1:x'));
+        syncCtl.add(syncWithTimelineEvent('!r1:x'));
 
         // Before debounce expires: no fetch yet.
         async.elapse(const Duration(milliseconds: 500));
@@ -439,11 +439,11 @@ void main() {
         async.flushMicrotasks();
         clearInteractions(mockClient);
 
-        syncCtl.add(_syncWithTimelineEvent('!r1:x'));
+        syncCtl.add(syncWithTimelineEvent('!r1:x'));
         async.elapse(const Duration(milliseconds: 200));
-        syncCtl.add(_syncWithTimelineEvent('!r2:x'));
+        syncCtl.add(syncWithTimelineEvent('!r2:x'));
         async.elapse(const Duration(milliseconds: 200));
-        syncCtl.add(_syncWithTimelineEvent('!r3:x'));
+        syncCtl.add(syncWithTimelineEvent('!r3:x'));
         async.elapse(const Duration(seconds: 1));
         async.flushMicrotasks();
 
@@ -467,7 +467,7 @@ void main() {
         async.flushMicrotasks();
         clearInteractions(mockClient);
 
-        syncCtl.add(_syncTypingOnly('!r1:x'));
+        syncCtl.add(syncTypingOnly('!r1:x'));
         async.elapse(const Duration(seconds: 5));
         async.flushMicrotasks();
 
@@ -491,7 +491,7 @@ void main() {
         async.flushMicrotasks();
         clearInteractions(mockClient);
 
-        syncCtl.add(_syncWithTimelineEvent('!r1:x'));
+        syncCtl.add(syncWithTimelineEvent('!r1:x'));
         async.elapse(const Duration(milliseconds: 200));
         controller.stopPolling();
         async.elapse(const Duration(seconds: 5));

--- a/test/services/inbox_controller_test.dart
+++ b/test/services/inbox_controller_test.dart
@@ -4,6 +4,7 @@ import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/features/notifications/services/inbox_controller.dart';
 import 'package:matrix/matrix.dart';
+import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
@@ -55,11 +56,15 @@ void main() {
 
   late MockRoom defaultRoom;
 
+  late CachedStreamController<SyncUpdate> syncCtl;
+
   setUp(() {
     mockClient = MockClient();
     defaultRoom = MockRoom();
+    syncCtl = CachedStreamController<SyncUpdate>();
     when(defaultRoom.membership).thenReturn(Membership.join);
     when(mockClient.getRoomById(any)).thenReturn(defaultRoom);
+    when(mockClient.onSync).thenReturn(syncCtl);
     controller = InboxController(client: mockClient);
   });
 
@@ -351,10 +356,46 @@ void main() {
     });
   });
 
-  // ── Polling ────────────────────────────────────────────────
+  // ── Sync-stream invalidation ──────────────────────────────
 
-  group('startPolling / stopPolling', () {
-    test('_pollOnce fires at 7s intervals', () {
+  SyncUpdate _syncWithTimelineEvent(String roomId) {
+    final ev = MatrixEvent(
+      type: 'm.room.message',
+      content: const {'body': 'hi', 'msgtype': 'm.text'},
+      senderId: '@bob:example.com',
+      eventId: 'sync-evt',
+      originServerTs: DateTime.fromMillisecondsSinceEpoch(1000),
+      roomId: roomId,
+    );
+    return SyncUpdate(
+      nextBatch: 'tok',
+      rooms: RoomsUpdate(
+        join: {
+          roomId: JoinedRoomUpdate(
+            timeline: TimelineUpdate(events: [ev]),
+          ),
+        },
+      ),
+    );
+  }
+
+  SyncUpdate _syncTypingOnly(String roomId) {
+    return SyncUpdate(
+      nextBatch: 'tok',
+      rooms: RoomsUpdate(
+        join: {
+          roomId: JoinedRoomUpdate(
+            ephemeral: [
+              BasicEvent(type: 'm.typing', content: const {'user_ids': []}),
+            ],
+          ),
+        },
+      ),
+    );
+  }
+
+  group('startPolling / stopPolling (sync-driven)', () {
+    test('sync timeline event triggers debounced fetch', () {
       fakeAsync((async) {
         when(mockClient.getNotifications(
           limit: anyNamed('limit'),
@@ -362,32 +403,100 @@ void main() {
         ),).thenAnswer((_) async => _makeResponse([]));
 
         controller.startPolling();
+        async.flushMicrotasks();
+        // Initial fetch is NOT triggered by startPolling (caller does it).
+        clearInteractions(mockClient);
 
-        // No calls at t=0
+        syncCtl.add(_syncWithTimelineEvent('!r1:x'));
+
+        // Before debounce expires: no fetch yet.
+        async.elapse(const Duration(milliseconds: 500));
         verifyNever(mockClient.getNotifications(
           limit: anyNamed('limit'),
           only: anyNamed('only'),
         ),);
 
-        // Advance to 7s
-        async.elapse(const Duration(seconds: 7));
-        verify(mockClient.getNotifications(
-          limit: anyNamed('limit'),
-          only: anyNamed('only'),
-        ),).called(1);
-
-        // Advance to 14s
-        async.elapse(const Duration(seconds: 7));
+        // After debounce: one fetch.
+        async.elapse(const Duration(milliseconds: 300));
+        async.flushMicrotasks();
         verify(mockClient.getNotifications(
           limit: anyNamed('limit'),
           only: anyNamed('only'),
         ),).called(1);
 
         controller.stopPolling();
+      });
+    });
 
-        // Reset interaction count, then verify no more calls
+    test('burst of sync updates coalesces to one fetch', () {
+      fakeAsync((async) {
+        when(mockClient.getNotifications(
+          limit: anyNamed('limit'),
+          only: anyNamed('only'),
+        ),).thenAnswer((_) async => _makeResponse([]));
+
+        controller.startPolling();
+        async.flushMicrotasks();
         clearInteractions(mockClient);
-        async.elapse(const Duration(seconds: 14));
+
+        syncCtl.add(_syncWithTimelineEvent('!r1:x'));
+        async.elapse(const Duration(milliseconds: 200));
+        syncCtl.add(_syncWithTimelineEvent('!r2:x'));
+        async.elapse(const Duration(milliseconds: 200));
+        syncCtl.add(_syncWithTimelineEvent('!r3:x'));
+        async.elapse(const Duration(seconds: 1));
+        async.flushMicrotasks();
+
+        verify(mockClient.getNotifications(
+          limit: anyNamed('limit'),
+          only: anyNamed('only'),
+        ),).called(1);
+
+        controller.stopPolling();
+      });
+    });
+
+    test('typing-only sync does not trigger fetch', () {
+      fakeAsync((async) {
+        when(mockClient.getNotifications(
+          limit: anyNamed('limit'),
+          only: anyNamed('only'),
+        ),).thenAnswer((_) async => _makeResponse([]));
+
+        controller.startPolling();
+        async.flushMicrotasks();
+        clearInteractions(mockClient);
+
+        syncCtl.add(_syncTypingOnly('!r1:x'));
+        async.elapse(const Duration(seconds: 5));
+        async.flushMicrotasks();
+
+        verifyNever(mockClient.getNotifications(
+          limit: anyNamed('limit'),
+          only: anyNamed('only'),
+        ),);
+
+        controller.stopPolling();
+      });
+    });
+
+    test('stopPolling cancels pending debounce', () {
+      fakeAsync((async) {
+        when(mockClient.getNotifications(
+          limit: anyNamed('limit'),
+          only: anyNamed('only'),
+        ),).thenAnswer((_) async => _makeResponse([]));
+
+        controller.startPolling();
+        async.flushMicrotasks();
+        clearInteractions(mockClient);
+
+        syncCtl.add(_syncWithTimelineEvent('!r1:x'));
+        async.elapse(const Duration(milliseconds: 200));
+        controller.stopPolling();
+        async.elapse(const Duration(seconds: 5));
+        async.flushMicrotasks();
+
         verifyNever(mockClient.getNotifications(
           limit: anyNamed('limit'),
           only: anyNamed('only'),
@@ -486,7 +595,7 @@ void main() {
       expect(controller.grouped[0].notifications, hasLength(1));
     });
 
-    test('polling updates stale local read state from server', () {
+    test('sync-triggered refetch updates stale local read state', () {
       fakeAsync((async) {
         when(mockClient.getNotifications(
           limit: anyNamed('limit'),
@@ -509,7 +618,21 @@ void main() {
             ]),);
 
         controller.startPolling();
-        async.elapse(const Duration(seconds: 7));
+        async.flushMicrotasks();
+        // Simulate a receipt from another device clearing 'e1'.
+        syncCtl.add(SyncUpdate(
+          nextBatch: 'tok',
+          rooms: RoomsUpdate(
+            join: {
+              '!r1:x': JoinedRoomUpdate(
+                ephemeral: [
+                  BasicEvent(type: 'm.receipt', content: const {}),
+                ],
+              ),
+            },
+          ),
+        ),);
+        async.elapse(const Duration(seconds: 1));
         async.flushMicrotasks();
         controller.stopPolling();
 
@@ -597,7 +720,7 @@ void main() {
       expect(controller.error, isNull);
     });
 
-    test('polling stops after M_UNKNOWN_TOKEN', () {
+    test('sync subscription stops after M_UNKNOWN_TOKEN', () {
       fakeAsync((async) {
         var callCount = 0;
         when(mockClient.getNotifications(
@@ -612,10 +735,32 @@ void main() {
         });
 
         controller.startPolling();
-        async.elapse(const Duration(seconds: 7));
+        unawaited(controller.fetch());
+        async.flushMicrotasks();
         expect(callCount, 1);
 
-        async.elapse(const Duration(seconds: 7));
+        // After token expiry, further sync events must not trigger fetch.
+        syncCtl.add(SyncUpdate(
+          nextBatch: 'tok',
+          rooms: RoomsUpdate(
+            join: {
+              '!r1:x': JoinedRoomUpdate(
+                timeline: TimelineUpdate(events: [
+                  MatrixEvent(
+                    type: 'm.room.message',
+                    content: const {'body': 'hi', 'msgtype': 'm.text'},
+                    senderId: '@b:x',
+                    eventId: 'e1',
+                    originServerTs: DateTime.fromMillisecondsSinceEpoch(1),
+                    roomId: '!r1:x',
+                  ),
+                ],),
+              ),
+            },
+          ),
+        ),);
+        async.elapse(const Duration(seconds: 5));
+        async.flushMicrotasks();
         expect(callCount, 1);
 
         controller.stopPolling();


### PR DESCRIPTION
## Summary

Final slice of the Threads (MSC3440) epic (#140). Closes #390. Inbox now surfaces thread activity per-thread instead of collapsing into per-room groups, plus a handful of follow-up fixes uncovered while testing the flow end-to-end.

### Inbox thread parity
- Sub-group notifications by `threadRootId` inside each room card; each thread renders its own header, reply count, and best-effort `In reply to "<root>"` preview (cached via `room.getEventById`)
- New `InboxFilter.threads` filter chip
- Promote `_isMention` → public `isMention`; tile shows `@you` / `@you in thread` badge in place of the bare "in thread" label
- Group-level Open routes to `Routes.roomThread` when the group collapses to a single thread, else `Routes.room`
- `markRoomAsRead` dispatches per-thread receipts in parallel via `Future.wait`, and skips the main receipt when a thread reply is newer than the latest main-timeline notification (avoids regressing the main read marker — neither Matrix SDK nor spec guards this server-side)
- Drive inbox refresh from `client.onSync` (debounced 750 ms) instead of a 7 s `Timer.periodic`; fewer wasted rebuilds, instant updates

### Thread screen fixes (uncovered while testing inbox→thread tap)
- Route inbox thread taps to `ThreadScreen` on wide layout (the routerChild was being discarded by `WideLayout._buildContentPane`)
- Load full thread reply history via `/relations/{root}/m.thread`, with `next_batch` pagination on scroll-up; main-timeline `_loadMore` stays gated in thread mode so room history isn't auto-paginated
- Drop `eventContextId` for the thread timeline so live events flow in (`Room.getTimeline(eventContextId:)` returns a context-window timeline with `allowNewEvent=false`, which silently dropped the user's own sent thread replies). Thread root + historic replies are merged via `extraEvents` instead

### Other fixes pulled in
- Drop chat compose auto-focus on `ChatScreen.initState` — programmatically requesting focus on a freshly-mounted FocusNode races against `EditableTextState._handleFocusChanged → _openInputConnection → renderEditable.size` (Flutter issue 126312, hits Linux on cold-boot to a chat route). User clicks compose to focus.
- Use `_visibleEvents.first` instead of `room.lastEvent` for the main-timeline receipt; if `lastEvent` happens to be a thread reply, the server returns `M_INVALID_PARAM: event_id ... is not related to thread main`
- Mobile chat AppBar declutter: on narrow layouts, fold the pin badge and threads icon into the overflow `PopupMenuButton` (with their badges); call and search stay inline; wide layout unchanged

## Test plan

- [x] `flutter test test/services/inbox_controller_test.dart` (35 tests, +6 new for sub-grouping, threads filter, parallel receipts, stale-main skip)
- [x] `flutter test test/widgets/inbox_screen_test.dart`
- [x] `flutter test` (full suite passes)
- [x] Manual smoke on Linux: multi-thread room shows multiple sub-tiles; Threads filter chip; mark-as-read clears all sub-groups in one round; tile + group Open both land on the right thread root
- [x] Manual smoke on Linux: open a thread from inbox, send a reply, see it appear; scroll up to load older replies via `/relations` pagination
- [x] Manual smoke on narrow window: chat AppBar shows back / avatar / call / search / overflow; overflow menu lists Pinned messages, Threads, Room details with badges; wide window keeps the inline icons