### PR TITLE
feat(whats-new): add Settings entry for release notes

### DIFF
--- a/lib/features/home/widgets/narrow_layout.dart
+++ b/lib/features/home/widgets/narrow_layout.dart
@@ -61,7 +61,8 @@ class _NarrowLayoutState extends State<NarrowLayout> {
         name == Routes.settingsDevices ||
         name == Routes.settingsVoiceVideo ||
         name == Routes.settingsRecoveryKey ||
-        name == Routes.spaceDetails;
+        name == Routes.spaceDetails ||
+        name == Routes.whatsNew;
   }
 
   @override

--- a/lib/features/home/widgets/wide_layout.dart
+++ b/lib/features/home/widgets/wide_layout.dart
@@ -128,7 +128,8 @@ class _WideLayoutState extends State<WideLayout> {
         name == Routes.spaceDetails ||
         name == Routes.inbox ||
         name == Routes.roomThread ||
-        name == Routes.roomThreads) {
+        name == Routes.roomThreads ||
+        name == Routes.whatsNew) {
       return widget.routerChild;
     }
 

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -455,6 +455,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 ),
                 const Divider(height: 1, indent: 56),
                 _SettingsTile(
+                  icon: Icons.auto_awesome_outlined,
+                  title: "What's new",
+                  subtitle: prefs.currentVersion != null
+                      ? 'v${prefs.currentVersion}'
+                      : 'Latest release notes',
+                  onTap: () => context.pushNamed(Routes.whatsNew),
+                ),
+                const Divider(height: 1, indent: 56),
+                _SettingsTile(
                   icon: Icons.code_rounded,
                   title: 'Source code',
                   subtitle: 'View on GitHub',


### PR DESCRIPTION
## Summary
- New `_SettingsTile` in Settings → ABOUT, between "Kohera" and "Source code".
- Tap pushes `Routes.whatsNew` (same detail page as banner [View]).
- Subtitle reads `v${prefs.currentVersion}` (sourced from `PackageInfo.fromPlatform()`); falls back to "Latest release notes" before init.
- Icon: `Icons.auto_awesome_outlined` to mirror the ✨ used in the epic mocks.

Closes #393. Part of #386.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test test/e2e/settings_screen_test.dart` — 10/10 pass
- [x] Manual: Settings → ABOUT → "What's new" pushes detail page; back returns to Settings; subtitle matches `pubspec.yaml` version