### PR TITLE
refactor(settings): merge Kohera and What's new tiles

### DIFF
--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -450,16 +450,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 _SettingsTile(
                   icon: Icons.info_outline_rounded,
                   title: 'Kohera',
-                  subtitle: 'v1.0.0 • Built with Flutter',
-                  onTap: () {},
-                ),
-                const Divider(height: 1, indent: 56),
-                _SettingsTile(
-                  icon: Icons.auto_awesome_outlined,
-                  title: "What's new",
                   subtitle: prefs.currentVersion != null
-                      ? 'v${prefs.currentVersion}'
-                      : 'Latest release notes',
+                      ? "v${prefs.currentVersion} · What's new"
+                      : "What's new",
                   onTap: () => context.pushNamed(Routes.whatsNew),
                 ),
                 const Divider(height: 1, indent: 56),

--- a/test/e2e/settings_screen_test.dart
+++ b/test/e2e/settings_screen_test.dart
@@ -244,14 +244,15 @@ void main() {
   // ── Group 6: About section ────────────────────────────────────
 
   group("Settings screen — what's new", () {
-    testWidgets("about section shows What's new tile", (tester) async {
+    testWidgets('about section shows merged Kohera tile', (tester) async {
       await tester.pumpWidget(buildSettingsApp());
       await tester.pumpAndSettle();
       await scrollToBottom(tester);
 
       expect(find.text('ABOUT'), findsOneWidget);
-      expect(find.text("What's new"), findsOneWidget);
-      expect(find.byIcon(Icons.auto_awesome_outlined), findsOneWidget);
+      expect(find.text('Kohera'), findsOneWidget);
+      expect(find.textContaining("What's new"), findsOneWidget);
+      expect(find.byIcon(Icons.info_outline_rounded), findsOneWidget);
     });
   });
 


### PR DESCRIPTION
## Summary
The ABOUT section had two overlapping tiles — Kohera (no-op, hardcoded `v1.0.0`) and What's new (live version, pushes to detail page). Merged into one:

```
[ⓘ]  Kohera
     v1.4.0 · What's new                                   ›
```

- Tap → release notes detail page (same as before).
- Subtitle reads live `prefs.currentVersion`, falling back to "What's new" before init.
- Info icon stays — matches About-section convention better than `auto_awesome`.

## Note on PR #413
PR #413 (test coverage) adds an assertion for the standalone "What's new" tile. After this PR merges, that test will need to update to look for `find.textContaining("What's new")` on the merged Kohera tile. Will rebase #413 once one of these lands.

## Test plan
- [x] Manual: Settings → ABOUT shows single tile, subtitle has live version + "What's new", tap pushes detail