### PR TITLE
feat(whats-new): version-bump detector in PreferencesService

### DIFF
--- a/lib/core/services/preferences_service.dart
+++ b/lib/core/services/preferences_service.dart
@@ -4,6 +4,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:kohera/core/theme/custom_theme.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// Controls how compact or spacious message bubbles appear.
@@ -60,20 +62,32 @@ enum MobileTab {
 
 /// Manages user preferences that persist across app restarts.
 class PreferencesService extends ChangeNotifier {
-  PreferencesService({SharedPreferences? prefs}) : _prefs = prefs;
+  PreferencesService({
+    SharedPreferences? prefs,
+    PackageInfo? packageInfo,
+  })  : _prefs = prefs,
+        _packageInfo = packageInfo;
 
   SharedPreferences? _prefs;
+  PackageInfo? _packageInfo;
+  String? _currentVersion;
   static const _defaultHomeserverKey = 'default_homeserver';
   static const _densityKey = 'message_density';
   static const _themeModeKey = 'theme_mode';
   static const _themePresetKey = 'theme_preset';
   static const _lastMobileTabKey = 'last_mobile_tab';
+  static const _lastSeenVersionKey = 'last_seen_version';
 
   /// Initialise the underlying [SharedPreferences] instance.
   /// Must be called (and awaited) before reading any values.
   Future<void> init() async {
     _prefs ??= await SharedPreferences.getInstance();
     await _prefs?.remove('room_filter');
+    _packageInfo ??= await PackageInfo.fromPlatform();
+    _currentVersion = _packageInfo?.version;
+    if (_currentVersion != null && lastSeenVersion == null) {
+      await _prefs?.setString(_lastSeenVersionKey, _currentVersion!);
+    }
     notifyListeners();
   }
 
@@ -614,6 +628,29 @@ class PreferencesService extends ChangeNotifier {
   Future<void> setPttSoundEnabled(bool value) async {
     await _prefs?.setBool(_pttSoundEnabledKey, value);
     debugPrint('[Kohera] PTT sound ${value ? "enabled" : "disabled"}');
+    notifyListeners();
+  }
+
+  // ── Version bump detection ────────────────────────────────────
+
+  String? get lastSeenVersion => _prefs?.getString(_lastSeenVersionKey);
+
+  String? get currentVersion => _currentVersion;
+
+  bool get hasVersionBumped {
+    final seen = lastSeenVersion;
+    final current = _currentVersion;
+    if (seen == null || current == null) return false;
+    try {
+      return Version.parse(current) > Version.parse(seen);
+    } on FormatException {
+      return false;
+    }
+  }
+
+  Future<void> markVersionSeen(String version) async {
+    await _prefs?.setString(_lastSeenVersionKey, version);
+    debugPrint('[Kohera] Marked version $version as seen');
     notifyListeners();
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -905,10 +905,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1070,13 +1070,13 @@ packages:
     source: hosted
     version: "2.2.0"
   package_info_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "8.3.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1270,7 +1270,7 @@ packages:
     source: hosted
     version: "6.1.5+1"
   pub_semver:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pub_semver
       sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
@@ -1670,18 +1670,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.16"
   timezone:
     dependency: "direct dev"
     description:
@@ -1870,10 +1870,10 @@ packages:
     dependency: transitive
     description:
       name: wakelock_plus
-      sha256: "9296d40c9adbedaba95d1e704f4e0b434be446e2792948d0e4aa977048104228"
+      sha256: "61713aa82b7f85c21c9f4cd0a148abd75f38a74ec645fcb1e446f882c82fd09b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.3.3"
   wakelock_plus_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,11 +36,13 @@ dependencies:
   media_kit: ^1.2.6
   media_kit_libs_video: ^1.0.7
   media_kit_video: ^2.0.1
+  package_info_plus: ^8.0.0
   pasteboard: ^0.5.0
   path: ^1.9.1
   path_provider: ^2.1.5
   permission_handler: ^11.4.0
   provider: ^6.1.2
+  pub_semver: ^2.1.4
   record: ^6.2.0
   scrollable_positioned_list: ^0.3.8
   shared_preferences: ^2.3.4

--- a/test/services/preferences_service_test.dart
+++ b/test/services/preferences_service_test.dart
@@ -1,6 +1,14 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/services/preferences_service.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+PackageInfo _fakePackageInfo(String version) => PackageInfo(
+      appName: 'kohera',
+      packageName: 'app.kohera',
+      version: version,
+      buildNumber: '1',
+    );
 
 void main() {
   late PreferencesService prefs;
@@ -438,6 +446,114 @@ void main() {
       expect(MobileTab.inbox.label, 'Inbox');
       expect(MobileTab.chats.label, 'Chats');
       expect(MobileTab.you.label, 'You');
+    });
+  });
+
+  group('version bump detection', () {
+    test('fresh install marks current as seen and reports no bump', () async {
+      SharedPreferences.setMockInitialValues({});
+      final sp = await SharedPreferences.getInstance();
+      final svc = PreferencesService(
+        prefs: sp,
+        packageInfo: _fakePackageInfo('1.4.0'),
+      );
+      await svc.init();
+
+      expect(svc.currentVersion, '1.4.0');
+      expect(svc.lastSeenVersion, '1.4.0');
+      expect(svc.hasVersionBumped, isFalse);
+    });
+
+    test('upgrade flags bump until dismissed', () async {
+      SharedPreferences.setMockInitialValues({'last_seen_version': '1.0.0'});
+      final sp = await SharedPreferences.getInstance();
+      final svc = PreferencesService(
+        prefs: sp,
+        packageInfo: _fakePackageInfo('1.4.0'),
+      );
+      await svc.init();
+
+      expect(svc.lastSeenVersion, '1.0.0');
+      expect(svc.hasVersionBumped, isTrue);
+
+      await svc.markVersionSeen('1.4.0');
+      expect(svc.lastSeenVersion, '1.4.0');
+      expect(svc.hasVersionBumped, isFalse);
+    });
+
+    test('same version reports no bump', () async {
+      SharedPreferences.setMockInitialValues({'last_seen_version': '1.4.0'});
+      final sp = await SharedPreferences.getInstance();
+      final svc = PreferencesService(
+        prefs: sp,
+        packageInfo: _fakePackageInfo('1.4.0'),
+      );
+      await svc.init();
+      expect(svc.hasVersionBumped, isFalse);
+    });
+
+    test('downgrade reports no bump', () async {
+      SharedPreferences.setMockInitialValues({'last_seen_version': '1.4.0'});
+      final sp = await SharedPreferences.getInstance();
+      final svc = PreferencesService(
+        prefs: sp,
+        packageInfo: _fakePackageInfo('1.0.0'),
+      );
+      await svc.init();
+      expect(svc.hasVersionBumped, isFalse);
+    });
+
+    test('pre-release suffix: beta -> stable is a bump', () async {
+      SharedPreferences.setMockInitialValues(
+        {'last_seen_version': '1.4.0-beta'},
+      );
+      final sp = await SharedPreferences.getInstance();
+      final svc = PreferencesService(
+        prefs: sp,
+        packageInfo: _fakePackageInfo('1.4.0'),
+      );
+      await svc.init();
+      expect(svc.hasVersionBumped, isTrue);
+    });
+
+    test('pre-release suffix: stable -> beta is not a bump', () async {
+      SharedPreferences.setMockInitialValues({'last_seen_version': '1.4.0'});
+      final sp = await SharedPreferences.getInstance();
+      final svc = PreferencesService(
+        prefs: sp,
+        packageInfo: _fakePackageInfo('1.4.0-beta'),
+      );
+      await svc.init();
+      expect(svc.hasVersionBumped, isFalse);
+    });
+
+    test('markVersionSeen notifies listeners', () async {
+      SharedPreferences.setMockInitialValues({'last_seen_version': '1.0.0'});
+      final sp = await SharedPreferences.getInstance();
+      final svc = PreferencesService(
+        prefs: sp,
+        packageInfo: _fakePackageInfo('1.4.0'),
+      );
+      await svc.init();
+
+      var notified = false;
+      svc.addListener(() => notified = true);
+      await svc.markVersionSeen('1.4.0');
+      expect(notified, isTrue);
+    });
+
+    test('malformed stored version does not throw and reports no bump',
+        () async {
+      SharedPreferences.setMockInitialValues(
+        {'last_seen_version': 'not-a-version'},
+      );
+      final sp = await SharedPreferences.getInstance();
+      final svc = PreferencesService(
+        prefs: sp,
+        packageInfo: _fakePackageInfo('1.4.0'),
+      );
+      await svc.init();
+      expect(svc.hasVersionBumped, isFalse);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Adds `lastSeenVersion`, `currentVersion`, `hasVersionBumped`, and `markVersionSeen` to `PreferencesService`, persisted via `SharedPreferences`.
- `init()` fetches the runtime version with `package_info_plus` and auto-marks it on fresh installs so the upcoming banner doesn't show on first launch.
- Uses `pub_semver` so pre-release suffixes compare per spec (e.g. `1.4.0-beta < 1.4.0`); downgrades and malformed input never flag a bump.

Foundation for the "What's new" banner. Closes #387, part of #386.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test test/services/preferences_service_test.dart` — 8 new cases (fresh install, upgrade/dismiss, same version, downgrade, pre-release in both directions, listener notification, malformed input) pass alongside existing 77
- [ ] Manual smoke on Linux once a downstream banner consumer lands