### PR TITLE
feat(whats-new): add release notes markdown renderer

### DIFF
--- a/lib/features/whats_new/widgets/release_notes_markdown.dart
+++ b/lib/features/whats_new/widgets/release_notes_markdown.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+typedef LinkLauncher = Future<bool> Function(Uri uri);
+
+/// Renders the markdown `body` of a GitHub release using Material You theming.
+///
+/// Headings, lists, inline code, code blocks, bold/italic, and links are
+/// supported. Links open in the platform's external browser by default.
+class ReleaseNotesMarkdown extends StatelessWidget {
+  const ReleaseNotesMarkdown({
+    required this.data,
+    super.key,
+    this.shrinkWrap = true,
+    this.padding = EdgeInsets.zero,
+    @visibleForTesting this.linkLauncher,
+  });
+
+  final String data;
+  final bool shrinkWrap;
+  final EdgeInsets padding;
+
+  /// Test seam — overrides the default `url_launcher` call.
+  final LinkLauncher? linkLauncher;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return MarkdownBody(
+      data: data,
+      shrinkWrap: shrinkWrap,
+      selectable: true,
+      onTapLink: (text, href, title) {
+        if (href == null) return;
+        final uri = Uri.tryParse(href);
+        if (uri == null) return;
+        final launcher = linkLauncher ??
+            (u) => launchUrl(u, mode: LaunchMode.externalApplication);
+        unawaited(launcher(uri));
+      },
+      styleSheet: _styleSheetFor(theme).copyWith(
+        textScaler: MediaQuery.textScalerOf(context),
+      ),
+    );
+  }
+}
+
+MarkdownStyleSheet _styleSheetFor(ThemeData theme) {
+  final colors = theme.colorScheme;
+  final text = theme.textTheme;
+  final codeBg = colors.surfaceContainerHighest;
+  final codeStyle = (text.bodyMedium ?? const TextStyle()).copyWith(
+    fontFamily: 'monospace',
+    color: colors.onSurface,
+    backgroundColor: codeBg,
+  );
+
+  return MarkdownStyleSheet.fromTheme(theme).copyWith(
+    a: TextStyle(
+      color: colors.primary,
+      decoration: TextDecoration.underline,
+      decorationColor: colors.primary,
+    ),
+    p: text.bodyMedium,
+    h1: text.headlineSmall?.copyWith(fontWeight: FontWeight.w600),
+    h2: text.titleLarge?.copyWith(fontWeight: FontWeight.w600),
+    h3: text.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+    h4: text.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+    code: codeStyle,
+    codeblockDecoration: BoxDecoration(
+      color: codeBg,
+      borderRadius: BorderRadius.circular(8),
+    ),
+    codeblockPadding: const EdgeInsets.all(12),
+    blockquote: text.bodyMedium?.copyWith(
+      color: colors.onSurfaceVariant,
+      fontStyle: FontStyle.italic,
+    ),
+    blockquoteDecoration: BoxDecoration(
+      border: Border(
+        left: BorderSide(color: colors.outlineVariant, width: 4),
+      ),
+    ),
+    blockquotePadding: const EdgeInsets.only(left: 12, top: 4, bottom: 4),
+    listBullet: text.bodyMedium,
+  );
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -528,6 +528,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_markdown_plus:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown_plus
+      sha256: "039177906850278e8fb1cd364115ee0a46281135932fa8ecea8455522166d2de"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.7"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -905,10 +913,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1670,18 +1678,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.16"
   timezone:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   flutter_background: ^1.0.0
   flutter_callkit_incoming: ^3.0.0
   flutter_local_notifications: ^21.0.0
+  flutter_markdown_plus: ^1.0.3
   flutter_secure_storage: ^10.0.0
   flutter_vodozemac: ^0.5.0
   flutter_webrtc: ^1.3.0

--- a/test/features/whats_new/release_notes_markdown_test.dart
+++ b/test/features/whats_new/release_notes_markdown_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/features/whats_new/widgets/release_notes_markdown.dart';
+
+const _sample = '''
+# Kohera 1.4.0
+
+Some intro paragraph with **bold** and *italic*.
+
+## Highlights
+
+- Faster sync
+- Bug fixes
+- `inline code` works
+
+```dart
+final x = 42;
+```
+
+[Release page](https://github.com/Quantumheart/Kohera/releases/tag/v1.4.0)
+''';
+
+Widget _harness(Widget child, {ThemeMode mode = ThemeMode.light}) {
+  return MaterialApp(
+    theme: ThemeData.light(useMaterial3: true),
+    darkTheme: ThemeData.dark(useMaterial3: true),
+    themeMode: mode,
+    home: Scaffold(
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: child,
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('renders sample release body without overflow', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(400, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(_harness(const ReleaseNotesMarkdown(data: _sample)));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Kohera 1.4.0'), findsWidgets);
+    expect(find.textContaining('Faster sync'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('renders in dark theme without exceptions', (tester) async {
+    await tester.pumpWidget(
+      _harness(
+        const ReleaseNotesMarkdown(data: _sample),
+        mode: ThemeMode.dark,
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('tapping a link invokes the launcher with the parsed Uri',
+      (tester) async {
+    Uri? launched;
+    await tester.pumpWidget(
+      _harness(
+        ReleaseNotesMarkdown(
+          data: _sample,
+          linkLauncher: (uri) async {
+            launched = uri;
+            return true;
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Release page'));
+    await tester.pump();
+
+    expect(launched, isNotNull);
+    expect(launched!.host, 'github.com');
+    expect(launched!.path, contains('Quantumheart/Kohera'));
+  });
+
+  testWidgets('empty markdown renders nothing and does not throw',
+      (tester) async {
+    await tester
+        .pumpWidget(_harness(const ReleaseNotesMarkdown(data: '')));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `ReleaseNotesMarkdown` (`lib/features/whats_new/widgets/release_notes_markdown.dart`) — a Material You-themed wrapper around `flutter_markdown_plus` that the upcoming detail page will use to render GitHub release bodies.
- Style sheet derives from the ambient `ThemeData`, so headings, code blocks, blockquotes, and links update on light/dark switch.
- Link taps default to `launchUrl(uri, mode: LaunchMode.externalApplication)`; a `@visibleForTesting` `linkLauncher` seam lets widget tests assert the parsed `Uri` without hitting `url_launcher`.
- Adds `flutter_markdown_plus` (the maintained fork of the now-archived `flutter_markdown`) as the dependency.

Closes #389, part of #386.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test test/features/whats_new/release_notes_markdown_test.dart` — 4 cases pass: sample body renders without overflow on a 400×800 surface, dark theme renders cleanly, link tap forwards parsed Uri to the launcher, empty markdown is a no-op
- [ ] Manual theme-switch + scroll smoke deferred to the detail page sub-issue, which is the first real consumer