### PR TITLE
test(whats-new): add detail page + settings tile widget tests

### DIFF
--- a/test/e2e/settings_screen_test.dart
+++ b/test/e2e/settings_screen_test.dart
@@ -241,7 +241,21 @@ void main() {
     });
   });
 
-  // ── Group 6: Add Account ──────────────────────────────────────
+  // ── Group 6: About section ────────────────────────────────────
+
+  group("Settings screen — what's new", () {
+    testWidgets('about section shows What\'s new tile', (tester) async {
+      await tester.pumpWidget(buildSettingsApp());
+      await tester.pumpAndSettle();
+      await scrollToBottom(tester);
+
+      expect(find.text('ABOUT'), findsOneWidget);
+      expect(find.text("What's new"), findsOneWidget);
+      expect(find.byIcon(Icons.auto_awesome_outlined), findsOneWidget);
+    });
+  });
+
+  // ── Group 7: Add Account ──────────────────────────────────────
 
   group('Settings screen — add account', () {
     testWidgets('add account button is visible', (tester) async {

--- a/test/e2e/settings_screen_test.dart
+++ b/test/e2e/settings_screen_test.dart
@@ -244,7 +244,7 @@ void main() {
   // ── Group 6: About section ────────────────────────────────────
 
   group("Settings screen — what's new", () {
-    testWidgets('about section shows What\'s new tile', (tester) async {
+    testWidgets("about section shows What's new tile", (tester) async {
       await tester.pumpWidget(buildSettingsApp());
       await tester.pumpAndSettle();
       await scrollToBottom(tester);

--- a/test/features/whats_new/whats_new_screen_test.dart
+++ b/test/features/whats_new/whats_new_screen_test.dart
@@ -1,0 +1,81 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:kohera/core/services/github_releases_service.dart';
+import 'package:kohera/features/whats_new/screens/whats_new_screen.dart';
+import 'package:provider/provider.dart';
+
+GitHubReleasesService _service({
+  required Directory cacheDir,
+  required Future<http.Response> Function(http.Request) handler,
+}) {
+  return GitHubReleasesService(
+    client: MockClient(handler),
+    cacheDirProvider: () async => cacheDir,
+  );
+}
+
+Widget _harness(GitHubReleasesService service) =>
+    Provider<GitHubReleasesService>.value(
+      value: service,
+      child: const MaterialApp(home: WhatsNewScreen()),
+    );
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('kohera_whats_new_screen_');
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  testWidgets('shows spinner while loading', (tester) async {
+    final completer = Completer<http.Response>();
+    addTearDown(() {
+      if (!completer.isCompleted) {
+        completer.complete(http.Response('{}', 500));
+      }
+    });
+    final svc = _service(
+      cacheDir: tempDir,
+      handler: (_) => completer.future,
+    );
+
+    await tester.pumpWidget(_harness(svc));
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text("What's new"), findsOneWidget);
+
+    completer.complete(http.Response('{}', 500));
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+  });
+
+  testWidgets('shows cloud_off + Retry when offline and no cache',
+      (tester) async {
+    final svc = _service(
+      cacheDir: tempDir,
+      handler: (_) async => throw const SocketException('offline'),
+    );
+
+    await tester.runAsync(() async {
+      await tester.pumpWidget(_harness(svc));
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+    });
+    await tester.pump();
+
+    expect(find.byIcon(Icons.cloud_off), findsOneWidget);
+    expect(find.text('Retry'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- New `whats_new_screen_test.dart` covers detail page **loading** (Completer-gated request keeps `_loading=true`) and **error** (offline + no cache → cloud_off + Retry).
- New "what's new" group in `settings_screen_test.dart` asserts the tile renders in ABOUT with `Icons.auto_awesome_outlined`.
- Loaded + offline-cached widget tests are intentionally omitted — rendering `MarkdownBody(selectable: true)` keeps the test idle queue alive indefinitely under `pumpAndSettle`. Equivalent assurance lives in `whats_new_offline_fallback_test.dart` and `github_releases_service_test.dart` at the service layer.

Closes #396. Part of #386.

## Coverage status for the epic
- Version-bump detector: `preferences_service_test.dart` (fresh / upgrade / same / downgrade / pre-release)
- Releases API client: `github_releases_service_test.dart` (200, 304, network error, force-refresh, coalescing, malformed cache)
- Cache round-trip: `whats_new_offline_fallback_test.dart`
- Banner: `whats_new_banner_test.dart`
- Markdown: `release_notes_markdown_test.dart`
- Detail page (loading + error): this PR
- Settings entry: this PR

## Test plan
- [x] `flutter test test/features/whats_new/ test/services/github_releases_service_test.dart test/services/preferences_service_test.dart test/e2e/settings_screen_test.dart` — 108 pass (~1s)