### PR TITLE
feat(whats-new): GitHub Releases API client with on-disk cache

### DIFF
--- a/lib/core/services/github_releases_service.dart
+++ b/lib/core/services/github_releases_service.dart
@@ -1,0 +1,222 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+// ── Release notes data model ─────────────────────────────────
+
+class ReleaseNotes {
+  ReleaseNotes({
+    required this.tagName,
+    required this.name,
+    required this.body,
+    required this.publishedAt,
+    required this.htmlUrl,
+    required this.fetchedAt,
+    this.etag,
+  });
+
+  final String tagName;
+  final String name;
+  final String body;
+  final DateTime publishedAt;
+  final String htmlUrl;
+  final DateTime fetchedAt;
+  final String? etag;
+
+  factory ReleaseNotes.fromGitHubJson(
+    Map<String, dynamic> json, {
+    required DateTime fetchedAt,
+    String? etag,
+  }) {
+    return ReleaseNotes(
+      tagName: json['tag_name'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      body: json['body'] as String? ?? '',
+      publishedAt:
+          DateTime.tryParse(json['published_at'] as String? ?? '') ??
+              fetchedAt,
+      htmlUrl: json['html_url'] as String? ?? '',
+      fetchedAt: fetchedAt,
+      etag: etag,
+    );
+  }
+
+  Map<String, dynamic> toCacheJson() => {
+        'tag_name': tagName,
+        'name': name,
+        'body': body,
+        'published_at': publishedAt.toIso8601String(),
+        'html_url': htmlUrl,
+        'fetched_at': fetchedAt.toIso8601String(),
+        if (etag != null) 'etag': etag,
+      };
+
+  factory ReleaseNotes.fromCacheJson(Map<String, dynamic> json) {
+    return ReleaseNotes(
+      tagName: json['tag_name'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      body: json['body'] as String? ?? '',
+      publishedAt:
+          DateTime.tryParse(json['published_at'] as String? ?? '') ??
+              DateTime.fromMillisecondsSinceEpoch(0),
+      htmlUrl: json['html_url'] as String? ?? '',
+      fetchedAt:
+          DateTime.tryParse(json['fetched_at'] as String? ?? '') ??
+              DateTime.fromMillisecondsSinceEpoch(0),
+      etag: json['etag'] as String?,
+    );
+  }
+
+  ReleaseNotes copyWith({DateTime? fetchedAt, String? etag}) => ReleaseNotes(
+        tagName: tagName,
+        name: name,
+        body: body,
+        publishedAt: publishedAt,
+        htmlUrl: htmlUrl,
+        fetchedAt: fetchedAt ?? this.fetchedAt,
+        etag: etag ?? this.etag,
+      );
+}
+
+// ── Service ──────────────────────────────────────────────────
+
+typedef CacheDirProvider = Future<Directory> Function();
+
+/// Fetches the latest release notes from the Kohera GitHub repository,
+/// with on-disk caching and ETag-based revalidation.
+class GitHubReleasesService {
+  GitHubReleasesService({
+    http.Client? client,
+    CacheDirProvider? cacheDirProvider,
+    Uri? endpoint,
+    Duration? cacheTtl,
+    Duration? requestTimeout,
+  })  : _client = client ?? http.Client(),
+        _cacheDirProvider = cacheDirProvider ?? getApplicationSupportDirectory,
+        _endpoint = endpoint ?? _defaultEndpoint,
+        _cacheTtl = cacheTtl ?? const Duration(hours: 6),
+        _requestTimeout = requestTimeout ?? const Duration(seconds: 10);
+
+  static final Uri _defaultEndpoint = Uri.parse(
+    'https://api.github.com/repos/Quantumheart/Kohera/releases/latest',
+  );
+  static const _cacheFileName = 'whats_new_cache.json';
+
+  final http.Client _client;
+  final CacheDirProvider _cacheDirProvider;
+  final Uri _endpoint;
+  final Duration _cacheTtl;
+  final Duration _requestTimeout;
+
+  ReleaseNotes? _memoryCache;
+  Future<ReleaseNotes?>? _inFlight;
+  bool _disposed = false;
+
+  void dispose() {
+    _disposed = true;
+    _client.close();
+  }
+
+  /// Returns the latest release. Prefers cache within [_cacheTtl].
+  /// On expiry, revalidates with `If-None-Match` and falls back to cache
+  /// on network errors.
+  Future<ReleaseNotes?> fetchLatest({bool forceRefresh = false}) {
+    if (_disposed) return Future<ReleaseNotes?>.value();
+    return _inFlight ??= _fetchLatest(forceRefresh: forceRefresh)
+        .whenComplete(() => _inFlight = null);
+  }
+
+  /// Reads the cached release without touching the network.
+  Future<ReleaseNotes?> getCached() async {
+    if (_memoryCache != null) return _memoryCache;
+    return _readDiskCache();
+  }
+
+  Future<ReleaseNotes?> _fetchLatest({required bool forceRefresh}) async {
+    final cached = await getCached();
+    if (!forceRefresh && cached != null && _isFresh(cached)) {
+      return cached;
+    }
+
+    try {
+      final headers = <String, String>{
+        'Accept': 'application/vnd.github+json',
+        'User-Agent': 'Kohera (Flutter Matrix client)',
+        'X-GitHub-Api-Version': '2022-11-28',
+      };
+      if (cached?.etag != null) {
+        headers['If-None-Match'] = cached!.etag!;
+      }
+
+      final response =
+          await _client.get(_endpoint, headers: headers).timeout(_requestTimeout);
+
+      if (response.statusCode == 304 && cached != null) {
+        final refreshed = cached.copyWith(fetchedAt: DateTime.now());
+        await _writeDiskCache(refreshed);
+        _memoryCache = refreshed;
+        return refreshed;
+      }
+
+      if (response.statusCode == 200) {
+        final json = jsonDecode(response.body) as Map<String, dynamic>;
+        final etag = response.headers['etag'];
+        final notes = ReleaseNotes.fromGitHubJson(
+          json,
+          fetchedAt: DateTime.now(),
+          etag: etag,
+        );
+        await _writeDiskCache(notes);
+        _memoryCache = notes;
+        return notes;
+      }
+
+      debugPrint(
+        '[Kohera] GitHub releases fetch returned ${response.statusCode}',
+      );
+      return cached;
+    } catch (e) {
+      debugPrint('[Kohera] GitHub releases fetch failed: $e');
+      return cached;
+    }
+  }
+
+  bool _isFresh(ReleaseNotes notes) =>
+      DateTime.now().difference(notes.fetchedAt) < _cacheTtl;
+
+  Future<File> _cacheFile() async {
+    final dir = await _cacheDirProvider();
+    return File(p.join(dir.path, _cacheFileName));
+  }
+
+  Future<ReleaseNotes?> _readDiskCache() async {
+    try {
+      final file = await _cacheFile();
+      if (!file.existsSync()) return null;
+      final contents = await file.readAsString();
+      if (contents.isEmpty) return null;
+      final json = jsonDecode(contents) as Map<String, dynamic>;
+      final notes = ReleaseNotes.fromCacheJson(json);
+      _memoryCache = notes;
+      return notes;
+    } catch (e) {
+      debugPrint('[Kohera] GitHub releases cache read failed: $e');
+      return null;
+    }
+  }
+
+  Future<void> _writeDiskCache(ReleaseNotes notes) async {
+    try {
+      final file = await _cacheFile();
+      await file.parent.create(recursive: true);
+      await file.writeAsString(jsonEncode(notes.toCacheJson()));
+    } catch (e) {
+      debugPrint('[Kohera] GitHub releases cache write failed: $e');
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:kohera/core/routing/app_router.dart';
 import 'package:kohera/core/services/app_config.dart';
 import 'package:kohera/core/services/call_service.dart';
 import 'package:kohera/core/services/client_manager.dart';
+import 'package:kohera/core/services/github_releases_service.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart';
@@ -137,6 +138,10 @@ class _KoheraAppState extends State<KoheraApp> {
         ChangeNotifierProvider(create: (_) => MediaPlaybackService()),
         Provider(
           create: (_) => OpenGraphService(),
+          dispose: (_, service) => service.dispose(),
+        ),
+        Provider(
+          create: (_) => GitHubReleasesService(),
           dispose: (_, service) => service.dispose(),
         ),
       ],

--- a/test/services/github_releases_service_test.dart
+++ b/test/services/github_releases_service_test.dart
@@ -1,0 +1,238 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:kohera/core/services/github_releases_service.dart';
+import 'package:path/path.dart' as p;
+
+const _sampleBody = r'''
+{
+  "tag_name": "v1.4.0",
+  "name": "Kohera 1.4.0",
+  "body": "## What's new\n- Faster sync\n- Bug fixes",
+  "published_at": "2026-05-01T12:00:00Z",
+  "html_url": "https://github.com/Quantumheart/Kohera/releases/tag/v1.4.0"
+}
+''';
+
+GitHubReleasesService _service({
+  required Directory cacheDir,
+  required MockClientHandler handler,
+  Duration? cacheTtl,
+}) {
+  return GitHubReleasesService(
+    client: MockClient(handler),
+    cacheDirProvider: () async => cacheDir,
+    cacheTtl: cacheTtl ?? const Duration(hours: 6),
+  );
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('kohera_releases_test_');
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  test('first call hits network and persists to cache', () async {
+    var calls = 0;
+    final svc = _service(
+      cacheDir: tempDir,
+      handler: (request) async {
+        calls++;
+        return http.Response(
+          _sampleBody,
+          200,
+          headers: {'etag': 'W/"abc123"'},
+        );
+      },
+    );
+
+    final notes = await svc.fetchLatest();
+    expect(calls, 1);
+    expect(notes, isNotNull);
+    expect(notes!.tagName, 'v1.4.0');
+    expect(notes.name, 'Kohera 1.4.0');
+    expect(notes.body, contains('Faster sync'));
+    expect(notes.htmlUrl, contains('Quantumheart/Kohera'));
+    expect(notes.etag, 'W/"abc123"');
+
+    final cacheFile = File(p.join(tempDir.path, 'whats_new_cache.json'));
+    expect(cacheFile.existsSync(), isTrue);
+  });
+
+  test('second call within TTL returns cached value without hitting network',
+      () async {
+    var calls = 0;
+    final svc = _service(
+      cacheDir: tempDir,
+      handler: (request) async {
+        calls++;
+        return http.Response(_sampleBody, 200);
+      },
+    );
+
+    await svc.fetchLatest();
+    await svc.fetchLatest();
+    await svc.fetchLatest();
+
+    expect(calls, 1);
+  });
+
+  test('expired cache triggers revalidation with If-None-Match header',
+      () async {
+    var calls = 0;
+    String? sentIfNoneMatch;
+    final svc = _service(
+      cacheDir: tempDir,
+      cacheTtl: Duration.zero,
+      handler: (request) async {
+        calls++;
+        sentIfNoneMatch = request.headers['If-None-Match'];
+        if (calls == 1) {
+          return http.Response(
+            _sampleBody,
+            200,
+            headers: {'etag': 'W/"abc123"'},
+          );
+        }
+        return http.Response('', 304);
+      },
+    );
+
+    final first = await svc.fetchLatest();
+    final second = await svc.fetchLatest();
+
+    expect(calls, 2);
+    expect(sentIfNoneMatch, 'W/"abc123"');
+    expect(second, isNotNull);
+    expect(second!.tagName, first!.tagName);
+    expect(second.body, first.body);
+    expect(second.fetchedAt.isAfter(first.fetchedAt), isTrue);
+  });
+
+  test('forceRefresh bypasses fresh cache', () async {
+    var calls = 0;
+    final svc = _service(
+      cacheDir: tempDir,
+      handler: (request) async {
+        calls++;
+        return http.Response(_sampleBody, 200);
+      },
+    );
+
+    await svc.fetchLatest();
+    await svc.fetchLatest(forceRefresh: true);
+    expect(calls, 2);
+  });
+
+  test('network error returns cached value if present', () async {
+    var calls = 0;
+    final svc = _service(
+      cacheDir: tempDir,
+      cacheTtl: Duration.zero,
+      handler: (request) async {
+        calls++;
+        if (calls == 1) {
+          return http.Response(_sampleBody, 200);
+        }
+        throw const SocketException('offline');
+      },
+    );
+
+    final first = await svc.fetchLatest();
+    final second = await svc.fetchLatest();
+
+    expect(first, isNotNull);
+    expect(second, isNotNull);
+    expect(second!.tagName, 'v1.4.0');
+  });
+
+  test('non-200, non-304 response returns cached value', () async {
+    var calls = 0;
+    final svc = _service(
+      cacheDir: tempDir,
+      cacheTtl: Duration.zero,
+      handler: (request) async {
+        calls++;
+        if (calls == 1) {
+          return http.Response(_sampleBody, 200);
+        }
+        return http.Response('rate limited', 403);
+      },
+    );
+
+    await svc.fetchLatest();
+    final second = await svc.fetchLatest();
+    expect(second, isNotNull);
+    expect(second!.tagName, 'v1.4.0');
+  });
+
+  test('getCached reads disk without hitting network', () async {
+    var calls = 0;
+    final svc = _service(
+      cacheDir: tempDir,
+      handler: (request) async {
+        calls++;
+        return http.Response(_sampleBody, 200);
+      },
+    );
+    await svc.fetchLatest();
+
+    final fresh = _service(
+      cacheDir: tempDir,
+      handler: (request) async {
+        calls++;
+        return http.Response('should not be called', 500);
+      },
+    );
+
+    final cached = await fresh.getCached();
+    expect(cached, isNotNull);
+    expect(cached!.tagName, 'v1.4.0');
+    expect(calls, 1);
+  });
+
+  test('concurrent fetchLatest calls coalesce to a single request', () async {
+    var calls = 0;
+    final svc = _service(
+      cacheDir: tempDir,
+      handler: (request) async {
+        calls++;
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        return http.Response(_sampleBody, 200);
+      },
+    );
+
+    final results = await Future.wait([
+      svc.fetchLatest(),
+      svc.fetchLatest(),
+      svc.fetchLatest(),
+    ]);
+
+    expect(calls, 1);
+    expect(results.every((r) => r != null), isTrue);
+  });
+
+  test('malformed cache file does not throw', () async {
+    final cacheFile = File(p.join(tempDir.path, 'whats_new_cache.json'))
+      ..writeAsStringSync('{not json');
+
+    final svc = _service(
+      cacheDir: tempDir,
+      handler: (request) async => http.Response(_sampleBody, 200),
+    );
+
+    final cached = await svc.getCached();
+    expect(cached, isNull);
+
+    final notes = await svc.fetchLatest();
+    expect(notes, isNotNull);
+    expect(cacheFile.existsSync(), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `GitHubReleasesService` that fetches `releases/latest` from `Quantumheart/Kohera`, parses `tag_name`/`name`/`body`/`published_at`/`html_url`, and caches to `whats_new_cache.json` in the application support directory.
- Revalidates with `If-None-Match` once the 6h TTL elapses; on `304` the cached copy stays and `fetched_at` is bumped.
- Network errors, timeouts, and non-2xx responses fall back to the cached copy — UI never crashes on fetch failure. Concurrent `fetchLatest()` calls coalesce to one in-flight request.
- Wired as a `Provider` in `main.dart` next to `OpenGraphService`. The banner widget (separate sub-issue) can `context.read<GitHubReleasesService>()` it.

Closes #388, part of #386.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test test/services/github_releases_service_test.dart` — 9 cases pass: cold fetch + persist, TTL hit, ETag revalidate (200 → 304 cycle), `forceRefresh`, network error fallback, 4xx fallback, `getCached` disk read, concurrent coalescing, malformed cache file
- [ ] Manual verification deferred to the banner widget sub-issue, which is what actually surfaces this data