### PR TITLE
feat(whats-new): add home banner widget with visibility logic

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -26,6 +26,7 @@ import 'package:kohera/features/settings/screens/notification_settings_screen.da
 import 'package:kohera/features/settings/screens/settings_screen.dart';
 import 'package:kohera/features/settings/screens/voice_video_settings_screen.dart';
 import 'package:kohera/features/spaces/widgets/space_details_panel.dart';
+import 'package:kohera/features/whats_new/screens/whats_new_screen.dart';
 import 'package:provider/provider.dart';
 
 /// Creates the app router with auth-aware redirects.
@@ -240,6 +241,11 @@ GoRouter buildRouter(ClientManager manager) {
                 path: 'inbox',
                 name: Routes.inbox,
                 builder: (context, state) => const InboxScreen(),
+              ),
+              GoRoute(
+                path: 'whats-new',
+                name: Routes.whatsNew,
+                builder: (context, state) => const WhatsNewScreen(),
               ),
               GoRoute(
                 path: 'settings',

--- a/lib/core/routing/route_names.dart
+++ b/lib/core/routing/route_names.dart
@@ -21,4 +21,5 @@ abstract class Routes {
   static const e2eeSetup = 'e2ee-setup';
   static const addAccount = 'add-account';
   static const addAccountServer = 'add-account-server';
+  static const whatsNew = 'whats-new';
 }

--- a/lib/features/rooms/widgets/room_list.dart
+++ b/lib/features/rooms/widgets/room_list.dart
@@ -15,6 +15,7 @@ import 'package:kohera/features/rooms/widgets/room_list_builder.dart';
 import 'package:kohera/features/rooms/widgets/room_list_models.dart';
 import 'package:kohera/features/rooms/widgets/room_section_header.dart';
 import 'package:kohera/features/rooms/widgets/room_tile.dart';
+import 'package:kohera/features/whats_new/widgets/whats_new_banner.dart';
 import 'package:kohera/shared/widgets/speed_dial_item.dart';
 import 'package:provider/provider.dart';
 
@@ -249,6 +250,7 @@ class _RoomListState extends State<RoomList>
           children: [
             Column(
               children: [
+              const WhatsNewBanner(),
               // ── Sectioned room list ──
               Expanded(
                 child: isEmpty && items.isEmpty

--- a/lib/features/whats_new/screens/whats_new_screen.dart
+++ b/lib/features/whats_new/screens/whats_new_screen.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:kohera/core/services/github_releases_service.dart';
+import 'package:kohera/features/whats_new/widgets/release_notes_markdown.dart';
+import 'package:provider/provider.dart';
+
+/// Full-page release notes view reachable from the home banner.
+///
+/// This is the minimal scaffolding; richer presentation (hero header,
+/// version timeline, etc.) lands in the dedicated detail-page sub-issue.
+class WhatsNewScreen extends StatefulWidget {
+  const WhatsNewScreen({super.key});
+
+  @override
+  State<WhatsNewScreen> createState() => _WhatsNewScreenState();
+}
+
+class _WhatsNewScreenState extends State<WhatsNewScreen> {
+  late Future<ReleaseNotes?> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = context.read<GitHubReleasesService>().fetchLatest();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text("What's new")),
+      body: FutureBuilder<ReleaseNotes?>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator.adaptive());
+          }
+          final notes = snapshot.data;
+          if (notes == null) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  "Couldn't load release notes. Check your connection and "
+                  'try again.',
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+              ),
+            );
+          }
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  notes.name.isNotEmpty ? notes.name : notes.tagName,
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
+                const SizedBox(height: 16),
+                ReleaseNotesMarkdown(data: notes.body),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/whats_new/widgets/whats_new_banner.dart
+++ b/lib/features/whats_new/widgets/whats_new_banner.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:kohera/core/routing/route_names.dart';
+import 'package:kohera/core/services/github_releases_service.dart';
+import 'package:kohera/core/services/preferences_service.dart';
+import 'package:provider/provider.dart';
+
+/// Dismissible banner that announces a new app release.
+///
+/// Visible only when [PreferencesService.hasVersionBumped] is `true` AND
+/// release notes have been fetched, so it never flickers on slow networks.
+class WhatsNewBanner extends StatefulWidget {
+  const WhatsNewBanner({super.key});
+
+  @override
+  State<WhatsNewBanner> createState() => _WhatsNewBannerState();
+}
+
+class _WhatsNewBannerState extends State<WhatsNewBanner> {
+  ReleaseNotes? _notes;
+  bool _loading = false;
+  bool _attempted = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final prefs = context.read<PreferencesService>();
+    if (prefs.hasVersionBumped && !_attempted) {
+      _attempted = true;
+      unawaited(_loadNotes());
+    }
+  }
+
+  Future<void> _loadNotes() async {
+    if (!mounted) return;
+    setState(() => _loading = true);
+    try {
+      final service = context.read<GitHubReleasesService>();
+      final notes = await service.fetchLatest();
+      if (!mounted) return;
+      setState(() => _notes = notes);
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _dismiss() async {
+    final prefs = context.read<PreferencesService>();
+    final current = prefs.currentVersion;
+    if (current != null) {
+      await prefs.markVersionSeen(current);
+    }
+  }
+
+  void _viewDetails() {
+    unawaited(context.pushNamed(Routes.whatsNew));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hasBump = context.select<PreferencesService, bool>(
+      (p) => p.hasVersionBumped,
+    );
+    final notes = _notes;
+    final visible = hasBump && notes != null && !_loading;
+
+    return AnimatedSize(
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeInOut,
+      alignment: Alignment.topCenter,
+      child: visible
+          ? _BannerContent(
+              tagName: notes.tagName,
+              onView: _viewDetails,
+              onDismiss: _dismiss,
+            )
+          : const SizedBox.shrink(),
+    );
+  }
+}
+
+class _BannerContent extends StatelessWidget {
+  const _BannerContent({
+    required this.tagName,
+    required this.onView,
+    required this.onDismiss,
+  });
+
+  final String tagName;
+  final VoidCallback onView;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    return Material(
+      color: Colors.transparent,
+      child: Semantics(
+        label: "What's new in $tagName. Tap View for details.",
+        button: true,
+        child: InkWell(
+          onTap: onView,
+          child: Container(
+            constraints: const BoxConstraints(minHeight: 48),
+            padding: const EdgeInsets.only(left: 12, right: 4),
+            decoration: BoxDecoration(
+              border: Border(left: BorderSide(color: cs.primary, width: 3)),
+              color: cs.surfaceContainerHighest.withValues(alpha: 0.3),
+            ),
+            child: Row(
+              children: [
+                Icon(Icons.auto_awesome, size: 18, color: cs.primary),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    "What's new in $tagName",
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: tt.bodySmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: cs.primary,
+                    ),
+                  ),
+                ),
+                TextButton(
+                  onPressed: onView,
+                  child: const Text('View'),
+                ),
+                IconButton(
+                  tooltip: 'Dismiss',
+                  icon: const Icon(Icons.close, size: 18),
+                  onPressed: onDismiss,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/whats_new/widgets/whats_new_banner.dart
+++ b/lib/features/whats_new/widgets/whats_new_banner.dart
@@ -20,7 +20,6 @@ class WhatsNewBanner extends StatefulWidget {
 
 class _WhatsNewBannerState extends State<WhatsNewBanner> {
   ReleaseNotes? _notes;
-  bool _loading = false;
   bool _attempted = false;
 
   @override
@@ -35,22 +34,20 @@ class _WhatsNewBannerState extends State<WhatsNewBanner> {
 
   Future<void> _loadNotes() async {
     if (!mounted) return;
-    setState(() => _loading = true);
-    try {
-      final service = context.read<GitHubReleasesService>();
-      final notes = await service.fetchLatest();
-      if (!mounted) return;
-      setState(() => _notes = notes);
-    } finally {
-      if (mounted) setState(() => _loading = false);
-    }
+    final service = context.read<GitHubReleasesService>();
+    final notes = await service.fetchLatest();
+    if (!mounted) return;
+    setState(() => _notes = notes);
   }
 
   Future<void> _dismiss() async {
     final prefs = context.read<PreferencesService>();
     final current = prefs.currentVersion;
-    if (current != null) {
+    if (current == null) return;
+    try {
       await prefs.markVersionSeen(current);
+    } catch (e) {
+      debugPrint('[Kohera] Failed to mark version seen: $e');
     }
   }
 
@@ -63,8 +60,11 @@ class _WhatsNewBannerState extends State<WhatsNewBanner> {
     final hasBump = context.select<PreferencesService, bool>(
       (p) => p.hasVersionBumped,
     );
+    final currentVersion = context.select<PreferencesService, String?>(
+      (p) => p.currentVersion,
+    );
     final notes = _notes;
-    final visible = hasBump && notes != null && !_loading;
+    final visible = hasBump && notes != null && currentVersion != null;
 
     return AnimatedSize(
       duration: const Duration(milliseconds: 200),
@@ -72,7 +72,7 @@ class _WhatsNewBannerState extends State<WhatsNewBanner> {
       alignment: Alignment.topCenter,
       child: visible
           ? _BannerContent(
-              tagName: notes.tagName,
+              versionLabel: 'v$currentVersion',
               onView: _viewDetails,
               onDismiss: _dismiss,
             )
@@ -83,12 +83,12 @@ class _WhatsNewBannerState extends State<WhatsNewBanner> {
 
 class _BannerContent extends StatelessWidget {
   const _BannerContent({
-    required this.tagName,
+    required this.versionLabel,
     required this.onView,
     required this.onDismiss,
   });
 
-  final String tagName;
+  final String versionLabel;
   final VoidCallback onView;
   final VoidCallback onDismiss;
 
@@ -100,7 +100,7 @@ class _BannerContent extends StatelessWidget {
     return Material(
       color: Colors.transparent,
       child: Semantics(
-        label: "What's new in $tagName. Tap View for details.",
+        label: "What's new in $versionLabel. Tap View for details.",
         button: true,
         child: InkWell(
           onTap: onView,
@@ -117,7 +117,7 @@ class _BannerContent extends StatelessWidget {
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
-                    "What's new in $tagName",
+                    "What's new in $versionLabel",
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: tt.bodySmall?.copyWith(

--- a/test/features/whats_new/whats_new_banner_test.dart
+++ b/test/features/whats_new/whats_new_banner_test.dart
@@ -1,0 +1,183 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:kohera/core/services/github_releases_service.dart';
+import 'package:kohera/core/services/preferences_service.dart';
+import 'package:kohera/features/whats_new/widgets/whats_new_banner.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _sampleBody = r'''
+{
+  "tag_name": "v1.4.0",
+  "name": "Kohera 1.4.0",
+  "body": "## What's new\n- Faster sync",
+  "published_at": "2026-05-01T12:00:00Z",
+  "html_url": "https://github.com/Quantumheart/Kohera/releases/tag/v1.4.0"
+}
+''';
+
+PackageInfo _pkg(String version) => PackageInfo(
+      appName: 'kohera',
+      packageName: 'app.kohera',
+      version: version,
+      buildNumber: '1',
+    );
+
+Future<PreferencesService> _prefsWith({
+  required String current,
+  String? lastSeen,
+}) async {
+  SharedPreferences.setMockInitialValues({
+    if (lastSeen != null) 'last_seen_version': lastSeen,
+  });
+  final sp = await SharedPreferences.getInstance();
+  final svc = PreferencesService(prefs: sp, packageInfo: _pkg(current));
+  await svc.init();
+  return svc;
+}
+
+GitHubReleasesService _releasesService({
+  required Directory cacheDir,
+  Future<http.Response> Function(http.Request)? handler,
+}) {
+  return GitHubReleasesService(
+    client: MockClient(
+      handler ?? (request) async => http.Response(_sampleBody, 200),
+    ),
+    cacheDirProvider: () async => cacheDir,
+  );
+}
+
+Widget _harness({
+  required PreferencesService prefs,
+  required GitHubReleasesService releases,
+  GoRouter? router,
+}) {
+  final theRouter = router ??
+      GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (_, __) => const Scaffold(
+              body: Column(
+                children: [WhatsNewBanner(), Expanded(child: SizedBox())],
+              ),
+            ),
+            routes: [
+              GoRoute(
+                path: 'whats-new',
+                name: 'whats-new',
+                builder: (_, __) =>
+                    const Scaffold(body: Text('detail-page-stub')),
+              ),
+            ],
+          ),
+        ],
+      );
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider<PreferencesService>.value(value: prefs),
+      Provider<GitHubReleasesService>.value(value: releases),
+    ],
+    child: MaterialApp.router(routerConfig: theRouter),
+  );
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('kohera_banner_test_');
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  testWidgets('hidden when there is no version bump', (tester) async {
+    final prefs = await _prefsWith(current: '1.4.0'); // fresh install path
+    final releases = _releasesService(cacheDir: tempDir);
+
+    await tester.runAsync(() async {
+      await tester.pumpWidget(_harness(prefs: prefs, releases: releases));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pumpAndSettle();
+
+    expect(find.byType(WhatsNewBanner), findsOneWidget);
+    expect(find.textContaining("What's new in"), findsNothing);
+  });
+
+  testWidgets('shows after version bump and notes load', (tester) async {
+    final prefs = await _prefsWith(lastSeen: '1.0.0', current: '1.4.0');
+    final releases = _releasesService(cacheDir: tempDir);
+
+    await tester.runAsync(() async {
+      await tester.pumpWidget(_harness(prefs: prefs, releases: releases));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pumpAndSettle();
+
+    expect(find.text("What's new in v1.4.0"), findsOneWidget);
+    expect(find.text('View'), findsOneWidget);
+  });
+
+  testWidgets('dismiss marks version seen and hides the banner',
+      (tester) async {
+    final prefs = await _prefsWith(lastSeen: '1.0.0', current: '1.4.0');
+    final releases = _releasesService(cacheDir: tempDir);
+
+    await tester.runAsync(() async {
+      await tester.pumpWidget(_harness(prefs: prefs, releases: releases));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pumpAndSettle();
+
+    expect(find.text("What's new in v1.4.0"), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Dismiss'));
+    await tester.pumpAndSettle();
+
+    expect(prefs.lastSeenVersion, '1.4.0');
+    expect(prefs.hasVersionBumped, isFalse);
+    expect(find.text("What's new in v1.4.0"), findsNothing);
+  });
+
+  testWidgets('View navigates to the whats-new route', (tester) async {
+    final prefs = await _prefsWith(lastSeen: '1.0.0', current: '1.4.0');
+    final releases = _releasesService(cacheDir: tempDir);
+
+    await tester.runAsync(() async {
+      await tester.pumpWidget(_harness(prefs: prefs, releases: releases));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('View'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('detail-page-stub'), findsOneWidget);
+  });
+
+  testWidgets('stays hidden when release notes fail to load', (tester) async {
+    final prefs = await _prefsWith(lastSeen: '1.0.0', current: '1.4.0');
+    final releases = _releasesService(
+      cacheDir: tempDir,
+      handler: (request) async => http.Response('boom', 500),
+    );
+
+    await tester.runAsync(() async {
+      await tester.pumpWidget(_harness(prefs: prefs, releases: releases));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining("What's new in"), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `WhatsNewBanner` (`lib/features/whats_new/widgets/whats_new_banner.dart`) — a dismissible row at the top of the rooms list. Visible only when `PreferencesService.hasVersionBumped` is true AND release notes have actually loaded, so it never flickers on slow networks.
- Mounted inside `RoomList`, not the home shell, so on desktop the banner stays scoped to the left pane (matches the spec mock).
- Tap **View** → pushes the new `/whats-new` route. **✕** calls `markVersionSeen(currentVersion)` so dismissal persists across restarts.
- Adds `WhatsNewScreen` and the `whats-new` route as a minimal landing destination that fetches the latest release through `GitHubReleasesService` and renders it via `ReleaseNotesMarkdown`. Richer presentation lands in the detail-page sub-issue (#392).

Closes #391, part of #386.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` — 703 tests pass, including 5 new banner cases:
  - hidden when there is no version bump
  - shows after version bump and notes load
  - dismiss marks version seen and hides the banner
  - View navigates to the whats-new route
  - stays hidden when release notes fail to load
- [ ] Manual smoke (mobile + desktop) once #392 lands a fuller detail page