### PR TITLE
ci: add commitlint to enforce conventional commits

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,17 @@
+name: Commitlint
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6
+        with:
+          configFile: commitlint.config.js
+          failOnWarnings: true

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -13,5 +13,5 @@ jobs:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6
         with:
-          configFile: commitlint.config.js
+          configFile: commitlint.config.mjs
           failOnWarnings: true

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      ['feat', 'fix', 'perf', 'refactor', 'style', 'docs', 'test', 'chore', 'ci', 'build', 'revert'],
+    ],
+  },
+};

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'type-enum': [


### PR DESCRIPTION
## Summary

Enforces conventional commits on every commit in a PR, so release-please (#401) gets clean input under the rebase-and-merge workflow.

- `commitlint.yml` runs on `pull_request` to master via `wagoid/commitlint-github-action`, which lints all commits in the PR head.
- `commitlint.config.js` extends `@commitlint/config-conventional` with an explicit `type-enum` matching the set in CLAUDE.md plus `perf`/`build`/`ci`/`revert` (release-please uses `perf` and `revert`).
- `failOnWarnings: true` — soft warnings block merge; flip to `false` if too strict in practice.

## Why rebase-and-merge needs this

Rebase-and-merge replays every PR commit onto master with its original message intact. PR title is invisible to release-please. So PR-title linting wouldn't help — every individual commit has to be a valid conv-commit, and that's what wagoid/commitlint-github-action checks.

## Test plan

- [x] Open a test PR with a non-conv commit (e.g. `wip foo`); commitlint check fails.
- [x] Rebase clean (`feat: …`); check passes.
- [x] Merge a real PR through rebase-and-merge; release-please picks up the entries on the next master push.