### PR TITLE
fix: stop CI hang in space discovery widget tests

### DIFF
--- a/lib/core/services/preferences_service.dart
+++ b/lib/core/services/preferences_service.dart
@@ -83,7 +83,13 @@ class PreferencesService extends ChangeNotifier {
   Future<void> init() async {
     _prefs ??= await SharedPreferences.getInstance();
     await _prefs?.remove('room_filter');
-    _packageInfo ??= await PackageInfo.fromPlatform();
+    if (_packageInfo == null) {
+      try {
+        _packageInfo = await PackageInfo.fromPlatform();
+      } on MissingPluginException {
+        _packageInfo = null;
+      }
+    }
     _currentVersion = _packageInfo?.version;
     if (_currentVersion != null && lastSeenVersion == null) {
       await _prefs?.setString(_lastSeenVersionKey, _currentVersion!);

--- a/test/widgets/space_discovery_server_test.dart
+++ b/test/widgets/space_discovery_server_test.dart
@@ -9,6 +9,7 @@ import 'package:matrix/matrix.dart';
 import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -52,8 +53,20 @@ void main() {
   late SelectionService selectionService;
   late PreferencesService prefsService;
 
-  Future<void> configureClient({required Uri homeserverUri}) async {
+  setUp(() async {
     SharedPreferences.setMockInitialValues({});
+    prefsService = PreferencesService(
+      packageInfo: PackageInfo(
+        appName: 'kohera',
+        packageName: 'kohera',
+        version: '0.0.0',
+        buildNumber: '0',
+      ),
+    );
+    await prefsService.init();
+  });
+
+  void configureClient({required Uri homeserverUri}) {
     mockClient = MockClient();
     mockMatrixService = MockMatrixService();
     when(mockMatrixService.client).thenReturn(mockClient);
@@ -62,8 +75,6 @@ void main() {
     when(mockClient.homeserver).thenReturn(homeserverUri);
     selectionService = SelectionService(client: mockClient);
     when(mockMatrixService.selection).thenReturn(selectionService);
-    prefsService = PreferencesService();
-    await prefsService.init();
   }
 
   Widget buildHarness(SpaceDiscoveryDataSource dataSource) {
@@ -97,7 +108,7 @@ void main() {
 
   testWidgets('switching to matrix.org queries it and resets cursor + search',
       (tester) async {
-    await configureClient(homeserverUri: Uri.parse('https://example.org'));
+    configureClient(homeserverUri: Uri.parse('https://example.org'));
     final ds = _SpyFakeDataSource();
     await tester.pumpWidget(buildHarness(ds));
     await openDialog(tester);
@@ -124,7 +135,7 @@ void main() {
   });
 
   testWidgets('federation failure shows server-named error', (tester) async {
-    await configureClient(homeserverUri: Uri.parse('https://example.org'));
+    configureClient(homeserverUri: Uri.parse('https://example.org'));
     final ds = _SpyFakeDataSource(failingServers: const {'matrix.org'});
     await tester.pumpWidget(buildHarness(ds));
     await openDialog(tester);
@@ -141,7 +152,7 @@ void main() {
 
   testWidgets('matrix.org user: own host shown without delete; defaults null',
       (tester) async {
-    await configureClient(homeserverUri: Uri.parse('https://matrix.org'));
+    configureClient(homeserverUri: Uri.parse('https://matrix.org'));
     final ds = _SpyFakeDataSource();
     await tester.pumpWidget(buildHarness(ds));
     await openDialog(tester);

--- a/test/widgets/space_discovery_servers_edit_test.dart
+++ b/test/widgets/space_discovery_servers_edit_test.dart
@@ -9,6 +9,7 @@ import 'package:matrix/matrix.dart';
 import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -47,7 +48,7 @@ void main() {
   late SelectionService selectionService;
   late PreferencesService prefsService;
 
-  Future<void> configure() async {
+  setUp(() async {
     SharedPreferences.setMockInitialValues({});
     mockClient = MockClient();
     mockMatrixService = MockMatrixService();
@@ -58,9 +59,16 @@ void main() {
         .thenReturn(Uri.parse('https://example.org'));
     selectionService = SelectionService(client: mockClient);
     when(mockMatrixService.selection).thenReturn(selectionService);
-    prefsService = PreferencesService();
+    prefsService = PreferencesService(
+      packageInfo: PackageInfo(
+        appName: 'kohera',
+        packageName: 'kohera',
+        version: '0.0.0',
+        buildNumber: '0',
+      ),
+    );
     await prefsService.init();
-  }
+  });
 
   Widget buildHarness(SpaceDiscoveryDataSource dataSource) {
     return MultiProvider(
@@ -93,7 +101,6 @@ void main() {
 
   testWidgets('add valid host: chip + prefs updated + query fires',
       (tester) async {
-    await configure();
     final ds = _SpyFakeDataSource();
     await tester.pumpWidget(buildHarness(ds));
     await openDialog(tester);
@@ -115,7 +122,6 @@ void main() {
 
   testWidgets('invalid host shows inline error and does not save',
       (tester) async {
-    await configure();
     final ds = _SpyFakeDataSource();
     await tester.pumpWidget(buildHarness(ds));
     await openDialog(tester);
@@ -136,7 +142,6 @@ void main() {
 
   testWidgets('remove non-default after confirm; selected falls back',
       (tester) async {
-    await configure();
     final ds = _SpyFakeDataSource();
     await tester.pumpWidget(buildHarness(ds));
     await openDialog(tester);
@@ -160,7 +165,6 @@ void main() {
   });
 
   testWidgets('own homeserver chip has no delete icon', (tester) async {
-    await configure();
     final ds = _SpyFakeDataSource();
     await tester.pumpWidget(buildHarness(ds));
     await openDialog(tester);
@@ -170,7 +174,6 @@ void main() {
   });
 
   testWidgets('rejects duplicate of existing server', (tester) async {
-    await configure();
     final ds = _SpyFakeDataSource();
     await tester.pumpWidget(buildHarness(ds));
     await openDialog(tester);
@@ -185,7 +188,6 @@ void main() {
   });
 
   testWidgets('rejects own homeserver as duplicate', (tester) async {
-    await configure();
     final ds = _SpyFakeDataSource();
     await tester.pumpWidget(buildHarness(ds));
     await openDialog(tester);


### PR DESCRIPTION
## Summary
- `PreferencesService.init()` calls `PackageInfo.fromPlatform()` (added in `0c1a34e`), which hits a platform channel with no test handler. In `testWidgets` fake-async zone the response never lands → 10-min `pumpAndSettle` watchdog fires.
- Catch `MissingPluginException` in `init()` so callers in real zones (e.g. `setUp`) recover.
- Move prefs setup to `setUp()` and inject a fake `PackageInfo` in `space_discovery_server_test.dart` and `space_discovery_servers_edit_test.dart` so `init()` never touches a platform channel from inside the fake-async zone.

## Test plan
- [x] `flutter test test/widgets/space_discovery_search_test.dart test/widgets/space_discovery_servers_edit_test.dart test/widgets/space_discovery_server_test.dart` — all 13 pass in ~2s.