### PR TITLE
fix(ios): move matrix DB out of App Group to avoid 0xdead10cc

### DIFF
--- a/ios/KoheraNotificationService/MegolmDecryptor.swift
+++ b/ios/KoheraNotificationService/MegolmDecryptor.swift
@@ -57,10 +57,10 @@ struct MegolmDecryptor {
             return nil
         }
 
-        let dbPath = containerURL.appendingPathComponent("kohera_\(clientName).db").path
+        let dbPath = containerURL.appendingPathComponent("kohera_\(clientName)_keys.db").path
         var db: OpaquePointer?
         guard sqlite3_open_v2(dbPath, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
-            NSLog("[KoheraNSE] Failed to open database")
+            NSLog("[KoheraNSE] Failed to open key mirror database at %@", dbPath)
             return nil
         }
         defer { sqlite3_close(db) }

--- a/lib/core/services/client_factory_native.dart
+++ b/lib/core/services/client_factory_native.dart
@@ -1,31 +1,43 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_vodozemac/flutter_vodozemac.dart' as vod;
 import 'package:kohera/core/services/client_factory_shared.dart';
-import 'package:kohera/features/notifications/services/apns_push_service.dart';
 import 'package:matrix/matrix.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:sqflite/sqflite.dart' as sqflite_native;
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
-Future<String> _getIosDatabasePath(String clientName) async {
+const _apnsChannel = MethodChannel('kohera/apns');
+
+Future<void> _migrateIosDbFromAppGroup(String clientName, String sandboxDb) async {
+  if (await File(sandboxDb).exists()) return;
+
+  String? appGroupPath;
   try {
-    final appGroupPath =
-        await apnsMethodChannel.invokeMethod<String>('getAppGroupPath');
-    if (appGroupPath != null) {
-      final sharedPath = p.join(appGroupPath, 'kohera_$clientName.db');
-      debugPrint('[Kohera] iOS database path: $sharedPath');
-      return sharedPath;
-    }
-  } catch (e) {
-    debugPrint('[Kohera] Failed to get App Group path: $e');
+    appGroupPath = await _apnsChannel.invokeMethod<String>('getAppGroupPath');
+  } on PlatformException catch (e) {
+    debugPrint('[Kohera] App Group lookup failed during DB migration: $e');
+    return;
   }
-  final dir = await getApplicationSupportDirectory();
-  final fallbackPath = p.join(dir.path, 'kohera_$clientName.db');
-  debugPrint('[Kohera] iOS database path (fallback): $fallbackPath');
-  return fallbackPath;
+  if (appGroupPath == null) return;
+
+  final legacyPath = p.join(appGroupPath, 'kohera_$clientName.db');
+  if (!await File(legacyPath).exists()) return;
+
+  debugPrint('[Kohera] Migrating Matrix DB from App Group to sandbox');
+  for (final suffix in const ['', '-wal', '-shm', '-journal']) {
+    final src = File('$legacyPath$suffix');
+    if (await src.exists()) {
+      try {
+        await src.copy('$sandboxDb$suffix');
+      } catch (e) {
+        debugPrint('[Kohera] DB migration copy failed for $suffix: $e');
+      }
+    }
+  }
 }
 
 // coverage:ignore-start
@@ -34,12 +46,12 @@ Future<Client> createDefaultClient(
   Future<void> Function(Client)? onSoftLogout,
 }) async {
   final Database sqfliteDb;
-  if (Platform.isIOS) {
-    final dbPath = await _getIosDatabasePath(clientName);
-    sqfliteDb = await sqflite_native.openDatabase(dbPath);
-  } else if (Platform.isAndroid) {
+  if (Platform.isIOS || Platform.isAndroid) {
     final dir = await getApplicationSupportDirectory();
     final dbPath = p.join(dir.path, 'kohera_$clientName.db');
+    if (Platform.isIOS) {
+      await _migrateIosDbFromAppGroup(clientName, dbPath);
+    }
     sqfliteDb = await sqflite_native.openDatabase(dbPath);
   } else {
     sqfliteFfiInit();

--- a/lib/core/services/client_factory_native.dart
+++ b/lib/core/services/client_factory_native.dart
@@ -13,7 +13,7 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 const _apnsChannel = MethodChannel('kohera/apns');
 
 Future<void> _migrateIosDbFromAppGroup(String clientName, String sandboxDb) async {
-  if (await File(sandboxDb).exists()) return;
+  if (File(sandboxDb).existsSync()) return;
 
   String? appGroupPath;
   try {
@@ -25,12 +25,12 @@ Future<void> _migrateIosDbFromAppGroup(String clientName, String sandboxDb) asyn
   if (appGroupPath == null) return;
 
   final legacyPath = p.join(appGroupPath, 'kohera_$clientName.db');
-  if (!await File(legacyPath).exists()) return;
+  if (!File(legacyPath).existsSync()) return;
 
   debugPrint('[Kohera] Migrating Matrix DB from App Group to sandbox');
   for (final suffix in const ['', '-wal', '-shm', '-journal']) {
     final src = File('$legacyPath$suffix');
-    if (await src.exists()) {
+    if (src.existsSync()) {
       try {
         await src.copy('$sandboxDb$suffix');
       } catch (e) {

--- a/lib/core/services/matrix_service.dart
+++ b/lib/core/services/matrix_service.dart
@@ -10,6 +10,7 @@ import 'package:kohera/core/services/sub_services/sync_service.dart';
 import 'package:kohera/core/services/sub_services/uia_service.dart';
 import 'package:kohera/core/utils/network_error.dart';
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart';
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart';
 import 'package:matrix/matrix.dart';
 // ignore: implementation_imports, no public API for ClientInitException
 import 'package:matrix/src/utils/client_init_exception.dart';
@@ -59,10 +60,12 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
       clientName: clientName,
     );
     callPushRuleManager = CallPushRuleManager(client: _client);
+    keyMirror = MegolmKeyMirror(client: _client, clientName: clientName);
     auth.addListener(_onAuthChanged);
   }
 
   late final CallPushRuleManager callPushRuleManager;
+  late final MegolmKeyMirror keyMirror;
 
   // ── Fields ──────────────────────────────────────────────────────
 
@@ -122,6 +125,7 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
     auth.removeListener(_onAuthChanged);
     auth.isLoggedIn = false;
     sync.cancelSyncSub();
+    unawaited(keyMirror.dispose());
     uia.dispose();
     selection.dispose();
     chatBackup.dispose();
@@ -244,10 +248,16 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
       uia.listenForUia();
       _listenForLoginState();
       unawaited(callPushRuleManager.ensureRule());
+      unawaited(
+        keyMirror.start().catchError((Object e) {
+          debugPrint('[Kohera] Key mirror start failed: $e');
+        }),
+      );
     } else {
       unawaited(_loginStateSub?.cancel());
       _loginStateSub = null;
       sync.cancelSyncSub();
+      unawaited(keyMirror.dispose());
       uia.clearCachedPassword();
       uia.cancelUiaSub();
       selection.resetSelection();

--- a/lib/features/notifications/services/megolm_key_mirror.dart
+++ b/lib/features/notifications/services/megolm_key_mirror.dart
@@ -62,7 +62,7 @@ class MegolmKeyMirror {
   Future<void> _migrateLegacyDbIfNeeded() async {
     final legacyPath = p.join(_appGroupPath!, _legacyDbName);
     final legacyFile = File(legacyPath);
-    if (!await legacyFile.exists()) return;
+    if (!legacyFile.existsSync()) return;
 
     debugPrint('[Kohera] Key mirror: migrating legacy App Group DB');
     sqflite.Database? legacy;
@@ -80,7 +80,7 @@ class MegolmKeyMirror {
 
     for (final suffix in const ['', '-wal', '-shm', '-journal']) {
       final f = File('$legacyPath$suffix');
-      if (await f.exists()) {
+      if (f.existsSync()) {
         try {
           await f.delete();
         } catch (e) {

--- a/lib/features/notifications/services/megolm_key_mirror.dart
+++ b/lib/features/notifications/services/megolm_key_mirror.dart
@@ -1,0 +1,198 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:kohera/features/notifications/services/apns_push_service.dart';
+import 'package:matrix/matrix.dart';
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqflite/sqflite.dart' as sqflite;
+
+class MegolmKeyMirror {
+  MegolmKeyMirror({required this.client, required this.clientName});
+
+  final Client client;
+  final String clientName;
+
+  final Set<String> _subscribedRooms = <String>{};
+  final List<StreamSubscription<dynamic>> _subs = [];
+  String? _appGroupPath;
+  bool _started = false;
+
+  String get _mirrorDbName => 'kohera_${clientName}_keys.db';
+  String get _legacyDbName => 'kohera_$clientName.db';
+  String get _backfillFlagKey => 'kohera_key_mirror_backfilled_$clientName';
+
+  Future<void> start() async {
+    if (_started || !Platform.isIOS) return;
+    _started = true;
+
+    _appGroupPath = await _resolveAppGroupPath();
+    if (_appGroupPath == null) {
+      debugPrint('[Kohera] Key mirror: no App Group path, skipping');
+      return;
+    }
+
+    await _migrateLegacyDbIfNeeded();
+    await _backfillIfNeeded();
+    _hookExistingRooms();
+    _subs.add(client.onSync.stream.listen((_) => _hookExistingRooms()));
+  }
+
+  Future<void> dispose() async {
+    for (final s in _subs) {
+      await s.cancel();
+    }
+    _subs.clear();
+    _subscribedRooms.clear();
+    _started = false;
+  }
+
+  Future<String?> _resolveAppGroupPath() async {
+    try {
+      return await apnsMethodChannel.invokeMethod<String>('getAppGroupPath');
+    } on PlatformException catch (e) {
+      debugPrint('[Kohera] Key mirror: failed to read App Group path: $e');
+      return null;
+    }
+  }
+
+  Future<void> _migrateLegacyDbIfNeeded() async {
+    final legacyPath = p.join(_appGroupPath!, _legacyDbName);
+    final legacyFile = File(legacyPath);
+    if (!await legacyFile.exists()) return;
+
+    debugPrint('[Kohera] Key mirror: migrating legacy App Group DB');
+    sqflite.Database? legacy;
+    try {
+      legacy = await sqflite.openReadOnlyDatabase(legacyPath);
+      final rows = await legacy.rawQuery(
+        'SELECT k, v FROM box_inbound_group_session',
+      );
+      await _writeRows(rows);
+    } catch (e) {
+      debugPrint('[Kohera] Key mirror: legacy migration failed: $e');
+    } finally {
+      await legacy?.close();
+    }
+
+    for (final suffix in const ['', '-wal', '-shm', '-journal']) {
+      final f = File('$legacyPath$suffix');
+      if (await f.exists()) {
+        try {
+          await f.delete();
+        } catch (e) {
+          debugPrint('[Kohera] Key mirror: failed to delete $f: $e');
+        }
+      }
+    }
+  }
+
+  Future<void> _backfillIfNeeded() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (prefs.getBool(_backfillFlagKey) ?? false) return;
+
+    try {
+      final sessions = await client.database.getAllInboundGroupSessions();
+      final rows = sessions
+          .map(
+            (s) => {
+              'k': s.sessionId,
+              'v': jsonEncode({
+                'room_id': s.roomId,
+                'session_id': s.sessionId,
+                'pickle': s.pickle,
+                'content': s.content,
+                'indexes': s.indexes,
+                'allowed_at_index': s.allowedAtIndex,
+                'sender_key': s.senderKey,
+                'sender_claimed_keys': s.senderClaimedKeys,
+              }),
+            },
+          )
+          .toList();
+      await _writeRows(rows);
+      await prefs.setBool(_backfillFlagKey, true);
+      debugPrint(
+        '[Kohera] Key mirror: backfilled ${rows.length} sessions',
+      );
+    } catch (e) {
+      debugPrint('[Kohera] Key mirror: backfill failed: $e');
+    }
+  }
+
+  void _hookExistingRooms() {
+    for (final room in client.rooms) {
+      if (_subscribedRooms.add(room.id)) {
+        _subs.add(
+          room.onSessionKeyReceived.stream.listen(
+            (sessionId) => unawaited(_mirrorSession(room.id, sessionId)),
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> _mirrorSession(String roomId, String sessionId) async {
+    try {
+      final session =
+          await client.database.getInboundGroupSession(roomId, sessionId);
+      if (session == null) return;
+      await _writeRows([
+        {
+          'k': sessionId,
+          'v': jsonEncode({
+            'room_id': session.roomId,
+            'session_id': session.sessionId,
+            'pickle': session.pickle,
+            'content': session.content,
+            'indexes': session.indexes,
+            'allowed_at_index': session.allowedAtIndex,
+            'sender_key': session.senderKey,
+            'sender_claimed_keys': session.senderClaimedKeys,
+          }),
+        },
+      ]);
+    } catch (e) {
+      debugPrint('[Kohera] Key mirror: failed to mirror $sessionId: $e');
+    }
+  }
+
+  Future<void> _writeRows(List<Map<String, Object?>> rows) async {
+    if (rows.isEmpty) return;
+    final dbPath = p.join(_appGroupPath!, _mirrorDbName);
+    sqflite.Database? db;
+    try {
+      db = await sqflite.openDatabase(
+        dbPath,
+        version: 1,
+        onCreate: (d, _) async {
+          await d.execute(
+            'CREATE TABLE IF NOT EXISTS box_inbound_group_session '
+            '(k TEXT PRIMARY KEY NOT NULL, v TEXT)',
+          );
+        },
+      );
+      final batch = db.batch();
+      for (final row in rows) {
+        batch.insert(
+          'box_inbound_group_session',
+          row,
+          conflictAlgorithm: sqflite.ConflictAlgorithm.replace,
+        );
+      }
+      await batch.commit(noResult: true);
+      await _checkpoint(db);
+    } finally {
+      await db?.close();
+    }
+  }
+
+  Future<void> _checkpoint(sqflite.Database db) async {
+    try {
+      await db.rawQuery('PRAGMA wal_checkpoint(TRUNCATE)');
+    } catch (_) {}
+  }
+}

--- a/test/screens/chat_search_test.mocks.dart
+++ b/test/screens/chat_search_test.mocks.dart
@@ -4,30 +4,32 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i13;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i14;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/src/utils/space_child.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -746,8 +748,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,8 +759,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,9 +769,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -777,9 +779,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -788,8 +790,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,8 +801,8 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,8 +811,8 @@ class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
         );
 }
 
-class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_72(
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -818,9 +821,19 @@ class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_73 extends _i1.SmartFake
+class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_74 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_73(
+  _FakeLatestReceiptState_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,8 +842,8 @@ class _FakeLatestReceiptState_73 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_74(
+class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -839,8 +852,8 @@ class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_75 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_75(
+class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -849,8 +862,8 @@ class _FakeUser_75 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_76 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_76(
+class _FakeRoom_77 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -859,9 +872,9 @@ class _FakeRoom_76 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_77 extends _i1.SmartFake
-    implements _i13.TimelineChunk {
-  _FakeTimelineChunk_77(
+class _FakeTimelineChunk_78 extends _i1.SmartFake
+    implements _i14.TimelineChunk {
+  _FakeTimelineChunk_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -888,12 +901,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1013,11 +1026,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1054,11 +1067,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1088,11 +1101,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1101,11 +1114,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1391,34 +1404,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1574,7 +1587,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1863,14 +1876,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2258,8 +2271,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2275,8 +2288,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2317,7 +2330,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2333,7 +2346,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2382,7 +2395,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2403,7 +2416,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2506,7 +2519,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2524,7 +2537,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3043,7 +3056,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3395,7 +3408,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3409,7 +3422,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3560,7 +3573,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4938,7 +4951,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4960,7 +4973,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5454,7 +5467,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5466,7 +5479,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6474,7 +6487,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6485,7 +6498,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6733,7 +6746,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6745,7 +6758,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7005,7 +7018,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7018,7 +7031,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7085,7 +7098,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7098,7 +7111,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7146,7 +7159,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7158,7 +7171,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7406,7 +7419,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7417,7 +7430,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7679,7 +7692,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7706,7 +7719,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7721,13 +7734,26 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7736,11 +7762,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7761,69 +7787,69 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7842,6 +7868,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7851,7 +7886,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7860,7 +7895,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7869,7 +7904,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7878,7 +7913,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7887,7 +7922,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7940,7 +7975,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8034,7 +8069,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8043,7 +8078,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8062,7 +8097,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8073,7 +8108,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8121,7 +8156,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8159,7 +8194,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8168,7 +8203,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8177,16 +8212,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8214,11 +8249,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8248,11 +8283,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_72(
+        returnValue: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_72(
+        returnValueForMissingStub: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
@@ -8305,11 +8340,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8345,11 +8380,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8365,11 +8400,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8378,11 +8413,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8405,11 +8440,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -8425,11 +8460,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8472,11 +8507,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_73(
+        returnValue: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_73(
+        returnValueForMissingStub: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8688,18 +8723,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i22.SpaceParent>[],
+        returnValueForMissingStub: <_i22.SpaceParent>[],
+      ) as List<_i22.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i22.SpaceChild>[],
+        returnValueForMissingStub: <_i22.SpaceChild>[],
+      ) as List<_i22.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8866,14 +8901,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8921,7 +8956,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8929,7 +8964,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8944,7 +8979,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8952,7 +8987,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9036,7 +9071,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9044,7 +9079,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9286,7 +9321,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9297,7 +9332,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9386,15 +9421,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i13.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i14.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i13.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i13.TimelineChunk?>.value(),
-      ) as _i5.Future<_i13.TimelineChunk?>);
+        returnValue: _i5.Future<_i14.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i14.TimelineChunk?>.value(),
+      ) as _i5.Future<_i14.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9435,7 +9470,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9452,7 +9487,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9516,14 +9551,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9539,14 +9574,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9602,7 +9637,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9610,7 +9645,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9922,11 +9957,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_76(
+        returnValue: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_76(
+        returnValueForMissingStub: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
@@ -9976,17 +10011,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i13.TimelineChunk get chunk => (super.noSuchMethod(
+  _i14.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_77(
+        returnValue: _FakeTimelineChunk_78(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_77(
+        returnValueForMissingStub: _FakeTimelineChunk_78(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i13.TimelineChunk);
+      ) as _i14.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10089,7 +10124,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i13.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i14.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,

--- a/test/screens/devices_screen_test.mocks.dart
+++ b/test/screens/devices_screen_test.mocks.dart
@@ -4,28 +4,30 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i15;
-import 'dart:ui' as _i17;
+import 'dart:typed_data' as _i16;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i13;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i14;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -744,8 +746,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -754,8 +757,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -764,9 +767,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -775,9 +777,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -786,8 +788,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -796,8 +799,18 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -824,12 +837,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i13.KeyVerificationMethod> get verificationMethods =>
+  Set<_i14.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i13.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i13.KeyVerificationMethod>{},
-      ) as Set<_i13.KeyVerificationMethod>);
+        returnValue: <_i14.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
+      ) as Set<_i14.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -949,11 +962,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -990,11 +1003,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1024,11 +1037,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1037,11 +1050,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1327,34 +1340,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i13.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i13.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i13.KeyVerification>
+  _i3.CachedStreamController<_i14.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i13.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i13.KeyVerification>(
+                _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i13.KeyVerification>);
+          ) as _i3.CachedStreamController<_i14.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1510,7 +1523,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i13.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1799,14 +1812,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2194,8 +2207,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2211,8 +2224,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2253,7 +2266,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2269,7 +2282,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2318,7 +2331,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2339,7 +2352,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2442,7 +2455,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2460,7 +2473,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2979,7 +2992,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i15.Uint8List? file, {
+    _i16.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3331,7 +3344,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3345,7 +3358,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3496,7 +3509,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i15.Uint8List? body,
+    _i16.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4874,7 +4887,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4896,7 +4909,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5390,7 +5403,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5402,7 +5415,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6410,7 +6423,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6421,7 +6434,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6669,7 +6682,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6681,7 +6694,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6941,7 +6954,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6954,7 +6967,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7021,7 +7034,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7034,7 +7047,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7082,7 +7095,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7094,7 +7107,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7342,7 +7355,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7353,7 +7366,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7615,7 +7628,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i15.Uint8List? body, {
+    _i16.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7642,7 +7655,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7657,13 +7670,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7672,11 +7698,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7697,69 +7723,69 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7778,6 +7804,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7787,7 +7822,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7796,7 +7831,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7805,7 +7840,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7814,7 +7849,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7823,7 +7858,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7876,7 +7911,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -7970,7 +8005,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -7979,7 +8014,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -7998,7 +8033,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8009,7 +8044,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8057,7 +8092,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8095,7 +8130,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8104,7 +8139,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8113,16 +8148,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i5.Future<_i17.AppExitResponse>);
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8146,7 +8181,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
 /// A class which mocks [ChatBackupService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockChatBackupService extends _i1.Mock implements _i9.ChatBackupService {
+class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
   @override
   bool get chatBackupEnabled => (super.noSuchMethod(
         Invocation.getter(#chatBackupEnabled),
@@ -8208,7 +8243,7 @@ class MockChatBackupService extends _i1.Mock implements _i9.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> runKeyRecovery({_i13.OpenSSSS? ssssKey}) =>
+  _i5.Future<void> runKeyRecovery({_i14.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
@@ -8262,7 +8297,7 @@ class MockChatBackupService extends _i1.Mock implements _i9.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8271,7 +8306,7 @@ class MockChatBackupService extends _i1.Mock implements _i9.ChatBackupService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/test/services/chat_message_actions_test.mocks.dart
+++ b/test/services/chat_message_actions_test.mocks.dart
@@ -4,35 +4,38 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i6;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i23;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i24;
 
-import 'package:flutter/foundation.dart' as _i15;
-import 'package:flutter/scheduler.dart' as _i17;
-import 'package:flutter/services.dart' as _i24;
-import 'package:flutter/src/material/banner.dart' as _i26;
-import 'package:flutter/src/material/scaffold.dart' as _i14;
-import 'package:flutter/src/material/snack_bar.dart' as _i25;
+import 'package:flutter/scheduler.dart' as _i18;
+import 'package:flutter/services.dart' as _i25;
+import 'package:flutter/src/foundation/assertions.dart' as _i28;
+import 'package:flutter/src/foundation/diagnostics.dart' as _i17;
+import 'package:flutter/src/material/banner.dart' as _i27;
+import 'package:flutter/src/material/scaffold.dart' as _i15;
+import 'package:flutter/src/material/snack_bar.dart' as _i26;
 import 'package:flutter/widgets.dart' as _i16;
 import 'package:http/http.dart' as _i5;
-import 'package:kohera/core/services/matrix_service.dart' as _i22;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i23;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i10;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i12;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i10;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i21;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i9;
+import 'package:matrix/encryption.dart' as _i22;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i7;
 import 'package:matrix/src/models/timeline_chunk.dart' as _i4;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i19;
+import 'package:matrix/src/utils/space_child.dart' as _i20;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i18;
+import 'package:mockito/src/dummies.dart' as _i19;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -842,8 +845,9 @@ class _FakeCallPushRuleManager_74 extends _i1.SmartFake
         );
 }
 
-class _FakeUiaService_75 extends _i1.SmartFake implements _i9.UiaService {
-  _FakeUiaService_75(
+class _FakeMegolmKeyMirror_75 extends _i1.SmartFake
+    implements _i9.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,9 +856,8 @@ class _FakeUiaService_75 extends _i1.SmartFake implements _i9.UiaService {
         );
 }
 
-class _FakeChatBackupService_76 extends _i1.SmartFake
-    implements _i10.ChatBackupService {
-  _FakeChatBackupService_76(
+class _FakeUiaService_76 extends _i1.SmartFake implements _i10.UiaService {
+  _FakeUiaService_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -863,9 +866,9 @@ class _FakeChatBackupService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_77 extends _i1.SmartFake
-    implements _i11.SelectionService {
-  _FakeSelectionService_77(
+class _FakeChatBackupService_77 extends _i1.SmartFake
+    implements _i11.ChatBackupService {
+  _FakeChatBackupService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -874,8 +877,9 @@ class _FakeSelectionService_77 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_78 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_78(
+class _FakeSelectionService_78 extends _i1.SmartFake
+    implements _i12.SelectionService {
+  _FakeSelectionService_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -884,8 +888,8 @@ class _FakeSyncService_78 extends _i1.SmartFake implements _i12.SyncService {
         );
 }
 
-class _FakeAuthService_79 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_79(
+class _FakeSyncService_79 extends _i1.SmartFake implements _i13.SyncService {
+  _FakeSyncService_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -894,24 +898,8 @@ class _FakeAuthService_79 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeScaffoldMessenger_80 extends _i1.SmartFake
-    implements _i14.ScaffoldMessenger {
-  _FakeScaffoldMessenger_80(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-
-  @override
-  String toString(
-          {_i15.DiagnosticLevel? minLevel = _i15.DiagnosticLevel.info}) =>
-      super.toString();
-}
-
-class _FakeBuildContext_81 extends _i1.SmartFake implements _i16.BuildContext {
-  _FakeBuildContext_81(
+class _FakeAuthService_80 extends _i1.SmartFake implements _i14.AuthService {
+  _FakeAuthService_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -920,19 +908,9 @@ class _FakeBuildContext_81 extends _i1.SmartFake implements _i16.BuildContext {
         );
 }
 
-class _FakeScaffoldFeatureController_82<T extends _i16.Widget, U>
-    extends _i1.SmartFake implements _i14.ScaffoldFeatureController<T, U> {
-  _FakeScaffoldFeatureController_82(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeWidget_83 extends _i1.SmartFake implements _i16.Widget {
-  _FakeWidget_83(
+class _FakeScaffoldMessenger_81 extends _i1.SmartFake
+    implements _i15.ScaffoldMessenger {
+  _FakeScaffoldMessenger_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -942,13 +920,49 @@ class _FakeWidget_83 extends _i1.SmartFake implements _i16.Widget {
 
   @override
   String toString(
-          {_i15.DiagnosticLevel? minLevel = _i15.DiagnosticLevel.info}) =>
+          {_i16.DiagnosticLevel? minLevel = _i16.DiagnosticLevel.info}) =>
       super.toString();
 }
 
-class _FakeDiagnosticsNode_84 extends _i1.SmartFake
-    implements _i15.DiagnosticsNode {
-  _FakeDiagnosticsNode_84(
+class _FakeBuildContext_82 extends _i1.SmartFake implements _i16.BuildContext {
+  _FakeBuildContext_82(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeScaffoldFeatureController_83<T extends _i16.Widget, U>
+    extends _i1.SmartFake implements _i15.ScaffoldFeatureController<T, U> {
+  _FakeScaffoldFeatureController_83(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeWidget_84 extends _i1.SmartFake implements _i16.Widget {
+  _FakeWidget_84(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+
+  @override
+  String toString(
+          {_i16.DiagnosticLevel? minLevel = _i16.DiagnosticLevel.info}) =>
+      super.toString();
+}
+
+class _FakeDiagnosticsNode_85 extends _i1.SmartFake
+    implements _i16.DiagnosticsNode {
+  _FakeDiagnosticsNode_85(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -958,14 +972,14 @@ class _FakeDiagnosticsNode_84 extends _i1.SmartFake
 
   @override
   String toString({
-    _i15.TextTreeConfiguration? parentConfiguration,
-    _i15.DiagnosticLevel? minLevel = _i15.DiagnosticLevel.info,
+    _i17.TextTreeConfiguration? parentConfiguration,
+    _i16.DiagnosticLevel? minLevel = _i16.DiagnosticLevel.info,
   }) =>
       super.toString();
 }
 
-class _FakeTicker_85 extends _i1.SmartFake implements _i17.Ticker {
-  _FakeTicker_85(
+class _FakeTicker_86 extends _i1.SmartFake implements _i18.Ticker {
+  _FakeTicker_86(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -984,11 +998,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1075,11 +1089,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -1115,11 +1129,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1135,11 +1149,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1148,11 +1162,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1195,11 +1209,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1458,18 +1472,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i19.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i19.SpaceParent>[],
-        returnValueForMissingStub: <_i19.SpaceParent>[],
-      ) as List<_i19.SpaceParent>);
+        returnValue: <_i20.SpaceParent>[],
+        returnValueForMissingStub: <_i20.SpaceParent>[],
+      ) as List<_i20.SpaceParent>);
 
   @override
-  List<_i19.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i19.SpaceChild>[],
-        returnValueForMissingStub: <_i19.SpaceChild>[],
-      ) as List<_i19.SpaceChild>);
+        returnValue: <_i20.SpaceChild>[],
+        returnValueForMissingStub: <_i20.SpaceChild>[],
+      ) as List<_i20.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -1636,14 +1650,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -1691,7 +1705,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i6.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -1699,7 +1713,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i18.dummyValue<String>(
+            _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -1714,7 +1728,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i6.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -1722,7 +1736,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i18.dummyValue<String>(
+            _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -1806,7 +1820,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i6.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -1814,7 +1828,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i18.dummyValue<String>(
+            _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2056,7 +2070,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2067,7 +2081,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i18.dummyValue<String>(
+            _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2372,7 +2386,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i6.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2380,7 +2394,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i18.dummyValue<String>(
+            _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2758,11 +2772,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -2771,11 +2785,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -2784,11 +2798,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -2797,11 +2811,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -2810,11 +2824,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -2879,11 +2893,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -2892,11 +2906,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -2949,11 +2963,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -3038,11 +3052,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -3060,11 +3074,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -3275,7 +3289,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i6.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i6.Future<_i20.Uint8List> Function(Uri)? downloadCallback,
+    _i6.Future<_i21.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -3340,7 +3354,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -3355,7 +3369,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i18.dummyValue<String>(
+            _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -3392,7 +3406,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -3406,7 +3420,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -3443,7 +3457,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -3457,7 +3471,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -3491,7 +3505,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -3504,7 +3518,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -3981,12 +3995,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i21.KeyVerificationMethod> get verificationMethods =>
+  Set<_i22.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i21.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i21.KeyVerificationMethod>{},
-      ) as Set<_i21.KeyVerificationMethod>);
+        returnValue: <_i22.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i22.KeyVerificationMethod>{},
+      ) as Set<_i22.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -4106,11 +4120,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -4147,11 +4161,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -4181,11 +4195,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -4194,11 +4208,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -4485,34 +4499,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i21.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i22.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_1<_i21.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_1<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_1<_i21.RoomKeyRequest>(
+            _FakeCachedStreamController_1<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i21.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i22.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i21.KeyVerification>
+  _i3.CachedStreamController<_i22.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_1<_i21.KeyVerification>(
+            returnValue: _FakeCachedStreamController_1<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_1<_i21.KeyVerification>(
+                _FakeCachedStreamController_1<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i21.KeyVerification>);
+          ) as _i3.CachedStreamController<_i22.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -4668,7 +4682,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i21.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i22.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -4957,14 +4971,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -5352,8 +5366,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValue: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -5369,8 +5383,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -5411,7 +5425,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -5427,7 +5441,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i18.dummyValue<String>(
+            _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -5476,7 +5490,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -5497,7 +5511,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i18.dummyValue<String>(
+            _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -5600,7 +5614,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -5618,7 +5632,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i18.dummyValue<String>(
+            _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -6140,7 +6154,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i6.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -6492,7 +6506,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -6506,7 +6520,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i18.dummyValue<String>(
+            _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -6657,7 +6671,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i5.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8035,7 +8049,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -8057,7 +8071,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i18.dummyValue<String>(
+            _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -8551,7 +8565,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -8563,7 +8577,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i18.dummyValue<String>(
+            _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -9571,7 +9585,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -9582,7 +9596,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i18.dummyValue<String>(
+            _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -9830,7 +9844,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9842,7 +9856,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i18.dummyValue<String>(
+            _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -10102,7 +10116,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -10115,7 +10129,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i18.dummyValue<String>(
+            _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -10182,7 +10196,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -10195,7 +10209,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i18.dummyValue<String>(
+            _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -10243,7 +10257,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i6.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -10255,7 +10269,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i18.dummyValue<String>(
+            _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -10503,7 +10517,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -10514,7 +10528,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i18.dummyValue<String>(
+            _i6.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -10776,7 +10790,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i6.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -10803,7 +10817,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
   @override
   _i8.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -10818,13 +10832,26 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i8.CallPushRuleManager);
 
   @override
+  _i9.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_75(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_75(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i9.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -10858,69 +10885,69 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as bool);
 
   @override
-  _i9.UiaService get uia => (super.noSuchMethod(
+  _i10.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_75(
+        returnValue: _FakeUiaService_76(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_75(
+        returnValueForMissingStub: _FakeUiaService_76(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i9.UiaService);
+      ) as _i10.UiaService);
 
   @override
-  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i11.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_76(
+        returnValue: _FakeChatBackupService_77(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_76(
+        returnValueForMissingStub: _FakeChatBackupService_77(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i10.ChatBackupService);
+      ) as _i11.ChatBackupService);
 
   @override
-  _i11.SelectionService get selection => (super.noSuchMethod(
+  _i12.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_77(
+        returnValue: _FakeSelectionService_78(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_77(
+        returnValueForMissingStub: _FakeSelectionService_78(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i11.SelectionService);
+      ) as _i12.SelectionService);
 
   @override
-  _i12.SyncService get sync => (super.noSuchMethod(
+  _i13.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_78(
+        returnValue: _FakeSyncService_79(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_78(
+        returnValueForMissingStub: _FakeSyncService_79(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i12.SyncService);
+      ) as _i13.SyncService);
 
   @override
-  _i13.AuthService get auth => (super.noSuchMethod(
+  _i14.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_79(
+        returnValue: _FakeAuthService_80(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_79(
+        returnValueForMissingStub: _FakeAuthService_80(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i13.AuthService);
+      ) as _i14.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -10939,6 +10966,15 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
+  set keyMirror(_i9.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -10948,7 +10984,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  set uia(_i9.UiaService? value) => super.noSuchMethod(
+  set uia(_i10.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -10957,7 +10993,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i11.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -10966,7 +11002,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  set selection(_i11.SelectionService? value) => super.noSuchMethod(
+  set selection(_i12.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -10975,7 +11011,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
+  set sync(_i13.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -10984,7 +11020,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
+  set auth(_i14.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -11037,7 +11073,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i24.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -11131,7 +11167,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i6.Future<void>);
 
   @override
-  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -11140,7 +11176,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -11159,7 +11195,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i6.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i25.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -11170,7 +11206,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i25.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -11256,7 +11292,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i24.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -11265,7 +11301,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i24.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -11274,16 +11310,16 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  _i6.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i6.Future<_i24.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i6.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+            _i6.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i6.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
-      ) as _i6.Future<_i23.AppExitResponse>);
+            _i6.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
+      ) as _i6.Future<_i24.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -11308,28 +11344,28 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockScaffoldMessengerState extends _i1.Mock
-    implements _i14.ScaffoldMessengerState {
+    implements _i15.ScaffoldMessengerState {
   @override
-  _i14.ScaffoldMessenger get widget => (super.noSuchMethod(
+  _i15.ScaffoldMessenger get widget => (super.noSuchMethod(
         Invocation.getter(#widget),
-        returnValue: _FakeScaffoldMessenger_80(
+        returnValue: _FakeScaffoldMessenger_81(
           this,
           Invocation.getter(#widget),
         ),
-        returnValueForMissingStub: _FakeScaffoldMessenger_80(
+        returnValueForMissingStub: _FakeScaffoldMessenger_81(
           this,
           Invocation.getter(#widget),
         ),
-      ) as _i14.ScaffoldMessenger);
+      ) as _i15.ScaffoldMessenger);
 
   @override
   _i16.BuildContext get context => (super.noSuchMethod(
         Invocation.getter(#context),
-        returnValue: _FakeBuildContext_81(
+        returnValue: _FakeBuildContext_82(
           this,
           Invocation.getter(#context),
         ),
-        returnValueForMissingStub: _FakeBuildContext_81(
+        returnValueForMissingStub: _FakeBuildContext_82(
           this,
           Invocation.getter(#context),
         ),
@@ -11352,9 +11388,9 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  _i14.ScaffoldFeatureController<_i25.SnackBar, _i25.SnackBarClosedReason>
+  _i15.ScaffoldFeatureController<_i26.SnackBar, _i26.SnackBarClosedReason>
       showSnackBar(
-    _i25.SnackBar? snackBar, {
+    _i26.SnackBar? snackBar, {
     _i16.AnimationStyle? snackBarAnimationStyle,
   }) =>
           (super.noSuchMethod(
@@ -11363,8 +11399,8 @@ class MockScaffoldMessengerState extends _i1.Mock
               [snackBar],
               {#snackBarAnimationStyle: snackBarAnimationStyle},
             ),
-            returnValue: _FakeScaffoldFeatureController_82<_i25.SnackBar,
-                _i25.SnackBarClosedReason>(
+            returnValue: _FakeScaffoldFeatureController_83<_i26.SnackBar,
+                _i26.SnackBarClosedReason>(
               this,
               Invocation.method(
                 #showSnackBar,
@@ -11372,8 +11408,8 @@ class MockScaffoldMessengerState extends _i1.Mock
                 {#snackBarAnimationStyle: snackBarAnimationStyle},
               ),
             ),
-            returnValueForMissingStub: _FakeScaffoldFeatureController_82<
-                _i25.SnackBar, _i25.SnackBarClosedReason>(
+            returnValueForMissingStub: _FakeScaffoldFeatureController_83<
+                _i26.SnackBar, _i26.SnackBarClosedReason>(
               this,
               Invocation.method(
                 #showSnackBar,
@@ -11381,13 +11417,13 @@ class MockScaffoldMessengerState extends _i1.Mock
                 {#snackBarAnimationStyle: snackBarAnimationStyle},
               ),
             ),
-          ) as _i14.ScaffoldFeatureController<_i25.SnackBar,
-              _i25.SnackBarClosedReason>);
+          ) as _i15.ScaffoldFeatureController<_i26.SnackBar,
+              _i26.SnackBarClosedReason>);
 
   @override
   void removeCurrentSnackBar(
-          {_i25.SnackBarClosedReason? reason =
-              _i25.SnackBarClosedReason.remove}) =>
+          {_i26.SnackBarClosedReason? reason =
+              _i26.SnackBarClosedReason.remove}) =>
       super.noSuchMethod(
         Invocation.method(
           #removeCurrentSnackBar,
@@ -11399,8 +11435,8 @@ class MockScaffoldMessengerState extends _i1.Mock
 
   @override
   void hideCurrentSnackBar(
-          {_i25.SnackBarClosedReason? reason =
-              _i25.SnackBarClosedReason.hide}) =>
+          {_i26.SnackBarClosedReason? reason =
+              _i26.SnackBarClosedReason.hide}) =>
       super.noSuchMethod(
         Invocation.method(
           #hideCurrentSnackBar,
@@ -11420,37 +11456,37 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  _i14.ScaffoldFeatureController<_i26.MaterialBanner,
-      _i26.MaterialBannerClosedReason> showMaterialBanner(
-          _i26.MaterialBanner? materialBanner) =>
+  _i15.ScaffoldFeatureController<_i27.MaterialBanner,
+      _i27.MaterialBannerClosedReason> showMaterialBanner(
+          _i27.MaterialBanner? materialBanner) =>
       (super.noSuchMethod(
         Invocation.method(
           #showMaterialBanner,
           [materialBanner],
         ),
-        returnValue: _FakeScaffoldFeatureController_82<_i26.MaterialBanner,
-            _i26.MaterialBannerClosedReason>(
+        returnValue: _FakeScaffoldFeatureController_83<_i27.MaterialBanner,
+            _i27.MaterialBannerClosedReason>(
           this,
           Invocation.method(
             #showMaterialBanner,
             [materialBanner],
           ),
         ),
-        returnValueForMissingStub: _FakeScaffoldFeatureController_82<
-            _i26.MaterialBanner, _i26.MaterialBannerClosedReason>(
+        returnValueForMissingStub: _FakeScaffoldFeatureController_83<
+            _i27.MaterialBanner, _i27.MaterialBannerClosedReason>(
           this,
           Invocation.method(
             #showMaterialBanner,
             [materialBanner],
           ),
         ),
-      ) as _i14.ScaffoldFeatureController<_i26.MaterialBanner,
-          _i26.MaterialBannerClosedReason>);
+      ) as _i15.ScaffoldFeatureController<_i27.MaterialBanner,
+          _i27.MaterialBannerClosedReason>);
 
   @override
   void removeCurrentMaterialBanner(
-          {_i26.MaterialBannerClosedReason? reason =
-              _i26.MaterialBannerClosedReason.remove}) =>
+          {_i27.MaterialBannerClosedReason? reason =
+              _i27.MaterialBannerClosedReason.remove}) =>
       super.noSuchMethod(
         Invocation.method(
           #removeCurrentMaterialBanner,
@@ -11462,8 +11498,8 @@ class MockScaffoldMessengerState extends _i1.Mock
 
   @override
   void hideCurrentMaterialBanner(
-          {_i26.MaterialBannerClosedReason? reason =
-              _i26.MaterialBannerClosedReason.hide}) =>
+          {_i27.MaterialBannerClosedReason? reason =
+              _i27.MaterialBannerClosedReason.hide}) =>
       super.noSuchMethod(
         Invocation.method(
           #hideCurrentMaterialBanner,
@@ -11488,14 +11524,14 @@ class MockScaffoldMessengerState extends _i1.Mock
           #build,
           [context],
         ),
-        returnValue: _FakeWidget_83(
+        returnValue: _FakeWidget_84(
           this,
           Invocation.method(
             #build,
             [context],
           ),
         ),
-        returnValueForMissingStub: _FakeWidget_83(
+        returnValueForMissingStub: _FakeWidget_84(
           this,
           Invocation.method(
             #build,
@@ -11523,7 +11559,7 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  void didUpdateWidget(_i14.ScaffoldMessenger? oldWidget) => super.noSuchMethod(
+  void didUpdateWidget(_i15.ScaffoldMessenger? oldWidget) => super.noSuchMethod(
         Invocation.method(
           #didUpdateWidget,
           [oldWidget],
@@ -11541,7 +11577,7 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  void setState(_i23.VoidCallback? fn) => super.noSuchMethod(
+  void setState(_i24.VoidCallback? fn) => super.noSuchMethod(
         Invocation.method(
           #setState,
           [fn],
@@ -11568,7 +11604,7 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  void debugFillProperties(_i15.DiagnosticPropertiesBuilder? properties) =>
+  void debugFillProperties(_i28.DiagnosticPropertiesBuilder? properties) =>
       super.noSuchMethod(
         Invocation.method(
           #debugFillProperties,
@@ -11579,7 +11615,7 @@ class MockScaffoldMessengerState extends _i1.Mock
 
   @override
   String toString(
-          {_i15.DiagnosticLevel? minLevel = _i15.DiagnosticLevel.info}) =>
+          {_i16.DiagnosticLevel? minLevel = _i16.DiagnosticLevel.info}) =>
       super.toString();
 
   @override
@@ -11588,14 +11624,14 @@ class MockScaffoldMessengerState extends _i1.Mock
           #toStringShort,
           [],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #toStringShort,
             [],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #toStringShort,
@@ -11605,9 +11641,9 @@ class MockScaffoldMessengerState extends _i1.Mock
       ) as String);
 
   @override
-  _i15.DiagnosticsNode toDiagnosticsNode({
+  _i16.DiagnosticsNode toDiagnosticsNode({
     String? name,
-    _i15.DiagnosticsTreeStyle? style,
+    _i28.DiagnosticsTreeStyle? style,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -11618,7 +11654,7 @@ class MockScaffoldMessengerState extends _i1.Mock
             #style: style,
           },
         ),
-        returnValue: _FakeDiagnosticsNode_84(
+        returnValue: _FakeDiagnosticsNode_85(
           this,
           Invocation.method(
             #toDiagnosticsNode,
@@ -11629,7 +11665,7 @@ class MockScaffoldMessengerState extends _i1.Mock
             },
           ),
         ),
-        returnValueForMissingStub: _FakeDiagnosticsNode_84(
+        returnValueForMissingStub: _FakeDiagnosticsNode_85(
           this,
           Invocation.method(
             #toDiagnosticsNode,
@@ -11640,27 +11676,27 @@ class MockScaffoldMessengerState extends _i1.Mock
             },
           ),
         ),
-      ) as _i15.DiagnosticsNode);
+      ) as _i16.DiagnosticsNode);
 
   @override
-  _i17.Ticker createTicker(_i17.TickerCallback? onTick) => (super.noSuchMethod(
+  _i18.Ticker createTicker(_i18.TickerCallback? onTick) => (super.noSuchMethod(
         Invocation.method(
           #createTicker,
           [onTick],
         ),
-        returnValue: _FakeTicker_85(
+        returnValue: _FakeTicker_86(
           this,
           Invocation.method(
             #createTicker,
             [onTick],
           ),
         ),
-        returnValueForMissingStub: _FakeTicker_85(
+        returnValueForMissingStub: _FakeTicker_86(
           this,
           Invocation.method(
             #createTicker,
             [onTick],
           ),
         ),
-      ) as _i17.Ticker);
+      ) as _i18.Ticker);
 }

--- a/test/services/ios_voip_push_service_test.mocks.dart
+++ b/test/services/ios_voip_push_service_test.mocks.dart
@@ -3,41 +3,43 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i11;
-import 'dart:typed_data' as _i21;
-import 'dart:ui' as _i17;
+import 'dart:async' as _i12;
+import 'dart:typed_data' as _i22;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
-import 'package:http/http.dart' as _i10;
-import 'package:kohera/core/services/call_service.dart' as _i22;
-import 'package:kohera/core/services/matrix_service.dart' as _i13;
-import 'package:kohera/core/services/preferences_service.dart' as _i14;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
+import 'package:http/http.dart' as _i11;
+import 'package:kohera/core/services/call_service.dart' as _i23;
+import 'package:kohera/core/services/matrix_service.dart' as _i14;
+import 'package:kohera/core/services/preferences_service.dart' as _i15;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i5;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i7;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i4;
-import 'package:kohera/features/calling/models/call_participant.dart' as _i25;
-import 'package:kohera/features/calling/models/call_state.dart' as _i27;
-import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i26;
-import 'package:kohera/features/calling/services/livekit_service.dart' as _i23;
-import 'package:kohera/features/calling/services/ringtone_service.dart' as _i28;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i7;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
+import 'package:kohera/features/calling/models/call_participant.dart' as _i26;
+import 'package:kohera/features/calling/models/call_state.dart' as _i28;
+import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i27;
+import 'package:kohera/features/calling/services/livekit_service.dart' as _i24;
+import 'package:kohera/features/calling/services/ringtone_service.dart' as _i29;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i3;
 import 'package:kohera/features/notifications/services/notification_service.dart'
-    as _i29;
-import 'package:livekit_client/livekit_client.dart' as _i24;
-import 'package:matrix/encryption.dart' as _i20;
-import 'package:matrix/matrix.dart' as _i3;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i12;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i15;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i9;
-import 'package:matrix/src/utils/space_child.dart' as _i30;
+    as _i30;
+import 'package:livekit_client/livekit_client.dart' as _i25;
+import 'package:matrix/encryption.dart' as _i21;
+import 'package:matrix/matrix.dart' as _i4;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i13;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i16;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i10;
+import 'package:matrix/src/utils/space_child.dart' as _i31;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -65,8 +67,9 @@ class _FakeCallPushRuleManager_0 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
-  _FakeClient_1(
+class _FakeMegolmKeyMirror_1 extends _i1.SmartFake
+    implements _i3.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_1(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -75,8 +78,8 @@ class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
         );
 }
 
-class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
-  _FakeUiaService_2(
+class _FakeClient_2 extends _i1.SmartFake implements _i4.Client {
+  _FakeClient_2(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -85,9 +88,8 @@ class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
         );
 }
 
-class _FakeChatBackupService_3 extends _i1.SmartFake
-    implements _i5.ChatBackupService {
-  _FakeChatBackupService_3(
+class _FakeUiaService_3 extends _i1.SmartFake implements _i5.UiaService {
+  _FakeUiaService_3(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -96,9 +98,9 @@ class _FakeChatBackupService_3 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_4 extends _i1.SmartFake
-    implements _i6.SelectionService {
-  _FakeSelectionService_4(
+class _FakeChatBackupService_4 extends _i1.SmartFake
+    implements _i6.ChatBackupService {
+  _FakeChatBackupService_4(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -107,8 +109,9 @@ class _FakeSelectionService_4 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
-  _FakeSyncService_5(
+class _FakeSelectionService_5 extends _i1.SmartFake
+    implements _i7.SelectionService {
+  _FakeSelectionService_5(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -117,8 +120,8 @@ class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
         );
 }
 
-class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
-  _FakeAuthService_6(
+class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
+  _FakeSyncService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -127,8 +130,8 @@ class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
         );
 }
 
-class _FakeDatabaseApi_7 extends _i1.SmartFake implements _i3.DatabaseApi {
-  _FakeDatabaseApi_7(
+class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
+  _FakeAuthService_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -137,8 +140,8 @@ class _FakeDatabaseApi_7 extends _i1.SmartFake implements _i3.DatabaseApi {
         );
 }
 
-class _FakeFilter_8 extends _i1.SmartFake implements _i3.Filter {
-  _FakeFilter_8(
+class _FakeDatabaseApi_8 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -147,9 +150,8 @@ class _FakeFilter_8 extends _i1.SmartFake implements _i3.Filter {
         );
 }
 
-class _FakeNativeImplementations_9 extends _i1.SmartFake
-    implements _i3.NativeImplementations {
-  _FakeNativeImplementations_9(
+class _FakeFilter_9 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -158,8 +160,9 @@ class _FakeNativeImplementations_9 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_10 extends _i1.SmartFake implements Duration {
-  _FakeDuration_10(
+class _FakeNativeImplementations_10 extends _i1.SmartFake
+    implements _i4.NativeImplementations {
+  _FakeNativeImplementations_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -168,9 +171,8 @@ class _FakeDuration_10 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_11 extends _i1.SmartFake
-    implements _i3.PushruleEvaluator {
-  _FakePushruleEvaluator_11(
+class _FakeDuration_11 extends _i1.SmartFake implements Duration {
+  _FakeDuration_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -179,8 +181,9 @@ class _FakePushruleEvaluator_11 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_12 extends _i1.SmartFake implements _i3.Profile {
-  _FakeProfile_12(
+class _FakePushruleEvaluator_12 extends _i1.SmartFake
+    implements _i4.PushruleEvaluator {
+  _FakePushruleEvaluator_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -189,9 +192,8 @@ class _FakeProfile_12 extends _i1.SmartFake implements _i3.Profile {
         );
 }
 
-class _FakeCachedStreamController_13<T> extends _i1.SmartFake
-    implements _i9.CachedStreamController<T> {
-  _FakeCachedStreamController_13(
+class _FakeProfile_13 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -200,8 +202,9 @@ class _FakeCachedStreamController_13<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_14 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_14(
+class _FakeCachedStreamController_14<T> extends _i1.SmartFake
+    implements _i10.CachedStreamController<T> {
+  _FakeCachedStreamController_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -210,8 +213,8 @@ class _FakeDateTime_14 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_15 extends _i1.SmartFake implements _i10.Client {
-  _FakeClient_15(
+class _FakeDateTime_15 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -220,9 +223,8 @@ class _FakeClient_15 extends _i1.SmartFake implements _i10.Client {
         );
 }
 
-class _FakeDiscoveryInformation_16 extends _i1.SmartFake
-    implements _i3.DiscoveryInformation {
-  _FakeDiscoveryInformation_16(
+class _FakeClient_16 extends _i1.SmartFake implements _i11.Client {
+  _FakeClient_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -231,9 +233,9 @@ class _FakeDiscoveryInformation_16 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_17 extends _i1.SmartFake
-    implements _i3.GetVersionsResponse {
-  _FakeGetVersionsResponse_17(
+class _FakeDiscoveryInformation_17 extends _i1.SmartFake
+    implements _i4.DiscoveryInformation {
+  _FakeDiscoveryInformation_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -242,9 +244,9 @@ class _FakeGetVersionsResponse_17 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_18 extends _i1.SmartFake
-    implements _i3.RegisterResponse {
-  _FakeRegisterResponse_18(
+class _FakeGetVersionsResponse_18 extends _i1.SmartFake
+    implements _i4.GetVersionsResponse {
+  _FakeGetVersionsResponse_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -253,8 +255,9 @@ class _FakeRegisterResponse_18 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_19 extends _i1.SmartFake implements _i3.LoginResponse {
-  _FakeLoginResponse_19(
+class _FakeRegisterResponse_19 extends _i1.SmartFake
+    implements _i4.RegisterResponse {
+  _FakeRegisterResponse_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -263,9 +266,8 @@ class _FakeLoginResponse_19 extends _i1.SmartFake implements _i3.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_20 extends _i1.SmartFake
-    implements _i3.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_20(
+class _FakeLoginResponse_20 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -274,8 +276,9 @@ class _FakeGetAuthMetadataResponse_20 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_21<T1> extends _i1.SmartFake implements _i11.Future<T1> {
-  _FakeFuture_21(
+class _FakeGetAuthMetadataResponse_21 extends _i1.SmartFake
+    implements _i4.GetAuthMetadataResponse {
+  _FakeGetAuthMetadataResponse_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -284,8 +287,8 @@ class _FakeFuture_21<T1> extends _i1.SmartFake implements _i11.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_22 extends _i1.SmartFake implements _i3.SyncUpdate {
-  _FakeSyncUpdate_22(
+class _FakeFuture_22<T1> extends _i1.SmartFake implements _i12.Future<T1> {
+  _FakeFuture_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -294,9 +297,8 @@ class _FakeSyncUpdate_22 extends _i1.SmartFake implements _i3.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_23 extends _i1.SmartFake
-    implements _i3.CachedProfileInformation {
-  _FakeCachedProfileInformation_23(
+class _FakeSyncUpdate_23 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -305,8 +307,9 @@ class _FakeCachedProfileInformation_23 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_24 extends _i1.SmartFake implements _i3.MediaConfig {
-  _FakeMediaConfig_24(
+class _FakeCachedProfileInformation_24 extends _i1.SmartFake
+    implements _i4.CachedProfileInformation {
+  _FakeCachedProfileInformation_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -315,8 +318,8 @@ class _FakeMediaConfig_24 extends _i1.SmartFake implements _i3.MediaConfig {
         );
 }
 
-class _FakeFileResponse_25 extends _i1.SmartFake implements _i12.FileResponse {
-  _FakeFileResponse_25(
+class _FakeMediaConfig_25 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -325,8 +328,8 @@ class _FakeFileResponse_25 extends _i1.SmartFake implements _i12.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_26 extends _i1.SmartFake implements _i3.PreviewForUrl {
-  _FakePreviewForUrl_26(
+class _FakeFileResponse_26 extends _i1.SmartFake implements _i13.FileResponse {
+  _FakeFileResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -335,8 +338,8 @@ class _FakePreviewForUrl_26 extends _i1.SmartFake implements _i3.PreviewForUrl {
         );
 }
 
-class _FakeUri_27 extends _i1.SmartFake implements Uri {
-  _FakeUri_27(
+class _FakePreviewForUrl_27 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -345,9 +348,8 @@ class _FakeUri_27 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_28 extends _i1.SmartFake
-    implements _i3.CachedPresence {
-  _FakeCachedPresence_28(
+class _FakeUri_28 extends _i1.SmartFake implements Uri {
+  _FakeUri_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -356,9 +358,9 @@ class _FakeCachedPresence_28 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_29 extends _i1.SmartFake
-    implements _i3.TurnServerCredentials {
-  _FakeTurnServerCredentials_29(
+class _FakeCachedPresence_29 extends _i1.SmartFake
+    implements _i4.CachedPresence {
+  _FakeCachedPresence_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -367,9 +369,9 @@ class _FakeTurnServerCredentials_29 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_30 extends _i1.SmartFake
-    implements _i3.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_30(
+class _FakeTurnServerCredentials_30 extends _i1.SmartFake
+    implements _i4.TurnServerCredentials {
+  _FakeTurnServerCredentials_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -378,8 +380,9 @@ class _FakeRoomKeysUpdateResponse_30 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_31 extends _i1.SmartFake implements _i3.KeyBackupData {
-  _FakeKeyBackupData_31(
+class _FakeRoomKeysUpdateResponse_31 extends _i1.SmartFake
+    implements _i4.RoomKeysUpdateResponse {
+  _FakeRoomKeysUpdateResponse_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -388,9 +391,8 @@ class _FakeKeyBackupData_31 extends _i1.SmartFake implements _i3.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_32 extends _i1.SmartFake
-    implements _i3.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_32(
+class _FakeKeyBackupData_32 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -399,9 +401,9 @@ class _FakeGetWellknownSupportResponse_32 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_33 extends _i1.SmartFake
-    implements _i3.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_33(
+class _FakeGetWellknownSupportResponse_33 extends _i1.SmartFake
+    implements _i4.GetWellknownSupportResponse {
+  _FakeGetWellknownSupportResponse_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -410,9 +412,9 @@ class _FakeGenerateLoginTokenResponse_33 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_34 extends _i1.SmartFake
-    implements _i3.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_34(
+class _FakeGenerateLoginTokenResponse_34 extends _i1.SmartFake
+    implements _i4.GenerateLoginTokenResponse {
+  _FakeGenerateLoginTokenResponse_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -421,9 +423,9 @@ class _FakeGetRoomSummaryResponse$3_34 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_35 extends _i1.SmartFake
-    implements _i3.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_35(
+class _FakeGetRoomSummaryResponse$3_35 extends _i1.SmartFake
+    implements _i4.GetRoomSummaryResponse$3 {
+  _FakeGetRoomSummaryResponse$3_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -432,9 +434,9 @@ class _FakeGetSpaceHierarchyResponse_35 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_36 extends _i1.SmartFake
-    implements _i3.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_36(
+class _FakeGetSpaceHierarchyResponse_36 extends _i1.SmartFake
+    implements _i4.GetSpaceHierarchyResponse {
+  _FakeGetSpaceHierarchyResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -443,9 +445,9 @@ class _FakeGetRelatingEventsResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_37 extends _i1.SmartFake
-    implements _i3.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_37(
+class _FakeGetRelatingEventsResponse_37 extends _i1.SmartFake
+    implements _i4.GetRelatingEventsResponse {
+  _FakeGetRelatingEventsResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -454,9 +456,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_38 extends _i1
-    .SmartFake implements _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_38(
+class _FakeGetRelatingEventsWithRelTypeResponse_38 extends _i1.SmartFake
+    implements _i4.GetRelatingEventsWithRelTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -465,9 +467,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_38 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_39 extends _i1.SmartFake
-    implements _i3.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_39(
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39 extends _i1
+    .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -476,9 +478,9 @@ class _FakeGetThreadRootsResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_40 extends _i1.SmartFake
-    implements _i3.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_40(
+class _FakeGetThreadRootsResponse_40 extends _i1.SmartFake
+    implements _i4.GetThreadRootsResponse {
+  _FakeGetThreadRootsResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -487,9 +489,9 @@ class _FakeGetEventByTimestampResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_41 extends _i1.SmartFake
-    implements _i3.RequestTokenResponse {
-  _FakeRequestTokenResponse_41(
+class _FakeGetEventByTimestampResponse_41 extends _i1.SmartFake
+    implements _i4.GetEventByTimestampResponse {
+  _FakeGetEventByTimestampResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -498,9 +500,9 @@ class _FakeRequestTokenResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_42 extends _i1.SmartFake
-    implements _i3.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_42(
+class _FakeRequestTokenResponse_42 extends _i1.SmartFake
+    implements _i4.RequestTokenResponse {
+  _FakeRequestTokenResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -509,8 +511,9 @@ class _FakeTokenOwnerInfo_42 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_43 extends _i1.SmartFake implements _i3.WhoIsInfo {
-  _FakeWhoIsInfo_43(
+class _FakeTokenOwnerInfo_43 extends _i1.SmartFake
+    implements _i4.TokenOwnerInfo {
+  _FakeTokenOwnerInfo_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -519,8 +522,8 @@ class _FakeWhoIsInfo_43 extends _i1.SmartFake implements _i3.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_44 extends _i1.SmartFake implements _i3.Capabilities {
-  _FakeCapabilities_44(
+class _FakeWhoIsInfo_44 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -529,8 +532,8 @@ class _FakeCapabilities_44 extends _i1.SmartFake implements _i3.Capabilities {
         );
 }
 
-class _FakeDevice_45 extends _i1.SmartFake implements _i3.Device {
-  _FakeDevice_45(
+class _FakeCapabilities_45 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -539,9 +542,8 @@ class _FakeDevice_45 extends _i1.SmartFake implements _i3.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_46 extends _i1.SmartFake
-    implements _i3.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_46(
+class _FakeDevice_46 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -550,9 +552,9 @@ class _FakeGetRoomIdByAliasResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_47 extends _i1.SmartFake
-    implements _i3.GetEventsResponse {
-  _FakeGetEventsResponse_47(
+class _FakeGetRoomIdByAliasResponse_47 extends _i1.SmartFake
+    implements _i4.GetRoomIdByAliasResponse {
+  _FakeGetRoomIdByAliasResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -561,9 +563,9 @@ class _FakeGetEventsResponse_47 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_48 extends _i1.SmartFake
-    implements _i3.PeekEventsResponse {
-  _FakePeekEventsResponse_48(
+class _FakeGetEventsResponse_48 extends _i1.SmartFake
+    implements _i4.GetEventsResponse {
+  _FakeGetEventsResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -572,8 +574,9 @@ class _FakePeekEventsResponse_48 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_49 extends _i1.SmartFake implements _i3.MatrixEvent {
-  _FakeMatrixEvent_49(
+class _FakePeekEventsResponse_49 extends _i1.SmartFake
+    implements _i4.PeekEventsResponse {
+  _FakePeekEventsResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -582,9 +585,8 @@ class _FakeMatrixEvent_49 extends _i1.SmartFake implements _i3.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_50 extends _i1.SmartFake
-    implements _i3.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_50(
+class _FakeMatrixEvent_50 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -593,9 +595,9 @@ class _FakeGetKeysChangesResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_51 extends _i1.SmartFake
-    implements _i3.ClaimKeysResponse {
-  _FakeClaimKeysResponse_51(
+class _FakeGetKeysChangesResponse_51 extends _i1.SmartFake
+    implements _i4.GetKeysChangesResponse {
+  _FakeGetKeysChangesResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -604,9 +606,9 @@ class _FakeClaimKeysResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_52 extends _i1.SmartFake
-    implements _i3.QueryKeysResponse {
-  _FakeQueryKeysResponse_52(
+class _FakeClaimKeysResponse_52 extends _i1.SmartFake
+    implements _i4.ClaimKeysResponse {
+  _FakeClaimKeysResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -615,9 +617,9 @@ class _FakeQueryKeysResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_53 extends _i1.SmartFake
-    implements _i3.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_53(
+class _FakeQueryKeysResponse_53 extends _i1.SmartFake
+    implements _i4.QueryKeysResponse {
+  _FakeQueryKeysResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -626,9 +628,9 @@ class _FakeGetNotificationsResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_54 extends _i1.SmartFake
-    implements _i3.GetPresenceResponse {
-  _FakeGetPresenceResponse_54(
+class _FakeGetNotificationsResponse_54 extends _i1.SmartFake
+    implements _i4.GetNotificationsResponse {
+  _FakeGetNotificationsResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -637,9 +639,9 @@ class _FakeGetPresenceResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_55 extends _i1.SmartFake
-    implements _i3.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_55(
+class _FakeGetPresenceResponse_55 extends _i1.SmartFake
+    implements _i4.GetPresenceResponse {
+  _FakeGetPresenceResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -648,9 +650,9 @@ class _FakeGetPublicRoomsResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_56 extends _i1.SmartFake
-    implements _i3.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_56(
+class _FakeGetPublicRoomsResponse_56 extends _i1.SmartFake
+    implements _i4.GetPublicRoomsResponse {
+  _FakeGetPublicRoomsResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -659,8 +661,9 @@ class _FakeQueryPublicRoomsResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_57 extends _i1.SmartFake implements _i3.PushRuleSet {
-  _FakePushRuleSet_57(
+class _FakeQueryPublicRoomsResponse_57 extends _i1.SmartFake
+    implements _i4.QueryPublicRoomsResponse {
+  _FakeQueryPublicRoomsResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -669,9 +672,8 @@ class _FakePushRuleSet_57 extends _i1.SmartFake implements _i3.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_58 extends _i1.SmartFake
-    implements _i3.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_58(
+class _FakePushRuleSet_58 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -680,8 +682,9 @@ class _FakeGetPushRulesGlobalResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_59 extends _i1.SmartFake implements _i3.PushRule {
-  _FakePushRule_59(
+class _FakeGetPushRulesGlobalResponse_59 extends _i1.SmartFake
+    implements _i4.GetPushRulesGlobalResponse {
+  _FakeGetPushRulesGlobalResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -690,9 +693,8 @@ class _FakePushRule_59 extends _i1.SmartFake implements _i3.PushRule {
         );
 }
 
-class _FakeRefreshResponse_60 extends _i1.SmartFake
-    implements _i3.RefreshResponse {
-  _FakeRefreshResponse_60(
+class _FakePushRule_60 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -701,8 +703,9 @@ class _FakeRefreshResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_61 extends _i1.SmartFake implements _i3.RoomKeys {
-  _FakeRoomKeys_61(
+class _FakeRefreshResponse_61 extends _i1.SmartFake
+    implements _i4.RefreshResponse {
+  _FakeRefreshResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -711,8 +714,8 @@ class _FakeRoomKeys_61 extends _i1.SmartFake implements _i3.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_62 extends _i1.SmartFake implements _i3.RoomKeyBackup {
-  _FakeRoomKeyBackup_62(
+class _FakeRoomKeys_62 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -721,9 +724,8 @@ class _FakeRoomKeyBackup_62 extends _i1.SmartFake implements _i3.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_63 extends _i1.SmartFake
-    implements _i3.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_63(
+class _FakeRoomKeyBackup_63 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -732,9 +734,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_64 extends _i1.SmartFake
-    implements _i3.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_64(
+class _FakeGetRoomKeysVersionCurrentResponse_64 extends _i1.SmartFake
+    implements _i4.GetRoomKeysVersionCurrentResponse {
+  _FakeGetRoomKeysVersionCurrentResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -743,8 +745,9 @@ class _FakeGetRoomKeysVersionResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_65 extends _i1.SmartFake implements _i3.EventContext {
-  _FakeEventContext_65(
+class _FakeGetRoomKeysVersionResponse_65 extends _i1.SmartFake
+    implements _i4.GetRoomKeysVersionResponse {
+  _FakeGetRoomKeysVersionResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -753,9 +756,8 @@ class _FakeEventContext_65 extends _i1.SmartFake implements _i3.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_66 extends _i1.SmartFake
-    implements _i3.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_66(
+class _FakeEventContext_66 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -764,8 +766,9 @@ class _FakeGetRoomEventsResponse_66 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_67 extends _i1.SmartFake implements _i3.SearchResults {
-  _FakeSearchResults_67(
+class _FakeGetRoomEventsResponse_67 extends _i1.SmartFake
+    implements _i4.GetRoomEventsResponse {
+  _FakeGetRoomEventsResponse_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -774,9 +777,8 @@ class _FakeSearchResults_67 extends _i1.SmartFake implements _i3.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_68 extends _i1.SmartFake
-    implements _i3.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_68(
+class _FakeSearchResults_68 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -785,9 +787,9 @@ class _FakeGetProtocolMetadataResponse$2_68 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_69 extends _i1.SmartFake
-    implements _i3.OpenIdCredentials {
-  _FakeOpenIdCredentials_69(
+class _FakeGetProtocolMetadataResponse$2_69 extends _i1.SmartFake
+    implements _i4.GetProtocolMetadataResponse$2 {
+  _FakeGetProtocolMetadataResponse$2_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -796,9 +798,9 @@ class _FakeOpenIdCredentials_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_70 extends _i1.SmartFake
-    implements _i3.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_70(
+class _FakeOpenIdCredentials_70 extends _i1.SmartFake
+    implements _i4.OpenIdCredentials {
+  _FakeOpenIdCredentials_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -807,9 +809,9 @@ class _FakeSearchUserDirectoryResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_71 extends _i1.SmartFake
-    implements _i3.CreateContentResponse {
-  _FakeCreateContentResponse_71(
+class _FakeSearchUserDirectoryResponse_71 extends _i1.SmartFake
+    implements _i4.SearchUserDirectoryResponse {
+  _FakeSearchUserDirectoryResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -818,8 +820,9 @@ class _FakeCreateContentResponse_71 extends _i1.SmartFake
         );
 }
 
-class _FakeResponse_72 extends _i1.SmartFake implements _i10.Response {
-  _FakeResponse_72(
+class _FakeCreateContentResponse_72 extends _i1.SmartFake
+    implements _i4.CreateContentResponse {
+  _FakeCreateContentResponse_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -828,9 +831,8 @@ class _FakeResponse_72 extends _i1.SmartFake implements _i10.Response {
         );
 }
 
-class _FakeMatrixService_73 extends _i1.SmartFake
-    implements _i13.MatrixService {
-  _FakeMatrixService_73(
+class _FakeResponse_73 extends _i1.SmartFake implements _i11.Response {
+  _FakeResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -839,9 +841,9 @@ class _FakeMatrixService_73 extends _i1.SmartFake
         );
 }
 
-class _FakePreferencesService_74 extends _i1.SmartFake
-    implements _i14.PreferencesService {
-  _FakePreferencesService_74(
+class _FakeMatrixService_74 extends _i1.SmartFake
+    implements _i14.MatrixService {
+  _FakeMatrixService_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -850,8 +852,9 @@ class _FakePreferencesService_74 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_75 extends _i1.SmartFake implements _i3.RoomSummary {
-  _FakeRoomSummary_75(
+class _FakePreferencesService_75 extends _i1.SmartFake
+    implements _i15.PreferencesService {
+  _FakePreferencesService_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -860,9 +863,8 @@ class _FakeRoomSummary_75 extends _i1.SmartFake implements _i3.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_76 extends _i1.SmartFake
-    implements _i3.LatestReceiptState {
-  _FakeLatestReceiptState_76(
+class _FakeRoomSummary_76 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -871,8 +873,9 @@ class _FakeLatestReceiptState_76 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_77 extends _i1.SmartFake implements _i3.Timeline {
-  _FakeTimeline_77(
+class _FakeLatestReceiptState_77 extends _i1.SmartFake
+    implements _i4.LatestReceiptState {
+  _FakeLatestReceiptState_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -881,8 +884,8 @@ class _FakeTimeline_77 extends _i1.SmartFake implements _i3.Timeline {
         );
 }
 
-class _FakeUser_78 extends _i1.SmartFake implements _i3.User {
-  _FakeUser_78(
+class _FakeTimeline_78 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -891,8 +894,8 @@ class _FakeUser_78 extends _i1.SmartFake implements _i3.User {
         );
 }
 
-class _FakeRoom_79 extends _i1.SmartFake implements _i3.Room {
-  _FakeRoom_79(
+class _FakeUser_79 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -901,9 +904,19 @@ class _FakeRoom_79 extends _i1.SmartFake implements _i3.Room {
         );
 }
 
-class _FakeTimelineChunk_80 extends _i1.SmartFake
-    implements _i15.TimelineChunk {
-  _FakeTimelineChunk_80(
+class _FakeRoom_80 extends _i1.SmartFake implements _i4.Room {
+  _FakeRoom_80(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeTimelineChunk_81 extends _i1.SmartFake
+    implements _i16.TimelineChunk {
+  _FakeTimelineChunk_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -915,7 +928,7 @@ class _FakeTimelineChunk_80 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -930,30 +943,43 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as _i2.CallPushRuleManager);
 
   @override
+  _i3.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i3.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
       ) as String);
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get isLoggedIn => (super.noSuchMethod(
@@ -970,69 +996,69 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  _i4.UiaService get uia => (super.noSuchMethod(
+  _i5.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_2(
+        returnValue: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_2(
+        returnValueForMissingStub: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i4.UiaService);
+      ) as _i5.UiaService);
 
   @override
-  _i5.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i6.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_3(
+        returnValue: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_3(
+        returnValueForMissingStub: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i5.ChatBackupService);
+      ) as _i6.ChatBackupService);
 
   @override
-  _i6.SelectionService get selection => (super.noSuchMethod(
+  _i7.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_4(
+        returnValue: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_4(
+        returnValueForMissingStub: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i6.SelectionService);
+      ) as _i7.SelectionService);
 
   @override
-  _i7.SyncService get sync => (super.noSuchMethod(
+  _i8.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_5(
+        returnValue: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_5(
+        returnValueForMissingStub: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i7.SyncService);
+      ) as _i8.SyncService);
 
   @override
-  _i8.AuthService get auth => (super.noSuchMethod(
+  _i9.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_6(
+        returnValue: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_6(
+        returnValueForMissingStub: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i8.AuthService);
+      ) as _i9.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1051,6 +1077,15 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
+  set keyMirror(_i3.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -1060,7 +1095,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set uia(_i4.UiaService? value) => super.noSuchMethod(
+  set uia(_i5.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -1069,7 +1104,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set chatBackup(_i5.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i6.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -1078,7 +1113,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set selection(_i6.SelectionService? value) => super.noSuchMethod(
+  set selection(_i7.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -1087,7 +1122,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set sync(_i7.SyncService? value) => super.noSuchMethod(
+  set sync(_i8.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -1096,7 +1131,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set auth(_i8.AuthService? value) => super.noSuchMethod(
+  set auth(_i9.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -1112,14 +1147,14 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  _i11.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1149,7 +1184,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1159,18 +1194,18 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i12.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<bool> login({
+  _i12.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1185,12 +1220,12 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<bool> completeSsoLogin({
+  _i12.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1203,13 +1238,13 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> completeRegistration(
-    _i3.RegisterResponse? response, {
+  _i12.Future<void> completeRegistration(
+    _i4.RegisterResponse? response, {
     String? password,
   }) =>
       (super.noSuchMethod(
@@ -1218,32 +1253,32 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> logout() => (super.noSuchMethod(
+  _i12.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i12.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1252,7 +1287,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1261,17 +1296,17 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1282,7 +1317,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1319,26 +1354,26 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+  _i12.Future<bool> didPushRouteInformation(
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1368,7 +1403,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1377,7 +1412,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1386,16 +1421,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i12.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i11.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i12.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i11.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i11.Future<_i17.AppExitResponse>);
+            _i12.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i12.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1419,27 +1454,27 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockClient extends _i1.Mock implements _i3.Client {
+class MockClient extends _i1.Mock implements _i4.Client {
   @override
-  _i3.DatabaseApi get database => (super.noSuchMethod(
+  _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_7(
+        returnValue: _FakeDatabaseApi_8(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_7(
+        returnValueForMissingStub: _FakeDatabaseApi_8(
           this,
           Invocation.getter(#database),
         ),
-      ) as _i3.DatabaseApi);
+      ) as _i4.DatabaseApi);
 
   @override
-  Set<_i20.KeyVerificationMethod> get verificationMethods =>
+  Set<_i21.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i20.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
-      ) as Set<_i20.KeyVerificationMethod>);
+        returnValue: <_i21.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i21.KeyVerificationMethod>{},
+      ) as Set<_i21.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1484,44 +1519,44 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  _i3.ShareKeysWith get shareKeysWith => (super.noSuchMethod(
+  _i4.ShareKeysWith get shareKeysWith => (super.noSuchMethod(
         Invocation.getter(#shareKeysWith),
-        returnValue: _i3.ShareKeysWith.all,
-        returnValueForMissingStub: _i3.ShareKeysWith.all,
-      ) as _i3.ShareKeysWith);
+        returnValue: _i4.ShareKeysWith.all,
+        returnValueForMissingStub: _i4.ShareKeysWith.all,
+      ) as _i4.ShareKeysWith);
 
   @override
-  Map<String, _i3.CommandExecutionCallback> get commands => (super.noSuchMethod(
+  Map<String, _i4.CommandExecutionCallback> get commands => (super.noSuchMethod(
         Invocation.getter(#commands),
-        returnValue: <String, _i3.CommandExecutionCallback>{},
-        returnValueForMissingStub: <String, _i3.CommandExecutionCallback>{},
-      ) as Map<String, _i3.CommandExecutionCallback>);
+        returnValue: <String, _i4.CommandExecutionCallback>{},
+        returnValueForMissingStub: <String, _i4.CommandExecutionCallback>{},
+      ) as Map<String, _i4.CommandExecutionCallback>);
 
   @override
-  _i3.Filter get syncFilter => (super.noSuchMethod(
+  _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_8(
+        returnValue: _FakeFilter_9(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_8(
+        returnValueForMissingStub: _FakeFilter_9(
           this,
           Invocation.getter(#syncFilter),
         ),
-      ) as _i3.Filter);
+      ) as _i4.Filter);
 
   @override
-  _i3.NativeImplementations get nativeImplementations => (super.noSuchMethod(
+  _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_9(
+        returnValue: _FakeNativeImplementations_10(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_9(
+        returnValueForMissingStub: _FakeNativeImplementations_10(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-      ) as _i3.NativeImplementations);
+      ) as _i4.NativeImplementations);
 
   @override
   bool get convertLinebreaksInFormatting => (super.noSuchMethod(
@@ -1533,11 +1568,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_10(
+        returnValue: _FakeDuration_11(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_10(
+        returnValueForMissingStub: _FakeDuration_11(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -1546,11 +1581,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_10(
+        returnValue: _FakeDuration_11(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_10(
+        returnValueForMissingStub: _FakeDuration_11(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -1559,36 +1594,36 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
       ) as String);
 
   @override
-  _i3.LoginState get loginState => (super.noSuchMethod(
+  _i4.LoginState get loginState => (super.noSuchMethod(
         Invocation.getter(#loginState),
-        returnValue: _i3.LoginState.loggedIn,
-        returnValueForMissingStub: _i3.LoginState.loggedIn,
-      ) as _i3.LoginState);
+        returnValue: _i4.LoginState.loggedIn,
+        returnValueForMissingStub: _i4.LoginState.loggedIn,
+      ) as _i4.LoginState);
 
   @override
-  List<_i3.Room> get rooms => (super.noSuchMethod(
+  List<_i4.Room> get rooms => (super.noSuchMethod(
         Invocation.getter(#rooms),
-        returnValue: <_i3.Room>[],
-        returnValueForMissingStub: <_i3.Room>[],
-      ) as List<_i3.Room>);
+        returnValue: <_i4.Room>[],
+        returnValueForMissingStub: <_i4.Room>[],
+      ) as List<_i4.Room>);
 
   @override
-  List<_i3.ArchivedRoom> get archivedRooms => (super.noSuchMethod(
+  List<_i4.ArchivedRoom> get archivedRooms => (super.noSuchMethod(
         Invocation.getter(#archivedRooms),
-        returnValue: <_i3.ArchivedRoom>[],
-        returnValueForMissingStub: <_i3.ArchivedRoom>[],
-      ) as List<_i3.ArchivedRoom>);
+        returnValue: <_i4.ArchivedRoom>[],
+        returnValueForMissingStub: <_i4.ArchivedRoom>[],
+      ) as List<_i4.ArchivedRoom>);
 
   @override
   bool get enableDehydratedDevices => (super.noSuchMethod(
@@ -1600,11 +1635,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1634,11 +1669,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1647,11 +1682,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1665,31 +1700,31 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  Map<String, _i3.BasicEvent> get accountData => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get accountData => (super.noSuchMethod(
         Invocation.getter(#accountData),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  _i3.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
+  _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_11(
+        returnValue: _FakePushruleEvaluator_12(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_11(
+        returnValueForMissingStub: _FakePushruleEvaluator_12(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-      ) as _i3.PushruleEvaluator);
+      ) as _i4.PushruleEvaluator);
 
   @override
-  Map<String, _i3.CachedPresence> get presences => (super.noSuchMethod(
+  Map<String, _i4.CachedPresence> get presences => (super.noSuchMethod(
         Invocation.getter(#presences),
-        returnValue: <String, _i3.CachedPresence>{},
-        returnValueForMissingStub: <String, _i3.CachedPresence>{},
-      ) as Map<String, _i3.CachedPresence>);
+        returnValue: <String, _i4.CachedPresence>{},
+        returnValueForMissingStub: <String, _i4.CachedPresence>{},
+      ) as Map<String, _i4.CachedPresence>);
 
   @override
   Map<String, List<String>> get directChats => (super.noSuchMethod(
@@ -1699,333 +1734,333 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i11.Future<_i3.Profile> get ownProfile => (super.noSuchMethod(
+  _i12.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_12(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_13(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_12(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_13(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i9.CachedStreamController<String> get onUserProfileUpdate =>
+  _i10.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i11.Future<List<_i3.Room>> get archive => (super.noSuchMethod(
+  _i12.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
+        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
-      ) as _i11.Future<List<_i3.Room>>);
+            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i12.Future<List<_i4.Room>>);
 
   @override
-  _i9.CachedStreamController<_i3.EventUpdate> get onEvent =>
+  _i10.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_13<_i3.EventUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i3.EventUpdate>(
+            _FakeCachedStreamController_14<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.EventUpdate>);
+      ) as _i10.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onTimelineEvent =>
+  _i10.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_13<_i3.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onHistoryEvent =>
+  _i10.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_13<_i3.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onNotification =>
+  _i10.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_13<_i3.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.ToDeviceEvent> get onToDeviceEvent =>
+  _i10.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_13<_i3.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_14<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i3.ToDeviceEvent>(
+            _FakeCachedStreamController_14<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.ToDeviceEvent>);
+      ) as _i10.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i9.CachedStreamController<List<_i3.BasicEventWithSender>> get onCallEvents =>
-      (super.noSuchMethod(
-        Invocation.getter(#onCallEvents),
-        returnValue:
-            _FakeCachedStreamController_13<List<_i3.BasicEventWithSender>>(
-          this,
-          Invocation.getter(#onCallEvents),
-        ),
-        returnValueForMissingStub:
-            _FakeCachedStreamController_13<List<_i3.BasicEventWithSender>>(
-          this,
-          Invocation.getter(#onCallEvents),
-        ),
-      ) as _i9.CachedStreamController<List<_i3.BasicEventWithSender>>);
+  _i10.CachedStreamController<List<_i4.BasicEventWithSender>>
+      get onCallEvents => (super.noSuchMethod(
+            Invocation.getter(#onCallEvents),
+            returnValue:
+                _FakeCachedStreamController_14<List<_i4.BasicEventWithSender>>(
+              this,
+              Invocation.getter(#onCallEvents),
+            ),
+            returnValueForMissingStub:
+                _FakeCachedStreamController_14<List<_i4.BasicEventWithSender>>(
+              this,
+              Invocation.getter(#onCallEvents),
+            ),
+          ) as _i10.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i9.CachedStreamController<_i3.LoginState> get onLoginStateChanged =>
+  _i10.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_13<_i3.LoginState>(
+        returnValue: _FakeCachedStreamController_14<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i3.LoginState>(
+            _FakeCachedStreamController_14<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i9.CachedStreamController<_i3.LoginState>);
+      ) as _i10.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i9.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i10.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_13<bool>(
+        returnValue: _FakeCachedStreamController_14<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i9.CachedStreamController<bool>);
+      ) as _i10.CachedStreamController<bool>);
 
   @override
-  _i9.CachedStreamController<_i3.SdkError> get onEncryptionError =>
+  _i10.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_13<_i3.SdkError>(
+        returnValue: _FakeCachedStreamController_14<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i3.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i9.CachedStreamController<_i3.SdkError>);
+      ) as _i10.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i9.CachedStreamController<_i3.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i10.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_13<_i3.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i3.SyncUpdate>(
+            _FakeCachedStreamController_14<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i9.CachedStreamController<_i3.SyncUpdate>);
+      ) as _i10.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.SyncStatusUpdate> get onSyncStatus =>
+  _i10.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_13<_i3.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i3.SyncStatusUpdate>(
+            _FakeCachedStreamController_14<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i9.CachedStreamController<_i3.SyncStatusUpdate>);
+      ) as _i10.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.Presence> get onPresence =>
+  _i10.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_13<_i3.Presence>(
+        returnValue: _FakeCachedStreamController_14<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i3.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i9.CachedStreamController<_i3.Presence>);
+      ) as _i10.CachedStreamController<_i4.Presence>);
 
   @override
-  _i9.CachedStreamController<_i3.CachedPresence> get onPresenceChanged =>
+  _i10.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_13<_i3.CachedPresence>(
+        returnValue: _FakeCachedStreamController_14<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i3.CachedPresence>(
+            _FakeCachedStreamController_14<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i9.CachedStreamController<_i3.CachedPresence>);
+      ) as _i10.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i9.CachedStreamController<_i3.BasicEvent> get onAccountData =>
+  _i10.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_13<_i3.BasicEvent>(
+        returnValue: _FakeCachedStreamController_14<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i3.BasicEvent>(
+            _FakeCachedStreamController_14<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i9.CachedStreamController<_i3.BasicEvent>);
+      ) as _i10.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i9.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
+  _i10.CachedStreamController<_i21.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_13<_i20.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_14<_i21.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i20.RoomKeyRequest>(
+            _FakeCachedStreamController_14<_i21.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i9.CachedStreamController<_i20.RoomKeyRequest>);
+      ) as _i10.CachedStreamController<_i21.RoomKeyRequest>);
 
   @override
-  _i9.CachedStreamController<_i20.KeyVerification>
+  _i10.CachedStreamController<_i21.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_13<_i20.KeyVerification>(
+            returnValue: _FakeCachedStreamController_14<_i21.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_13<_i20.KeyVerification>(
+                _FakeCachedStreamController_14<_i21.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i9.CachedStreamController<_i20.KeyVerification>);
+          ) as _i10.CachedStreamController<_i21.KeyVerification>);
 
   @override
-  _i9.CachedStreamController<_i3.UiaRequest<dynamic>> get onUiaRequest =>
+  _i10.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_13<_i3.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_14<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i3.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_14<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i9.CachedStreamController<_i3.UiaRequest<dynamic>>);
+      ) as _i10.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onGroupMember =>
+  _i10.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_13<_i3.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<String> get onCancelSendEvent =>
+  _i10.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i9.CachedStreamController<({String roomId, _i3.StrippedStateEvent state})>
+  _i10.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_13<
-                ({String roomId, _i3.StrippedStateEvent state})>(
+            returnValue: _FakeCachedStreamController_14<
+                ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_13<
-                ({String roomId, _i3.StrippedStateEvent state})>(
+            returnValueForMissingStub: _FakeCachedStreamController_14<
+                ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i9.CachedStreamController<
-              ({String roomId, _i3.StrippedStateEvent state})>);
+          ) as _i10.CachedStreamController<
+              ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
   int get syncErrorTimeoutSec => (super.noSuchMethod(
@@ -2044,11 +2079,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_14(
+        returnValue: _FakeDateTime_15(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_14(
+        returnValueForMissingStub: _FakeDateTime_15(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2069,33 +2104,33 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  _i3.RoomSorter get sortRoomsBy => (super.noSuchMethod(
+  _i4.RoomSorter get sortRoomsBy => (super.noSuchMethod(
         Invocation.getter(#sortRoomsBy),
         returnValue: (
-          _i3.Room a,
-          _i3.Room b,
+          _i4.Room a,
+          _i4.Room b,
         ) =>
             0,
         returnValueForMissingStub: (
-          _i3.Room a,
-          _i3.Room b,
+          _i4.Room a,
+          _i4.Room b,
         ) =>
             0,
-      ) as _i3.RoomSorter);
+      ) as _i4.RoomSorter);
 
   @override
-  Map<String, _i3.DeviceKeysList> get userDeviceKeys => (super.noSuchMethod(
+  Map<String, _i4.DeviceKeysList> get userDeviceKeys => (super.noSuchMethod(
         Invocation.getter(#userDeviceKeys),
-        returnValue: <String, _i3.DeviceKeysList>{},
-        returnValueForMissingStub: <String, _i3.DeviceKeysList>{},
-      ) as Map<String, _i3.DeviceKeysList>);
+        returnValue: <String, _i4.DeviceKeysList>{},
+        returnValueForMissingStub: <String, _i4.DeviceKeysList>{},
+      ) as Map<String, _i4.DeviceKeysList>);
 
   @override
-  List<_i3.DeviceKeys> get unverifiedDevices => (super.noSuchMethod(
+  List<_i4.DeviceKeys> get unverifiedDevices => (super.noSuchMethod(
         Invocation.getter(#unverifiedDevices),
-        returnValue: <_i3.DeviceKeys>[],
-        returnValueForMissingStub: <_i3.DeviceKeys>[],
-      ) as List<_i3.DeviceKeys>);
+        returnValue: <_i4.DeviceKeys>[],
+        returnValueForMissingStub: <_i4.DeviceKeys>[],
+      ) as List<_i4.DeviceKeys>);
 
   @override
   bool get allPushNotificationsMuted => (super.noSuchMethod(
@@ -2112,7 +2147,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as List<String>);
 
   @override
-  set database(_i3.DatabaseApi? db) => super.noSuchMethod(
+  set database(_i4.DatabaseApi? db) => super.noSuchMethod(
         Invocation.setter(
           #database,
           db,
@@ -2121,7 +2156,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i21.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2167,7 +2202,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set shareKeysWith(_i3.ShareKeysWith? value) => super.noSuchMethod(
+  set shareKeysWith(_i4.ShareKeysWith? value) => super.noSuchMethod(
         Invocation.setter(
           #shareKeysWith,
           value,
@@ -2176,7 +2211,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set onSoftLogout(_i11.Future<void> Function(_i3.Client)? value) =>
+  set onSoftLogout(_i12.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2187,8 +2222,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
 
   @override
   set customImageResizer(
-          _i11.Future<_i3.MatrixImageFileResizedResponse?> Function(
-                  _i3.MatrixImageFileResizeArguments)?
+          _i12.Future<_i4.MatrixImageFileResizedResponse?> Function(
+                  _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
         Invocation.setter(
@@ -2226,7 +2261,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set rooms(List<_i3.Room>? newList) => super.noSuchMethod(
+  set rooms(List<_i4.Room>? newList) => super.noSuchMethod(
         Invocation.setter(
           #rooms,
           newList,
@@ -2235,7 +2270,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set presences(Map<String, _i3.CachedPresence>? value) => super.noSuchMethod(
+  set presences(Map<String, _i4.CachedPresence>? value) => super.noSuchMethod(
         Invocation.setter(
           #presences,
           value,
@@ -2262,7 +2297,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set syncPresence(_i3.PresenceType? value) => super.noSuchMethod(
+  set syncPresence(_i4.PresenceType? value) => super.noSuchMethod(
         Invocation.setter(
           #syncPresence,
           value,
@@ -2298,7 +2333,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2307,7 +2342,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set roomsLoading(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2316,7 +2351,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set firstSyncReceived(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -2343,20 +2378,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i10.Client get httpClient => (super.noSuchMethod(
+  _i11.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_15(
+        returnValue: _FakeClient_16(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_15(
+        returnValueForMissingStub: _FakeClient_16(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i10.Client);
+      ) as _i11.Client);
 
   @override
-  set httpClient(_i10.Client? value) => super.noSuchMethod(
+  set httpClient(_i11.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -2383,7 +2418,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<void> refreshAccessToken(
+  _i12.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2391,9 +2426,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -2411,14 +2446,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2428,22 +2463,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as String);
 
   @override
-  _i3.Room? getRoomByAlias(String? alias) => (super.noSuchMethod(
+  _i4.Room? getRoomByAlias(String? alias) => (super.noSuchMethod(
         Invocation.method(
           #getRoomByAlias,
           [alias],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.Room?);
+      ) as _i4.Room?);
 
   @override
-  _i3.Room? getRoomById(String? id) => (super.noSuchMethod(
+  _i4.Room? getRoomById(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getRoomById,
           [id],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.Room?);
+      ) as _i4.Room?);
 
   @override
   String? getDirectChatFromUserId(String? userId) => (super.noSuchMethod(
@@ -2455,38 +2490,38 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as String?);
 
   @override
-  _i11.Future<_i3.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i12.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_16(
+        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_17(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_16(
+        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_17(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i11.Future<_i3.DiscoveryInformation>);
+      ) as _i12.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i11.Future<
+  _i12.Future<
       (
-        _i3.DiscoveryInformation?,
-        _i3.GetVersionsResponse,
-        List<_i3.LoginFlow>,
-        _i3.GetAuthMetadataResponse?
+        _i4.DiscoveryInformation?,
+        _i4.GetVersionsResponse,
+        List<_i4.LoginFlow>,
+        _i4.GetAuthMetadataResponse?
       )> checkHomeserver(
     Uri? homeserverUrl, {
     bool? checkWellKnown = true,
@@ -2503,15 +2538,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i11.Future<
+        returnValue: _i12.Future<
             (
-              _i3.DiscoveryInformation?,
-              _i3.GetVersionsResponse,
-              List<_i3.LoginFlow>,
-              _i3.GetAuthMetadataResponse?
+              _i4.DiscoveryInformation?,
+              _i4.GetVersionsResponse,
+              List<_i4.LoginFlow>,
+              _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_17(
+          _FakeGetVersionsResponse_18(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2523,18 +2558,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
           ),
-          <_i3.LoginFlow>[],
+          <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i11.Future<
+        returnValueForMissingStub: _i12.Future<
             (
-              _i3.DiscoveryInformation?,
-              _i3.GetVersionsResponse,
-              List<_i3.LoginFlow>,
-              _i3.GetAuthMetadataResponse?
+              _i4.DiscoveryInformation?,
+              _i4.GetVersionsResponse,
+              List<_i4.LoginFlow>,
+              _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_17(
+          _FakeGetVersionsResponse_18(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2546,19 +2581,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
           ),
-          <_i3.LoginFlow>[],
+          <_i4.LoginFlow>[],
           null
         )),
-      ) as _i11.Future<
+      ) as _i12.Future<
           (
-            _i3.DiscoveryInformation?,
-            _i3.GetVersionsResponse,
-            List<_i3.LoginFlow>,
-            _i3.GetAuthMetadataResponse?
+            _i4.DiscoveryInformation?,
+            _i4.GetVersionsResponse,
+            List<_i4.LoginFlow>,
+            _i4.GetAuthMetadataResponse?
           )>);
 
   @override
-  _i11.Future<_i3.DiscoveryInformation> getWellknown({
+  _i12.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2571,8 +2606,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_16(
+        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_17(
           this,
           Invocation.method(
             #getWellknown,
@@ -2583,8 +2618,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_16(
+        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_17(
           this,
           Invocation.method(
             #getWellknown,
@@ -2595,19 +2630,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.DiscoveryInformation>);
+      ) as _i12.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i11.Future<_i3.RegisterResponse> register({
+  _i12.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
     String? initialDeviceDisplayName,
     bool? inhibitLogin,
     bool? refreshToken,
-    _i3.AuthenticationData? auth,
-    _i3.AccountKind? kind,
-    void Function(_i3.InitState)? onInitStateChanged,
+    _i4.AuthenticationData? auth,
+    _i4.AccountKind? kind,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2626,7 +2661,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<_i3.RegisterResponse>.value(_FakeRegisterResponse_18(
+            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_19(
           this,
           Invocation.method(
             #register,
@@ -2645,7 +2680,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RegisterResponse>.value(_FakeRegisterResponse_18(
+            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_19(
           this,
           Invocation.method(
             #register,
@@ -2663,12 +2698,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RegisterResponse>);
+      ) as _i12.Future<_i4.RegisterResponse>);
 
   @override
-  _i11.Future<_i3.LoginResponse> login(
+  _i12.Future<_i4.LoginResponse> login(
     String? type, {
-    _i3.AuthenticationIdentifier? identifier,
+    _i4.AuthenticationIdentifier? identifier,
     String? password,
     String? token,
     String? deviceId,
@@ -2677,7 +2712,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? user,
     String? medium,
     String? address,
-    void Function(_i3.InitState)? onInitStateChanged,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2696,7 +2731,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i11.Future<_i3.LoginResponse>.value(_FakeLoginResponse_19(
+        returnValue: _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_20(
           this,
           Invocation.method(
             #login,
@@ -2716,7 +2751,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.LoginResponse>.value(_FakeLoginResponse_19(
+            _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_20(
           this,
           Invocation.method(
             #login,
@@ -2735,10 +2770,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.LoginResponse>);
+      ) as _i12.Future<_i4.LoginResponse>);
 
   @override
-  _i11.Future<_i3.GetAuthMetadataResponse> getAuthMetadata({
+  _i12.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2751,8 +2786,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_20(
+        returnValue: _i12.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_21(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2764,8 +2799,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_20(
+            _i12.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_21(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2776,80 +2811,80 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetAuthMetadataResponse>);
+      ) as _i12.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i11.Future<void> logout() => (super.noSuchMethod(
+  _i12.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> logoutAll() => (super.noSuchMethod(
+  _i12.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<T> uiaRequestBackground<T>(
-          _i11.Future<T> Function(_i3.AuthenticationData?)? request) =>
+  _i12.Future<T> uiaRequestBackground<T>(
+          _i12.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i11.Future<T>.value(v),
+              (T v) => _i12.Future<T>.value(v),
             ) ??
-            _FakeFuture_21<T>(
+            _FakeFuture_22<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i11.Future<T>.value(v),
+              (T v) => _i12.Future<T>.value(v),
             ) ??
-            _FakeFuture_21<T>(
+            _FakeFuture_22<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i11.Future<T>);
+      ) as _i12.Future<T>);
 
   @override
-  _i11.Future<String> startDirectChat(
+  _i12.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
-    List<_i3.StateEvent>? initialState,
+    List<_i4.StateEvent>? initialState,
     bool? waitForSync = true,
     Map<String, dynamic>? powerLevelContentOverride,
-    _i3.CreateRoomPreset? preset = _i3.CreateRoomPreset.trustedPrivateChat,
+    _i4.CreateRoomPreset? preset = _i4.CreateRoomPreset.trustedPrivateChat,
     bool? skipExistingChat = false,
   }) =>
       (super.noSuchMethod(
@@ -2865,7 +2900,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2881,7 +2916,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i16.dummyValue<String>(
+            _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2896,17 +2931,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<String> createGroupChat({
+  _i12.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
-    _i3.CreateRoomPreset? preset = _i3.CreateRoomPreset.privateChat,
-    List<_i3.StateEvent>? initialState,
-    _i3.Visibility? visibility,
-    _i3.HistoryVisibility? historyVisibility,
+    _i4.CreateRoomPreset? preset = _i4.CreateRoomPreset.privateChat,
+    List<_i4.StateEvent>? initialState,
+    _i4.Visibility? visibility,
+    _i4.HistoryVisibility? historyVisibility,
     bool? waitForSync = true,
     bool? groupCall = false,
     bool? federated = true,
@@ -2930,7 +2965,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2951,7 +2986,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i16.dummyValue<String>(
+            _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2971,10 +3006,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> waitForRoomInSync(
+  _i12.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -2990,7 +3025,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_22(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3003,7 +3038,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_22(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3015,27 +3050,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i12.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<String> createSpace({
+  _i12.Future<String> createSpace({
     String? name,
     String? topic,
-    _i3.Visibility? visibility = _i3.Visibility.public,
+    _i4.Visibility? visibility = _i4.Visibility.public,
     String? spaceAliasName,
     List<String>? invite,
-    List<_i3.Invite3pid>? invite3pid,
+    List<_i4.Invite3pid>? invite3pid,
     String? roomVersion,
     bool? waitForSync = false,
   }) =>
@@ -3054,7 +3089,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3072,7 +3107,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i16.dummyValue<String>(
+            _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3089,10 +3124,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.Profile> fetchOwnProfileFromServer(
+  _i12.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3100,7 +3135,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_12(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_13(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3109,7 +3144,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_12(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_13(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3117,10 +3152,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i11.Future<_i3.Profile> fetchOwnProfile({
+  _i12.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3133,7 +3168,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_12(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_13(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3145,7 +3180,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_12(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_13(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3156,10 +3191,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i11.Future<_i3.CachedProfileInformation> getUserProfile(
+  _i12.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3173,8 +3208,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i11.Future<_i3.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_23(
+        returnValue: _i12.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_24(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3186,8 +3221,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_23(
+            _i12.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_24(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3198,10 +3233,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.CachedProfileInformation>);
+      ) as _i12.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i11.Future<_i3.Profile> getProfileFromUserId(
+  _i12.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3219,7 +3254,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_12(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_13(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3233,7 +3268,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_12(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_13(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3246,17 +3281,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i3.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
+  _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getArchiveRoomFromCache,
           [roomId],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.ArchivedRoom?);
+      ) as _i4.ArchivedRoom?);
 
   @override
   void clearArchivesFromCache() => super.noSuchMethod(
@@ -3268,31 +3303,31 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<List<_i3.Room>> loadArchive() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
+        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
-      ) as _i11.Future<List<_i3.Room>>);
+            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i12.Future<List<_i4.Room>>);
 
   @override
-  _i11.Future<List<_i3.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i12.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i11.Future<List<_i3.ArchivedRoom>>.value(<_i3.ArchivedRoom>[]),
+            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ArchivedRoom>>.value(<_i3.ArchivedRoom>[]),
-      ) as _i11.Future<List<_i3.ArchivedRoom>>);
+            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i12.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i11.Future<_i3.GetVersionsResponse> getVersions({
+  _i12.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3305,8 +3340,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_17(
+        returnValue: _i12.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_18(
           this,
           Invocation.method(
             #getVersions,
@@ -3317,8 +3352,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_17(
+        returnValueForMissingStub: _i12.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_18(
           this,
           Invocation.method(
             #getVersions,
@@ -3329,20 +3364,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetVersionsResponse>);
+      ) as _i12.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i11.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i12.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<_i3.MediaConfig> getConfig({
+  _i12.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3355,7 +3390,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_24(
+        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_25(
           this,
           Invocation.method(
             #getConfig,
@@ -3367,7 +3402,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_24(
+            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_25(
           this,
           Invocation.method(
             #getConfig,
@@ -3378,10 +3413,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.MediaConfig>);
+      ) as _i12.Future<_i4.MediaConfig>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContent(
+  _i12.Future<_i13.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -3401,7 +3436,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContent,
@@ -3417,7 +3452,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContent,
@@ -3432,10 +3467,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentOverrideName(
+  _i12.Future<_i13.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -3457,7 +3492,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3474,7 +3509,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3490,15 +3525,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentThumbnail(
+  _i12.Future<_i13.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
     int? height, {
-    _i3.Method? method,
+    _i4.Method? method,
     bool? allowRemote,
     int? timeoutMs,
     bool? allowRedirect,
@@ -3521,7 +3556,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3541,7 +3576,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3560,10 +3595,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i3.PreviewForUrl> getUrlPreview(
+  _i12.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -3573,7 +3608,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_26(
+        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_27(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3582,7 +3617,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_26(
+            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_27(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3590,11 +3625,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i11.Future<_i3.PreviewForUrl>);
+      ) as _i12.Future<_i4.PreviewForUrl>);
 
   @override
-  _i11.Future<Uri> uploadContent(
-    _i21.Uint8List? file, {
+  _i12.Future<Uri> uploadContent(
+    _i22.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3607,7 +3642,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i11.Future<Uri>.value(_FakeUri_27(
+        returnValue: _i12.Future<Uri>.value(_FakeUri_28(
           this,
           Invocation.method(
             #uploadContent,
@@ -3618,7 +3653,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<Uri>.value(_FakeUri_27(
+        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_28(
           this,
           Invocation.method(
             #uploadContent,
@@ -3629,10 +3664,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<Uri>);
+      ) as _i12.Future<Uri>);
 
   @override
-  _i11.Future<void> setTyping(
+  _i12.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -3648,43 +3683,43 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> exportDump() => (super.noSuchMethod(
+  _i12.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i12.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> setAvatar(_i3.MatrixFile? file) => (super.noSuchMethod(
+  _i12.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Event?> getEventByPushNotification(
-    _i3.PushNotification? notification, {
+  _i12.Future<_i4.Event?> getEventByPushNotification(
+    _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
     bool? returnNullIfSeen = true,
@@ -3699,12 +3734,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
-  _i11.Future<void> init({
+  _i12.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -3717,7 +3752,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     bool? waitForFirstSync = true,
     bool? waitUntilLoadCompletedLoaded = true,
     void Function()? onMigration,
-    void Function(_i3.InitState)? onInitStateChanged,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3739,9 +3774,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -3753,42 +3788,42 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<void> clear() => (super.noSuchMethod(
+  _i12.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i12.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ensureNotSoftLoggedOut(
+  _i12.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> handleSync(
-    _i3.SyncUpdate? sync, {
-    _i3.Direction? direction,
+  _i12.Future<void> handleSync(
+    _i4.SyncUpdate? sync, {
+    _i4.Direction? direction,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3796,44 +3831,44 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i3.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
+  _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeysByCurve25519Key,
           [senderKey],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.DeviceKeys?);
+      ) as _i4.DeviceKeys?);
 
   @override
-  _i11.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i12.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i12.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDevice(
+  _i12.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -3847,12 +3882,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             messages,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDevicesOfUserIds(
+  _i12.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -3868,13 +3903,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDeviceEncrypted(
-    List<_i3.DeviceKeys>? deviceKeys,
+  _i12.Future<void> sendToDeviceEncrypted(
+    List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
     String? messageId,
@@ -3893,13 +3928,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDeviceEncryptedChunked(
-    List<_i3.DeviceKeys>? deviceKeys,
+  _i12.Future<void> sendToDeviceEncryptedChunked(
+    List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
   ) =>
@@ -3912,28 +3947,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
             message,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i12.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> joinRoom(
+  _i12.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
     String? reason,
-    _i3.ThirdPartySigned? thirdPartySigned,
+    _i4.ThirdPartySigned? thirdPartySigned,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3946,7 +3981,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3960,7 +3995,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i16.dummyValue<String>(
+            _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3973,13 +4008,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> changePassword(
+  _i12.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
     bool? logoutDevices,
   }) =>
       (super.noSuchMethod(
@@ -3992,22 +4027,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> clearCache() => (super.noSuchMethod(
+  _i12.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ignoreUser(
+  _i12.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4017,22 +4052,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i12.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.CachedPresence> fetchCurrentPresence(
+  _i12.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4043,7 +4078,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i11.Future<_i3.CachedPresence>.value(_FakeCachedPresence_28(
+            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_29(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4052,7 +4087,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.CachedPresence>.value(_FakeCachedPresence_28(
+            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_29(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4060,32 +4095,32 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i11.Future<_i3.CachedPresence>);
+      ) as _i12.Future<_i4.CachedPresence>);
 
   @override
-  _i11.Future<void> abortSync() => (super.noSuchMethod(
+  _i12.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i12.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEventWithMetadata(
+  _i12.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4105,14 +4140,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i10.BaseResponse? response,
-    _i21.Uint8List? body,
+    _i11.BaseResponse? response,
+    _i22.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4144,8 +4179,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as Never);
 
   @override
-  _i11.Future<Map<String, Object?>> request(
-    _i3.RequestType? type,
+  _i12.Future<Map<String, Object?>> request(
+    _i4.RequestType? type,
     String? action, {
     dynamic data = '',
     String? contentType = 'application/json',
@@ -4165,14 +4200,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> postPusher(
-    _i3.Pusher? pusher, {
+  _i12.Future<void> postPusher(
+    _i4.Pusher? pusher, {
     bool? append,
   }) =>
       (super.noSuchMethod(
@@ -4181,57 +4216,57 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deletePusher(_i3.PusherId? pusher) => (super.noSuchMethod(
+  _i12.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i12.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i12.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i11.Future<_i3.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_29(
+        returnValue: _i12.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_30(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_29(
+        returnValueForMissingStub: _i12.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_30(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.TurnServerCredentials>);
+      ) as _i12.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4245,8 +4280,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_30(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4258,8 +4293,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_30(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4270,14 +4305,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
-    _i3.KeyBackupData? data,
+    _i4.KeyBackupData? data,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4289,8 +4324,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             data,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_30(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4303,8 +4338,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_30(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4316,10 +4351,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.KeyBackupData> getRoomKeysBySessionId(
+  _i12.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4333,7 +4368,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_31(
+        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_32(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4345,7 +4380,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_31(
+            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_32(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4356,17 +4391,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.KeyBackupData>);
+      ) as _i12.Future<_i4.KeyBackupData>);
 
   @override
-  _i11.Future<_i3.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i12.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i11.Future<_i3.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_32(
+        returnValue: _i12.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_33(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -4374,18 +4409,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_32(
+            _i12.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_33(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.GetWellknownSupportResponse>);
+      ) as _i12.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i11.Future<int> pingAppservice(
+  _i12.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -4395,21 +4430,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i11.Future<int>.value(0),
-        returnValueForMissingStub: _i11.Future<int>.value(0),
-      ) as _i11.Future<int>);
+        returnValue: _i12.Future<int>.value(0),
+        returnValueForMissingStub: _i12.Future<int>.value(0),
+      ) as _i12.Future<int>);
 
   @override
-  _i11.Future<_i3.GenerateLoginTokenResponse> generateLoginToken(
-          {_i3.AuthenticationData? auth}) =>
+  _i12.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+          {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
           #generateLoginToken,
           [],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<_i3.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_33(
+        returnValue: _i12.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_34(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4418,8 +4453,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_33(
+            _i12.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_34(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4427,15 +4462,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i11.Future<_i3.GenerateLoginTokenResponse>);
+      ) as _i12.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i11.Future<_i3.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i12.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_24(
+        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_25(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -4443,17 +4478,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_24(
+            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_25(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.MediaConfig>);
+      ) as _i12.Future<_i4.MediaConfig>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentAuthed(
+  _i12.Future<_i13.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -4467,7 +4502,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4479,7 +4514,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4490,10 +4525,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentOverrideNameAuthed(
+  _i12.Future<_i13.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4509,7 +4544,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4522,7 +4557,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4534,10 +4569,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i3.PreviewForUrl> getUrlPreviewAuthed(
+  _i12.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -4547,7 +4582,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_26(
+        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_27(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4556,7 +4591,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_26(
+            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_27(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4564,15 +4599,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i11.Future<_i3.PreviewForUrl>);
+      ) as _i12.Future<_i4.PreviewForUrl>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentThumbnailAuthed(
+  _i12.Future<_i13.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
     int? height, {
-    _i3.Method? method,
+    _i4.Method? method,
     int? timeoutMs,
     bool? animated,
   }) =>
@@ -4591,7 +4626,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4609,7 +4644,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4626,21 +4661,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<bool> registrationTokenValidity(String? token) =>
+  _i12.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<_i3.GetRoomSummaryResponse$3> getRoomSummary(
+  _i12.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -4650,8 +4685,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i11.Future<_i3.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_34(
+        returnValue: _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_35(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4660,8 +4695,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_34(
+            _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_35(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4669,10 +4704,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#via: via},
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomSummaryResponse$3>);
+      ) as _i12.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i11.Future<_i3.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i12.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -4690,8 +4725,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #from: from,
           },
         ),
-        returnValue: _i11.Future<_i3.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_35(
+        returnValue: _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_36(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4705,8 +4740,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_35(
+            _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_36(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4719,16 +4754,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetSpaceHierarchyResponse>);
+      ) as _i12.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsResponse> getRelatingEvents(
+  _i12.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
       (super.noSuchMethod(
@@ -4746,8 +4781,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i11.Future<_i3.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_36(
+        returnValue: _i12.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_37(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4765,8 +4800,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_36(
+            _i12.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_37(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4783,10 +4818,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetRelatingEventsResponse>);
+      ) as _i12.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>
+  _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -4794,7 +4829,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
           (super.noSuchMethod(
@@ -4814,8 +4849,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
             returnValue:
-                _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_37(
+                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_38(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4834,8 +4869,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_37(
+                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_38(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4853,10 +4888,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-          ) as _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i12.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -4865,7 +4900,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
           (super.noSuchMethod(
@@ -4885,9 +4920,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i11.Future<
-                    _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_38(
+            returnValue: _i12.Future<
+                    _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -4906,9 +4941,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i11.Future<
-                    _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_38(
+            returnValueForMissingStub: _i12.Future<
+                    _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -4927,13 +4962,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-          ) as _i11
-              .Future<_i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
+          ) as _i12
+              .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i11.Future<_i3.GetThreadRootsResponse> getThreadRoots(
+  _i12.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
-    _i3.Include? include,
+    _i4.Include? include,
     int? limit,
     String? from,
   }) =>
@@ -4947,8 +4982,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #from: from,
           },
         ),
-        returnValue: _i11.Future<_i3.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_39(
+        returnValue: _i12.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_40(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -4961,8 +4996,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_39(
+            _i12.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_40(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -4974,13 +5009,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetThreadRootsResponse>);
+      ) as _i12.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i11.Future<_i3.GetEventByTimestampResponse> getEventByTimestamp(
+  _i12.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4991,8 +5026,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             dir,
           ],
         ),
-        returnValue: _i11.Future<_i3.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_40(
+        returnValue: _i12.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_41(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5004,8 +5039,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_40(
+            _i12.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_41(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5016,36 +5051,36 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.GetEventByTimestampResponse>);
+      ) as _i12.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i12.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyIdentifier>?>.value(),
-      ) as _i11.Future<List<_i3.ThirdPartyIdentifier>?>);
+            _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i12.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i11.Future<Uri?> post3PIDs(_i3.ThreePidCredentials? threePidCreds) =>
+  _i12.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i11.Future<Uri?>.value(),
-        returnValueForMissingStub: _i11.Future<Uri?>.value(),
-      ) as _i11.Future<Uri?>);
+        returnValue: _i12.Future<Uri?>.value(),
+        returnValueForMissingStub: _i12.Future<Uri?>.value(),
+      ) as _i12.Future<Uri?>);
 
   @override
-  _i11.Future<void> add3PID(
+  _i12.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5056,12 +5091,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> bind3PID(
+  _i12.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5077,14 +5112,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             sid,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> delete3pidFromAccount(
+  _i12.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
-    _i3.ThirdPartyIdentifierMedium? medium, {
+    _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
   }) =>
       (super.noSuchMethod(
@@ -5096,14 +5131,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5125,8 +5160,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5142,8 +5177,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5159,10 +5194,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5186,8 +5221,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5204,8 +5239,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5222,12 +5257,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> unbind3pidFromAccount(
+  _i12.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
-    _i3.ThirdPartyIdentifierMedium? medium, {
+    _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
   }) =>
       (super.noSuchMethod(
@@ -5239,15 +5274,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> deactivateAccount({
-    _i3.AuthenticationData? auth,
+  _i12.Future<_i4.IdServerUnbindResult> deactivateAccount({
+    _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
   }) =>
@@ -5261,14 +5296,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5290,8 +5325,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5307,8 +5342,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5324,10 +5359,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5351,8 +5386,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5369,8 +5404,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5387,16 +5422,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i12.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i11.Future<_i3.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_42(
+            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_43(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -5404,22 +5439,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_42(
+            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_43(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.TokenOwnerInfo>);
+      ) as _i12.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i11.Future<_i3.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i12.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i11.Future<_i3.WhoIsInfo>.value(_FakeWhoIsInfo_43(
+        returnValue: _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_44(
           this,
           Invocation.method(
             #getWhoIs,
@@ -5427,22 +5462,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.WhoIsInfo>.value(_FakeWhoIsInfo_43(
+            _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_44(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i11.Future<_i3.WhoIsInfo>);
+      ) as _i12.Future<_i4.WhoIsInfo>);
 
   @override
-  _i11.Future<_i3.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i12.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i11.Future<_i3.Capabilities>.value(_FakeCapabilities_44(
+        returnValue: _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_45(
           this,
           Invocation.method(
             #getCapabilities,
@@ -5450,29 +5485,29 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Capabilities>.value(_FakeCapabilities_44(
+            _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_45(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.Capabilities>);
+      ) as _i12.Future<_i4.Capabilities>);
 
   @override
-  _i11.Future<String> createRoom({
+  _i12.Future<String> createRoom({
     Map<String, Object?>? creationContent,
-    List<_i3.StateEvent>? initialState,
+    List<_i4.StateEvent>? initialState,
     List<String>? invite,
-    List<_i3.Invite3pid>? invite3pid,
+    List<_i4.Invite3pid>? invite3pid,
     bool? isDirect,
     String? name,
     Map<String, Object?>? powerLevelContentOverride,
-    _i3.CreateRoomPreset? preset,
+    _i4.CreateRoomPreset? preset,
     String? roomAliasName,
     String? roomVersion,
     String? topic,
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5493,7 +5528,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5515,7 +5550,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i16.dummyValue<String>(
+            _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5536,12 +5571,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> deleteDevices(
+  _i12.Future<void> deleteDevices(
     List<String>? devices, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5549,24 +5584,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.Device>?> getDevices() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Device>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.Device>?>.value(),
-      ) as _i11.Future<List<_i3.Device>?>);
+        returnValue: _i12.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.Device>?>.value(),
+      ) as _i12.Future<List<_i4.Device>?>);
 
   @override
-  _i11.Future<void> deleteDevice(
+  _i12.Future<void> deleteDevice(
     String? deviceId, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5574,34 +5609,34 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i12.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i11.Future<_i3.Device>.value(_FakeDevice_45(
+        returnValue: _i12.Future<_i4.Device>.value(_FakeDevice_46(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.Device>.value(_FakeDevice_45(
+        returnValueForMissingStub: _i12.Future<_i4.Device>.value(_FakeDevice_46(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i11.Future<_i3.Device>);
+      ) as _i12.Future<_i4.Device>);
 
   @override
-  _i11.Future<void> updateDevice(
+  _i12.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -5611,15 +5646,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i12.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5631,26 +5666,26 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i12.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i11.Future<_i3.Visibility?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Visibility?>.value(),
-      ) as _i11.Future<_i3.Visibility?>);
+        returnValue: _i12.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Visibility?>.value(),
+      ) as _i12.Future<_i4.Visibility?>);
 
   @override
-  _i11.Future<void> setRoomVisibilityOnDirectory(
+  _i12.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5658,30 +5693,30 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i12.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i12.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i11.Future<_i3.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_46(
+        returnValue: _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_47(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -5689,18 +5724,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_46(
+            _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_47(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomIdByAliasResponse>);
+      ) as _i12.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i11.Future<void> setRoomAlias(
+  _i12.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -5712,12 +5747,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             roomId,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetEventsResponse> getEvents({
+  _i12.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -5731,7 +5766,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<_i3.GetEventsResponse>.value(_FakeGetEventsResponse_47(
+            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_48(
           this,
           Invocation.method(
             #getEvents,
@@ -5743,7 +5778,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetEventsResponse>.value(_FakeGetEventsResponse_47(
+            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_48(
           this,
           Invocation.method(
             #getEvents,
@@ -5754,10 +5789,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetEventsResponse>);
+      ) as _i12.Future<_i4.GetEventsResponse>);
 
   @override
-  _i11.Future<_i3.PeekEventsResponse> peekEvents({
+  _i12.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -5772,8 +5807,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i11.Future<_i3.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_48(
+        returnValue: _i12.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_49(
           this,
           Invocation.method(
             #peekEvents,
@@ -5785,8 +5820,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_48(
+        returnValueForMissingStub: _i12.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_49(
           this,
           Invocation.method(
             #peekEvents,
@@ -5798,16 +5833,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.PeekEventsResponse>);
+      ) as _i12.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i11.Future<_i3.MatrixEvent> getOneEvent(String? eventId) =>
+  _i12.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_49(
+        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_50(
           this,
           Invocation.method(
             #getOneEvent,
@@ -5815,27 +5850,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_49(
+            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_50(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i11.Future<_i3.MatrixEvent>);
+      ) as _i12.Future<_i4.MatrixEvent>);
 
   @override
-  _i11.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i12.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i11.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i11.Future<List<String>>.value(<String>[]),
-      ) as _i11.Future<List<String>>);
+        returnValue: _i12.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
+      ) as _i12.Future<List<String>>);
 
   @override
-  _i11.Future<_i3.GetKeysChangesResponse> getKeysChanges(
+  _i12.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -5847,8 +5882,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             to,
           ],
         ),
-        returnValue: _i11.Future<_i3.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_50(
+        returnValue: _i12.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_51(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5859,8 +5894,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_50(
+            _i12.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_51(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5870,10 +5905,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.GetKeysChangesResponse>);
+      ) as _i12.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i11.Future<_i3.ClaimKeysResponse> claimKeys(
+  _i12.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -5884,7 +5919,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i11.Future<_i3.ClaimKeysResponse>.value(_FakeClaimKeysResponse_51(
+            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_52(
           this,
           Invocation.method(
             #claimKeys,
@@ -5893,7 +5928,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.ClaimKeysResponse>.value(_FakeClaimKeysResponse_51(
+            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_52(
           this,
           Invocation.method(
             #claimKeys,
@@ -5901,14 +5936,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i11.Future<_i3.ClaimKeysResponse>);
+      ) as _i12.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i11.Future<void> uploadCrossSigningKeys({
-    _i3.AuthenticationData? auth,
-    _i3.MatrixCrossSigningKey? masterKey,
-    _i3.MatrixCrossSigningKey? selfSigningKey,
-    _i3.MatrixCrossSigningKey? userSigningKey,
+  _i12.Future<void> uploadCrossSigningKeys({
+    _i4.AuthenticationData? auth,
+    _i4.MatrixCrossSigningKey? masterKey,
+    _i4.MatrixCrossSigningKey? selfSigningKey,
+    _i4.MatrixCrossSigningKey? userSigningKey,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5921,12 +5956,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.QueryKeysResponse> queryKeys(
+  _i12.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -5937,7 +5972,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i11.Future<_i3.QueryKeysResponse>.value(_FakeQueryKeysResponse_52(
+            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_53(
           this,
           Invocation.method(
             #queryKeys,
@@ -5946,7 +5981,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.QueryKeysResponse>.value(_FakeQueryKeysResponse_52(
+            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_53(
           this,
           Invocation.method(
             #queryKeys,
@@ -5954,10 +5989,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i11.Future<_i3.QueryKeysResponse>);
+      ) as _i12.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i11.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -5965,15 +6000,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i11.Future<
+            returnValue: _i12.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i11.Future<
+            returnValueForMissingStub: _i12.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i11.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i11.Future<Map<String, int>> uploadKeys({
-    _i3.MatrixDeviceKeys? deviceKeys,
+  _i12.Future<Map<String, int>> uploadKeys({
+    _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
   }) =>
@@ -5987,13 +6022,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i11.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i12.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i11.Future<Map<String, int>>);
+            _i12.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i12.Future<Map<String, int>>);
 
   @override
-  _i11.Future<String> knockRoom(
+  _i12.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6007,7 +6042,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6019,7 +6054,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i16.dummyValue<String>(
+            _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6030,20 +6065,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<List<_i3.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i12.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.LoginFlow>?>.value(),
-      ) as _i11.Future<List<_i3.LoginFlow>?>);
+        returnValue: _i12.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i12.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i11.Future<_i3.GetNotificationsResponse> getNotifications({
+  _i12.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6058,8 +6093,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #only: only,
           },
         ),
-        returnValue: _i11.Future<_i3.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_53(
+        returnValue: _i12.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_54(
           this,
           Invocation.method(
             #getNotifications,
@@ -6072,8 +6107,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_53(
+            _i12.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_54(
           this,
           Invocation.method(
             #getNotifications,
@@ -6085,37 +6120,37 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetNotificationsResponse>);
+      ) as _i12.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i11.Future<_i3.GetPresenceResponse> getPresence(String? userId) =>
+  _i12.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i11.Future<_i3.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_54(
+        returnValue: _i12.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_55(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_54(
+        returnValueForMissingStub: _i12.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_55(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i11.Future<_i3.GetPresenceResponse>);
+      ) as _i12.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i11.Future<void> setPresence(
+  _i12.Future<void> setPresence(
     String? userId,
-    _i3.PresenceType? presence, {
+    _i4.PresenceType? presence, {
     String? statusMsg,
   }) =>
       (super.noSuchMethod(
@@ -6127,12 +6162,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, Object?>> deleteProfileField(
+  _i12.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6145,13 +6180,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getProfileField(
+  _i12.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6164,13 +6199,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<Map<String, Object?>> setProfileField(
+  _i12.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6185,13 +6220,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.GetPublicRoomsResponse> getPublicRooms({
+  _i12.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6206,8 +6241,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #server: server,
           },
         ),
-        returnValue: _i11.Future<_i3.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_55(
+        returnValue: _i12.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_56(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6220,8 +6255,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_55(
+            _i12.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_56(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6233,12 +6268,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetPublicRoomsResponse>);
+      ) as _i12.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i11.Future<_i3.QueryPublicRoomsResponse> queryPublicRooms({
+  _i12.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
-    _i3.PublicRoomQueryFilter? filter,
+    _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
     int? limit,
     String? since,
@@ -6257,8 +6292,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i11.Future<_i3.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_56(
+        returnValue: _i12.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_57(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6274,8 +6309,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_56(
+            _i12.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_57(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6290,25 +6325,25 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.QueryPublicRoomsResponse>);
+      ) as _i12.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i11.Future<List<_i3.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Pusher>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.Pusher>?>.value(),
-      ) as _i11.Future<List<_i3.Pusher>?>);
+        returnValue: _i12.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.Pusher>?>.value(),
+      ) as _i12.Future<List<_i4.Pusher>?>);
 
   @override
-  _i11.Future<_i3.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i12.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i11.Future<_i3.PushRuleSet>.value(_FakePushRuleSet_57(
+        returnValue: _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_58(
           this,
           Invocation.method(
             #getPushRules,
@@ -6316,24 +6351,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PushRuleSet>.value(_FakePushRuleSet_57(
+            _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_58(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.PushRuleSet>);
+      ) as _i12.Future<_i4.PushRuleSet>);
 
   @override
-  _i11.Future<_i3.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i12.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i11.Future<_i3.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_58(
+        returnValue: _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_59(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -6341,19 +6376,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_58(
+            _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_59(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.GetPushRulesGlobalResponse>);
+      ) as _i12.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i11.Future<void> deletePushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> deletePushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -6364,13 +6399,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.PushRule> getPushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<_i4.PushRule> getPushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -6381,7 +6416,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<_i3.PushRule>.value(_FakePushRule_59(
+        returnValue: _i12.Future<_i4.PushRule>.value(_FakePushRule_60(
           this,
           Invocation.method(
             #getPushRule,
@@ -6392,7 +6427,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PushRule>.value(_FakePushRule_59(
+            _i12.Future<_i4.PushRule>.value(_FakePushRule_60(
           this,
           Invocation.method(
             #getPushRule,
@@ -6402,16 +6437,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.PushRule>);
+      ) as _i12.Future<_i4.PushRule>);
 
   @override
-  _i11.Future<void> setPushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
     String? before,
     String? after,
-    List<_i3.PushCondition>? conditions,
+    List<_i4.PushCondition>? conditions,
     String? pattern,
   }) =>
       (super.noSuchMethod(
@@ -6429,13 +6464,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<Object?>> getPushRuleActions(
-    _i3.PushRuleKind? kind,
+  _i12.Future<List<Object?>> getPushRuleActions(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -6446,14 +6481,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i12.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i11.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i11.Future<List<Object?>>);
+            _i12.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i12.Future<List<Object?>>);
 
   @override
-  _i11.Future<void> setPushRuleActions(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRuleActions(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
   ) =>
@@ -6466,13 +6501,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             actions,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<bool> isPushRuleEnabled(
-    _i3.PushRuleKind? kind,
+  _i12.Future<bool> isPushRuleEnabled(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -6483,13 +6518,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> setPushRuleEnabled(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRuleEnabled(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
   ) =>
@@ -6502,19 +6537,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
             enabled,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.RefreshResponse> refresh(String? refreshToken) =>
+  _i12.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i11.Future<_i3.RefreshResponse>.value(_FakeRefreshResponse_60(
+            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_61(
           this,
           Invocation.method(
             #refresh,
@@ -6522,28 +6557,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RefreshResponse>.value(_FakeRefreshResponse_60(
+            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_61(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i11.Future<_i3.RefreshResponse>);
+      ) as _i12.Future<_i4.RefreshResponse>);
 
   @override
-  _i11.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i12.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i11.Future<bool?>.value(),
-        returnValueForMissingStub: _i11.Future<bool?>.value(),
-      ) as _i11.Future<bool?>);
+        returnValue: _i12.Future<bool?>.value(),
+        returnValueForMissingStub: _i12.Future<bool?>.value(),
+      ) as _i12.Future<bool?>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6565,8 +6600,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6582,8 +6617,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6599,10 +6634,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6626,8 +6661,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6644,8 +6679,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6662,17 +6697,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_30(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -6680,23 +6715,23 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_30(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i12.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i11.Future<_i3.RoomKeys>.value(_FakeRoomKeys_61(
+        returnValue: _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_62(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -6704,19 +6739,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeys>.value(_FakeRoomKeys_61(
+            _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_62(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeys>);
+      ) as _i12.Future<_i4.RoomKeys>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeys(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
-    _i3.RoomKeys? body,
+    _i4.RoomKeys? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6726,8 +6761,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_30(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6738,8 +6773,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_30(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6749,10 +6784,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6764,8 +6799,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_30(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6776,8 +6811,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_30(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6787,10 +6822,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeyBackup> getRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6802,7 +6837,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeyBackup>.value(_FakeRoomKeyBackup_62(
+        returnValue: _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_63(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6813,7 +6848,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeyBackup>.value(_FakeRoomKeyBackup_62(
+            _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_63(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6823,13 +6858,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeyBackup>);
+      ) as _i12.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
-    _i3.RoomKeyBackup? body,
+    _i4.RoomKeyBackup? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6840,8 +6875,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_30(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6853,8 +6888,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_30(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6865,10 +6900,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6882,8 +6917,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_30(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -6895,8 +6930,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_30(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -6907,10 +6942,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.KeyBackupData> getRoomKeyBySessionId(
+  _i12.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6924,7 +6959,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_31(
+        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_32(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -6936,7 +6971,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_31(
+            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_32(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -6947,14 +6982,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.KeyBackupData>);
+      ) as _i12.Future<_i4.KeyBackupData>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
-    _i3.KeyBackupData? body,
+    _i4.KeyBackupData? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6966,8 +7001,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_30(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -6980,8 +7015,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_30(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -6993,18 +7028,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>
+  _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_63(
+                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_64(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7012,19 +7047,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_63(
+                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_64(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>);
+          ) as _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i11.Future<String> postRoomKeysVersion(
-    _i3.BackupAlgorithm? algorithm,
+  _i12.Future<String> postRoomKeysVersion(
+    _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
       (super.noSuchMethod(
@@ -7035,7 +7070,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             authData,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7046,7 +7081,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i16.dummyValue<String>(
+            _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7056,29 +7091,29 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i12.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i12.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i11.Future<_i3.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_64(
+        returnValue: _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_65(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7086,20 +7121,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_64(
+            _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_65(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomKeysVersionResponse>);
+      ) as _i12.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i12.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
-    _i3.BackupAlgorithm? algorithm,
+    _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
       (super.noSuchMethod(
@@ -7112,24 +7147,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i12.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i11.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i11.Future<List<String>>.value(<String>[]),
-      ) as _i11.Future<List<String>>);
+        returnValue: _i12.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
+      ) as _i12.Future<List<String>>);
 
   @override
-  _i11.Future<void> ban(
+  _i12.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7143,12 +7178,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.EventContext> getEventContext(
+  _i12.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7166,7 +7201,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<_i3.EventContext>.value(_FakeEventContext_65(
+        returnValue: _i12.Future<_i4.EventContext>.value(_FakeEventContext_66(
           this,
           Invocation.method(
             #getEventContext,
@@ -7181,7 +7216,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.EventContext>.value(_FakeEventContext_65(
+            _i12.Future<_i4.EventContext>.value(_FakeEventContext_66(
           this,
           Invocation.method(
             #getEventContext,
@@ -7195,10 +7230,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.EventContext>);
+      ) as _i12.Future<_i4.EventContext>);
 
   @override
-  _i11.Future<_i3.MatrixEvent> getOneRoomEvent(
+  _i12.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7210,7 +7245,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             eventId,
           ],
         ),
-        returnValue: _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_49(
+        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_50(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7221,7 +7256,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_49(
+            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_50(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7231,22 +7266,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.MatrixEvent>);
+      ) as _i12.Future<_i4.MatrixEvent>);
 
   @override
-  _i11.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i12.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> inviteBy3PID(
+  _i12.Future<void> inviteBy3PID(
     String? roomId,
-    _i3.Invite3pid? body,
+    _i4.Invite3pid? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7256,12 +7291,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> inviteUser(
+  _i12.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7275,15 +7310,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> joinRoomById(
+  _i12.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
-    _i3.ThirdPartySigned? thirdPartySigned,
+    _i4.ThirdPartySigned? thirdPartySigned,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7294,7 +7329,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7306,7 +7341,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i16.dummyValue<String>(
+            _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7317,23 +7352,23 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<Map<String, _i3.RoomMember>?> getJoinedMembersByRoom(
+  _i12.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i11.Future<Map<String, _i3.RoomMember>?>.value(),
+        returnValue: _i12.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i11.Future<Map<String, _i3.RoomMember>?>.value(),
-      ) as _i11.Future<Map<String, _i3.RoomMember>?>);
+            _i12.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i12.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i11.Future<void> kick(
+  _i12.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7347,12 +7382,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> leaveRoom(
+  _i12.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -7362,16 +7397,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.MatrixEvent>?> getMembersByRoom(
+  _i12.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
-    _i3.Membership? membership,
-    _i3.Membership? notMembership,
+    _i4.Membership? membership,
+    _i4.Membership? notMembership,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7383,14 +7418,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i11.Future<List<_i3.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.MatrixEvent>?>.value(),
-      ) as _i11.Future<List<_i3.MatrixEvent>?>);
+        returnValue: _i12.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i12.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i11.Future<_i3.GetRoomEventsResponse> getRoomEvents(
+  _i12.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
-    _i3.Direction? dir, {
+    _i4.Direction? dir, {
     String? from,
     String? to,
     int? limit,
@@ -7410,8 +7445,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<_i3.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_66(
+        returnValue: _i12.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_67(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7427,8 +7462,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_66(
+        returnValueForMissingStub: _i12.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_67(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7444,10 +7479,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomEventsResponse>);
+      ) as _i12.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i11.Future<void> setReadMarker(
+  _i12.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -7463,14 +7498,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> postReceipt(
+  _i12.Future<void> postReceipt(
     String? roomId,
-    _i3.ReceiptType? receiptType,
+    _i4.ReceiptType? receiptType,
     String? eventId, {
     String? threadId,
   }) =>
@@ -7484,12 +7519,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEvent(
+  _i12.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -7505,12 +7540,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> reportRoom(
+  _i12.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -7522,12 +7557,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             reason,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> reportEvent(
+  _i12.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -7545,12 +7580,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #score: score,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> sendMessage(
+  _i12.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -7566,7 +7601,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7579,7 +7614,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i16.dummyValue<String>(
+            _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7591,27 +7626,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<List<_i3.MatrixEvent>> getRoomState(String? roomId) =>
+  _i12.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i11.Future<List<_i3.MatrixEvent>>.value(<_i3.MatrixEvent>[]),
+            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.MatrixEvent>>.value(<_i3.MatrixEvent>[]),
-      ) as _i11.Future<List<_i3.MatrixEvent>>);
+            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i12.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i12.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
-    _i3.Format? format,
+    _i4.Format? format,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7624,13 +7659,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#format: format},
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<String> setRoomStateWithKey(
+  _i12.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -7646,7 +7681,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7659,7 +7694,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i16.dummyValue<String>(
+            _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7671,10 +7706,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> unban(
+  _i12.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7688,12 +7723,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> upgradeRoom(
+  _i12.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -7707,7 +7742,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i11.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7719,7 +7754,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i16.dummyValue<String>(
+            _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7730,11 +7765,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.SearchResults> search(
-    _i3.Categories? searchCategories, {
+  _i12.Future<_i4.SearchResults> search(
+    _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
       (super.noSuchMethod(
@@ -7743,7 +7778,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i11.Future<_i3.SearchResults>.value(_FakeSearchResults_67(
+        returnValue: _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_68(
           this,
           Invocation.method(
             #search,
@@ -7752,7 +7787,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SearchResults>.value(_FakeSearchResults_67(
+            _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_68(
           this,
           Invocation.method(
             #search,
@@ -7760,14 +7795,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i11.Future<_i3.SearchResults>);
+      ) as _i12.Future<_i4.SearchResults>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> sync({
+  _i12.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
-    _i3.PresenceType? setPresence,
+    _i4.PresenceType? setPresence,
     int? timeout,
     bool? useStateAfter,
   }) =>
@@ -7784,7 +7819,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_22(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
           this,
           Invocation.method(
             #sync,
@@ -7800,7 +7835,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_22(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
           this,
           Invocation.method(
             #sync,
@@ -7815,22 +7850,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<List<_i3.Location>> queryLocationByAlias(String? alias) =>
+  _i12.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
+        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
-      ) as _i11.Future<List<_i3.Location>>);
+            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i12.Future<List<_i4.Location>>);
 
   @override
-  _i11.Future<List<_i3.Location>> queryLocationByProtocol(
+  _i12.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -7840,21 +7875,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
+        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
-      ) as _i11.Future<List<_i3.Location>>);
+            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i12.Future<List<_i4.Location>>);
 
   @override
-  _i11.Future<_i3.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i12.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i11.Future<_i3.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_68(
+        returnValue: _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_69(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -7862,45 +7897,45 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_68(
+            _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_69(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i11.Future<_i3.GetProtocolMetadataResponse$2>);
+      ) as _i12.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i11.Future<Map<String, _i3.GetProtocolsResponse$2>> getProtocols() =>
+  _i12.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>.value(
-            <String, _i3.GetProtocolsResponse$2>{}),
+        returnValue: _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>.value(
-                <String, _i3.GetProtocolsResponse$2>{}),
-      ) as _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>);
+            _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+                <String, _i4.GetProtocolsResponse$2>{}),
+      ) as _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
-      ) as _i11.Future<List<_i3.ThirdPartyUser>>);
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyUser>> queryUserByProtocol(
+  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -7911,13 +7946,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
-      ) as _i11.Future<List<_i3.ThirdPartyUser>>);
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getAccountData(
+  _i12.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -7930,13 +7965,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> setAccountData(
+  _i12.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -7950,14 +7985,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> defineFilter(
+  _i12.Future<String> defineFilter(
     String? userId,
-    _i3.Filter? body,
+    _i4.Filter? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7967,7 +8002,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7978,7 +8013,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i16.dummyValue<String>(
+            _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7988,10 +8023,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.Filter> getFilter(
+  _i12.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8003,7 +8038,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             filterId,
           ],
         ),
-        returnValue: _i11.Future<_i3.Filter>.value(_FakeFilter_8(
+        returnValue: _i12.Future<_i4.Filter>.value(_FakeFilter_9(
           this,
           Invocation.method(
             #getFilter,
@@ -8013,7 +8048,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.Filter>.value(_FakeFilter_8(
+        returnValueForMissingStub: _i12.Future<_i4.Filter>.value(_FakeFilter_9(
           this,
           Invocation.method(
             #getFilter,
@@ -8023,10 +8058,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.Filter>);
+      ) as _i12.Future<_i4.Filter>);
 
   @override
-  _i11.Future<_i3.OpenIdCredentials> requestOpenIdToken(
+  _i12.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8039,7 +8074,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<_i3.OpenIdCredentials>.value(_FakeOpenIdCredentials_69(
+            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_70(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8050,7 +8085,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.OpenIdCredentials>.value(_FakeOpenIdCredentials_69(
+            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_70(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8060,10 +8095,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.OpenIdCredentials>);
+      ) as _i12.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i11.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i12.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8078,13 +8113,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> setAccountDataPerRoom(
+  _i12.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8100,12 +8135,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, _i3.Tag>?> getRoomTags(
+  _i12.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8117,12 +8152,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             roomId,
           ],
         ),
-        returnValue: _i11.Future<Map<String, _i3.Tag>?>.value(),
-        returnValueForMissingStub: _i11.Future<Map<String, _i3.Tag>?>.value(),
-      ) as _i11.Future<Map<String, _i3.Tag>?>);
+        returnValue: _i12.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i12.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i12.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i11.Future<void> deleteRoomTag(
+  _i12.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8136,16 +8171,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             tag,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setRoomTag(
+  _i12.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
-    _i3.Tag? body,
+    _i4.Tag? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8157,12 +8192,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.SearchUserDirectoryResponse> searchUserDirectory(
+  _i12.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8172,8 +8207,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i11.Future<_i3.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_70(
+        returnValue: _i12.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_71(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8182,8 +8217,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_70(
+            _i12.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_71(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8191,10 +8226,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i11.Future<_i3.SearchUserDirectoryResponse>);
+      ) as _i12.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> reportUser(
+  _i12.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8207,40 +8242,40 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i12.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i11.Future<_i3.CreateContentResponse>.value(
-            _FakeCreateContentResponse_71(
+        returnValue: _i12.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_72(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.CreateContentResponse>.value(
-            _FakeCreateContentResponse_71(
+        returnValueForMissingStub: _i12.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_72(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.CreateContentResponse>);
+      ) as _i12.Future<_i4.CreateContentResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> uploadContentToMXC(
+  _i12.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i21.Uint8List? body, {
+    _i22.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8258,28 +8293,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [CallService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCallService extends _i1.Mock implements _i22.CallService {
+class MockCallService extends _i1.Mock implements _i23.CallService {
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get initialized => (super.noSuchMethod(
@@ -8289,36 +8324,36 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       ) as bool);
 
   @override
-  _i23.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
+  _i24.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
         Invocation.getter(#httpPostForTest),
         returnValue: (
-          _i10.Client httpClient,
+          _i11.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i11.Future<_i10.Response>.value(_FakeResponse_72(
+            _i12.Future<_i11.Response>.value(_FakeResponse_73(
           this,
           Invocation.getter(#httpPostForTest),
         )),
         returnValueForMissingStub: (
-          _i10.Client httpClient,
+          _i11.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i11.Future<_i10.Response>.value(_FakeResponse_72(
+            _i12.Future<_i11.Response>.value(_FakeResponse_73(
           this,
           Invocation.getter(#httpPostForTest),
         )),
-      ) as _i23.HttpPostFunction);
+      ) as _i24.HttpPostFunction);
 
   @override
-  List<_i24.RemoteParticipant> get participants => (super.noSuchMethod(
+  List<_i25.RemoteParticipant> get participants => (super.noSuchMethod(
         Invocation.getter(#participants),
-        returnValue: <_i24.RemoteParticipant>[],
-        returnValueForMissingStub: <_i24.RemoteParticipant>[],
-      ) as List<_i24.RemoteParticipant>);
+        returnValue: <_i25.RemoteParticipant>[],
+        returnValueForMissingStub: <_i25.RemoteParticipant>[],
+      ) as List<_i25.RemoteParticipant>);
 
   @override
   bool get isMicEnabled => (super.noSuchMethod(
@@ -8349,14 +8384,14 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       ) as bool);
 
   @override
-  List<_i24.Participant<_i24.TrackPublication<_i24.Track>>>
+  List<_i25.Participant<_i25.TrackPublication<_i25.Track>>>
       get activeSpeakers => (super.noSuchMethod(
             Invocation.getter(#activeSpeakers),
-            returnValue: <_i24
-                .Participant<_i24.TrackPublication<_i24.Track>>>[],
-            returnValueForMissingStub: <_i24
-                .Participant<_i24.TrackPublication<_i24.Track>>>[],
-          ) as List<_i24.Participant<_i24.TrackPublication<_i24.Track>>>);
+            returnValue: <_i25
+                .Participant<_i25.TrackPublication<_i25.Track>>>[],
+            returnValueForMissingStub: <_i25
+                .Participant<_i25.TrackPublication<_i25.Track>>>[],
+          ) as List<_i25.Participant<_i25.TrackPublication<_i25.Track>>>);
 
   @override
   bool get isCallingAvailable => (super.noSuchMethod(
@@ -8366,11 +8401,11 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       ) as bool);
 
   @override
-  List<_i25.CallParticipant> get allParticipants => (super.noSuchMethod(
+  List<_i26.CallParticipant> get allParticipants => (super.noSuchMethod(
         Invocation.getter(#allParticipants),
-        returnValue: <_i25.CallParticipant>[],
-        returnValueForMissingStub: <_i25.CallParticipant>[],
-      ) as List<_i25.CallParticipant>);
+        returnValue: <_i26.CallParticipant>[],
+        returnValueForMissingStub: <_i26.CallParticipant>[],
+      ) as List<_i26.CallParticipant>);
 
   @override
   bool get isSpeakerOn => (super.noSuchMethod(
@@ -8380,29 +8415,29 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       ) as bool);
 
   @override
-  _i11.Stream<_i26.IncomingCallInfo> get incomingCallStream =>
+  _i12.Stream<_i27.IncomingCallInfo> get incomingCallStream =>
       (super.noSuchMethod(
         Invocation.getter(#incomingCallStream),
-        returnValue: _i11.Stream<_i26.IncomingCallInfo>.empty(),
-        returnValueForMissingStub: _i11.Stream<_i26.IncomingCallInfo>.empty(),
-      ) as _i11.Stream<_i26.IncomingCallInfo>);
+        returnValue: _i12.Stream<_i27.IncomingCallInfo>.empty(),
+        returnValueForMissingStub: _i12.Stream<_i27.IncomingCallInfo>.empty(),
+      ) as _i12.Stream<_i27.IncomingCallInfo>);
 
   @override
-  _i11.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
+  _i12.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
         Invocation.getter(#nativeAcceptedCallStream),
-        returnValue: _i11.Stream<String>.empty(),
-        returnValueForMissingStub: _i11.Stream<String>.empty(),
-      ) as _i11.Stream<String>);
+        returnValue: _i12.Stream<String>.empty(),
+        returnValueForMissingStub: _i12.Stream<String>.empty(),
+      ) as _i12.Stream<String>);
 
   @override
-  _i27.KoheraCallState get callState => (super.noSuchMethod(
+  _i28.KoheraCallState get callState => (super.noSuchMethod(
         Invocation.getter(#callState),
-        returnValue: _i27.KoheraCallState.idle,
-        returnValueForMissingStub: _i27.KoheraCallState.idle,
-      ) as _i27.KoheraCallState);
+        returnValue: _i28.KoheraCallState.idle,
+        returnValueForMissingStub: _i28.KoheraCallState.idle,
+      ) as _i28.KoheraCallState);
 
   @override
-  set preferencesService(_i14.PreferencesService? prefs) => super.noSuchMethod(
+  set preferencesService(_i15.PreferencesService? prefs) => super.noSuchMethod(
         Invocation.setter(
           #preferencesService,
           prefs,
@@ -8411,7 +8446,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  set ringtoneService(_i28.RingtoneService? service) => super.noSuchMethod(
+  set ringtoneService(_i29.RingtoneService? service) => super.noSuchMethod(
         Invocation.setter(
           #ringtoneService,
           service,
@@ -8420,7 +8455,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  set roomFactoryForTest(_i23.LiveKitRoomFactory? factory) =>
+  set roomFactoryForTest(_i24.LiveKitRoomFactory? factory) =>
       super.noSuchMethod(
         Invocation.setter(
           #roomFactoryForTest,
@@ -8430,7 +8465,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  set httpPostForTest(_i23.HttpPostFunction? fn) => super.noSuchMethod(
+  set httpPostForTest(_i24.HttpPostFunction? fn) => super.noSuchMethod(
         Invocation.setter(
           #httpPostForTest,
           fn,
@@ -8464,27 +8499,27 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  _i11.Future<void> toggleMicrophone() => (super.noSuchMethod(
+  _i12.Future<void> toggleMicrophone() => (super.noSuchMethod(
         Invocation.method(
           #toggleMicrophone,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> toggleCamera() => (super.noSuchMethod(
+  _i12.Future<void> toggleCamera() => (super.noSuchMethod(
         Invocation.method(
           #toggleCamera,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> toggleScreenShare({
+  _i12.Future<void> toggleScreenShare({
     String? sourceId,
     bool? captureScreenAudio = false,
   }) =>
@@ -8497,39 +8532,39 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
             #captureScreenAudio: captureScreenAudio,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> toggleScreenAudio() => (super.noSuchMethod(
+  _i12.Future<void> toggleScreenAudio() => (super.noSuchMethod(
         Invocation.method(
           #toggleScreenAudio,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
+  _i12.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
         Invocation.method(
           #setOutputVolume,
           [volume],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> toggleSpeaker() => (super.noSuchMethod(
+  _i12.Future<void> toggleSpeaker() => (super.noSuchMethod(
         Invocation.method(
           #toggleSpeaker,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void setVoipPushHandlesCallKit(bool? value) => super.noSuchMethod(
@@ -8550,7 +8585,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  void updateClient(_i3.Client? newClient) => super.noSuchMethod(
+  void updateClient(_i4.Client? newClient) => super.noSuchMethod(
         Invocation.method(
           #updateClient,
           [newClient],
@@ -8559,7 +8594,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8587,36 +8622,36 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  _i11.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
+  _i12.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #joinCall,
           [roomId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> leaveCall() => (super.noSuchMethod(
+  _i12.Future<void> leaveCall() => (super.noSuchMethod(
         Invocation.method(
           #leaveCall,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> acceptCall({bool? withVideo = false}) =>
+  _i12.Future<void> acceptCall({bool? withVideo = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #acceptCall,
           [],
           {#withVideo: withVideo},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void declineCall() => super.noSuchMethod(
@@ -8638,9 +8673,9 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  _i11.Future<void> initiateCall(
+  _i12.Future<void> initiateCall(
     String? roomId, {
-    _i26.CallType? type = _i26.CallType.voice,
+    _i27.CallType? type = _i27.CallType.voice,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8648,9 +8683,9 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
           [roomId],
           {#type: type},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   bool roomHasActiveCall(String? roomId) => (super.noSuchMethod(
@@ -8743,7 +8778,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8752,7 +8787,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8761,17 +8796,17 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  _i11.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8782,7 +8817,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8819,26 +8854,26 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  _i11.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+  _i12.Future<bool> didPushRouteInformation(
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -8868,7 +8903,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8877,7 +8912,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8886,16 +8921,16 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  _i11.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i12.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i11.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i12.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i11.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i11.Future<_i17.AppExitResponse>);
+            _i12.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i12.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8920,32 +8955,32 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockNotificationService extends _i1.Mock
-    implements _i29.NotificationService {
+    implements _i30.NotificationService {
   @override
-  _i13.MatrixService get matrixService => (super.noSuchMethod(
+  _i14.MatrixService get matrixService => (super.noSuchMethod(
         Invocation.getter(#matrixService),
-        returnValue: _FakeMatrixService_73(
+        returnValue: _FakeMatrixService_74(
           this,
           Invocation.getter(#matrixService),
         ),
-        returnValueForMissingStub: _FakeMatrixService_73(
+        returnValueForMissingStub: _FakeMatrixService_74(
           this,
           Invocation.getter(#matrixService),
         ),
-      ) as _i13.MatrixService);
+      ) as _i14.MatrixService);
 
   @override
-  _i14.PreferencesService get preferencesService => (super.noSuchMethod(
+  _i15.PreferencesService get preferencesService => (super.noSuchMethod(
         Invocation.getter(#preferencesService),
-        returnValue: _FakePreferencesService_74(
+        returnValue: _FakePreferencesService_75(
           this,
           Invocation.getter(#preferencesService),
         ),
-        returnValueForMissingStub: _FakePreferencesService_74(
+        returnValueForMissingStub: _FakePreferencesService_75(
           this,
           Invocation.getter(#preferencesService),
         ),
-      ) as _i14.PreferencesService);
+      ) as _i15.PreferencesService);
 
   @override
   bool get isAppResumed => (super.noSuchMethod(
@@ -8964,14 +8999,14 @@ class MockNotificationService extends _i1.Mock
       );
 
   @override
-  _i11.Future<void> init() => (super.noSuchMethod(
+  _i12.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void startListening() => super.noSuchMethod(
@@ -8992,8 +9027,8 @@ class MockNotificationService extends _i1.Mock
       );
 
   @override
-  _i11.Future<String?> downloadAvatarToTemp(
-    _i3.Client? client,
+  _i12.Future<String?> downloadAvatarToTemp(
+    _i4.Client? client,
     Uri? avatarUrl,
     String? userId,
   ) =>
@@ -9006,9 +9041,9 @@ class MockNotificationService extends _i1.Mock
             userId,
           ],
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
   void navigateToRoom(String? roomId) => super.noSuchMethod(
@@ -9020,7 +9055,7 @@ class MockNotificationService extends _i1.Mock
       );
 
   @override
-  _i11.Future<void> showPushNotification({
+  _i12.Future<void> showPushNotification({
     required String? roomId,
     required String? title,
     required String? body,
@@ -9037,29 +9072,29 @@ class MockNotificationService extends _i1.Mock
             #senderName: senderName,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> cancelForRoom(String? roomId) => (super.noSuchMethod(
+  _i12.Future<void> cancelForRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #cancelForRoom,
           [roomId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> cancelAll() => (super.noSuchMethod(
+  _i12.Future<void> cancelAll() => (super.noSuchMethod(
         Invocation.method(
           #cancelAll,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -9074,26 +9109,26 @@ class MockNotificationService extends _i1.Mock
 /// A class which mocks [Room].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockRoom extends _i1.Mock implements _i3.Room {
+class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
       ) as String);
 
   @override
-  _i3.Membership get membership => (super.noSuchMethod(
+  _i4.Membership get membership => (super.noSuchMethod(
         Invocation.getter(#membership),
-        returnValue: _i3.Membership.ban,
-        returnValueForMissingStub: _i3.Membership.ban,
-      ) as _i3.Membership);
+        returnValue: _i4.Membership.ban,
+        returnValueForMissingStub: _i4.Membership.ban,
+      ) as _i4.Membership);
 
   @override
   int get notificationCount => (super.noSuchMethod(
@@ -9110,47 +9145,47 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i3.RoomSummary get summary => (super.noSuchMethod(
+  _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_75(
+        returnValue: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_75(
+        returnValueForMissingStub: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
-      ) as _i3.RoomSummary);
+      ) as _i4.RoomSummary);
 
   @override
-  Map<String, Map<String, _i3.StrippedStateEvent>> get states =>
+  Map<String, Map<String, _i4.StrippedStateEvent>> get states =>
       (super.noSuchMethod(
         Invocation.getter(#states),
-        returnValue: <String, Map<String, _i3.StrippedStateEvent>>{},
+        returnValue: <String, Map<String, _i4.StrippedStateEvent>>{},
         returnValueForMissingStub: <String,
-            Map<String, _i3.StrippedStateEvent>>{},
-      ) as Map<String, Map<String, _i3.StrippedStateEvent>>);
+            Map<String, _i4.StrippedStateEvent>>{},
+      ) as Map<String, Map<String, _i4.StrippedStateEvent>>);
 
   @override
-  Map<String, _i3.BasicEvent> get ephemerals => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get ephemerals => (super.noSuchMethod(
         Invocation.getter(#ephemerals),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  Map<String, _i3.BasicEvent> get roomAccountData => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get roomAccountData => (super.noSuchMethod(
         Invocation.getter(#roomAccountData),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i11.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i12.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i11.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i11.Completer<dynamic>>[],
-      ) as List<_i11.Completer<dynamic>>);
+        returnValue: <_i12.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i12.Completer<dynamic>>[],
+      ) as List<_i12.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -9169,51 +9204,51 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i9.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i10.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i9.CachedStreamController<String> get onSessionKeyReceived =>
+  _i10.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -9229,11 +9264,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -9242,11 +9277,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -9260,24 +9295,24 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i3.User> get typingUsers => (super.noSuchMethod(
+  List<_i4.User> get typingUsers => (super.noSuchMethod(
         Invocation.getter(#typingUsers),
-        returnValue: <_i3.User>[],
-        returnValueForMissingStub: <_i3.User>[],
-      ) as List<_i3.User>);
+        returnValue: <_i4.User>[],
+        returnValueForMissingStub: <_i4.User>[],
+      ) as List<_i4.User>);
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get isAbandonedDMRoom => (super.noSuchMethod(
@@ -9289,11 +9324,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -9302,22 +9337,22 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_14(
+        returnValue: _FakeDateTime_15(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_14(
+        returnValueForMissingStub: _FakeDateTime_15(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
       ) as DateTime);
 
   @override
-  Map<String, _i3.Tag> get tags => (super.noSuchMethod(
+  Map<String, _i4.Tag> get tags => (super.noSuchMethod(
         Invocation.getter(#tags),
-        returnValue: <String, _i3.Tag>{},
-        returnValueForMissingStub: <String, _i3.Tag>{},
-      ) as Map<String, _i3.Tag>);
+        returnValue: <String, _i4.Tag>{},
+        returnValueForMissingStub: <String, _i4.Tag>{},
+      ) as Map<String, _i4.Tag>);
 
   @override
   bool get markedUnread => (super.noSuchMethod(
@@ -9334,17 +9369,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.LatestReceiptState get receiptState => (super.noSuchMethod(
+  _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_76(
+        returnValue: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_76(
+        returnValueForMissingStub: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
-      ) as _i3.LatestReceiptState);
+      ) as _i4.LatestReceiptState);
 
   @override
   bool get isUnread => (super.noSuchMethod(
@@ -9361,18 +9396,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i11.Future<_i3.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i12.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_22(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_22(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -9382,20 +9417,20 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  Map<String, _i3.MatrixFile> get sendingFilePlaceholders =>
+  Map<String, _i4.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
-        returnValue: <String, _i3.MatrixFile>{},
-        returnValueForMissingStub: <String, _i3.MatrixFile>{},
-      ) as Map<String, _i3.MatrixFile>);
+        returnValue: <String, _i4.MatrixFile>{},
+        returnValueForMissingStub: <String, _i4.MatrixFile>{},
+      ) as Map<String, _i4.MatrixFile>);
 
   @override
-  Map<String, _i3.MatrixImageFile> get sendingFileThumbnails =>
+  Map<String, _i4.MatrixImageFile> get sendingFileThumbnails =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFileThumbnails),
-        returnValue: <String, _i3.MatrixImageFile>{},
-        returnValueForMissingStub: <String, _i3.MatrixImageFile>{},
-      ) as Map<String, _i3.MatrixImageFile>);
+        returnValue: <String, _i4.MatrixImageFile>{},
+        returnValueForMissingStub: <String, _i4.MatrixImageFile>{},
+      ) as Map<String, _i4.MatrixImageFile>);
 
   @override
   bool get isFederated => (super.noSuchMethod(
@@ -9496,11 +9531,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.PushRuleState get pushRuleState => (super.noSuchMethod(
+  _i4.PushRuleState get pushRuleState => (super.noSuchMethod(
         Invocation.getter(#pushRuleState),
-        returnValue: _i3.PushRuleState.notify,
-        returnValueForMissingStub: _i3.PushRuleState.notify,
-      ) as _i3.PushRuleState);
+        returnValue: _i4.PushRuleState.notify,
+        returnValueForMissingStub: _i4.PushRuleState.notify,
+      ) as _i4.PushRuleState);
 
   @override
   bool get canChangeJoinRules => (super.noSuchMethod(
@@ -9510,11 +9545,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.GuestAccess get guestAccess => (super.noSuchMethod(
+  _i4.GuestAccess get guestAccess => (super.noSuchMethod(
         Invocation.getter(#guestAccess),
-        returnValue: _i3.GuestAccess.canJoin,
-        returnValueForMissingStub: _i3.GuestAccess.canJoin,
-      ) as _i3.GuestAccess);
+        returnValue: _i4.GuestAccess.canJoin,
+        returnValueForMissingStub: _i4.GuestAccess.canJoin,
+      ) as _i4.GuestAccess);
 
   @override
   bool get canChangeGuestAccess => (super.noSuchMethod(
@@ -9552,21 +9587,21 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i30.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i31.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i30.SpaceParent>[],
-        returnValueForMissingStub: <_i30.SpaceParent>[],
-      ) as List<_i30.SpaceParent>);
+        returnValue: <_i31.SpaceParent>[],
+        returnValueForMissingStub: <_i31.SpaceParent>[],
+      ) as List<_i31.SpaceParent>);
 
   @override
-  List<_i30.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i31.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i30.SpaceChild>[],
-        returnValueForMissingStub: <_i30.SpaceChild>[],
-      ) as List<_i30.SpaceChild>);
+        returnValue: <_i31.SpaceChild>[],
+        returnValueForMissingStub: <_i31.SpaceChild>[],
+      ) as List<_i31.SpaceChild>);
 
   @override
-  set membership(_i3.Membership? value) => super.noSuchMethod(
+  set membership(_i4.Membership? value) => super.noSuchMethod(
         Invocation.setter(
           #membership,
           value,
@@ -9602,7 +9637,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set summary(_i3.RoomSummary? value) => super.noSuchMethod(
+  set summary(_i4.RoomSummary? value) => super.noSuchMethod(
         Invocation.setter(
           #summary,
           value,
@@ -9611,7 +9646,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set states(Map<String, Map<String, _i3.StrippedStateEvent>>? value) =>
+  set states(Map<String, Map<String, _i4.StrippedStateEvent>>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #states,
@@ -9621,7 +9656,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set ephemerals(Map<String, _i3.BasicEvent>? value) => super.noSuchMethod(
+  set ephemerals(Map<String, _i4.BasicEvent>? value) => super.noSuchMethod(
         Invocation.setter(
           #ephemerals,
           value,
@@ -9630,7 +9665,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set roomAccountData(Map<String, _i3.BasicEvent>? value) => super.noSuchMethod(
+  set roomAccountData(Map<String, _i4.BasicEvent>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomAccountData,
           value,
@@ -9648,7 +9683,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set lastEvent(_i3.Event? value) => super.noSuchMethod(
+  set lastEvent(_i4.Event? value) => super.noSuchMethod(
         Invocation.setter(
           #lastEvent,
           value,
@@ -9657,7 +9692,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set receiptState(_i3.LatestReceiptState? value) => super.noSuchMethod(
+  set receiptState(_i4.LatestReceiptState? value) => super.noSuchMethod(
         Invocation.setter(
           #receiptState,
           value,
@@ -9676,17 +9711,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i11.Future<void> postLoad() => (super.noSuchMethod(
+  _i12.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i3.StrippedStateEvent? getState(
+  _i4.StrippedStateEvent? getState(
     String? typeKey, [
     String? stateKey = '',
   ]) =>
@@ -9699,10 +9734,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.StrippedStateEvent?);
+      ) as _i4.StrippedStateEvent?);
 
   @override
-  void setState(_i3.StrippedStateEvent? state) => super.noSuchMethod(
+  void setState(_i4.StrippedStateEvent? state) => super.noSuchMethod(
         Invocation.method(
           #setState,
           [state],
@@ -9711,33 +9746,33 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  _i11.Future<List<_i3.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i12.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
+        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
-      ) as _i11.Future<List<_i3.User>>);
+            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i12.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
-          [_i3.MatrixLocalizations? i18n =
-              const _i3.MatrixDefaultLocalizations()]) =>
+          [_i4.MatrixLocalizations? i18n =
+              const _i4.MatrixDefaultLocalizations()]) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9747,18 +9782,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as String);
 
   @override
-  _i11.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i12.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Event?> refreshLastEvent(
+  _i12.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9766,12 +9801,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
-  void setEphemeral(_i3.BasicEvent? ephemeral) => super.noSuchMethod(
+  void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
         Invocation.method(
           #setEphemeral,
           [ephemeral],
@@ -9780,12 +9815,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  _i11.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i12.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i11.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9793,22 +9828,22 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i16.dummyValue<String>(
+            _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i12.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i11.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9816,17 +9851,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i16.dummyValue<String>(
+            _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> addTag(
+  _i12.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -9836,27 +9871,27 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i12.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i12.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_22(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -9864,43 +9899,43 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_22(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i12.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i12.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i12.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i11.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9908,14 +9943,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i16.dummyValue<String>(
+            _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -9927,10 +9962,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as String?);
 
   @override
-  _i11.Future<String?> sendTextEvent(
+  _i12.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     bool? parseMarkdown = true,
     bool? parseCommands = true,
@@ -9959,12 +9994,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendReaction(
+  _i12.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -9978,12 +10013,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendLocation(
+  _i12.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -9997,18 +10032,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendFileEvent(
-    _i3.MatrixFile? file, {
+  _i12.Future<String?> sendFileEvent(
+    _i4.MatrixFile? file, {
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     int? shrinkImageMaxDimension,
-    _i3.MatrixImageFile? thumbnail,
+    _i4.MatrixImageFile? thumbnail,
     Map<String, dynamic>? extraContent,
     String? threadRootEventId,
     String? threadLastEventId,
@@ -10030,29 +10065,29 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<_i3.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i12.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i11.Future<_i3.EncryptionHealthState>.value(
-            _i3.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i11.Future<_i3.EncryptionHealthState>.value(
-            _i3.EncryptionHealthState.allVerified),
-      ) as _i11.Future<_i3.EncryptionHealthState>);
+        returnValue: _i12.Future<_i4.EncryptionHealthState>.value(
+            _i4.EncryptionHealthState.allVerified),
+        returnValueForMissingStub: _i12.Future<_i4.EncryptionHealthState>.value(
+            _i4.EncryptionHealthState.allVerified),
+      ) as _i12.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i11.Future<String?> sendEvent(
+  _i12.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     String? threadRootEventId,
     String? threadLastEventId,
@@ -10072,73 +10107,73 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i12.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> leave() => (super.noSuchMethod(
+  _i12.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> forget() => (super.noSuchMethod(
+  _i12.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> setPower(
+  _i12.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -10150,7 +10185,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             power,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10161,7 +10196,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i16.dummyValue<String>(
+            _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10171,10 +10206,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> invite(
+  _i12.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -10184,16 +10219,16 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<int> requestHistory({
+  _i12.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
-    dynamic direction = _i3.Direction.b,
-    _i3.StateFilter? filter,
+    dynamic direction = _i4.Direction.b,
+    _i4.StateFilter? filter,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -10206,32 +10241,32 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<int>.value(0),
-        returnValueForMissingStub: _i11.Future<int>.value(0),
-      ) as _i11.Future<int>);
+        returnValue: _i12.Future<int>.value(0),
+        returnValueForMissingStub: _i12.Future<int>.value(0),
+      ) as _i12.Future<int>);
 
   @override
-  _i11.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i12.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setReadMarker(
+  _i12.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -10245,25 +10280,25 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #public: public,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i15.TimelineChunk?> getEventContext(String? eventId) =>
+  _i12.Future<_i16.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i11.Future<_i15.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i11.Future<_i15.TimelineChunk?>.value(),
-      ) as _i11.Future<_i15.TimelineChunk?>);
+        returnValue: _i12.Future<_i16.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i12.Future<_i16.TimelineChunk?>.value(),
+      ) as _i12.Future<_i16.TimelineChunk?>);
 
   @override
-  _i11.Future<void> postReceipt(
+  _i12.Future<void> postReceipt(
     String? eventId, {
-    _i3.ReceiptType? type = _i3.ReceiptType.mRead,
+    _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -10271,12 +10306,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Timeline> getTimeline({
+  _i12.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -10299,7 +10334,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i11.Future<_i3.Timeline>.value(_FakeTimeline_77(
+        returnValue: _i12.Future<_i4.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -10316,7 +10351,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Timeline>.value(_FakeTimeline_77(
+            _i12.Future<_i4.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -10332,30 +10367,30 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Timeline>);
+      ) as _i12.Future<_i4.Timeline>);
 
   @override
-  List<_i3.User> getParticipants(
-          [List<_i3.Membership>? membershipFilter = const [
-            _i3.Membership.join,
-            _i3.Membership.invite,
-            _i3.Membership.knock,
+  List<_i4.User> getParticipants(
+          [List<_i4.Membership>? membershipFilter = const [
+            _i4.Membership.join,
+            _i4.Membership.invite,
+            _i4.Membership.knock,
           ]]) =>
       (super.noSuchMethod(
         Invocation.method(
           #getParticipants,
           [membershipFilter],
         ),
-        returnValue: <_i3.User>[],
-        returnValueForMissingStub: <_i3.User>[],
-      ) as List<_i3.User>);
+        returnValue: <_i4.User>[],
+        returnValueForMissingStub: <_i4.User>[],
+      ) as List<_i4.User>);
 
   @override
-  _i11.Future<List<_i3.User>> requestParticipants([
-    List<_i3.Membership>? membershipFilter = const [
-      _i3.Membership.join,
-      _i3.Membership.invite,
-      _i3.Membership.knock,
+  _i12.Future<List<_i4.User>> requestParticipants([
+    List<_i4.Membership>? membershipFilter = const [
+      _i4.Membership.join,
+      _i4.Membership.invite,
+      _i4.Membership.knock,
     ],
     bool? suppressWarning = false,
     bool? cache,
@@ -10369,58 +10404,58 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             cache,
           ],
         ),
-        returnValue: _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
+        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
-      ) as _i11.Future<List<_i3.User>>);
+            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i12.Future<List<_i4.User>>);
 
   @override
-  _i3.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
+  _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
         Invocation.method(
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-      ) as _i3.User);
+      ) as _i4.User);
 
   @override
-  _i3.User unsafeGetUserFromMemoryOrFallback(String? mxID) =>
+  _i4.User unsafeGetUserFromMemoryOrFallback(String? mxID) =>
       (super.noSuchMethod(
         Invocation.method(
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-      ) as _i3.User);
+      ) as _i4.User);
 
   @override
-  _i11.Future<_i3.User?> requestUser(
+  _i12.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -10436,19 +10471,19 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i11.Future<_i3.User?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.User?>.value(),
-      ) as _i11.Future<_i3.User?>);
+        returnValue: _i12.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.User?>.value(),
+      ) as _i12.Future<_i4.User?>);
 
   @override
-  _i11.Future<_i3.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i12.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -10461,12 +10496,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i11.Future<String> setAvatar(_i3.MatrixFile? file) => (super.noSuchMethod(
+  _i12.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i11.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10474,14 +10509,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i16.dummyValue<String>(
+            _i12.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -10504,14 +10539,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i11.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i12.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -10550,18 +10585,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i11.Future<void> setPushRuleState(_i3.PushRuleState? newState) =>
+  _i12.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEvent(
+  _i12.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -10575,12 +10610,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> setTyping(
+  _i12.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -10590,13 +10625,13 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setJoinRules(
-    _i3.JoinRules? joinRules, {
+  _i12.Future<void> setJoinRules(
+    _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
   }) =>
@@ -10609,59 +10644,59 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setGuestAccess(_i3.GuestAccess? guestAccess) =>
+  _i12.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setHistoryVisibility(
-          _i3.HistoryVisibility? historyVisibility) =>
+  _i12.Future<void> setHistoryVisibility(
+          _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i12.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i12.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i11.Future<List<_i3.DeviceKeys>>.value(<_i3.DeviceKeys>[]),
+            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.DeviceKeys>>.value(<_i3.DeviceKeys>[]),
-      ) as _i11.Future<List<_i3.DeviceKeys>>);
+            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i12.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i11.Future<void> requestSessionKey(
+  _i12.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -10673,12 +10708,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             senderKey,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setSpaceChild(
+  _i12.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -10694,51 +10729,51 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i12.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i11.Future<Uri>.value(_FakeUri_27(
+        returnValue: _i12.Future<Uri>.value(_FakeUri_28(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<Uri>.value(_FakeUri_27(
+        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_28(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i11.Future<Uri>);
+      ) as _i12.Future<Uri>);
 
   @override
-  _i11.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i12.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<
+  _i12.Future<
       ({
-        List<_i3.Event> events,
+        List<_i4.Event> events,
         String? nextBatch,
         DateTime? searchedUntil
       })> searchEvents({
     String? searchTerm,
-    bool Function(_i3.Event)? searchFunc,
+    bool Function(_i4.Event)? searchFunc,
     String? nextBatch,
     int? limit = 1000,
     Set<String>? includeEventTypes = const {
@@ -10758,23 +10793,23 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i11.Future<
+        returnValue: _i12.Future<
                 ({
-                  List<_i3.Event> events,
+                  List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
-            (events: <_i3.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i11.Future<
+            (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
+        returnValueForMissingStub: _i12.Future<
                 ({
-                  List<_i3.Event> events,
+                  List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
-            (events: <_i3.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i11.Future<
+            (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
+      ) as _i12.Future<
           ({
-            List<_i3.Event> events,
+            List<_i4.Event> events,
             String? nextBatch,
             DateTime? searchedUntil
           })>);
@@ -10783,34 +10818,34 @@ class MockRoom extends _i1.Mock implements _i3.Room {
 /// A class which mocks [Timeline].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockTimeline extends _i1.Mock implements _i3.Timeline {
+class MockTimeline extends _i1.Mock implements _i4.Timeline {
   @override
-  _i3.Room get room => (super.noSuchMethod(
+  _i4.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_79(
+        returnValue: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_79(
+        returnValueForMissingStub: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
-      ) as _i3.Room);
+      ) as _i4.Room);
 
   @override
-  List<_i3.Event> get events => (super.noSuchMethod(
+  List<_i4.Event> get events => (super.noSuchMethod(
         Invocation.getter(#events),
-        returnValue: <_i3.Event>[],
-        returnValueForMissingStub: <_i3.Event>[],
-      ) as List<_i3.Event>);
+        returnValue: <_i4.Event>[],
+        returnValueForMissingStub: <_i4.Event>[],
+      ) as List<_i4.Event>);
 
   @override
-  Map<String, Map<String, Set<_i3.Event>>> get aggregatedEvents =>
+  Map<String, Map<String, Set<_i4.Event>>> get aggregatedEvents =>
       (super.noSuchMethod(
         Invocation.getter(#aggregatedEvents),
-        returnValue: <String, Map<String, Set<_i3.Event>>>{},
-        returnValueForMissingStub: <String, Map<String, Set<_i3.Event>>>{},
-      ) as Map<String, Map<String, Set<_i3.Event>>>);
+        returnValue: <String, Map<String, Set<_i4.Event>>>{},
+        returnValueForMissingStub: <String, Map<String, Set<_i4.Event>>>{},
+      ) as Map<String, Map<String, Set<_i4.Event>>>);
 
   @override
   bool get isRequestingHistory => (super.noSuchMethod(
@@ -10841,17 +10876,17 @@ class MockTimeline extends _i1.Mock implements _i3.Timeline {
       ) as bool);
 
   @override
-  _i15.TimelineChunk get chunk => (super.noSuchMethod(
+  _i16.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_80(
+        returnValue: _FakeTimelineChunk_81(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_80(
+        returnValueForMissingStub: _FakeTimelineChunk_81(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i15.TimelineChunk);
+      ) as _i16.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10868,7 +10903,7 @@ class MockTimeline extends _i1.Mock implements _i3.Timeline {
       ) as bool);
 
   @override
-  set timelineSub(_i11.StreamSubscription<_i3.Event>? value) =>
+  set timelineSub(_i12.StreamSubscription<_i4.Event>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #timelineSub,
@@ -10878,7 +10913,7 @@ class MockTimeline extends _i1.Mock implements _i3.Timeline {
       );
 
   @override
-  set historySub(_i11.StreamSubscription<_i3.Event>? value) =>
+  set historySub(_i12.StreamSubscription<_i4.Event>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #historySub,
@@ -10888,7 +10923,7 @@ class MockTimeline extends _i1.Mock implements _i3.Timeline {
       );
 
   @override
-  set roomSub(_i11.StreamSubscription<_i3.SyncUpdate>? value) =>
+  set roomSub(_i12.StreamSubscription<_i4.SyncUpdate>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #roomSub,
@@ -10898,7 +10933,7 @@ class MockTimeline extends _i1.Mock implements _i3.Timeline {
       );
 
   @override
-  set sessionIdReceivedSub(_i11.StreamSubscription<String>? value) =>
+  set sessionIdReceivedSub(_i12.StreamSubscription<String>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #sessionIdReceivedSub,
@@ -10908,7 +10943,7 @@ class MockTimeline extends _i1.Mock implements _i3.Timeline {
       );
 
   @override
-  set cancelSendEventSub(_i11.StreamSubscription<String>? value) =>
+  set cancelSendEventSub(_i12.StreamSubscription<String>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #cancelSendEventSub,
@@ -10954,7 +10989,7 @@ class MockTimeline extends _i1.Mock implements _i3.Timeline {
       );
 
   @override
-  set chunk(_i15.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i16.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -10963,19 +10998,19 @@ class MockTimeline extends _i1.Mock implements _i3.Timeline {
       );
 
   @override
-  _i11.Future<_i3.Event?> getEventById(String? id) => (super.noSuchMethod(
+  _i12.Future<_i4.Event?> getEventById(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [id],
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
-  _i11.Future<void> requestHistory({
+  _i12.Future<void> requestHistory({
     int? historyCount = 30,
-    _i3.StateFilter? filter,
+    _i4.StateFilter? filter,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -10986,14 +11021,14 @@ class MockTimeline extends _i1.Mock implements _i3.Timeline {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> requestFuture({
+  _i12.Future<void> requestFuture({
     int? historyCount = 30,
-    _i3.StateFilter? filter,
+    _i4.StateFilter? filter,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -11004,15 +11039,15 @@ class MockTimeline extends _i1.Mock implements _i3.Timeline {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<int> getRoomEvents({
+  _i12.Future<int> getRoomEvents({
     int? historyCount = 30,
-    dynamic direction = _i3.Direction.b,
-    _i3.StateFilter? filter,
+    dynamic direction = _i4.Direction.b,
+    _i4.StateFilter? filter,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -11024,9 +11059,9 @@ class MockTimeline extends _i1.Mock implements _i3.Timeline {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<int>.value(0),
-        returnValueForMissingStub: _i11.Future<int>.value(0),
-      ) as _i11.Future<int>);
+        returnValue: _i12.Future<int>.value(0),
+        returnValueForMissingStub: _i12.Future<int>.value(0),
+      ) as _i12.Future<int>);
 
   @override
   void cancelSubscriptions() => super.noSuchMethod(
@@ -11055,7 +11090,7 @@ class MockTimeline extends _i1.Mock implements _i3.Timeline {
       );
 
   @override
-  _i11.Future<void> setReadMarker({
+  _i12.Future<void> setReadMarker({
     String? eventId,
     bool? public,
   }) =>
@@ -11068,12 +11103,12 @@ class MockTimeline extends _i1.Mock implements _i3.Timeline {
             #public: public,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  void addAggregatedEvent(_i3.Event? event) => super.noSuchMethod(
+  void addAggregatedEvent(_i4.Event? event) => super.noSuchMethod(
         Invocation.method(
           #addAggregatedEvent,
           [event],
@@ -11082,7 +11117,7 @@ class MockTimeline extends _i1.Mock implements _i3.Timeline {
       );
 
   @override
-  void removeAggregatedEvent(_i3.Event? event) => super.noSuchMethod(
+  void removeAggregatedEvent(_i4.Event? event) => super.noSuchMethod(
         Invocation.method(
           #removeAggregatedEvent,
           [event],
@@ -11091,13 +11126,13 @@ class MockTimeline extends _i1.Mock implements _i3.Timeline {
       );
 
   @override
-  _i11.Stream<List<_i3.Event>> searchEvent({
+  _i12.Stream<List<_i4.Event>> searchEvent({
     String? searchTerm,
     int? requestHistoryCount = 100,
     int? maxHistoryRequests = 10,
     String? sinceEventId,
     int? limit,
-    bool Function(_i3.Event)? searchFunc,
+    bool Function(_i4.Event)? searchFunc,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -11112,19 +11147,19 @@ class MockTimeline extends _i1.Mock implements _i3.Timeline {
             #searchFunc: searchFunc,
           },
         ),
-        returnValue: _i11.Stream<List<_i3.Event>>.empty(),
-        returnValueForMissingStub: _i11.Stream<List<_i3.Event>>.empty(),
-      ) as _i11.Stream<List<_i3.Event>>);
+        returnValue: _i12.Stream<List<_i4.Event>>.empty(),
+        returnValueForMissingStub: _i12.Stream<List<_i4.Event>>.empty(),
+      ) as _i12.Stream<List<_i4.Event>>);
 
   @override
-  _i11.Stream<(List<_i3.Event>, String?)> startSearch({
+  _i12.Stream<(List<_i4.Event>, String?)> startSearch({
     String? searchTerm,
     int? requestHistoryCount = 100,
     int? maxHistoryRequests = 10,
     String? prevBatch,
     String? sinceEventId,
     int? limit,
-    bool Function(_i3.Event)? searchFunc,
+    bool Function(_i4.Event)? searchFunc,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -11140,8 +11175,8 @@ class MockTimeline extends _i1.Mock implements _i3.Timeline {
             #searchFunc: searchFunc,
           },
         ),
-        returnValue: _i11.Stream<(List<_i3.Event>, String?)>.empty(),
+        returnValue: _i12.Stream<(List<_i4.Event>, String?)>.empty(),
         returnValueForMissingStub:
-            _i11.Stream<(List<_i3.Event>, String?)>.empty(),
-      ) as _i11.Stream<(List<_i3.Event>, String?)>);
+            _i12.Stream<(List<_i4.Event>, String?)>.empty(),
+      ) as _i12.Stream<(List<_i4.Event>, String?)>);
 }

--- a/test/services/notification_service_test.mocks.dart
+++ b/test/services/notification_service_test.mocks.dart
@@ -3,43 +3,45 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i11;
-import 'dart:typed_data' as _i19;
-import 'dart:ui' as _i15;
+import 'dart:async' as _i12;
+import 'dart:typed_data' as _i20;
+import 'dart:ui' as _i16;
 
-import 'package:flutter/services.dart' as _i16;
-import 'package:flutter/widgets.dart' as _i17;
+import 'package:flutter/services.dart' as _i17;
+import 'package:flutter/widgets.dart' as _i18;
 import 'package:flutter_local_notifications/src/flutter_local_notifications_plugin.dart'
-    as _i22;
-import 'package:flutter_local_notifications/src/initialization_settings.dart'
     as _i23;
-import 'package:flutter_local_notifications/src/notification_details.dart'
-    as _i25;
-import 'package:flutter_local_notifications/src/platform_specifics/android/schedule_mode.dart'
-    as _i27;
-import 'package:flutter_local_notifications/src/types.dart' as _i28;
-import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart'
+import 'package:flutter_local_notifications/src/initialization_settings.dart'
     as _i24;
-import 'package:http/http.dart' as _i10;
-import 'package:kohera/core/services/matrix_service.dart' as _i13;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
+import 'package:flutter_local_notifications/src/notification_details.dart'
+    as _i26;
+import 'package:flutter_local_notifications/src/platform_specifics/android/schedule_mode.dart'
+    as _i28;
+import 'package:flutter_local_notifications/src/types.dart' as _i29;
+import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart'
+    as _i25;
+import 'package:http/http.dart' as _i11;
+import 'package:kohera/core/services/matrix_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i5;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i7;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i4;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i7;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
-import 'package:matrix/encryption.dart' as _i18;
-import 'package:matrix/matrix.dart' as _i3;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i12;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i9;
-import 'package:matrix/src/utils/space_child.dart' as _i20;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i3;
+import 'package:matrix/encryption.dart' as _i19;
+import 'package:matrix/matrix.dart' as _i4;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i13;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i10;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
-import 'package:timezone/timezone.dart' as _i26;
+import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:timezone/timezone.dart' as _i27;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -67,8 +69,9 @@ class _FakeCallPushRuleManager_0 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
-  _FakeClient_1(
+class _FakeMegolmKeyMirror_1 extends _i1.SmartFake
+    implements _i3.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_1(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -77,8 +80,8 @@ class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
         );
 }
 
-class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
-  _FakeUiaService_2(
+class _FakeClient_2 extends _i1.SmartFake implements _i4.Client {
+  _FakeClient_2(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -87,9 +90,8 @@ class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
         );
 }
 
-class _FakeChatBackupService_3 extends _i1.SmartFake
-    implements _i5.ChatBackupService {
-  _FakeChatBackupService_3(
+class _FakeUiaService_3 extends _i1.SmartFake implements _i5.UiaService {
+  _FakeUiaService_3(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -98,9 +100,9 @@ class _FakeChatBackupService_3 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_4 extends _i1.SmartFake
-    implements _i6.SelectionService {
-  _FakeSelectionService_4(
+class _FakeChatBackupService_4 extends _i1.SmartFake
+    implements _i6.ChatBackupService {
+  _FakeChatBackupService_4(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -109,8 +111,9 @@ class _FakeSelectionService_4 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
-  _FakeSyncService_5(
+class _FakeSelectionService_5 extends _i1.SmartFake
+    implements _i7.SelectionService {
+  _FakeSelectionService_5(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -119,8 +122,8 @@ class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
         );
 }
 
-class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
-  _FakeAuthService_6(
+class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
+  _FakeSyncService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -129,8 +132,8 @@ class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
         );
 }
 
-class _FakeDatabaseApi_7 extends _i1.SmartFake implements _i3.DatabaseApi {
-  _FakeDatabaseApi_7(
+class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
+  _FakeAuthService_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -139,8 +142,8 @@ class _FakeDatabaseApi_7 extends _i1.SmartFake implements _i3.DatabaseApi {
         );
 }
 
-class _FakeFilter_8 extends _i1.SmartFake implements _i3.Filter {
-  _FakeFilter_8(
+class _FakeDatabaseApi_8 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -149,9 +152,8 @@ class _FakeFilter_8 extends _i1.SmartFake implements _i3.Filter {
         );
 }
 
-class _FakeNativeImplementations_9 extends _i1.SmartFake
-    implements _i3.NativeImplementations {
-  _FakeNativeImplementations_9(
+class _FakeFilter_9 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -160,8 +162,9 @@ class _FakeNativeImplementations_9 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_10 extends _i1.SmartFake implements Duration {
-  _FakeDuration_10(
+class _FakeNativeImplementations_10 extends _i1.SmartFake
+    implements _i4.NativeImplementations {
+  _FakeNativeImplementations_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -170,9 +173,8 @@ class _FakeDuration_10 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_11 extends _i1.SmartFake
-    implements _i3.PushruleEvaluator {
-  _FakePushruleEvaluator_11(
+class _FakeDuration_11 extends _i1.SmartFake implements Duration {
+  _FakeDuration_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -181,8 +183,9 @@ class _FakePushruleEvaluator_11 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_12 extends _i1.SmartFake implements _i3.Profile {
-  _FakeProfile_12(
+class _FakePushruleEvaluator_12 extends _i1.SmartFake
+    implements _i4.PushruleEvaluator {
+  _FakePushruleEvaluator_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -191,9 +194,8 @@ class _FakeProfile_12 extends _i1.SmartFake implements _i3.Profile {
         );
 }
 
-class _FakeCachedStreamController_13<T> extends _i1.SmartFake
-    implements _i9.CachedStreamController<T> {
-  _FakeCachedStreamController_13(
+class _FakeProfile_13 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -202,8 +204,9 @@ class _FakeCachedStreamController_13<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_14 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_14(
+class _FakeCachedStreamController_14<T> extends _i1.SmartFake
+    implements _i10.CachedStreamController<T> {
+  _FakeCachedStreamController_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -212,8 +215,8 @@ class _FakeDateTime_14 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_15 extends _i1.SmartFake implements _i10.Client {
-  _FakeClient_15(
+class _FakeDateTime_15 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -222,9 +225,8 @@ class _FakeClient_15 extends _i1.SmartFake implements _i10.Client {
         );
 }
 
-class _FakeDiscoveryInformation_16 extends _i1.SmartFake
-    implements _i3.DiscoveryInformation {
-  _FakeDiscoveryInformation_16(
+class _FakeClient_16 extends _i1.SmartFake implements _i11.Client {
+  _FakeClient_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -233,9 +235,9 @@ class _FakeDiscoveryInformation_16 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_17 extends _i1.SmartFake
-    implements _i3.GetVersionsResponse {
-  _FakeGetVersionsResponse_17(
+class _FakeDiscoveryInformation_17 extends _i1.SmartFake
+    implements _i4.DiscoveryInformation {
+  _FakeDiscoveryInformation_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -244,9 +246,9 @@ class _FakeGetVersionsResponse_17 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_18 extends _i1.SmartFake
-    implements _i3.RegisterResponse {
-  _FakeRegisterResponse_18(
+class _FakeGetVersionsResponse_18 extends _i1.SmartFake
+    implements _i4.GetVersionsResponse {
+  _FakeGetVersionsResponse_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -255,8 +257,9 @@ class _FakeRegisterResponse_18 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_19 extends _i1.SmartFake implements _i3.LoginResponse {
-  _FakeLoginResponse_19(
+class _FakeRegisterResponse_19 extends _i1.SmartFake
+    implements _i4.RegisterResponse {
+  _FakeRegisterResponse_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -265,9 +268,8 @@ class _FakeLoginResponse_19 extends _i1.SmartFake implements _i3.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_20 extends _i1.SmartFake
-    implements _i3.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_20(
+class _FakeLoginResponse_20 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -276,8 +278,9 @@ class _FakeGetAuthMetadataResponse_20 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_21<T1> extends _i1.SmartFake implements _i11.Future<T1> {
-  _FakeFuture_21(
+class _FakeGetAuthMetadataResponse_21 extends _i1.SmartFake
+    implements _i4.GetAuthMetadataResponse {
+  _FakeGetAuthMetadataResponse_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -286,8 +289,8 @@ class _FakeFuture_21<T1> extends _i1.SmartFake implements _i11.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_22 extends _i1.SmartFake implements _i3.SyncUpdate {
-  _FakeSyncUpdate_22(
+class _FakeFuture_22<T1> extends _i1.SmartFake implements _i12.Future<T1> {
+  _FakeFuture_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -296,9 +299,8 @@ class _FakeSyncUpdate_22 extends _i1.SmartFake implements _i3.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_23 extends _i1.SmartFake
-    implements _i3.CachedProfileInformation {
-  _FakeCachedProfileInformation_23(
+class _FakeSyncUpdate_23 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -307,8 +309,9 @@ class _FakeCachedProfileInformation_23 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_24 extends _i1.SmartFake implements _i3.MediaConfig {
-  _FakeMediaConfig_24(
+class _FakeCachedProfileInformation_24 extends _i1.SmartFake
+    implements _i4.CachedProfileInformation {
+  _FakeCachedProfileInformation_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -317,8 +320,8 @@ class _FakeMediaConfig_24 extends _i1.SmartFake implements _i3.MediaConfig {
         );
 }
 
-class _FakeFileResponse_25 extends _i1.SmartFake implements _i12.FileResponse {
-  _FakeFileResponse_25(
+class _FakeMediaConfig_25 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -327,8 +330,8 @@ class _FakeFileResponse_25 extends _i1.SmartFake implements _i12.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_26 extends _i1.SmartFake implements _i3.PreviewForUrl {
-  _FakePreviewForUrl_26(
+class _FakeFileResponse_26 extends _i1.SmartFake implements _i13.FileResponse {
+  _FakeFileResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -337,8 +340,8 @@ class _FakePreviewForUrl_26 extends _i1.SmartFake implements _i3.PreviewForUrl {
         );
 }
 
-class _FakeUri_27 extends _i1.SmartFake implements Uri {
-  _FakeUri_27(
+class _FakePreviewForUrl_27 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -347,9 +350,8 @@ class _FakeUri_27 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_28 extends _i1.SmartFake
-    implements _i3.CachedPresence {
-  _FakeCachedPresence_28(
+class _FakeUri_28 extends _i1.SmartFake implements Uri {
+  _FakeUri_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -358,9 +360,9 @@ class _FakeCachedPresence_28 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_29 extends _i1.SmartFake
-    implements _i3.TurnServerCredentials {
-  _FakeTurnServerCredentials_29(
+class _FakeCachedPresence_29 extends _i1.SmartFake
+    implements _i4.CachedPresence {
+  _FakeCachedPresence_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -369,9 +371,9 @@ class _FakeTurnServerCredentials_29 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_30 extends _i1.SmartFake
-    implements _i3.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_30(
+class _FakeTurnServerCredentials_30 extends _i1.SmartFake
+    implements _i4.TurnServerCredentials {
+  _FakeTurnServerCredentials_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -380,8 +382,9 @@ class _FakeRoomKeysUpdateResponse_30 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_31 extends _i1.SmartFake implements _i3.KeyBackupData {
-  _FakeKeyBackupData_31(
+class _FakeRoomKeysUpdateResponse_31 extends _i1.SmartFake
+    implements _i4.RoomKeysUpdateResponse {
+  _FakeRoomKeysUpdateResponse_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -390,9 +393,8 @@ class _FakeKeyBackupData_31 extends _i1.SmartFake implements _i3.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_32 extends _i1.SmartFake
-    implements _i3.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_32(
+class _FakeKeyBackupData_32 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -401,9 +403,9 @@ class _FakeGetWellknownSupportResponse_32 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_33 extends _i1.SmartFake
-    implements _i3.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_33(
+class _FakeGetWellknownSupportResponse_33 extends _i1.SmartFake
+    implements _i4.GetWellknownSupportResponse {
+  _FakeGetWellknownSupportResponse_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -412,9 +414,9 @@ class _FakeGenerateLoginTokenResponse_33 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_34 extends _i1.SmartFake
-    implements _i3.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_34(
+class _FakeGenerateLoginTokenResponse_34 extends _i1.SmartFake
+    implements _i4.GenerateLoginTokenResponse {
+  _FakeGenerateLoginTokenResponse_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -423,9 +425,9 @@ class _FakeGetRoomSummaryResponse$3_34 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_35 extends _i1.SmartFake
-    implements _i3.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_35(
+class _FakeGetRoomSummaryResponse$3_35 extends _i1.SmartFake
+    implements _i4.GetRoomSummaryResponse$3 {
+  _FakeGetRoomSummaryResponse$3_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -434,9 +436,9 @@ class _FakeGetSpaceHierarchyResponse_35 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_36 extends _i1.SmartFake
-    implements _i3.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_36(
+class _FakeGetSpaceHierarchyResponse_36 extends _i1.SmartFake
+    implements _i4.GetSpaceHierarchyResponse {
+  _FakeGetSpaceHierarchyResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -445,9 +447,9 @@ class _FakeGetRelatingEventsResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_37 extends _i1.SmartFake
-    implements _i3.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_37(
+class _FakeGetRelatingEventsResponse_37 extends _i1.SmartFake
+    implements _i4.GetRelatingEventsResponse {
+  _FakeGetRelatingEventsResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -456,9 +458,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_38 extends _i1
-    .SmartFake implements _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_38(
+class _FakeGetRelatingEventsWithRelTypeResponse_38 extends _i1.SmartFake
+    implements _i4.GetRelatingEventsWithRelTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -467,9 +469,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_38 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_39 extends _i1.SmartFake
-    implements _i3.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_39(
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39 extends _i1
+    .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -478,9 +480,9 @@ class _FakeGetThreadRootsResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_40 extends _i1.SmartFake
-    implements _i3.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_40(
+class _FakeGetThreadRootsResponse_40 extends _i1.SmartFake
+    implements _i4.GetThreadRootsResponse {
+  _FakeGetThreadRootsResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -489,9 +491,9 @@ class _FakeGetEventByTimestampResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_41 extends _i1.SmartFake
-    implements _i3.RequestTokenResponse {
-  _FakeRequestTokenResponse_41(
+class _FakeGetEventByTimestampResponse_41 extends _i1.SmartFake
+    implements _i4.GetEventByTimestampResponse {
+  _FakeGetEventByTimestampResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -500,9 +502,9 @@ class _FakeRequestTokenResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_42 extends _i1.SmartFake
-    implements _i3.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_42(
+class _FakeRequestTokenResponse_42 extends _i1.SmartFake
+    implements _i4.RequestTokenResponse {
+  _FakeRequestTokenResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -511,8 +513,9 @@ class _FakeTokenOwnerInfo_42 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_43 extends _i1.SmartFake implements _i3.WhoIsInfo {
-  _FakeWhoIsInfo_43(
+class _FakeTokenOwnerInfo_43 extends _i1.SmartFake
+    implements _i4.TokenOwnerInfo {
+  _FakeTokenOwnerInfo_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -521,8 +524,8 @@ class _FakeWhoIsInfo_43 extends _i1.SmartFake implements _i3.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_44 extends _i1.SmartFake implements _i3.Capabilities {
-  _FakeCapabilities_44(
+class _FakeWhoIsInfo_44 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -531,8 +534,8 @@ class _FakeCapabilities_44 extends _i1.SmartFake implements _i3.Capabilities {
         );
 }
 
-class _FakeDevice_45 extends _i1.SmartFake implements _i3.Device {
-  _FakeDevice_45(
+class _FakeCapabilities_45 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -541,9 +544,8 @@ class _FakeDevice_45 extends _i1.SmartFake implements _i3.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_46 extends _i1.SmartFake
-    implements _i3.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_46(
+class _FakeDevice_46 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -552,9 +554,9 @@ class _FakeGetRoomIdByAliasResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_47 extends _i1.SmartFake
-    implements _i3.GetEventsResponse {
-  _FakeGetEventsResponse_47(
+class _FakeGetRoomIdByAliasResponse_47 extends _i1.SmartFake
+    implements _i4.GetRoomIdByAliasResponse {
+  _FakeGetRoomIdByAliasResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -563,9 +565,9 @@ class _FakeGetEventsResponse_47 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_48 extends _i1.SmartFake
-    implements _i3.PeekEventsResponse {
-  _FakePeekEventsResponse_48(
+class _FakeGetEventsResponse_48 extends _i1.SmartFake
+    implements _i4.GetEventsResponse {
+  _FakeGetEventsResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -574,8 +576,9 @@ class _FakePeekEventsResponse_48 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_49 extends _i1.SmartFake implements _i3.MatrixEvent {
-  _FakeMatrixEvent_49(
+class _FakePeekEventsResponse_49 extends _i1.SmartFake
+    implements _i4.PeekEventsResponse {
+  _FakePeekEventsResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -584,9 +587,8 @@ class _FakeMatrixEvent_49 extends _i1.SmartFake implements _i3.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_50 extends _i1.SmartFake
-    implements _i3.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_50(
+class _FakeMatrixEvent_50 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -595,9 +597,9 @@ class _FakeGetKeysChangesResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_51 extends _i1.SmartFake
-    implements _i3.ClaimKeysResponse {
-  _FakeClaimKeysResponse_51(
+class _FakeGetKeysChangesResponse_51 extends _i1.SmartFake
+    implements _i4.GetKeysChangesResponse {
+  _FakeGetKeysChangesResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -606,9 +608,9 @@ class _FakeClaimKeysResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_52 extends _i1.SmartFake
-    implements _i3.QueryKeysResponse {
-  _FakeQueryKeysResponse_52(
+class _FakeClaimKeysResponse_52 extends _i1.SmartFake
+    implements _i4.ClaimKeysResponse {
+  _FakeClaimKeysResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -617,9 +619,9 @@ class _FakeQueryKeysResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_53 extends _i1.SmartFake
-    implements _i3.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_53(
+class _FakeQueryKeysResponse_53 extends _i1.SmartFake
+    implements _i4.QueryKeysResponse {
+  _FakeQueryKeysResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -628,9 +630,9 @@ class _FakeGetNotificationsResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_54 extends _i1.SmartFake
-    implements _i3.GetPresenceResponse {
-  _FakeGetPresenceResponse_54(
+class _FakeGetNotificationsResponse_54 extends _i1.SmartFake
+    implements _i4.GetNotificationsResponse {
+  _FakeGetNotificationsResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -639,9 +641,9 @@ class _FakeGetPresenceResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_55 extends _i1.SmartFake
-    implements _i3.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_55(
+class _FakeGetPresenceResponse_55 extends _i1.SmartFake
+    implements _i4.GetPresenceResponse {
+  _FakeGetPresenceResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -650,9 +652,9 @@ class _FakeGetPublicRoomsResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_56 extends _i1.SmartFake
-    implements _i3.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_56(
+class _FakeGetPublicRoomsResponse_56 extends _i1.SmartFake
+    implements _i4.GetPublicRoomsResponse {
+  _FakeGetPublicRoomsResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -661,8 +663,9 @@ class _FakeQueryPublicRoomsResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_57 extends _i1.SmartFake implements _i3.PushRuleSet {
-  _FakePushRuleSet_57(
+class _FakeQueryPublicRoomsResponse_57 extends _i1.SmartFake
+    implements _i4.QueryPublicRoomsResponse {
+  _FakeQueryPublicRoomsResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -671,9 +674,8 @@ class _FakePushRuleSet_57 extends _i1.SmartFake implements _i3.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_58 extends _i1.SmartFake
-    implements _i3.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_58(
+class _FakePushRuleSet_58 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -682,8 +684,9 @@ class _FakeGetPushRulesGlobalResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_59 extends _i1.SmartFake implements _i3.PushRule {
-  _FakePushRule_59(
+class _FakeGetPushRulesGlobalResponse_59 extends _i1.SmartFake
+    implements _i4.GetPushRulesGlobalResponse {
+  _FakeGetPushRulesGlobalResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -692,9 +695,8 @@ class _FakePushRule_59 extends _i1.SmartFake implements _i3.PushRule {
         );
 }
 
-class _FakeRefreshResponse_60 extends _i1.SmartFake
-    implements _i3.RefreshResponse {
-  _FakeRefreshResponse_60(
+class _FakePushRule_60 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -703,8 +705,9 @@ class _FakeRefreshResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_61 extends _i1.SmartFake implements _i3.RoomKeys {
-  _FakeRoomKeys_61(
+class _FakeRefreshResponse_61 extends _i1.SmartFake
+    implements _i4.RefreshResponse {
+  _FakeRefreshResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -713,8 +716,8 @@ class _FakeRoomKeys_61 extends _i1.SmartFake implements _i3.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_62 extends _i1.SmartFake implements _i3.RoomKeyBackup {
-  _FakeRoomKeyBackup_62(
+class _FakeRoomKeys_62 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -723,9 +726,8 @@ class _FakeRoomKeyBackup_62 extends _i1.SmartFake implements _i3.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_63 extends _i1.SmartFake
-    implements _i3.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_63(
+class _FakeRoomKeyBackup_63 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -734,9 +736,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_64 extends _i1.SmartFake
-    implements _i3.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_64(
+class _FakeGetRoomKeysVersionCurrentResponse_64 extends _i1.SmartFake
+    implements _i4.GetRoomKeysVersionCurrentResponse {
+  _FakeGetRoomKeysVersionCurrentResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -745,8 +747,9 @@ class _FakeGetRoomKeysVersionResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_65 extends _i1.SmartFake implements _i3.EventContext {
-  _FakeEventContext_65(
+class _FakeGetRoomKeysVersionResponse_65 extends _i1.SmartFake
+    implements _i4.GetRoomKeysVersionResponse {
+  _FakeGetRoomKeysVersionResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -755,9 +758,8 @@ class _FakeEventContext_65 extends _i1.SmartFake implements _i3.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_66 extends _i1.SmartFake
-    implements _i3.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_66(
+class _FakeEventContext_66 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,8 +768,9 @@ class _FakeGetRoomEventsResponse_66 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_67 extends _i1.SmartFake implements _i3.SearchResults {
-  _FakeSearchResults_67(
+class _FakeGetRoomEventsResponse_67 extends _i1.SmartFake
+    implements _i4.GetRoomEventsResponse {
+  _FakeGetRoomEventsResponse_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -776,9 +779,8 @@ class _FakeSearchResults_67 extends _i1.SmartFake implements _i3.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_68 extends _i1.SmartFake
-    implements _i3.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_68(
+class _FakeSearchResults_68 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -787,9 +789,9 @@ class _FakeGetProtocolMetadataResponse$2_68 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_69 extends _i1.SmartFake
-    implements _i3.OpenIdCredentials {
-  _FakeOpenIdCredentials_69(
+class _FakeGetProtocolMetadataResponse$2_69 extends _i1.SmartFake
+    implements _i4.GetProtocolMetadataResponse$2 {
+  _FakeGetProtocolMetadataResponse$2_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,9 +800,9 @@ class _FakeOpenIdCredentials_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_70 extends _i1.SmartFake
-    implements _i3.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_70(
+class _FakeOpenIdCredentials_70 extends _i1.SmartFake
+    implements _i4.OpenIdCredentials {
+  _FakeOpenIdCredentials_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -809,9 +811,9 @@ class _FakeSearchUserDirectoryResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_71 extends _i1.SmartFake
-    implements _i3.CreateContentResponse {
-  _FakeCreateContentResponse_71(
+class _FakeSearchUserDirectoryResponse_71 extends _i1.SmartFake
+    implements _i4.SearchUserDirectoryResponse {
+  _FakeSearchUserDirectoryResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -820,8 +822,9 @@ class _FakeCreateContentResponse_71 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_72 extends _i1.SmartFake implements _i3.RoomSummary {
-  _FakeRoomSummary_72(
+class _FakeCreateContentResponse_72 extends _i1.SmartFake
+    implements _i4.CreateContentResponse {
+  _FakeCreateContentResponse_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -830,9 +833,8 @@ class _FakeRoomSummary_72 extends _i1.SmartFake implements _i3.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_73 extends _i1.SmartFake
-    implements _i3.LatestReceiptState {
-  _FakeLatestReceiptState_73(
+class _FakeRoomSummary_73 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -841,8 +843,9 @@ class _FakeLatestReceiptState_73 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_74 extends _i1.SmartFake implements _i3.Timeline {
-  _FakeTimeline_74(
+class _FakeLatestReceiptState_74 extends _i1.SmartFake
+    implements _i4.LatestReceiptState {
+  _FakeLatestReceiptState_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -851,8 +854,18 @@ class _FakeTimeline_74 extends _i1.SmartFake implements _i3.Timeline {
         );
 }
 
-class _FakeUser_75 extends _i1.SmartFake implements _i3.User {
-  _FakeUser_75(
+class _FakeTimeline_75 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeUser_76 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -864,7 +877,7 @@ class _FakeUser_75 extends _i1.SmartFake implements _i3.User {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -879,30 +892,43 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as _i2.CallPushRuleManager);
 
   @override
+  _i3.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i3.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
       ) as String);
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get isLoggedIn => (super.noSuchMethod(
@@ -919,69 +945,69 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  _i4.UiaService get uia => (super.noSuchMethod(
+  _i5.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_2(
+        returnValue: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_2(
+        returnValueForMissingStub: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i4.UiaService);
+      ) as _i5.UiaService);
 
   @override
-  _i5.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i6.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_3(
+        returnValue: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_3(
+        returnValueForMissingStub: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i5.ChatBackupService);
+      ) as _i6.ChatBackupService);
 
   @override
-  _i6.SelectionService get selection => (super.noSuchMethod(
+  _i7.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_4(
+        returnValue: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_4(
+        returnValueForMissingStub: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i6.SelectionService);
+      ) as _i7.SelectionService);
 
   @override
-  _i7.SyncService get sync => (super.noSuchMethod(
+  _i8.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_5(
+        returnValue: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_5(
+        returnValueForMissingStub: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i7.SyncService);
+      ) as _i8.SyncService);
 
   @override
-  _i8.AuthService get auth => (super.noSuchMethod(
+  _i9.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_6(
+        returnValue: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_6(
+        returnValueForMissingStub: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i8.AuthService);
+      ) as _i9.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1000,6 +1026,15 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
+  set keyMirror(_i3.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -1009,7 +1044,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set uia(_i4.UiaService? value) => super.noSuchMethod(
+  set uia(_i5.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -1018,7 +1053,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set chatBackup(_i5.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i6.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -1027,7 +1062,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set selection(_i6.SelectionService? value) => super.noSuchMethod(
+  set selection(_i7.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -1036,7 +1071,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set sync(_i7.SyncService? value) => super.noSuchMethod(
+  set sync(_i8.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -1045,7 +1080,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set auth(_i8.AuthService? value) => super.noSuchMethod(
+  set auth(_i9.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -1061,14 +1096,14 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  _i11.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1098,7 +1133,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i15.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i16.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1108,18 +1143,18 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i12.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<bool> login({
+  _i12.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1134,12 +1169,12 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<bool> completeSsoLogin({
+  _i12.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1152,13 +1187,13 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> completeRegistration(
-    _i3.RegisterResponse? response, {
+  _i12.Future<void> completeRegistration(
+    _i4.RegisterResponse? response, {
     String? password,
   }) =>
       (super.noSuchMethod(
@@ -1167,32 +1202,32 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> logout() => (super.noSuchMethod(
+  _i12.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i12.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  void addListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1201,7 +1236,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void removeListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1210,17 +1245,17 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i16.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i17.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1231,7 +1266,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i16.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i17.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1268,26 +1303,26 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<bool> didPushRouteInformation(
-          _i17.RouteInformation? routeInformation) =>
+  _i12.Future<bool> didPushRouteInformation(
+          _i18.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1317,7 +1352,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i15.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i16.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1326,7 +1361,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i15.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i16.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1335,16 +1370,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<_i15.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i12.Future<_i16.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
-      ) as _i11.Future<_i15.AppExitResponse>);
+            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
+      ) as _i12.Future<_i16.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1368,27 +1403,27 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockClient extends _i1.Mock implements _i3.Client {
+class MockClient extends _i1.Mock implements _i4.Client {
   @override
-  _i3.DatabaseApi get database => (super.noSuchMethod(
+  _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_7(
+        returnValue: _FakeDatabaseApi_8(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_7(
+        returnValueForMissingStub: _FakeDatabaseApi_8(
           this,
           Invocation.getter(#database),
         ),
-      ) as _i3.DatabaseApi);
+      ) as _i4.DatabaseApi);
 
   @override
-  Set<_i18.KeyVerificationMethod> get verificationMethods =>
+  Set<_i19.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i18.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
-      ) as Set<_i18.KeyVerificationMethod>);
+        returnValue: <_i19.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
+      ) as Set<_i19.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1433,44 +1468,44 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  _i3.ShareKeysWith get shareKeysWith => (super.noSuchMethod(
+  _i4.ShareKeysWith get shareKeysWith => (super.noSuchMethod(
         Invocation.getter(#shareKeysWith),
-        returnValue: _i3.ShareKeysWith.all,
-        returnValueForMissingStub: _i3.ShareKeysWith.all,
-      ) as _i3.ShareKeysWith);
+        returnValue: _i4.ShareKeysWith.all,
+        returnValueForMissingStub: _i4.ShareKeysWith.all,
+      ) as _i4.ShareKeysWith);
 
   @override
-  Map<String, _i3.CommandExecutionCallback> get commands => (super.noSuchMethod(
+  Map<String, _i4.CommandExecutionCallback> get commands => (super.noSuchMethod(
         Invocation.getter(#commands),
-        returnValue: <String, _i3.CommandExecutionCallback>{},
-        returnValueForMissingStub: <String, _i3.CommandExecutionCallback>{},
-      ) as Map<String, _i3.CommandExecutionCallback>);
+        returnValue: <String, _i4.CommandExecutionCallback>{},
+        returnValueForMissingStub: <String, _i4.CommandExecutionCallback>{},
+      ) as Map<String, _i4.CommandExecutionCallback>);
 
   @override
-  _i3.Filter get syncFilter => (super.noSuchMethod(
+  _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_8(
+        returnValue: _FakeFilter_9(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_8(
+        returnValueForMissingStub: _FakeFilter_9(
           this,
           Invocation.getter(#syncFilter),
         ),
-      ) as _i3.Filter);
+      ) as _i4.Filter);
 
   @override
-  _i3.NativeImplementations get nativeImplementations => (super.noSuchMethod(
+  _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_9(
+        returnValue: _FakeNativeImplementations_10(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_9(
+        returnValueForMissingStub: _FakeNativeImplementations_10(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-      ) as _i3.NativeImplementations);
+      ) as _i4.NativeImplementations);
 
   @override
   bool get convertLinebreaksInFormatting => (super.noSuchMethod(
@@ -1482,11 +1517,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_10(
+        returnValue: _FakeDuration_11(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_10(
+        returnValueForMissingStub: _FakeDuration_11(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -1495,11 +1530,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_10(
+        returnValue: _FakeDuration_11(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_10(
+        returnValueForMissingStub: _FakeDuration_11(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -1508,36 +1543,36 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
       ) as String);
 
   @override
-  _i3.LoginState get loginState => (super.noSuchMethod(
+  _i4.LoginState get loginState => (super.noSuchMethod(
         Invocation.getter(#loginState),
-        returnValue: _i3.LoginState.loggedIn,
-        returnValueForMissingStub: _i3.LoginState.loggedIn,
-      ) as _i3.LoginState);
+        returnValue: _i4.LoginState.loggedIn,
+        returnValueForMissingStub: _i4.LoginState.loggedIn,
+      ) as _i4.LoginState);
 
   @override
-  List<_i3.Room> get rooms => (super.noSuchMethod(
+  List<_i4.Room> get rooms => (super.noSuchMethod(
         Invocation.getter(#rooms),
-        returnValue: <_i3.Room>[],
-        returnValueForMissingStub: <_i3.Room>[],
-      ) as List<_i3.Room>);
+        returnValue: <_i4.Room>[],
+        returnValueForMissingStub: <_i4.Room>[],
+      ) as List<_i4.Room>);
 
   @override
-  List<_i3.ArchivedRoom> get archivedRooms => (super.noSuchMethod(
+  List<_i4.ArchivedRoom> get archivedRooms => (super.noSuchMethod(
         Invocation.getter(#archivedRooms),
-        returnValue: <_i3.ArchivedRoom>[],
-        returnValueForMissingStub: <_i3.ArchivedRoom>[],
-      ) as List<_i3.ArchivedRoom>);
+        returnValue: <_i4.ArchivedRoom>[],
+        returnValueForMissingStub: <_i4.ArchivedRoom>[],
+      ) as List<_i4.ArchivedRoom>);
 
   @override
   bool get enableDehydratedDevices => (super.noSuchMethod(
@@ -1549,11 +1584,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1583,11 +1618,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1596,11 +1631,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1614,31 +1649,31 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  Map<String, _i3.BasicEvent> get accountData => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get accountData => (super.noSuchMethod(
         Invocation.getter(#accountData),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  _i3.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
+  _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_11(
+        returnValue: _FakePushruleEvaluator_12(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_11(
+        returnValueForMissingStub: _FakePushruleEvaluator_12(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-      ) as _i3.PushruleEvaluator);
+      ) as _i4.PushruleEvaluator);
 
   @override
-  Map<String, _i3.CachedPresence> get presences => (super.noSuchMethod(
+  Map<String, _i4.CachedPresence> get presences => (super.noSuchMethod(
         Invocation.getter(#presences),
-        returnValue: <String, _i3.CachedPresence>{},
-        returnValueForMissingStub: <String, _i3.CachedPresence>{},
-      ) as Map<String, _i3.CachedPresence>);
+        returnValue: <String, _i4.CachedPresence>{},
+        returnValueForMissingStub: <String, _i4.CachedPresence>{},
+      ) as Map<String, _i4.CachedPresence>);
 
   @override
   Map<String, List<String>> get directChats => (super.noSuchMethod(
@@ -1648,333 +1683,333 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i11.Future<_i3.Profile> get ownProfile => (super.noSuchMethod(
+  _i12.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_12(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_13(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_12(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_13(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i9.CachedStreamController<String> get onUserProfileUpdate =>
+  _i10.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i11.Future<List<_i3.Room>> get archive => (super.noSuchMethod(
+  _i12.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
+        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
-      ) as _i11.Future<List<_i3.Room>>);
+            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i12.Future<List<_i4.Room>>);
 
   @override
-  _i9.CachedStreamController<_i3.EventUpdate> get onEvent =>
+  _i10.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_13<_i3.EventUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i3.EventUpdate>(
+            _FakeCachedStreamController_14<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.EventUpdate>);
+      ) as _i10.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onTimelineEvent =>
+  _i10.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_13<_i3.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onHistoryEvent =>
+  _i10.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_13<_i3.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onNotification =>
+  _i10.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_13<_i3.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.ToDeviceEvent> get onToDeviceEvent =>
+  _i10.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_13<_i3.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_14<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i3.ToDeviceEvent>(
+            _FakeCachedStreamController_14<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.ToDeviceEvent>);
+      ) as _i10.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i9.CachedStreamController<List<_i3.BasicEventWithSender>> get onCallEvents =>
-      (super.noSuchMethod(
-        Invocation.getter(#onCallEvents),
-        returnValue:
-            _FakeCachedStreamController_13<List<_i3.BasicEventWithSender>>(
-          this,
-          Invocation.getter(#onCallEvents),
-        ),
-        returnValueForMissingStub:
-            _FakeCachedStreamController_13<List<_i3.BasicEventWithSender>>(
-          this,
-          Invocation.getter(#onCallEvents),
-        ),
-      ) as _i9.CachedStreamController<List<_i3.BasicEventWithSender>>);
+  _i10.CachedStreamController<List<_i4.BasicEventWithSender>>
+      get onCallEvents => (super.noSuchMethod(
+            Invocation.getter(#onCallEvents),
+            returnValue:
+                _FakeCachedStreamController_14<List<_i4.BasicEventWithSender>>(
+              this,
+              Invocation.getter(#onCallEvents),
+            ),
+            returnValueForMissingStub:
+                _FakeCachedStreamController_14<List<_i4.BasicEventWithSender>>(
+              this,
+              Invocation.getter(#onCallEvents),
+            ),
+          ) as _i10.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i9.CachedStreamController<_i3.LoginState> get onLoginStateChanged =>
+  _i10.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_13<_i3.LoginState>(
+        returnValue: _FakeCachedStreamController_14<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i3.LoginState>(
+            _FakeCachedStreamController_14<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i9.CachedStreamController<_i3.LoginState>);
+      ) as _i10.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i9.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i10.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_13<bool>(
+        returnValue: _FakeCachedStreamController_14<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i9.CachedStreamController<bool>);
+      ) as _i10.CachedStreamController<bool>);
 
   @override
-  _i9.CachedStreamController<_i3.SdkError> get onEncryptionError =>
+  _i10.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_13<_i3.SdkError>(
+        returnValue: _FakeCachedStreamController_14<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i3.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i9.CachedStreamController<_i3.SdkError>);
+      ) as _i10.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i9.CachedStreamController<_i3.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i10.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_13<_i3.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i3.SyncUpdate>(
+            _FakeCachedStreamController_14<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i9.CachedStreamController<_i3.SyncUpdate>);
+      ) as _i10.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.SyncStatusUpdate> get onSyncStatus =>
+  _i10.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_13<_i3.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_14<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i3.SyncStatusUpdate>(
+            _FakeCachedStreamController_14<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i9.CachedStreamController<_i3.SyncStatusUpdate>);
+      ) as _i10.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.Presence> get onPresence =>
+  _i10.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_13<_i3.Presence>(
+        returnValue: _FakeCachedStreamController_14<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i3.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i9.CachedStreamController<_i3.Presence>);
+      ) as _i10.CachedStreamController<_i4.Presence>);
 
   @override
-  _i9.CachedStreamController<_i3.CachedPresence> get onPresenceChanged =>
+  _i10.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_13<_i3.CachedPresence>(
+        returnValue: _FakeCachedStreamController_14<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i3.CachedPresence>(
+            _FakeCachedStreamController_14<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i9.CachedStreamController<_i3.CachedPresence>);
+      ) as _i10.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i9.CachedStreamController<_i3.BasicEvent> get onAccountData =>
+  _i10.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_13<_i3.BasicEvent>(
+        returnValue: _FakeCachedStreamController_14<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i3.BasicEvent>(
+            _FakeCachedStreamController_14<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i9.CachedStreamController<_i3.BasicEvent>);
+      ) as _i10.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i9.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
+  _i10.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_13<_i18.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_14<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i18.RoomKeyRequest>(
+            _FakeCachedStreamController_14<_i19.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i9.CachedStreamController<_i18.RoomKeyRequest>);
+      ) as _i10.CachedStreamController<_i19.RoomKeyRequest>);
 
   @override
-  _i9.CachedStreamController<_i18.KeyVerification>
+  _i10.CachedStreamController<_i19.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_13<_i18.KeyVerification>(
+            returnValue: _FakeCachedStreamController_14<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_13<_i18.KeyVerification>(
+                _FakeCachedStreamController_14<_i19.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i9.CachedStreamController<_i18.KeyVerification>);
+          ) as _i10.CachedStreamController<_i19.KeyVerification>);
 
   @override
-  _i9.CachedStreamController<_i3.UiaRequest<dynamic>> get onUiaRequest =>
+  _i10.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_13<_i3.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_14<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_13<_i3.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_14<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i9.CachedStreamController<_i3.UiaRequest<dynamic>>);
+      ) as _i10.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onGroupMember =>
+  _i10.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_13<_i3.Event>(
+        returnValue: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<String> get onCancelSendEvent =>
+  _i10.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i9.CachedStreamController<({String roomId, _i3.StrippedStateEvent state})>
+  _i10.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_13<
-                ({String roomId, _i3.StrippedStateEvent state})>(
+            returnValue: _FakeCachedStreamController_14<
+                ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_13<
-                ({String roomId, _i3.StrippedStateEvent state})>(
+            returnValueForMissingStub: _FakeCachedStreamController_14<
+                ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i9.CachedStreamController<
-              ({String roomId, _i3.StrippedStateEvent state})>);
+          ) as _i10.CachedStreamController<
+              ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
   int get syncErrorTimeoutSec => (super.noSuchMethod(
@@ -1993,11 +2028,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_14(
+        returnValue: _FakeDateTime_15(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_14(
+        returnValueForMissingStub: _FakeDateTime_15(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2018,33 +2053,33 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  _i3.RoomSorter get sortRoomsBy => (super.noSuchMethod(
+  _i4.RoomSorter get sortRoomsBy => (super.noSuchMethod(
         Invocation.getter(#sortRoomsBy),
         returnValue: (
-          _i3.Room a,
-          _i3.Room b,
+          _i4.Room a,
+          _i4.Room b,
         ) =>
             0,
         returnValueForMissingStub: (
-          _i3.Room a,
-          _i3.Room b,
+          _i4.Room a,
+          _i4.Room b,
         ) =>
             0,
-      ) as _i3.RoomSorter);
+      ) as _i4.RoomSorter);
 
   @override
-  Map<String, _i3.DeviceKeysList> get userDeviceKeys => (super.noSuchMethod(
+  Map<String, _i4.DeviceKeysList> get userDeviceKeys => (super.noSuchMethod(
         Invocation.getter(#userDeviceKeys),
-        returnValue: <String, _i3.DeviceKeysList>{},
-        returnValueForMissingStub: <String, _i3.DeviceKeysList>{},
-      ) as Map<String, _i3.DeviceKeysList>);
+        returnValue: <String, _i4.DeviceKeysList>{},
+        returnValueForMissingStub: <String, _i4.DeviceKeysList>{},
+      ) as Map<String, _i4.DeviceKeysList>);
 
   @override
-  List<_i3.DeviceKeys> get unverifiedDevices => (super.noSuchMethod(
+  List<_i4.DeviceKeys> get unverifiedDevices => (super.noSuchMethod(
         Invocation.getter(#unverifiedDevices),
-        returnValue: <_i3.DeviceKeys>[],
-        returnValueForMissingStub: <_i3.DeviceKeys>[],
-      ) as List<_i3.DeviceKeys>);
+        returnValue: <_i4.DeviceKeys>[],
+        returnValueForMissingStub: <_i4.DeviceKeys>[],
+      ) as List<_i4.DeviceKeys>);
 
   @override
   bool get allPushNotificationsMuted => (super.noSuchMethod(
@@ -2061,7 +2096,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as List<String>);
 
   @override
-  set database(_i3.DatabaseApi? db) => super.noSuchMethod(
+  set database(_i4.DatabaseApi? db) => super.noSuchMethod(
         Invocation.setter(
           #database,
           db,
@@ -2070,7 +2105,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2116,7 +2151,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set shareKeysWith(_i3.ShareKeysWith? value) => super.noSuchMethod(
+  set shareKeysWith(_i4.ShareKeysWith? value) => super.noSuchMethod(
         Invocation.setter(
           #shareKeysWith,
           value,
@@ -2125,7 +2160,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set onSoftLogout(_i11.Future<void> Function(_i3.Client)? value) =>
+  set onSoftLogout(_i12.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2136,8 +2171,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
 
   @override
   set customImageResizer(
-          _i11.Future<_i3.MatrixImageFileResizedResponse?> Function(
-                  _i3.MatrixImageFileResizeArguments)?
+          _i12.Future<_i4.MatrixImageFileResizedResponse?> Function(
+                  _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
         Invocation.setter(
@@ -2175,7 +2210,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set rooms(List<_i3.Room>? newList) => super.noSuchMethod(
+  set rooms(List<_i4.Room>? newList) => super.noSuchMethod(
         Invocation.setter(
           #rooms,
           newList,
@@ -2184,7 +2219,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set presences(Map<String, _i3.CachedPresence>? value) => super.noSuchMethod(
+  set presences(Map<String, _i4.CachedPresence>? value) => super.noSuchMethod(
         Invocation.setter(
           #presences,
           value,
@@ -2211,7 +2246,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set syncPresence(_i3.PresenceType? value) => super.noSuchMethod(
+  set syncPresence(_i4.PresenceType? value) => super.noSuchMethod(
         Invocation.setter(
           #syncPresence,
           value,
@@ -2247,7 +2282,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2256,7 +2291,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set roomsLoading(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2265,7 +2300,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set firstSyncReceived(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -2292,20 +2327,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i10.Client get httpClient => (super.noSuchMethod(
+  _i11.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_15(
+        returnValue: _FakeClient_16(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_15(
+        returnValueForMissingStub: _FakeClient_16(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i10.Client);
+      ) as _i11.Client);
 
   @override
-  set httpClient(_i10.Client? value) => super.noSuchMethod(
+  set httpClient(_i11.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -2332,7 +2367,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<void> refreshAccessToken(
+  _i12.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2340,9 +2375,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -2360,14 +2395,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2377,22 +2412,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as String);
 
   @override
-  _i3.Room? getRoomByAlias(String? alias) => (super.noSuchMethod(
+  _i4.Room? getRoomByAlias(String? alias) => (super.noSuchMethod(
         Invocation.method(
           #getRoomByAlias,
           [alias],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.Room?);
+      ) as _i4.Room?);
 
   @override
-  _i3.Room? getRoomById(String? id) => (super.noSuchMethod(
+  _i4.Room? getRoomById(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getRoomById,
           [id],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.Room?);
+      ) as _i4.Room?);
 
   @override
   String? getDirectChatFromUserId(String? userId) => (super.noSuchMethod(
@@ -2404,38 +2439,38 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as String?);
 
   @override
-  _i11.Future<_i3.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i12.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_16(
+        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_17(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_16(
+        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_17(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i11.Future<_i3.DiscoveryInformation>);
+      ) as _i12.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i11.Future<
+  _i12.Future<
       (
-        _i3.DiscoveryInformation?,
-        _i3.GetVersionsResponse,
-        List<_i3.LoginFlow>,
-        _i3.GetAuthMetadataResponse?
+        _i4.DiscoveryInformation?,
+        _i4.GetVersionsResponse,
+        List<_i4.LoginFlow>,
+        _i4.GetAuthMetadataResponse?
       )> checkHomeserver(
     Uri? homeserverUrl, {
     bool? checkWellKnown = true,
@@ -2452,15 +2487,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i11.Future<
+        returnValue: _i12.Future<
             (
-              _i3.DiscoveryInformation?,
-              _i3.GetVersionsResponse,
-              List<_i3.LoginFlow>,
-              _i3.GetAuthMetadataResponse?
+              _i4.DiscoveryInformation?,
+              _i4.GetVersionsResponse,
+              List<_i4.LoginFlow>,
+              _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_17(
+          _FakeGetVersionsResponse_18(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2472,18 +2507,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
           ),
-          <_i3.LoginFlow>[],
+          <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i11.Future<
+        returnValueForMissingStub: _i12.Future<
             (
-              _i3.DiscoveryInformation?,
-              _i3.GetVersionsResponse,
-              List<_i3.LoginFlow>,
-              _i3.GetAuthMetadataResponse?
+              _i4.DiscoveryInformation?,
+              _i4.GetVersionsResponse,
+              List<_i4.LoginFlow>,
+              _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_17(
+          _FakeGetVersionsResponse_18(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2495,19 +2530,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
           ),
-          <_i3.LoginFlow>[],
+          <_i4.LoginFlow>[],
           null
         )),
-      ) as _i11.Future<
+      ) as _i12.Future<
           (
-            _i3.DiscoveryInformation?,
-            _i3.GetVersionsResponse,
-            List<_i3.LoginFlow>,
-            _i3.GetAuthMetadataResponse?
+            _i4.DiscoveryInformation?,
+            _i4.GetVersionsResponse,
+            List<_i4.LoginFlow>,
+            _i4.GetAuthMetadataResponse?
           )>);
 
   @override
-  _i11.Future<_i3.DiscoveryInformation> getWellknown({
+  _i12.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2520,8 +2555,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_16(
+        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_17(
           this,
           Invocation.method(
             #getWellknown,
@@ -2532,8 +2567,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_16(
+        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_17(
           this,
           Invocation.method(
             #getWellknown,
@@ -2544,19 +2579,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.DiscoveryInformation>);
+      ) as _i12.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i11.Future<_i3.RegisterResponse> register({
+  _i12.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
     String? initialDeviceDisplayName,
     bool? inhibitLogin,
     bool? refreshToken,
-    _i3.AuthenticationData? auth,
-    _i3.AccountKind? kind,
-    void Function(_i3.InitState)? onInitStateChanged,
+    _i4.AuthenticationData? auth,
+    _i4.AccountKind? kind,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2575,7 +2610,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<_i3.RegisterResponse>.value(_FakeRegisterResponse_18(
+            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_19(
           this,
           Invocation.method(
             #register,
@@ -2594,7 +2629,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RegisterResponse>.value(_FakeRegisterResponse_18(
+            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_19(
           this,
           Invocation.method(
             #register,
@@ -2612,12 +2647,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RegisterResponse>);
+      ) as _i12.Future<_i4.RegisterResponse>);
 
   @override
-  _i11.Future<_i3.LoginResponse> login(
+  _i12.Future<_i4.LoginResponse> login(
     String? type, {
-    _i3.AuthenticationIdentifier? identifier,
+    _i4.AuthenticationIdentifier? identifier,
     String? password,
     String? token,
     String? deviceId,
@@ -2626,7 +2661,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? user,
     String? medium,
     String? address,
-    void Function(_i3.InitState)? onInitStateChanged,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2645,7 +2680,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i11.Future<_i3.LoginResponse>.value(_FakeLoginResponse_19(
+        returnValue: _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_20(
           this,
           Invocation.method(
             #login,
@@ -2665,7 +2700,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.LoginResponse>.value(_FakeLoginResponse_19(
+            _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_20(
           this,
           Invocation.method(
             #login,
@@ -2684,10 +2719,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.LoginResponse>);
+      ) as _i12.Future<_i4.LoginResponse>);
 
   @override
-  _i11.Future<_i3.GetAuthMetadataResponse> getAuthMetadata({
+  _i12.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2700,8 +2735,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_20(
+        returnValue: _i12.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_21(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2713,8 +2748,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_20(
+            _i12.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_21(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2725,80 +2760,80 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetAuthMetadataResponse>);
+      ) as _i12.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i11.Future<void> logout() => (super.noSuchMethod(
+  _i12.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> logoutAll() => (super.noSuchMethod(
+  _i12.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<T> uiaRequestBackground<T>(
-          _i11.Future<T> Function(_i3.AuthenticationData?)? request) =>
+  _i12.Future<T> uiaRequestBackground<T>(
+          _i12.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i11.Future<T>.value(v),
+              (T v) => _i12.Future<T>.value(v),
             ) ??
-            _FakeFuture_21<T>(
+            _FakeFuture_22<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i11.Future<T>.value(v),
+              (T v) => _i12.Future<T>.value(v),
             ) ??
-            _FakeFuture_21<T>(
+            _FakeFuture_22<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i11.Future<T>);
+      ) as _i12.Future<T>);
 
   @override
-  _i11.Future<String> startDirectChat(
+  _i12.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
-    List<_i3.StateEvent>? initialState,
+    List<_i4.StateEvent>? initialState,
     bool? waitForSync = true,
     Map<String, dynamic>? powerLevelContentOverride,
-    _i3.CreateRoomPreset? preset = _i3.CreateRoomPreset.trustedPrivateChat,
+    _i4.CreateRoomPreset? preset = _i4.CreateRoomPreset.trustedPrivateChat,
     bool? skipExistingChat = false,
   }) =>
       (super.noSuchMethod(
@@ -2814,7 +2849,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2830,7 +2865,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2845,17 +2880,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<String> createGroupChat({
+  _i12.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
-    _i3.CreateRoomPreset? preset = _i3.CreateRoomPreset.privateChat,
-    List<_i3.StateEvent>? initialState,
-    _i3.Visibility? visibility,
-    _i3.HistoryVisibility? historyVisibility,
+    _i4.CreateRoomPreset? preset = _i4.CreateRoomPreset.privateChat,
+    List<_i4.StateEvent>? initialState,
+    _i4.Visibility? visibility,
+    _i4.HistoryVisibility? historyVisibility,
     bool? waitForSync = true,
     bool? groupCall = false,
     bool? federated = true,
@@ -2879,7 +2914,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2900,7 +2935,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2920,10 +2955,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> waitForRoomInSync(
+  _i12.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -2939,7 +2974,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_22(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2952,7 +2987,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_22(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2964,27 +2999,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i12.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<String> createSpace({
+  _i12.Future<String> createSpace({
     String? name,
     String? topic,
-    _i3.Visibility? visibility = _i3.Visibility.public,
+    _i4.Visibility? visibility = _i4.Visibility.public,
     String? spaceAliasName,
     List<String>? invite,
-    List<_i3.Invite3pid>? invite3pid,
+    List<_i4.Invite3pid>? invite3pid,
     String? roomVersion,
     bool? waitForSync = false,
   }) =>
@@ -3003,7 +3038,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3021,7 +3056,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3038,10 +3073,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.Profile> fetchOwnProfileFromServer(
+  _i12.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3049,7 +3084,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_12(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_13(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3058,7 +3093,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_12(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_13(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3066,10 +3101,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i11.Future<_i3.Profile> fetchOwnProfile({
+  _i12.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3082,7 +3117,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_12(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_13(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3094,7 +3129,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_12(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_13(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3105,10 +3140,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i11.Future<_i3.CachedProfileInformation> getUserProfile(
+  _i12.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3122,8 +3157,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i11.Future<_i3.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_23(
+        returnValue: _i12.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_24(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3135,8 +3170,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_23(
+            _i12.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_24(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3147,10 +3182,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.CachedProfileInformation>);
+      ) as _i12.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i11.Future<_i3.Profile> getProfileFromUserId(
+  _i12.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3168,7 +3203,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_12(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_13(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3182,7 +3217,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_12(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_13(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3195,17 +3230,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i3.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
+  _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getArchiveRoomFromCache,
           [roomId],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.ArchivedRoom?);
+      ) as _i4.ArchivedRoom?);
 
   @override
   void clearArchivesFromCache() => super.noSuchMethod(
@@ -3217,31 +3252,31 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<List<_i3.Room>> loadArchive() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
+        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
-      ) as _i11.Future<List<_i3.Room>>);
+            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i12.Future<List<_i4.Room>>);
 
   @override
-  _i11.Future<List<_i3.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i12.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i11.Future<List<_i3.ArchivedRoom>>.value(<_i3.ArchivedRoom>[]),
+            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ArchivedRoom>>.value(<_i3.ArchivedRoom>[]),
-      ) as _i11.Future<List<_i3.ArchivedRoom>>);
+            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i12.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i11.Future<_i3.GetVersionsResponse> getVersions({
+  _i12.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3254,8 +3289,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_17(
+        returnValue: _i12.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_18(
           this,
           Invocation.method(
             #getVersions,
@@ -3266,8 +3301,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_17(
+        returnValueForMissingStub: _i12.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_18(
           this,
           Invocation.method(
             #getVersions,
@@ -3278,20 +3313,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetVersionsResponse>);
+      ) as _i12.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i11.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i12.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<_i3.MediaConfig> getConfig({
+  _i12.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3304,7 +3339,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_24(
+        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_25(
           this,
           Invocation.method(
             #getConfig,
@@ -3316,7 +3351,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_24(
+            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_25(
           this,
           Invocation.method(
             #getConfig,
@@ -3327,10 +3362,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.MediaConfig>);
+      ) as _i12.Future<_i4.MediaConfig>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContent(
+  _i12.Future<_i13.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -3350,7 +3385,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContent,
@@ -3366,7 +3401,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContent,
@@ -3381,10 +3416,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentOverrideName(
+  _i12.Future<_i13.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -3406,7 +3441,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3423,7 +3458,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3439,15 +3474,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentThumbnail(
+  _i12.Future<_i13.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
     int? height, {
-    _i3.Method? method,
+    _i4.Method? method,
     bool? allowRemote,
     int? timeoutMs,
     bool? allowRedirect,
@@ -3470,7 +3505,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3490,7 +3525,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3509,10 +3544,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i3.PreviewForUrl> getUrlPreview(
+  _i12.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -3522,7 +3557,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_26(
+        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_27(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3531,7 +3566,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_26(
+            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_27(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3539,11 +3574,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i11.Future<_i3.PreviewForUrl>);
+      ) as _i12.Future<_i4.PreviewForUrl>);
 
   @override
-  _i11.Future<Uri> uploadContent(
-    _i19.Uint8List? file, {
+  _i12.Future<Uri> uploadContent(
+    _i20.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3556,7 +3591,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i11.Future<Uri>.value(_FakeUri_27(
+        returnValue: _i12.Future<Uri>.value(_FakeUri_28(
           this,
           Invocation.method(
             #uploadContent,
@@ -3567,7 +3602,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<Uri>.value(_FakeUri_27(
+        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_28(
           this,
           Invocation.method(
             #uploadContent,
@@ -3578,10 +3613,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<Uri>);
+      ) as _i12.Future<Uri>);
 
   @override
-  _i11.Future<void> setTyping(
+  _i12.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -3597,43 +3632,43 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> exportDump() => (super.noSuchMethod(
+  _i12.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i12.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> setAvatar(_i3.MatrixFile? file) => (super.noSuchMethod(
+  _i12.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Event?> getEventByPushNotification(
-    _i3.PushNotification? notification, {
+  _i12.Future<_i4.Event?> getEventByPushNotification(
+    _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
     bool? returnNullIfSeen = true,
@@ -3648,12 +3683,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
-  _i11.Future<void> init({
+  _i12.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -3666,7 +3701,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     bool? waitForFirstSync = true,
     bool? waitUntilLoadCompletedLoaded = true,
     void Function()? onMigration,
-    void Function(_i3.InitState)? onInitStateChanged,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3688,9 +3723,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -3702,42 +3737,42 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<void> clear() => (super.noSuchMethod(
+  _i12.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i12.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ensureNotSoftLoggedOut(
+  _i12.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> handleSync(
-    _i3.SyncUpdate? sync, {
-    _i3.Direction? direction,
+  _i12.Future<void> handleSync(
+    _i4.SyncUpdate? sync, {
+    _i4.Direction? direction,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3745,44 +3780,44 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i3.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
+  _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeysByCurve25519Key,
           [senderKey],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.DeviceKeys?);
+      ) as _i4.DeviceKeys?);
 
   @override
-  _i11.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i12.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i12.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDevice(
+  _i12.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -3796,12 +3831,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             messages,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDevicesOfUserIds(
+  _i12.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -3817,13 +3852,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDeviceEncrypted(
-    List<_i3.DeviceKeys>? deviceKeys,
+  _i12.Future<void> sendToDeviceEncrypted(
+    List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
     String? messageId,
@@ -3842,13 +3877,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDeviceEncryptedChunked(
-    List<_i3.DeviceKeys>? deviceKeys,
+  _i12.Future<void> sendToDeviceEncryptedChunked(
+    List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
   ) =>
@@ -3861,28 +3896,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
             message,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i12.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> joinRoom(
+  _i12.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
     String? reason,
-    _i3.ThirdPartySigned? thirdPartySigned,
+    _i4.ThirdPartySigned? thirdPartySigned,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3895,7 +3930,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3909,7 +3944,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3922,13 +3957,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> changePassword(
+  _i12.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
     bool? logoutDevices,
   }) =>
       (super.noSuchMethod(
@@ -3941,22 +3976,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> clearCache() => (super.noSuchMethod(
+  _i12.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ignoreUser(
+  _i12.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -3966,22 +4001,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i12.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.CachedPresence> fetchCurrentPresence(
+  _i12.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -3992,7 +4027,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i11.Future<_i3.CachedPresence>.value(_FakeCachedPresence_28(
+            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_29(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4001,7 +4036,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.CachedPresence>.value(_FakeCachedPresence_28(
+            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_29(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4009,32 +4044,32 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i11.Future<_i3.CachedPresence>);
+      ) as _i12.Future<_i4.CachedPresence>);
 
   @override
-  _i11.Future<void> abortSync() => (super.noSuchMethod(
+  _i12.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i12.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEventWithMetadata(
+  _i12.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4054,14 +4089,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i10.BaseResponse? response,
-    _i19.Uint8List? body,
+    _i11.BaseResponse? response,
+    _i20.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4093,8 +4128,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as Never);
 
   @override
-  _i11.Future<Map<String, Object?>> request(
-    _i3.RequestType? type,
+  _i12.Future<Map<String, Object?>> request(
+    _i4.RequestType? type,
     String? action, {
     dynamic data = '',
     String? contentType = 'application/json',
@@ -4114,14 +4149,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> postPusher(
-    _i3.Pusher? pusher, {
+  _i12.Future<void> postPusher(
+    _i4.Pusher? pusher, {
     bool? append,
   }) =>
       (super.noSuchMethod(
@@ -4130,57 +4165,57 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deletePusher(_i3.PusherId? pusher) => (super.noSuchMethod(
+  _i12.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i12.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i12.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i11.Future<_i3.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_29(
+        returnValue: _i12.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_30(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_29(
+        returnValueForMissingStub: _i12.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_30(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.TurnServerCredentials>);
+      ) as _i12.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4194,8 +4229,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_30(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4207,8 +4242,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_30(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4219,14 +4254,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
-    _i3.KeyBackupData? data,
+    _i4.KeyBackupData? data,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4238,8 +4273,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             data,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_30(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4252,8 +4287,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_30(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4265,10 +4300,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.KeyBackupData> getRoomKeysBySessionId(
+  _i12.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4282,7 +4317,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_31(
+        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_32(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4294,7 +4329,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_31(
+            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_32(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4305,17 +4340,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.KeyBackupData>);
+      ) as _i12.Future<_i4.KeyBackupData>);
 
   @override
-  _i11.Future<_i3.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i12.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i11.Future<_i3.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_32(
+        returnValue: _i12.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_33(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -4323,18 +4358,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_32(
+            _i12.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_33(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.GetWellknownSupportResponse>);
+      ) as _i12.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i11.Future<int> pingAppservice(
+  _i12.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -4344,21 +4379,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i11.Future<int>.value(0),
-        returnValueForMissingStub: _i11.Future<int>.value(0),
-      ) as _i11.Future<int>);
+        returnValue: _i12.Future<int>.value(0),
+        returnValueForMissingStub: _i12.Future<int>.value(0),
+      ) as _i12.Future<int>);
 
   @override
-  _i11.Future<_i3.GenerateLoginTokenResponse> generateLoginToken(
-          {_i3.AuthenticationData? auth}) =>
+  _i12.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+          {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
           #generateLoginToken,
           [],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<_i3.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_33(
+        returnValue: _i12.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_34(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4367,8 +4402,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_33(
+            _i12.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_34(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4376,15 +4411,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i11.Future<_i3.GenerateLoginTokenResponse>);
+      ) as _i12.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i11.Future<_i3.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i12.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_24(
+        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_25(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -4392,17 +4427,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_24(
+            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_25(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.MediaConfig>);
+      ) as _i12.Future<_i4.MediaConfig>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentAuthed(
+  _i12.Future<_i13.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -4416,7 +4451,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4428,7 +4463,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4439,10 +4474,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentOverrideNameAuthed(
+  _i12.Future<_i13.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4458,7 +4493,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4471,7 +4506,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4483,10 +4518,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i3.PreviewForUrl> getUrlPreviewAuthed(
+  _i12.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -4496,7 +4531,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_26(
+        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_27(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4505,7 +4540,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_26(
+            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_27(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4513,15 +4548,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i11.Future<_i3.PreviewForUrl>);
+      ) as _i12.Future<_i4.PreviewForUrl>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentThumbnailAuthed(
+  _i12.Future<_i13.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
     int? height, {
-    _i3.Method? method,
+    _i4.Method? method,
     int? timeoutMs,
     bool? animated,
   }) =>
@@ -4540,7 +4575,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4558,7 +4593,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_25(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4575,21 +4610,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<bool> registrationTokenValidity(String? token) =>
+  _i12.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<_i3.GetRoomSummaryResponse$3> getRoomSummary(
+  _i12.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -4599,8 +4634,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i11.Future<_i3.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_34(
+        returnValue: _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_35(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4609,8 +4644,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_34(
+            _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_35(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4618,10 +4653,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#via: via},
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomSummaryResponse$3>);
+      ) as _i12.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i11.Future<_i3.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i12.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -4639,8 +4674,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #from: from,
           },
         ),
-        returnValue: _i11.Future<_i3.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_35(
+        returnValue: _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_36(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4654,8 +4689,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_35(
+            _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_36(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4668,16 +4703,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetSpaceHierarchyResponse>);
+      ) as _i12.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsResponse> getRelatingEvents(
+  _i12.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
       (super.noSuchMethod(
@@ -4695,8 +4730,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i11.Future<_i3.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_36(
+        returnValue: _i12.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_37(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4714,8 +4749,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_36(
+            _i12.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_37(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4732,10 +4767,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetRelatingEventsResponse>);
+      ) as _i12.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>
+  _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -4743,7 +4778,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
           (super.noSuchMethod(
@@ -4763,8 +4798,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
             returnValue:
-                _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_37(
+                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_38(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4783,8 +4818,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_37(
+                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_38(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4802,10 +4837,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-          ) as _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i12.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -4814,7 +4849,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
           (super.noSuchMethod(
@@ -4834,9 +4869,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i11.Future<
-                    _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_38(
+            returnValue: _i12.Future<
+                    _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -4855,9 +4890,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i11.Future<
-                    _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_38(
+            returnValueForMissingStub: _i12.Future<
+                    _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -4876,13 +4911,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-          ) as _i11
-              .Future<_i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
+          ) as _i12
+              .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i11.Future<_i3.GetThreadRootsResponse> getThreadRoots(
+  _i12.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
-    _i3.Include? include,
+    _i4.Include? include,
     int? limit,
     String? from,
   }) =>
@@ -4896,8 +4931,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #from: from,
           },
         ),
-        returnValue: _i11.Future<_i3.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_39(
+        returnValue: _i12.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_40(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -4910,8 +4945,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_39(
+            _i12.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_40(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -4923,13 +4958,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetThreadRootsResponse>);
+      ) as _i12.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i11.Future<_i3.GetEventByTimestampResponse> getEventByTimestamp(
+  _i12.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4940,8 +4975,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             dir,
           ],
         ),
-        returnValue: _i11.Future<_i3.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_40(
+        returnValue: _i12.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_41(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -4953,8 +4988,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_40(
+            _i12.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_41(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -4965,36 +5000,36 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.GetEventByTimestampResponse>);
+      ) as _i12.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i12.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyIdentifier>?>.value(),
-      ) as _i11.Future<List<_i3.ThirdPartyIdentifier>?>);
+            _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i12.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i11.Future<Uri?> post3PIDs(_i3.ThreePidCredentials? threePidCreds) =>
+  _i12.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i11.Future<Uri?>.value(),
-        returnValueForMissingStub: _i11.Future<Uri?>.value(),
-      ) as _i11.Future<Uri?>);
+        returnValue: _i12.Future<Uri?>.value(),
+        returnValueForMissingStub: _i12.Future<Uri?>.value(),
+      ) as _i12.Future<Uri?>);
 
   @override
-  _i11.Future<void> add3PID(
+  _i12.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5005,12 +5040,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> bind3PID(
+  _i12.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5026,14 +5061,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             sid,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> delete3pidFromAccount(
+  _i12.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
-    _i3.ThirdPartyIdentifierMedium? medium, {
+    _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
   }) =>
       (super.noSuchMethod(
@@ -5045,14 +5080,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5074,8 +5109,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5091,8 +5126,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5108,10 +5143,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5135,8 +5170,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5153,8 +5188,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5171,12 +5206,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> unbind3pidFromAccount(
+  _i12.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
-    _i3.ThirdPartyIdentifierMedium? medium, {
+    _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
   }) =>
       (super.noSuchMethod(
@@ -5188,15 +5223,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> deactivateAccount({
-    _i3.AuthenticationData? auth,
+  _i12.Future<_i4.IdServerUnbindResult> deactivateAccount({
+    _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
   }) =>
@@ -5210,14 +5245,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5239,8 +5274,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5256,8 +5291,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5273,10 +5308,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5300,8 +5335,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5318,8 +5353,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5336,16 +5371,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i12.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i11.Future<_i3.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_42(
+            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_43(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -5353,22 +5388,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_42(
+            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_43(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.TokenOwnerInfo>);
+      ) as _i12.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i11.Future<_i3.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i12.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i11.Future<_i3.WhoIsInfo>.value(_FakeWhoIsInfo_43(
+        returnValue: _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_44(
           this,
           Invocation.method(
             #getWhoIs,
@@ -5376,22 +5411,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.WhoIsInfo>.value(_FakeWhoIsInfo_43(
+            _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_44(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i11.Future<_i3.WhoIsInfo>);
+      ) as _i12.Future<_i4.WhoIsInfo>);
 
   @override
-  _i11.Future<_i3.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i12.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i11.Future<_i3.Capabilities>.value(_FakeCapabilities_44(
+        returnValue: _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_45(
           this,
           Invocation.method(
             #getCapabilities,
@@ -5399,29 +5434,29 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Capabilities>.value(_FakeCapabilities_44(
+            _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_45(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.Capabilities>);
+      ) as _i12.Future<_i4.Capabilities>);
 
   @override
-  _i11.Future<String> createRoom({
+  _i12.Future<String> createRoom({
     Map<String, Object?>? creationContent,
-    List<_i3.StateEvent>? initialState,
+    List<_i4.StateEvent>? initialState,
     List<String>? invite,
-    List<_i3.Invite3pid>? invite3pid,
+    List<_i4.Invite3pid>? invite3pid,
     bool? isDirect,
     String? name,
     Map<String, Object?>? powerLevelContentOverride,
-    _i3.CreateRoomPreset? preset,
+    _i4.CreateRoomPreset? preset,
     String? roomAliasName,
     String? roomVersion,
     String? topic,
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5442,7 +5477,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5464,7 +5499,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5485,12 +5520,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> deleteDevices(
+  _i12.Future<void> deleteDevices(
     List<String>? devices, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5498,24 +5533,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.Device>?> getDevices() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Device>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.Device>?>.value(),
-      ) as _i11.Future<List<_i3.Device>?>);
+        returnValue: _i12.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.Device>?>.value(),
+      ) as _i12.Future<List<_i4.Device>?>);
 
   @override
-  _i11.Future<void> deleteDevice(
+  _i12.Future<void> deleteDevice(
     String? deviceId, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5523,34 +5558,34 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i12.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i11.Future<_i3.Device>.value(_FakeDevice_45(
+        returnValue: _i12.Future<_i4.Device>.value(_FakeDevice_46(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.Device>.value(_FakeDevice_45(
+        returnValueForMissingStub: _i12.Future<_i4.Device>.value(_FakeDevice_46(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i11.Future<_i3.Device>);
+      ) as _i12.Future<_i4.Device>);
 
   @override
-  _i11.Future<void> updateDevice(
+  _i12.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -5560,15 +5595,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i12.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5580,26 +5615,26 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i12.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i11.Future<_i3.Visibility?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Visibility?>.value(),
-      ) as _i11.Future<_i3.Visibility?>);
+        returnValue: _i12.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Visibility?>.value(),
+      ) as _i12.Future<_i4.Visibility?>);
 
   @override
-  _i11.Future<void> setRoomVisibilityOnDirectory(
+  _i12.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5607,30 +5642,30 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i12.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i12.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i11.Future<_i3.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_46(
+        returnValue: _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_47(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -5638,18 +5673,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_46(
+            _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_47(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomIdByAliasResponse>);
+      ) as _i12.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i11.Future<void> setRoomAlias(
+  _i12.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -5661,12 +5696,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             roomId,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetEventsResponse> getEvents({
+  _i12.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -5680,7 +5715,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<_i3.GetEventsResponse>.value(_FakeGetEventsResponse_47(
+            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_48(
           this,
           Invocation.method(
             #getEvents,
@@ -5692,7 +5727,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetEventsResponse>.value(_FakeGetEventsResponse_47(
+            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_48(
           this,
           Invocation.method(
             #getEvents,
@@ -5703,10 +5738,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetEventsResponse>);
+      ) as _i12.Future<_i4.GetEventsResponse>);
 
   @override
-  _i11.Future<_i3.PeekEventsResponse> peekEvents({
+  _i12.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -5721,8 +5756,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i11.Future<_i3.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_48(
+        returnValue: _i12.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_49(
           this,
           Invocation.method(
             #peekEvents,
@@ -5734,8 +5769,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_48(
+        returnValueForMissingStub: _i12.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_49(
           this,
           Invocation.method(
             #peekEvents,
@@ -5747,16 +5782,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.PeekEventsResponse>);
+      ) as _i12.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i11.Future<_i3.MatrixEvent> getOneEvent(String? eventId) =>
+  _i12.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_49(
+        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_50(
           this,
           Invocation.method(
             #getOneEvent,
@@ -5764,27 +5799,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_49(
+            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_50(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i11.Future<_i3.MatrixEvent>);
+      ) as _i12.Future<_i4.MatrixEvent>);
 
   @override
-  _i11.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i12.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i11.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i11.Future<List<String>>.value(<String>[]),
-      ) as _i11.Future<List<String>>);
+        returnValue: _i12.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
+      ) as _i12.Future<List<String>>);
 
   @override
-  _i11.Future<_i3.GetKeysChangesResponse> getKeysChanges(
+  _i12.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -5796,8 +5831,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             to,
           ],
         ),
-        returnValue: _i11.Future<_i3.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_50(
+        returnValue: _i12.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_51(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5808,8 +5843,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_50(
+            _i12.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_51(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5819,10 +5854,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.GetKeysChangesResponse>);
+      ) as _i12.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i11.Future<_i3.ClaimKeysResponse> claimKeys(
+  _i12.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -5833,7 +5868,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i11.Future<_i3.ClaimKeysResponse>.value(_FakeClaimKeysResponse_51(
+            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_52(
           this,
           Invocation.method(
             #claimKeys,
@@ -5842,7 +5877,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.ClaimKeysResponse>.value(_FakeClaimKeysResponse_51(
+            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_52(
           this,
           Invocation.method(
             #claimKeys,
@@ -5850,14 +5885,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i11.Future<_i3.ClaimKeysResponse>);
+      ) as _i12.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i11.Future<void> uploadCrossSigningKeys({
-    _i3.AuthenticationData? auth,
-    _i3.MatrixCrossSigningKey? masterKey,
-    _i3.MatrixCrossSigningKey? selfSigningKey,
-    _i3.MatrixCrossSigningKey? userSigningKey,
+  _i12.Future<void> uploadCrossSigningKeys({
+    _i4.AuthenticationData? auth,
+    _i4.MatrixCrossSigningKey? masterKey,
+    _i4.MatrixCrossSigningKey? selfSigningKey,
+    _i4.MatrixCrossSigningKey? userSigningKey,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5870,12 +5905,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.QueryKeysResponse> queryKeys(
+  _i12.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -5886,7 +5921,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i11.Future<_i3.QueryKeysResponse>.value(_FakeQueryKeysResponse_52(
+            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_53(
           this,
           Invocation.method(
             #queryKeys,
@@ -5895,7 +5930,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.QueryKeysResponse>.value(_FakeQueryKeysResponse_52(
+            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_53(
           this,
           Invocation.method(
             #queryKeys,
@@ -5903,10 +5938,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i11.Future<_i3.QueryKeysResponse>);
+      ) as _i12.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i11.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -5914,15 +5949,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i11.Future<
+            returnValue: _i12.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i11.Future<
+            returnValueForMissingStub: _i12.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i11.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i11.Future<Map<String, int>> uploadKeys({
-    _i3.MatrixDeviceKeys? deviceKeys,
+  _i12.Future<Map<String, int>> uploadKeys({
+    _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
   }) =>
@@ -5936,13 +5971,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i11.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i12.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i11.Future<Map<String, int>>);
+            _i12.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i12.Future<Map<String, int>>);
 
   @override
-  _i11.Future<String> knockRoom(
+  _i12.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -5956,7 +5991,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5968,7 +6003,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5979,20 +6014,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<List<_i3.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i12.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.LoginFlow>?>.value(),
-      ) as _i11.Future<List<_i3.LoginFlow>?>);
+        returnValue: _i12.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i12.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i11.Future<_i3.GetNotificationsResponse> getNotifications({
+  _i12.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6007,8 +6042,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #only: only,
           },
         ),
-        returnValue: _i11.Future<_i3.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_53(
+        returnValue: _i12.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_54(
           this,
           Invocation.method(
             #getNotifications,
@@ -6021,8 +6056,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_53(
+            _i12.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_54(
           this,
           Invocation.method(
             #getNotifications,
@@ -6034,37 +6069,37 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetNotificationsResponse>);
+      ) as _i12.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i11.Future<_i3.GetPresenceResponse> getPresence(String? userId) =>
+  _i12.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i11.Future<_i3.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_54(
+        returnValue: _i12.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_55(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_54(
+        returnValueForMissingStub: _i12.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_55(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i11.Future<_i3.GetPresenceResponse>);
+      ) as _i12.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i11.Future<void> setPresence(
+  _i12.Future<void> setPresence(
     String? userId,
-    _i3.PresenceType? presence, {
+    _i4.PresenceType? presence, {
     String? statusMsg,
   }) =>
       (super.noSuchMethod(
@@ -6076,12 +6111,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, Object?>> deleteProfileField(
+  _i12.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6094,13 +6129,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getProfileField(
+  _i12.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6113,13 +6148,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<Map<String, Object?>> setProfileField(
+  _i12.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6134,13 +6169,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.GetPublicRoomsResponse> getPublicRooms({
+  _i12.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6155,8 +6190,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #server: server,
           },
         ),
-        returnValue: _i11.Future<_i3.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_55(
+        returnValue: _i12.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_56(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6169,8 +6204,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_55(
+            _i12.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_56(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6182,12 +6217,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetPublicRoomsResponse>);
+      ) as _i12.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i11.Future<_i3.QueryPublicRoomsResponse> queryPublicRooms({
+  _i12.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
-    _i3.PublicRoomQueryFilter? filter,
+    _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
     int? limit,
     String? since,
@@ -6206,8 +6241,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i11.Future<_i3.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_56(
+        returnValue: _i12.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_57(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6223,8 +6258,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_56(
+            _i12.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_57(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6239,25 +6274,25 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.QueryPublicRoomsResponse>);
+      ) as _i12.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i11.Future<List<_i3.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Pusher>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.Pusher>?>.value(),
-      ) as _i11.Future<List<_i3.Pusher>?>);
+        returnValue: _i12.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.Pusher>?>.value(),
+      ) as _i12.Future<List<_i4.Pusher>?>);
 
   @override
-  _i11.Future<_i3.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i12.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i11.Future<_i3.PushRuleSet>.value(_FakePushRuleSet_57(
+        returnValue: _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_58(
           this,
           Invocation.method(
             #getPushRules,
@@ -6265,24 +6300,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PushRuleSet>.value(_FakePushRuleSet_57(
+            _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_58(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.PushRuleSet>);
+      ) as _i12.Future<_i4.PushRuleSet>);
 
   @override
-  _i11.Future<_i3.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i12.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i11.Future<_i3.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_58(
+        returnValue: _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_59(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -6290,19 +6325,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_58(
+            _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_59(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.GetPushRulesGlobalResponse>);
+      ) as _i12.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i11.Future<void> deletePushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> deletePushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -6313,13 +6348,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.PushRule> getPushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<_i4.PushRule> getPushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -6330,7 +6365,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<_i3.PushRule>.value(_FakePushRule_59(
+        returnValue: _i12.Future<_i4.PushRule>.value(_FakePushRule_60(
           this,
           Invocation.method(
             #getPushRule,
@@ -6341,7 +6376,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PushRule>.value(_FakePushRule_59(
+            _i12.Future<_i4.PushRule>.value(_FakePushRule_60(
           this,
           Invocation.method(
             #getPushRule,
@@ -6351,16 +6386,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.PushRule>);
+      ) as _i12.Future<_i4.PushRule>);
 
   @override
-  _i11.Future<void> setPushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
     String? before,
     String? after,
-    List<_i3.PushCondition>? conditions,
+    List<_i4.PushCondition>? conditions,
     String? pattern,
   }) =>
       (super.noSuchMethod(
@@ -6378,13 +6413,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<Object?>> getPushRuleActions(
-    _i3.PushRuleKind? kind,
+  _i12.Future<List<Object?>> getPushRuleActions(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -6395,14 +6430,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i12.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i11.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i11.Future<List<Object?>>);
+            _i12.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i12.Future<List<Object?>>);
 
   @override
-  _i11.Future<void> setPushRuleActions(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRuleActions(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
   ) =>
@@ -6415,13 +6450,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             actions,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<bool> isPushRuleEnabled(
-    _i3.PushRuleKind? kind,
+  _i12.Future<bool> isPushRuleEnabled(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -6432,13 +6467,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> setPushRuleEnabled(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRuleEnabled(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
   ) =>
@@ -6451,19 +6486,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
             enabled,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.RefreshResponse> refresh(String? refreshToken) =>
+  _i12.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i11.Future<_i3.RefreshResponse>.value(_FakeRefreshResponse_60(
+            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_61(
           this,
           Invocation.method(
             #refresh,
@@ -6471,28 +6506,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RefreshResponse>.value(_FakeRefreshResponse_60(
+            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_61(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i11.Future<_i3.RefreshResponse>);
+      ) as _i12.Future<_i4.RefreshResponse>);
 
   @override
-  _i11.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i12.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i11.Future<bool?>.value(),
-        returnValueForMissingStub: _i11.Future<bool?>.value(),
-      ) as _i11.Future<bool?>);
+        returnValue: _i12.Future<bool?>.value(),
+        returnValueForMissingStub: _i12.Future<bool?>.value(),
+      ) as _i12.Future<bool?>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6514,8 +6549,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6531,8 +6566,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6548,10 +6583,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6575,8 +6610,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6593,8 +6628,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_41(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_42(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6611,17 +6646,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_30(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -6629,23 +6664,23 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_30(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i12.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i11.Future<_i3.RoomKeys>.value(_FakeRoomKeys_61(
+        returnValue: _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_62(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -6653,19 +6688,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeys>.value(_FakeRoomKeys_61(
+            _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_62(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeys>);
+      ) as _i12.Future<_i4.RoomKeys>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeys(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
-    _i3.RoomKeys? body,
+    _i4.RoomKeys? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6675,8 +6710,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_30(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6687,8 +6722,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_30(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6698,10 +6733,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6713,8 +6748,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_30(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6725,8 +6760,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_30(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6736,10 +6771,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeyBackup> getRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6751,7 +6786,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeyBackup>.value(_FakeRoomKeyBackup_62(
+        returnValue: _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_63(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6762,7 +6797,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeyBackup>.value(_FakeRoomKeyBackup_62(
+            _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_63(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6772,13 +6807,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeyBackup>);
+      ) as _i12.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
-    _i3.RoomKeyBackup? body,
+    _i4.RoomKeyBackup? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6789,8 +6824,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_30(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6802,8 +6837,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_30(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6814,10 +6849,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6831,8 +6866,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_30(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -6844,8 +6879,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_30(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -6856,10 +6891,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.KeyBackupData> getRoomKeyBySessionId(
+  _i12.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6873,7 +6908,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_31(
+        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_32(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -6885,7 +6920,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_31(
+            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_32(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -6896,14 +6931,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.KeyBackupData>);
+      ) as _i12.Future<_i4.KeyBackupData>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
-    _i3.KeyBackupData? body,
+    _i4.KeyBackupData? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6915,8 +6950,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_30(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -6929,8 +6964,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_30(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_31(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -6942,18 +6977,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>
+  _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_63(
+                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_64(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -6961,19 +6996,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_63(
+                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_64(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>);
+          ) as _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i11.Future<String> postRoomKeysVersion(
-    _i3.BackupAlgorithm? algorithm,
+  _i12.Future<String> postRoomKeysVersion(
+    _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
       (super.noSuchMethod(
@@ -6984,7 +7019,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             authData,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6995,7 +7030,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7005,29 +7040,29 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i12.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i12.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i11.Future<_i3.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_64(
+        returnValue: _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_65(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7035,20 +7070,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_64(
+            _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_65(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomKeysVersionResponse>);
+      ) as _i12.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i12.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
-    _i3.BackupAlgorithm? algorithm,
+    _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
       (super.noSuchMethod(
@@ -7061,24 +7096,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i12.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i11.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i11.Future<List<String>>.value(<String>[]),
-      ) as _i11.Future<List<String>>);
+        returnValue: _i12.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
+      ) as _i12.Future<List<String>>);
 
   @override
-  _i11.Future<void> ban(
+  _i12.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7092,12 +7127,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.EventContext> getEventContext(
+  _i12.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7115,7 +7150,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<_i3.EventContext>.value(_FakeEventContext_65(
+        returnValue: _i12.Future<_i4.EventContext>.value(_FakeEventContext_66(
           this,
           Invocation.method(
             #getEventContext,
@@ -7130,7 +7165,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.EventContext>.value(_FakeEventContext_65(
+            _i12.Future<_i4.EventContext>.value(_FakeEventContext_66(
           this,
           Invocation.method(
             #getEventContext,
@@ -7144,10 +7179,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.EventContext>);
+      ) as _i12.Future<_i4.EventContext>);
 
   @override
-  _i11.Future<_i3.MatrixEvent> getOneRoomEvent(
+  _i12.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7159,7 +7194,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             eventId,
           ],
         ),
-        returnValue: _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_49(
+        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_50(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7170,7 +7205,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_49(
+            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_50(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7180,22 +7215,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.MatrixEvent>);
+      ) as _i12.Future<_i4.MatrixEvent>);
 
   @override
-  _i11.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i12.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> inviteBy3PID(
+  _i12.Future<void> inviteBy3PID(
     String? roomId,
-    _i3.Invite3pid? body,
+    _i4.Invite3pid? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7205,12 +7240,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> inviteUser(
+  _i12.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7224,15 +7259,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> joinRoomById(
+  _i12.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
-    _i3.ThirdPartySigned? thirdPartySigned,
+    _i4.ThirdPartySigned? thirdPartySigned,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7243,7 +7278,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7255,7 +7290,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7266,23 +7301,23 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<Map<String, _i3.RoomMember>?> getJoinedMembersByRoom(
+  _i12.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i11.Future<Map<String, _i3.RoomMember>?>.value(),
+        returnValue: _i12.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i11.Future<Map<String, _i3.RoomMember>?>.value(),
-      ) as _i11.Future<Map<String, _i3.RoomMember>?>);
+            _i12.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i12.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i11.Future<void> kick(
+  _i12.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7296,12 +7331,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> leaveRoom(
+  _i12.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -7311,16 +7346,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.MatrixEvent>?> getMembersByRoom(
+  _i12.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
-    _i3.Membership? membership,
-    _i3.Membership? notMembership,
+    _i4.Membership? membership,
+    _i4.Membership? notMembership,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7332,14 +7367,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i11.Future<List<_i3.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.MatrixEvent>?>.value(),
-      ) as _i11.Future<List<_i3.MatrixEvent>?>);
+        returnValue: _i12.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i12.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i11.Future<_i3.GetRoomEventsResponse> getRoomEvents(
+  _i12.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
-    _i3.Direction? dir, {
+    _i4.Direction? dir, {
     String? from,
     String? to,
     int? limit,
@@ -7359,8 +7394,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<_i3.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_66(
+        returnValue: _i12.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_67(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7376,8 +7411,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_66(
+        returnValueForMissingStub: _i12.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_67(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7393,10 +7428,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomEventsResponse>);
+      ) as _i12.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i11.Future<void> setReadMarker(
+  _i12.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -7412,14 +7447,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> postReceipt(
+  _i12.Future<void> postReceipt(
     String? roomId,
-    _i3.ReceiptType? receiptType,
+    _i4.ReceiptType? receiptType,
     String? eventId, {
     String? threadId,
   }) =>
@@ -7433,12 +7468,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEvent(
+  _i12.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -7454,12 +7489,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> reportRoom(
+  _i12.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -7471,12 +7506,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             reason,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> reportEvent(
+  _i12.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -7494,12 +7529,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #score: score,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> sendMessage(
+  _i12.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -7515,7 +7550,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7528,7 +7563,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7540,27 +7575,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<List<_i3.MatrixEvent>> getRoomState(String? roomId) =>
+  _i12.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i11.Future<List<_i3.MatrixEvent>>.value(<_i3.MatrixEvent>[]),
+            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.MatrixEvent>>.value(<_i3.MatrixEvent>[]),
-      ) as _i11.Future<List<_i3.MatrixEvent>>);
+            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i12.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i12.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
-    _i3.Format? format,
+    _i4.Format? format,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7573,13 +7608,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#format: format},
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<String> setRoomStateWithKey(
+  _i12.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -7595,7 +7630,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7608,7 +7643,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7620,10 +7655,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> unban(
+  _i12.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7637,12 +7672,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> upgradeRoom(
+  _i12.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -7656,7 +7691,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7668,7 +7703,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7679,11 +7714,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.SearchResults> search(
-    _i3.Categories? searchCategories, {
+  _i12.Future<_i4.SearchResults> search(
+    _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
       (super.noSuchMethod(
@@ -7692,7 +7727,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i11.Future<_i3.SearchResults>.value(_FakeSearchResults_67(
+        returnValue: _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_68(
           this,
           Invocation.method(
             #search,
@@ -7701,7 +7736,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SearchResults>.value(_FakeSearchResults_67(
+            _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_68(
           this,
           Invocation.method(
             #search,
@@ -7709,14 +7744,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i11.Future<_i3.SearchResults>);
+      ) as _i12.Future<_i4.SearchResults>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> sync({
+  _i12.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
-    _i3.PresenceType? setPresence,
+    _i4.PresenceType? setPresence,
     int? timeout,
     bool? useStateAfter,
   }) =>
@@ -7733,7 +7768,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_22(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
           this,
           Invocation.method(
             #sync,
@@ -7749,7 +7784,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_22(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
           this,
           Invocation.method(
             #sync,
@@ -7764,22 +7799,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<List<_i3.Location>> queryLocationByAlias(String? alias) =>
+  _i12.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
+        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
-      ) as _i11.Future<List<_i3.Location>>);
+            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i12.Future<List<_i4.Location>>);
 
   @override
-  _i11.Future<List<_i3.Location>> queryLocationByProtocol(
+  _i12.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -7789,21 +7824,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
+        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
-      ) as _i11.Future<List<_i3.Location>>);
+            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i12.Future<List<_i4.Location>>);
 
   @override
-  _i11.Future<_i3.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i12.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i11.Future<_i3.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_68(
+        returnValue: _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_69(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -7811,45 +7846,45 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_68(
+            _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_69(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i11.Future<_i3.GetProtocolMetadataResponse$2>);
+      ) as _i12.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i11.Future<Map<String, _i3.GetProtocolsResponse$2>> getProtocols() =>
+  _i12.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>.value(
-            <String, _i3.GetProtocolsResponse$2>{}),
+        returnValue: _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>.value(
-                <String, _i3.GetProtocolsResponse$2>{}),
-      ) as _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>);
+            _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+                <String, _i4.GetProtocolsResponse$2>{}),
+      ) as _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
-      ) as _i11.Future<List<_i3.ThirdPartyUser>>);
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyUser>> queryUserByProtocol(
+  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -7860,13 +7895,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
-      ) as _i11.Future<List<_i3.ThirdPartyUser>>);
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getAccountData(
+  _i12.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -7879,13 +7914,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> setAccountData(
+  _i12.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -7899,14 +7934,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> defineFilter(
+  _i12.Future<String> defineFilter(
     String? userId,
-    _i3.Filter? body,
+    _i4.Filter? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7916,7 +7951,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7927,7 +7962,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7937,10 +7972,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.Filter> getFilter(
+  _i12.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -7952,7 +7987,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             filterId,
           ],
         ),
-        returnValue: _i11.Future<_i3.Filter>.value(_FakeFilter_8(
+        returnValue: _i12.Future<_i4.Filter>.value(_FakeFilter_9(
           this,
           Invocation.method(
             #getFilter,
@@ -7962,7 +7997,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.Filter>.value(_FakeFilter_8(
+        returnValueForMissingStub: _i12.Future<_i4.Filter>.value(_FakeFilter_9(
           this,
           Invocation.method(
             #getFilter,
@@ -7972,10 +8007,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.Filter>);
+      ) as _i12.Future<_i4.Filter>);
 
   @override
-  _i11.Future<_i3.OpenIdCredentials> requestOpenIdToken(
+  _i12.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -7988,7 +8023,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<_i3.OpenIdCredentials>.value(_FakeOpenIdCredentials_69(
+            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_70(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -7999,7 +8034,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.OpenIdCredentials>.value(_FakeOpenIdCredentials_69(
+            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_70(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8009,10 +8044,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.OpenIdCredentials>);
+      ) as _i12.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i11.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i12.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8027,13 +8062,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> setAccountDataPerRoom(
+  _i12.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8049,12 +8084,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, _i3.Tag>?> getRoomTags(
+  _i12.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8066,12 +8101,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             roomId,
           ],
         ),
-        returnValue: _i11.Future<Map<String, _i3.Tag>?>.value(),
-        returnValueForMissingStub: _i11.Future<Map<String, _i3.Tag>?>.value(),
-      ) as _i11.Future<Map<String, _i3.Tag>?>);
+        returnValue: _i12.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i12.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i12.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i11.Future<void> deleteRoomTag(
+  _i12.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8085,16 +8120,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             tag,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setRoomTag(
+  _i12.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
-    _i3.Tag? body,
+    _i4.Tag? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8106,12 +8141,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.SearchUserDirectoryResponse> searchUserDirectory(
+  _i12.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8121,8 +8156,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i11.Future<_i3.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_70(
+        returnValue: _i12.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_71(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8131,8 +8166,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_70(
+            _i12.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_71(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8140,10 +8175,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i11.Future<_i3.SearchUserDirectoryResponse>);
+      ) as _i12.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> reportUser(
+  _i12.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8156,40 +8191,40 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i12.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i11.Future<_i3.CreateContentResponse>.value(
-            _FakeCreateContentResponse_71(
+        returnValue: _i12.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_72(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.CreateContentResponse>.value(
-            _FakeCreateContentResponse_71(
+        returnValueForMissingStub: _i12.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_72(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.CreateContentResponse>);
+      ) as _i12.Future<_i4.CreateContentResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> uploadContentToMXC(
+  _i12.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i19.Uint8List? body, {
+    _i20.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8207,35 +8242,35 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [Room].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockRoom extends _i1.Mock implements _i3.Room {
+class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
       ) as String);
 
   @override
-  _i3.Membership get membership => (super.noSuchMethod(
+  _i4.Membership get membership => (super.noSuchMethod(
         Invocation.getter(#membership),
-        returnValue: _i3.Membership.ban,
-        returnValueForMissingStub: _i3.Membership.ban,
-      ) as _i3.Membership);
+        returnValue: _i4.Membership.ban,
+        returnValueForMissingStub: _i4.Membership.ban,
+      ) as _i4.Membership);
 
   @override
   int get notificationCount => (super.noSuchMethod(
@@ -8252,47 +8287,47 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i3.RoomSummary get summary => (super.noSuchMethod(
+  _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_72(
+        returnValue: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_72(
+        returnValueForMissingStub: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
-      ) as _i3.RoomSummary);
+      ) as _i4.RoomSummary);
 
   @override
-  Map<String, Map<String, _i3.StrippedStateEvent>> get states =>
+  Map<String, Map<String, _i4.StrippedStateEvent>> get states =>
       (super.noSuchMethod(
         Invocation.getter(#states),
-        returnValue: <String, Map<String, _i3.StrippedStateEvent>>{},
+        returnValue: <String, Map<String, _i4.StrippedStateEvent>>{},
         returnValueForMissingStub: <String,
-            Map<String, _i3.StrippedStateEvent>>{},
-      ) as Map<String, Map<String, _i3.StrippedStateEvent>>);
+            Map<String, _i4.StrippedStateEvent>>{},
+      ) as Map<String, Map<String, _i4.StrippedStateEvent>>);
 
   @override
-  Map<String, _i3.BasicEvent> get ephemerals => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get ephemerals => (super.noSuchMethod(
         Invocation.getter(#ephemerals),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  Map<String, _i3.BasicEvent> get roomAccountData => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get roomAccountData => (super.noSuchMethod(
         Invocation.getter(#roomAccountData),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i11.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i12.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i11.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i11.Completer<dynamic>>[],
-      ) as List<_i11.Completer<dynamic>>);
+        returnValue: <_i12.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i12.Completer<dynamic>>[],
+      ) as List<_i12.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -8311,51 +8346,51 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i9.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i10.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i9.CachedStreamController<String> get onSessionKeyReceived =>
+  _i10.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_13<String>(
+        returnValue: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_13<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8371,11 +8406,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8384,11 +8419,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8402,24 +8437,24 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i3.User> get typingUsers => (super.noSuchMethod(
+  List<_i4.User> get typingUsers => (super.noSuchMethod(
         Invocation.getter(#typingUsers),
-        returnValue: <_i3.User>[],
-        returnValueForMissingStub: <_i3.User>[],
-      ) as List<_i3.User>);
+        returnValue: <_i4.User>[],
+        returnValueForMissingStub: <_i4.User>[],
+      ) as List<_i4.User>);
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get isAbandonedDMRoom => (super.noSuchMethod(
@@ -8431,11 +8466,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8444,22 +8479,22 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_14(
+        returnValue: _FakeDateTime_15(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_14(
+        returnValueForMissingStub: _FakeDateTime_15(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
       ) as DateTime);
 
   @override
-  Map<String, _i3.Tag> get tags => (super.noSuchMethod(
+  Map<String, _i4.Tag> get tags => (super.noSuchMethod(
         Invocation.getter(#tags),
-        returnValue: <String, _i3.Tag>{},
-        returnValueForMissingStub: <String, _i3.Tag>{},
-      ) as Map<String, _i3.Tag>);
+        returnValue: <String, _i4.Tag>{},
+        returnValueForMissingStub: <String, _i4.Tag>{},
+      ) as Map<String, _i4.Tag>);
 
   @override
   bool get markedUnread => (super.noSuchMethod(
@@ -8476,17 +8511,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.LatestReceiptState get receiptState => (super.noSuchMethod(
+  _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_73(
+        returnValue: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_73(
+        returnValueForMissingStub: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
-      ) as _i3.LatestReceiptState);
+      ) as _i4.LatestReceiptState);
 
   @override
   bool get isUnread => (super.noSuchMethod(
@@ -8503,18 +8538,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i11.Future<_i3.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i12.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_22(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_22(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -8524,20 +8559,20 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  Map<String, _i3.MatrixFile> get sendingFilePlaceholders =>
+  Map<String, _i4.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
-        returnValue: <String, _i3.MatrixFile>{},
-        returnValueForMissingStub: <String, _i3.MatrixFile>{},
-      ) as Map<String, _i3.MatrixFile>);
+        returnValue: <String, _i4.MatrixFile>{},
+        returnValueForMissingStub: <String, _i4.MatrixFile>{},
+      ) as Map<String, _i4.MatrixFile>);
 
   @override
-  Map<String, _i3.MatrixImageFile> get sendingFileThumbnails =>
+  Map<String, _i4.MatrixImageFile> get sendingFileThumbnails =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFileThumbnails),
-        returnValue: <String, _i3.MatrixImageFile>{},
-        returnValueForMissingStub: <String, _i3.MatrixImageFile>{},
-      ) as Map<String, _i3.MatrixImageFile>);
+        returnValue: <String, _i4.MatrixImageFile>{},
+        returnValueForMissingStub: <String, _i4.MatrixImageFile>{},
+      ) as Map<String, _i4.MatrixImageFile>);
 
   @override
   bool get isFederated => (super.noSuchMethod(
@@ -8638,11 +8673,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.PushRuleState get pushRuleState => (super.noSuchMethod(
+  _i4.PushRuleState get pushRuleState => (super.noSuchMethod(
         Invocation.getter(#pushRuleState),
-        returnValue: _i3.PushRuleState.notify,
-        returnValueForMissingStub: _i3.PushRuleState.notify,
-      ) as _i3.PushRuleState);
+        returnValue: _i4.PushRuleState.notify,
+        returnValueForMissingStub: _i4.PushRuleState.notify,
+      ) as _i4.PushRuleState);
 
   @override
   bool get canChangeJoinRules => (super.noSuchMethod(
@@ -8652,11 +8687,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.GuestAccess get guestAccess => (super.noSuchMethod(
+  _i4.GuestAccess get guestAccess => (super.noSuchMethod(
         Invocation.getter(#guestAccess),
-        returnValue: _i3.GuestAccess.canJoin,
-        returnValueForMissingStub: _i3.GuestAccess.canJoin,
-      ) as _i3.GuestAccess);
+        returnValue: _i4.GuestAccess.canJoin,
+        returnValueForMissingStub: _i4.GuestAccess.canJoin,
+      ) as _i4.GuestAccess);
 
   @override
   bool get canChangeGuestAccess => (super.noSuchMethod(
@@ -8694,21 +8729,21 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i20.SpaceParent>[],
-        returnValueForMissingStub: <_i20.SpaceParent>[],
-      ) as List<_i20.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i20.SpaceChild>[],
-        returnValueForMissingStub: <_i20.SpaceChild>[],
-      ) as List<_i20.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
-  set membership(_i3.Membership? value) => super.noSuchMethod(
+  set membership(_i4.Membership? value) => super.noSuchMethod(
         Invocation.setter(
           #membership,
           value,
@@ -8744,7 +8779,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set summary(_i3.RoomSummary? value) => super.noSuchMethod(
+  set summary(_i4.RoomSummary? value) => super.noSuchMethod(
         Invocation.setter(
           #summary,
           value,
@@ -8753,7 +8788,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set states(Map<String, Map<String, _i3.StrippedStateEvent>>? value) =>
+  set states(Map<String, Map<String, _i4.StrippedStateEvent>>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #states,
@@ -8763,7 +8798,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set ephemerals(Map<String, _i3.BasicEvent>? value) => super.noSuchMethod(
+  set ephemerals(Map<String, _i4.BasicEvent>? value) => super.noSuchMethod(
         Invocation.setter(
           #ephemerals,
           value,
@@ -8772,7 +8807,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set roomAccountData(Map<String, _i3.BasicEvent>? value) => super.noSuchMethod(
+  set roomAccountData(Map<String, _i4.BasicEvent>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomAccountData,
           value,
@@ -8790,7 +8825,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set lastEvent(_i3.Event? value) => super.noSuchMethod(
+  set lastEvent(_i4.Event? value) => super.noSuchMethod(
         Invocation.setter(
           #lastEvent,
           value,
@@ -8799,7 +8834,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set receiptState(_i3.LatestReceiptState? value) => super.noSuchMethod(
+  set receiptState(_i4.LatestReceiptState? value) => super.noSuchMethod(
         Invocation.setter(
           #receiptState,
           value,
@@ -8818,17 +8853,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i11.Future<void> postLoad() => (super.noSuchMethod(
+  _i12.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i3.StrippedStateEvent? getState(
+  _i4.StrippedStateEvent? getState(
     String? typeKey, [
     String? stateKey = '',
   ]) =>
@@ -8841,10 +8876,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.StrippedStateEvent?);
+      ) as _i4.StrippedStateEvent?);
 
   @override
-  void setState(_i3.StrippedStateEvent? state) => super.noSuchMethod(
+  void setState(_i4.StrippedStateEvent? state) => super.noSuchMethod(
         Invocation.method(
           #setState,
           [state],
@@ -8853,33 +8888,33 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  _i11.Future<List<_i3.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i12.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
+        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
-      ) as _i11.Future<List<_i3.User>>);
+            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i12.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
-          [_i3.MatrixLocalizations? i18n =
-              const _i3.MatrixDefaultLocalizations()]) =>
+          [_i4.MatrixLocalizations? i18n =
+              const _i4.MatrixDefaultLocalizations()]) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8889,18 +8924,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as String);
 
   @override
-  _i11.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i12.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Event?> refreshLastEvent(
+  _i12.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8908,12 +8943,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
-  void setEphemeral(_i3.BasicEvent? ephemeral) => super.noSuchMethod(
+  void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
         Invocation.method(
           #setEphemeral,
           [ephemeral],
@@ -8922,12 +8957,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  _i11.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i12.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8935,22 +8970,22 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i12.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8958,17 +8993,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> addTag(
+  _i12.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -8978,27 +9013,27 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i12.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i12.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_22(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -9006,43 +9041,43 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_22(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i12.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i12.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i12.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9050,14 +9085,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -9069,10 +9104,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as String?);
 
   @override
-  _i11.Future<String?> sendTextEvent(
+  _i12.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     bool? parseMarkdown = true,
     bool? parseCommands = true,
@@ -9101,12 +9136,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendReaction(
+  _i12.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -9120,12 +9155,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendLocation(
+  _i12.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -9139,18 +9174,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendFileEvent(
-    _i3.MatrixFile? file, {
+  _i12.Future<String?> sendFileEvent(
+    _i4.MatrixFile? file, {
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     int? shrinkImageMaxDimension,
-    _i3.MatrixImageFile? thumbnail,
+    _i4.MatrixImageFile? thumbnail,
     Map<String, dynamic>? extraContent,
     String? threadRootEventId,
     String? threadLastEventId,
@@ -9172,29 +9207,29 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<_i3.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i12.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i11.Future<_i3.EncryptionHealthState>.value(
-            _i3.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i11.Future<_i3.EncryptionHealthState>.value(
-            _i3.EncryptionHealthState.allVerified),
-      ) as _i11.Future<_i3.EncryptionHealthState>);
+        returnValue: _i12.Future<_i4.EncryptionHealthState>.value(
+            _i4.EncryptionHealthState.allVerified),
+        returnValueForMissingStub: _i12.Future<_i4.EncryptionHealthState>.value(
+            _i4.EncryptionHealthState.allVerified),
+      ) as _i12.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i11.Future<String?> sendEvent(
+  _i12.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     String? threadRootEventId,
     String? threadLastEventId,
@@ -9214,73 +9249,73 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i12.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> leave() => (super.noSuchMethod(
+  _i12.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> forget() => (super.noSuchMethod(
+  _i12.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> setPower(
+  _i12.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -9292,7 +9327,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             power,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9303,7 +9338,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9313,10 +9348,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> invite(
+  _i12.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -9326,16 +9361,16 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<int> requestHistory({
+  _i12.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
-    dynamic direction = _i3.Direction.b,
-    _i3.StateFilter? filter,
+    dynamic direction = _i4.Direction.b,
+    _i4.StateFilter? filter,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9348,32 +9383,32 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<int>.value(0),
-        returnValueForMissingStub: _i11.Future<int>.value(0),
-      ) as _i11.Future<int>);
+        returnValue: _i12.Future<int>.value(0),
+        returnValueForMissingStub: _i12.Future<int>.value(0),
+      ) as _i12.Future<int>);
 
   @override
-  _i11.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i12.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setReadMarker(
+  _i12.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -9387,25 +9422,25 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #public: public,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
+  _i12.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i11.Future<_i21.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i11.Future<_i21.TimelineChunk?>.value(),
-      ) as _i11.Future<_i21.TimelineChunk?>);
+        returnValue: _i12.Future<_i22.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i12.Future<_i22.TimelineChunk?>.value(),
+      ) as _i12.Future<_i22.TimelineChunk?>);
 
   @override
-  _i11.Future<void> postReceipt(
+  _i12.Future<void> postReceipt(
     String? eventId, {
-    _i3.ReceiptType? type = _i3.ReceiptType.mRead,
+    _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9413,12 +9448,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Timeline> getTimeline({
+  _i12.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -9441,7 +9476,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i11.Future<_i3.Timeline>.value(_FakeTimeline_74(
+        returnValue: _i12.Future<_i4.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9458,7 +9493,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Timeline>.value(_FakeTimeline_74(
+            _i12.Future<_i4.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9474,30 +9509,30 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Timeline>);
+      ) as _i12.Future<_i4.Timeline>);
 
   @override
-  List<_i3.User> getParticipants(
-          [List<_i3.Membership>? membershipFilter = const [
-            _i3.Membership.join,
-            _i3.Membership.invite,
-            _i3.Membership.knock,
+  List<_i4.User> getParticipants(
+          [List<_i4.Membership>? membershipFilter = const [
+            _i4.Membership.join,
+            _i4.Membership.invite,
+            _i4.Membership.knock,
           ]]) =>
       (super.noSuchMethod(
         Invocation.method(
           #getParticipants,
           [membershipFilter],
         ),
-        returnValue: <_i3.User>[],
-        returnValueForMissingStub: <_i3.User>[],
-      ) as List<_i3.User>);
+        returnValue: <_i4.User>[],
+        returnValueForMissingStub: <_i4.User>[],
+      ) as List<_i4.User>);
 
   @override
-  _i11.Future<List<_i3.User>> requestParticipants([
-    List<_i3.Membership>? membershipFilter = const [
-      _i3.Membership.join,
-      _i3.Membership.invite,
-      _i3.Membership.knock,
+  _i12.Future<List<_i4.User>> requestParticipants([
+    List<_i4.Membership>? membershipFilter = const [
+      _i4.Membership.join,
+      _i4.Membership.invite,
+      _i4.Membership.knock,
     ],
     bool? suppressWarning = false,
     bool? cache,
@@ -9511,58 +9546,58 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             cache,
           ],
         ),
-        returnValue: _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
+        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
-      ) as _i11.Future<List<_i3.User>>);
+            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i12.Future<List<_i4.User>>);
 
   @override
-  _i3.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
+  _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
         Invocation.method(
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-      ) as _i3.User);
+      ) as _i4.User);
 
   @override
-  _i3.User unsafeGetUserFromMemoryOrFallback(String? mxID) =>
+  _i4.User unsafeGetUserFromMemoryOrFallback(String? mxID) =>
       (super.noSuchMethod(
         Invocation.method(
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-      ) as _i3.User);
+      ) as _i4.User);
 
   @override
-  _i11.Future<_i3.User?> requestUser(
+  _i12.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -9578,19 +9613,19 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i11.Future<_i3.User?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.User?>.value(),
-      ) as _i11.Future<_i3.User?>);
+        returnValue: _i12.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.User?>.value(),
+      ) as _i12.Future<_i4.User?>);
 
   @override
-  _i11.Future<_i3.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i12.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -9603,12 +9638,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i11.Future<String> setAvatar(_i3.MatrixFile? file) => (super.noSuchMethod(
+  _i12.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9616,14 +9651,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -9646,14 +9681,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i11.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i12.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -9692,18 +9727,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i11.Future<void> setPushRuleState(_i3.PushRuleState? newState) =>
+  _i12.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEvent(
+  _i12.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -9717,12 +9752,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> setTyping(
+  _i12.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -9732,13 +9767,13 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setJoinRules(
-    _i3.JoinRules? joinRules, {
+  _i12.Future<void> setJoinRules(
+    _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
   }) =>
@@ -9751,59 +9786,59 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setGuestAccess(_i3.GuestAccess? guestAccess) =>
+  _i12.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setHistoryVisibility(
-          _i3.HistoryVisibility? historyVisibility) =>
+  _i12.Future<void> setHistoryVisibility(
+          _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i12.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i12.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i11.Future<List<_i3.DeviceKeys>>.value(<_i3.DeviceKeys>[]),
+            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.DeviceKeys>>.value(<_i3.DeviceKeys>[]),
-      ) as _i11.Future<List<_i3.DeviceKeys>>);
+            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i12.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i11.Future<void> requestSessionKey(
+  _i12.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -9815,12 +9850,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             senderKey,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setSpaceChild(
+  _i12.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -9836,51 +9871,51 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i12.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i11.Future<Uri>.value(_FakeUri_27(
+        returnValue: _i12.Future<Uri>.value(_FakeUri_28(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<Uri>.value(_FakeUri_27(
+        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_28(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i11.Future<Uri>);
+      ) as _i12.Future<Uri>);
 
   @override
-  _i11.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i12.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<
+  _i12.Future<
       ({
-        List<_i3.Event> events,
+        List<_i4.Event> events,
         String? nextBatch,
         DateTime? searchedUntil
       })> searchEvents({
     String? searchTerm,
-    bool Function(_i3.Event)? searchFunc,
+    bool Function(_i4.Event)? searchFunc,
     String? nextBatch,
     int? limit = 1000,
     Set<String>? includeEventTypes = const {
@@ -9900,23 +9935,23 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i11.Future<
+        returnValue: _i12.Future<
                 ({
-                  List<_i3.Event> events,
+                  List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
-            (events: <_i3.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i11.Future<
+            (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
+        returnValueForMissingStub: _i12.Future<
                 ({
-                  List<_i3.Event> events,
+                  List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
-            (events: <_i3.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i11.Future<
+            (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
+      ) as _i12.Future<
           ({
-            List<_i3.Event> events,
+            List<_i4.Event> events,
             String? nextBatch,
             DateTime? searchedUntil
           })>);
@@ -9926,13 +9961,13 @@ class MockRoom extends _i1.Mock implements _i3.Room {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockFlutterLocalNotificationsPlugin extends _i1.Mock
-    implements _i22.FlutterLocalNotificationsPlugin {
+    implements _i23.FlutterLocalNotificationsPlugin {
   @override
-  _i11.Future<bool?> initialize({
-    required _i23.InitializationSettings? settings,
-    _i24.DidReceiveNotificationResponseCallback?
+  _i12.Future<bool?> initialize({
+    required _i24.InitializationSettings? settings,
+    _i25.DidReceiveNotificationResponseCallback?
         onDidReceiveNotificationResponse,
-    _i24.DidReceiveBackgroundNotificationResponseCallback?
+    _i25.DidReceiveBackgroundNotificationResponseCallback?
         onDidReceiveBackgroundNotificationResponse,
   }) =>
       (super.noSuchMethod(
@@ -9946,29 +9981,29 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
                 onDidReceiveBackgroundNotificationResponse,
           },
         ),
-        returnValue: _i11.Future<bool?>.value(),
-        returnValueForMissingStub: _i11.Future<bool?>.value(),
-      ) as _i11.Future<bool?>);
+        returnValue: _i12.Future<bool?>.value(),
+        returnValueForMissingStub: _i12.Future<bool?>.value(),
+      ) as _i12.Future<bool?>);
 
   @override
-  _i11.Future<_i24.NotificationAppLaunchDetails?>
+  _i12.Future<_i25.NotificationAppLaunchDetails?>
       getNotificationAppLaunchDetails() => (super.noSuchMethod(
             Invocation.method(
               #getNotificationAppLaunchDetails,
               [],
             ),
             returnValue:
-                _i11.Future<_i24.NotificationAppLaunchDetails?>.value(),
+                _i12.Future<_i25.NotificationAppLaunchDetails?>.value(),
             returnValueForMissingStub:
-                _i11.Future<_i24.NotificationAppLaunchDetails?>.value(),
-          ) as _i11.Future<_i24.NotificationAppLaunchDetails?>);
+                _i12.Future<_i25.NotificationAppLaunchDetails?>.value(),
+          ) as _i12.Future<_i25.NotificationAppLaunchDetails?>);
 
   @override
-  _i11.Future<void> show({
+  _i12.Future<void> show({
     required int? id,
     String? title,
     String? body,
-    _i25.NotificationDetails? notificationDetails,
+    _i26.NotificationDetails? notificationDetails,
     String? payload,
   }) =>
       (super.noSuchMethod(
@@ -9983,12 +10018,12 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #payload: payload,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> cancel({
+  _i12.Future<void> cancel({
     required int? id,
     String? tag,
   }) =>
@@ -10001,40 +10036,40 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #tag: tag,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> cancelAll() => (super.noSuchMethod(
+  _i12.Future<void> cancelAll() => (super.noSuchMethod(
         Invocation.method(
           #cancelAll,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> cancelAllPendingNotifications() => (super.noSuchMethod(
+  _i12.Future<void> cancelAllPendingNotifications() => (super.noSuchMethod(
         Invocation.method(
           #cancelAllPendingNotifications,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> zonedSchedule({
+  _i12.Future<void> zonedSchedule({
     required int? id,
-    required _i26.TZDateTime? scheduledDate,
-    required _i25.NotificationDetails? notificationDetails,
-    required _i27.AndroidScheduleMode? androidScheduleMode,
+    required _i27.TZDateTime? scheduledDate,
+    required _i26.NotificationDetails? notificationDetails,
+    required _i28.AndroidScheduleMode? androidScheduleMode,
     String? title,
     String? body,
     String? payload,
-    _i28.DateTimeComponents? matchDateTimeComponents,
+    _i29.DateTimeComponents? matchDateTimeComponents,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -10051,16 +10086,16 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #matchDateTimeComponents: matchDateTimeComponents,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> periodicallyShow({
+  _i12.Future<void> periodicallyShow({
     required int? id,
-    required _i24.RepeatInterval? repeatInterval,
-    required _i25.NotificationDetails? notificationDetails,
-    required _i27.AndroidScheduleMode? androidScheduleMode,
+    required _i25.RepeatInterval? repeatInterval,
+    required _i26.NotificationDetails? notificationDetails,
+    required _i28.AndroidScheduleMode? androidScheduleMode,
     String? title,
     String? body,
     String? payload,
@@ -10079,19 +10114,19 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #payload: payload,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> periodicallyShowWithDuration({
+  _i12.Future<void> periodicallyShowWithDuration({
     required int? id,
     required Duration? repeatDurationInterval,
-    required _i25.NotificationDetails? notificationDetails,
+    required _i26.NotificationDetails? notificationDetails,
     String? title,
     String? body,
-    _i27.AndroidScheduleMode? androidScheduleMode =
-        _i27.AndroidScheduleMode.exact,
+    _i28.AndroidScheduleMode? androidScheduleMode =
+        _i28.AndroidScheduleMode.exact,
     String? payload,
   }) =>
       (super.noSuchMethod(
@@ -10108,36 +10143,36 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #payload: payload,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i24.PendingNotificationRequest>>
+  _i12.Future<List<_i25.PendingNotificationRequest>>
       pendingNotificationRequests() => (super.noSuchMethod(
             Invocation.method(
               #pendingNotificationRequests,
               [],
             ),
             returnValue:
-                _i11.Future<List<_i24.PendingNotificationRequest>>.value(
-                    <_i24.PendingNotificationRequest>[]),
+                _i12.Future<List<_i25.PendingNotificationRequest>>.value(
+                    <_i25.PendingNotificationRequest>[]),
             returnValueForMissingStub:
-                _i11.Future<List<_i24.PendingNotificationRequest>>.value(
-                    <_i24.PendingNotificationRequest>[]),
-          ) as _i11.Future<List<_i24.PendingNotificationRequest>>);
+                _i12.Future<List<_i25.PendingNotificationRequest>>.value(
+                    <_i25.PendingNotificationRequest>[]),
+          ) as _i12.Future<List<_i25.PendingNotificationRequest>>);
 
   @override
-  _i11.Future<List<_i24.ActiveNotification>> getActiveNotifications() =>
+  _i12.Future<List<_i25.ActiveNotification>> getActiveNotifications() =>
       (super.noSuchMethod(
         Invocation.method(
           #getActiveNotifications,
           [],
         ),
-        returnValue: _i11.Future<List<_i24.ActiveNotification>>.value(
-            <_i24.ActiveNotification>[]),
+        returnValue: _i12.Future<List<_i25.ActiveNotification>>.value(
+            <_i25.ActiveNotification>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i24.ActiveNotification>>.value(
-                <_i24.ActiveNotification>[]),
-      ) as _i11.Future<List<_i24.ActiveNotification>>);
+            _i12.Future<List<_i25.ActiveNotification>>.value(
+                <_i25.ActiveNotification>[]),
+      ) as _i12.Future<List<_i25.ActiveNotification>>);
 }

--- a/test/widgets/add_existing_rooms_dialog_test.mocks.dart
+++ b/test/widgets/add_existing_rooms_dialog_test.mocks.dart
@@ -3,31 +3,33 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i11;
-import 'dart:typed_data' as _i21;
-import 'dart:ui' as _i15;
+import 'dart:async' as _i12;
+import 'dart:typed_data' as _i22;
+import 'dart:ui' as _i16;
 
-import 'package:flutter/services.dart' as _i16;
-import 'package:flutter/widgets.dart' as _i17;
-import 'package:http/http.dart' as _i10;
-import 'package:kohera/core/services/matrix_service.dart' as _i13;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
+import 'package:flutter/services.dart' as _i17;
+import 'package:flutter/widgets.dart' as _i18;
+import 'package:http/http.dart' as _i11;
+import 'package:kohera/core/services/matrix_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i5;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i7;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i4;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i7;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
-import 'package:matrix/encryption.dart' as _i20;
-import 'package:matrix/matrix.dart' as _i3;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i12;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i9;
-import 'package:matrix/src/utils/space_child.dart' as _i18;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i3;
+import 'package:matrix/encryption.dart' as _i21;
+import 'package:matrix/matrix.dart' as _i4;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i13;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i20;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i10;
+import 'package:matrix/src/utils/space_child.dart' as _i19;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -55,8 +57,9 @@ class _FakeCallPushRuleManager_0 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
-  _FakeClient_1(
+class _FakeMegolmKeyMirror_1 extends _i1.SmartFake
+    implements _i3.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_1(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -65,8 +68,8 @@ class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
         );
 }
 
-class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
-  _FakeUiaService_2(
+class _FakeClient_2 extends _i1.SmartFake implements _i4.Client {
+  _FakeClient_2(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -75,9 +78,8 @@ class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
         );
 }
 
-class _FakeChatBackupService_3 extends _i1.SmartFake
-    implements _i5.ChatBackupService {
-  _FakeChatBackupService_3(
+class _FakeUiaService_3 extends _i1.SmartFake implements _i5.UiaService {
+  _FakeUiaService_3(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -86,9 +88,9 @@ class _FakeChatBackupService_3 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_4 extends _i1.SmartFake
-    implements _i6.SelectionService {
-  _FakeSelectionService_4(
+class _FakeChatBackupService_4 extends _i1.SmartFake
+    implements _i6.ChatBackupService {
+  _FakeChatBackupService_4(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -97,8 +99,9 @@ class _FakeSelectionService_4 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
-  _FakeSyncService_5(
+class _FakeSelectionService_5 extends _i1.SmartFake
+    implements _i7.SelectionService {
+  _FakeSelectionService_5(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -107,8 +110,8 @@ class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
         );
 }
 
-class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
-  _FakeAuthService_6(
+class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
+  _FakeSyncService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -117,8 +120,8 @@ class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
         );
 }
 
-class _FakeRoomSummary_7 extends _i1.SmartFake implements _i3.RoomSummary {
-  _FakeRoomSummary_7(
+class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
+  _FakeAuthService_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -127,9 +130,8 @@ class _FakeRoomSummary_7 extends _i1.SmartFake implements _i3.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_8<T> extends _i1.SmartFake
-    implements _i9.CachedStreamController<T> {
-  _FakeCachedStreamController_8(
+class _FakeRoomSummary_8 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -138,8 +140,9 @@ class _FakeCachedStreamController_8<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_9 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_9(
+class _FakeCachedStreamController_9<T> extends _i1.SmartFake
+    implements _i10.CachedStreamController<T> {
+  _FakeCachedStreamController_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -148,9 +151,8 @@ class _FakeDateTime_9 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_10 extends _i1.SmartFake
-    implements _i3.LatestReceiptState {
-  _FakeLatestReceiptState_10(
+class _FakeDateTime_10 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -159,8 +161,9 @@ class _FakeLatestReceiptState_10 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_11 extends _i1.SmartFake implements _i3.SyncUpdate {
-  _FakeSyncUpdate_11(
+class _FakeLatestReceiptState_11 extends _i1.SmartFake
+    implements _i4.LatestReceiptState {
+  _FakeLatestReceiptState_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -169,8 +172,8 @@ class _FakeSyncUpdate_11 extends _i1.SmartFake implements _i3.SyncUpdate {
         );
 }
 
-class _FakeTimeline_12 extends _i1.SmartFake implements _i3.Timeline {
-  _FakeTimeline_12(
+class _FakeSyncUpdate_12 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -179,8 +182,8 @@ class _FakeTimeline_12 extends _i1.SmartFake implements _i3.Timeline {
         );
 }
 
-class _FakeUser_13 extends _i1.SmartFake implements _i3.User {
-  _FakeUser_13(
+class _FakeTimeline_13 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -189,8 +192,8 @@ class _FakeUser_13 extends _i1.SmartFake implements _i3.User {
         );
 }
 
-class _FakeUri_14 extends _i1.SmartFake implements Uri {
-  _FakeUri_14(
+class _FakeUser_14 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -199,8 +202,8 @@ class _FakeUri_14 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_15 extends _i1.SmartFake implements _i3.DatabaseApi {
-  _FakeDatabaseApi_15(
+class _FakeUri_15 extends _i1.SmartFake implements Uri {
+  _FakeUri_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -209,8 +212,8 @@ class _FakeDatabaseApi_15 extends _i1.SmartFake implements _i3.DatabaseApi {
         );
 }
 
-class _FakeFilter_16 extends _i1.SmartFake implements _i3.Filter {
-  _FakeFilter_16(
+class _FakeDatabaseApi_16 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -219,9 +222,8 @@ class _FakeFilter_16 extends _i1.SmartFake implements _i3.Filter {
         );
 }
 
-class _FakeNativeImplementations_17 extends _i1.SmartFake
-    implements _i3.NativeImplementations {
-  _FakeNativeImplementations_17(
+class _FakeFilter_17 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -230,8 +232,9 @@ class _FakeNativeImplementations_17 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_18 extends _i1.SmartFake implements Duration {
-  _FakeDuration_18(
+class _FakeNativeImplementations_18 extends _i1.SmartFake
+    implements _i4.NativeImplementations {
+  _FakeNativeImplementations_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -240,9 +243,8 @@ class _FakeDuration_18 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_19 extends _i1.SmartFake
-    implements _i3.PushruleEvaluator {
-  _FakePushruleEvaluator_19(
+class _FakeDuration_19 extends _i1.SmartFake implements Duration {
+  _FakeDuration_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -251,8 +253,9 @@ class _FakePushruleEvaluator_19 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_20 extends _i1.SmartFake implements _i3.Profile {
-  _FakeProfile_20(
+class _FakePushruleEvaluator_20 extends _i1.SmartFake
+    implements _i4.PushruleEvaluator {
+  _FakePushruleEvaluator_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -261,8 +264,8 @@ class _FakeProfile_20 extends _i1.SmartFake implements _i3.Profile {
         );
 }
 
-class _FakeClient_21 extends _i1.SmartFake implements _i10.Client {
-  _FakeClient_21(
+class _FakeProfile_21 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -271,9 +274,8 @@ class _FakeClient_21 extends _i1.SmartFake implements _i10.Client {
         );
 }
 
-class _FakeDiscoveryInformation_22 extends _i1.SmartFake
-    implements _i3.DiscoveryInformation {
-  _FakeDiscoveryInformation_22(
+class _FakeClient_22 extends _i1.SmartFake implements _i11.Client {
+  _FakeClient_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -282,9 +284,9 @@ class _FakeDiscoveryInformation_22 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_23 extends _i1.SmartFake
-    implements _i3.GetVersionsResponse {
-  _FakeGetVersionsResponse_23(
+class _FakeDiscoveryInformation_23 extends _i1.SmartFake
+    implements _i4.DiscoveryInformation {
+  _FakeDiscoveryInformation_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -293,9 +295,9 @@ class _FakeGetVersionsResponse_23 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_24 extends _i1.SmartFake
-    implements _i3.RegisterResponse {
-  _FakeRegisterResponse_24(
+class _FakeGetVersionsResponse_24 extends _i1.SmartFake
+    implements _i4.GetVersionsResponse {
+  _FakeGetVersionsResponse_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -304,8 +306,9 @@ class _FakeRegisterResponse_24 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_25 extends _i1.SmartFake implements _i3.LoginResponse {
-  _FakeLoginResponse_25(
+class _FakeRegisterResponse_25 extends _i1.SmartFake
+    implements _i4.RegisterResponse {
+  _FakeRegisterResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -314,9 +317,8 @@ class _FakeLoginResponse_25 extends _i1.SmartFake implements _i3.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_26 extends _i1.SmartFake
-    implements _i3.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_26(
+class _FakeLoginResponse_26 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -325,8 +327,9 @@ class _FakeGetAuthMetadataResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_27<T1> extends _i1.SmartFake implements _i11.Future<T1> {
-  _FakeFuture_27(
+class _FakeGetAuthMetadataResponse_27 extends _i1.SmartFake
+    implements _i4.GetAuthMetadataResponse {
+  _FakeGetAuthMetadataResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -335,9 +338,8 @@ class _FakeFuture_27<T1> extends _i1.SmartFake implements _i11.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_28 extends _i1.SmartFake
-    implements _i3.CachedProfileInformation {
-  _FakeCachedProfileInformation_28(
+class _FakeFuture_28<T1> extends _i1.SmartFake implements _i12.Future<T1> {
+  _FakeFuture_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -346,8 +348,9 @@ class _FakeCachedProfileInformation_28 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_29 extends _i1.SmartFake implements _i3.MediaConfig {
-  _FakeMediaConfig_29(
+class _FakeCachedProfileInformation_29 extends _i1.SmartFake
+    implements _i4.CachedProfileInformation {
+  _FakeCachedProfileInformation_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -356,8 +359,8 @@ class _FakeMediaConfig_29 extends _i1.SmartFake implements _i3.MediaConfig {
         );
 }
 
-class _FakeFileResponse_30 extends _i1.SmartFake implements _i12.FileResponse {
-  _FakeFileResponse_30(
+class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -366,8 +369,8 @@ class _FakeFileResponse_30 extends _i1.SmartFake implements _i12.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_31 extends _i1.SmartFake implements _i3.PreviewForUrl {
-  _FakePreviewForUrl_31(
+class _FakeFileResponse_31 extends _i1.SmartFake implements _i13.FileResponse {
+  _FakeFileResponse_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -376,9 +379,8 @@ class _FakePreviewForUrl_31 extends _i1.SmartFake implements _i3.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_32 extends _i1.SmartFake
-    implements _i3.CachedPresence {
-  _FakeCachedPresence_32(
+class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -387,9 +389,9 @@ class _FakeCachedPresence_32 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_33 extends _i1.SmartFake
-    implements _i3.TurnServerCredentials {
-  _FakeTurnServerCredentials_33(
+class _FakeCachedPresence_33 extends _i1.SmartFake
+    implements _i4.CachedPresence {
+  _FakeCachedPresence_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -398,9 +400,9 @@ class _FakeTurnServerCredentials_33 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
-    implements _i3.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_34(
+class _FakeTurnServerCredentials_34 extends _i1.SmartFake
+    implements _i4.TurnServerCredentials {
+  _FakeTurnServerCredentials_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -409,8 +411,9 @@ class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i3.KeyBackupData {
-  _FakeKeyBackupData_35(
+class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
+    implements _i4.RoomKeysUpdateResponse {
+  _FakeRoomKeysUpdateResponse_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -419,9 +422,8 @@ class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i3.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
-    implements _i3.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_36(
+class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -430,9 +432,9 @@ class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
-    implements _i3.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_37(
+class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
+    implements _i4.GetWellknownSupportResponse {
+  _FakeGetWellknownSupportResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -441,9 +443,9 @@ class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
-    implements _i3.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_38(
+class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
+    implements _i4.GenerateLoginTokenResponse {
+  _FakeGenerateLoginTokenResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -452,9 +454,9 @@ class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
-    implements _i3.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_39(
+class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
+    implements _i4.GetRoomSummaryResponse$3 {
+  _FakeGetRoomSummaryResponse$3_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -463,9 +465,9 @@ class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
-    implements _i3.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_40(
+class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
+    implements _i4.GetSpaceHierarchyResponse {
+  _FakeGetSpaceHierarchyResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -474,9 +476,9 @@ class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
-    implements _i3.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_41(
+class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
+    implements _i4.GetRelatingEventsResponse {
+  _FakeGetRelatingEventsResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -485,9 +487,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
-    .SmartFake implements _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
+    implements _i4.GetRelatingEventsWithRelTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -496,9 +498,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
-    implements _i3.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_43(
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
+    .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -507,9 +509,9 @@ class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
-    implements _i3.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_44(
+class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
+    implements _i4.GetThreadRootsResponse {
+  _FakeGetThreadRootsResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -518,9 +520,9 @@ class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_45 extends _i1.SmartFake
-    implements _i3.RequestTokenResponse {
-  _FakeRequestTokenResponse_45(
+class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
+    implements _i4.GetEventByTimestampResponse {
+  _FakeGetEventByTimestampResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -529,9 +531,9 @@ class _FakeRequestTokenResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
-    implements _i3.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_46(
+class _FakeRequestTokenResponse_46 extends _i1.SmartFake
+    implements _i4.RequestTokenResponse {
+  _FakeRequestTokenResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -540,8 +542,9 @@ class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i3.WhoIsInfo {
-  _FakeWhoIsInfo_47(
+class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
+    implements _i4.TokenOwnerInfo {
+  _FakeTokenOwnerInfo_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -550,8 +553,8 @@ class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i3.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_48 extends _i1.SmartFake implements _i3.Capabilities {
-  _FakeCapabilities_48(
+class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -560,8 +563,8 @@ class _FakeCapabilities_48 extends _i1.SmartFake implements _i3.Capabilities {
         );
 }
 
-class _FakeDevice_49 extends _i1.SmartFake implements _i3.Device {
-  _FakeDevice_49(
+class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -570,9 +573,8 @@ class _FakeDevice_49 extends _i1.SmartFake implements _i3.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
-    implements _i3.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_50(
+class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -581,9 +583,9 @@ class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_51 extends _i1.SmartFake
-    implements _i3.GetEventsResponse {
-  _FakeGetEventsResponse_51(
+class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
+    implements _i4.GetRoomIdByAliasResponse {
+  _FakeGetRoomIdByAliasResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -592,9 +594,9 @@ class _FakeGetEventsResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_52 extends _i1.SmartFake
-    implements _i3.PeekEventsResponse {
-  _FakePeekEventsResponse_52(
+class _FakeGetEventsResponse_52 extends _i1.SmartFake
+    implements _i4.GetEventsResponse {
+  _FakeGetEventsResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -603,8 +605,9 @@ class _FakePeekEventsResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i3.MatrixEvent {
-  _FakeMatrixEvent_53(
+class _FakePeekEventsResponse_53 extends _i1.SmartFake
+    implements _i4.PeekEventsResponse {
+  _FakePeekEventsResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -613,9 +616,8 @@ class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i3.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
-    implements _i3.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_54(
+class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -624,9 +626,9 @@ class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_55 extends _i1.SmartFake
-    implements _i3.ClaimKeysResponse {
-  _FakeClaimKeysResponse_55(
+class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
+    implements _i4.GetKeysChangesResponse {
+  _FakeGetKeysChangesResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -635,9 +637,9 @@ class _FakeClaimKeysResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_56 extends _i1.SmartFake
-    implements _i3.QueryKeysResponse {
-  _FakeQueryKeysResponse_56(
+class _FakeClaimKeysResponse_56 extends _i1.SmartFake
+    implements _i4.ClaimKeysResponse {
+  _FakeClaimKeysResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -646,9 +648,9 @@ class _FakeQueryKeysResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
-    implements _i3.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_57(
+class _FakeQueryKeysResponse_57 extends _i1.SmartFake
+    implements _i4.QueryKeysResponse {
+  _FakeQueryKeysResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -657,9 +659,9 @@ class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_58 extends _i1.SmartFake
-    implements _i3.GetPresenceResponse {
-  _FakeGetPresenceResponse_58(
+class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
+    implements _i4.GetNotificationsResponse {
+  _FakeGetNotificationsResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -668,9 +670,9 @@ class _FakeGetPresenceResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
-    implements _i3.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_59(
+class _FakeGetPresenceResponse_59 extends _i1.SmartFake
+    implements _i4.GetPresenceResponse {
+  _FakeGetPresenceResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -679,9 +681,9 @@ class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
-    implements _i3.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_60(
+class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
+    implements _i4.GetPublicRoomsResponse {
+  _FakeGetPublicRoomsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -690,8 +692,9 @@ class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_61 extends _i1.SmartFake implements _i3.PushRuleSet {
-  _FakePushRuleSet_61(
+class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
+    implements _i4.QueryPublicRoomsResponse {
+  _FakeQueryPublicRoomsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -700,9 +703,8 @@ class _FakePushRuleSet_61 extends _i1.SmartFake implements _i3.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
-    implements _i3.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_62(
+class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -711,8 +713,9 @@ class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_63 extends _i1.SmartFake implements _i3.PushRule {
-  _FakePushRule_63(
+class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
+    implements _i4.GetPushRulesGlobalResponse {
+  _FakeGetPushRulesGlobalResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -721,9 +724,8 @@ class _FakePushRule_63 extends _i1.SmartFake implements _i3.PushRule {
         );
 }
 
-class _FakeRefreshResponse_64 extends _i1.SmartFake
-    implements _i3.RefreshResponse {
-  _FakeRefreshResponse_64(
+class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -732,8 +734,9 @@ class _FakeRefreshResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_65 extends _i1.SmartFake implements _i3.RoomKeys {
-  _FakeRoomKeys_65(
+class _FakeRefreshResponse_65 extends _i1.SmartFake
+    implements _i4.RefreshResponse {
+  _FakeRefreshResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -742,8 +745,8 @@ class _FakeRoomKeys_65 extends _i1.SmartFake implements _i3.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i3.RoomKeyBackup {
-  _FakeRoomKeyBackup_66(
+class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -752,9 +755,8 @@ class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i3.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
-    implements _i3.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_67(
+class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -763,9 +765,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
-    implements _i3.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_68(
+class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
+    implements _i4.GetRoomKeysVersionCurrentResponse {
+  _FakeGetRoomKeysVersionCurrentResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -774,8 +776,9 @@ class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_69 extends _i1.SmartFake implements _i3.EventContext {
-  _FakeEventContext_69(
+class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
+    implements _i4.GetRoomKeysVersionResponse {
+  _FakeGetRoomKeysVersionResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -784,9 +787,8 @@ class _FakeEventContext_69 extends _i1.SmartFake implements _i3.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
-    implements _i3.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_70(
+class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -795,8 +797,9 @@ class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_71 extends _i1.SmartFake implements _i3.SearchResults {
-  _FakeSearchResults_71(
+class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
+    implements _i4.GetRoomEventsResponse {
+  _FakeGetRoomEventsResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -805,9 +808,8 @@ class _FakeSearchResults_71 extends _i1.SmartFake implements _i3.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
-    implements _i3.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_72(
+class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -816,9 +818,9 @@ class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_73 extends _i1.SmartFake
-    implements _i3.OpenIdCredentials {
-  _FakeOpenIdCredentials_73(
+class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
+    implements _i4.GetProtocolMetadataResponse$2 {
+  _FakeGetProtocolMetadataResponse$2_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -827,9 +829,9 @@ class _FakeOpenIdCredentials_73 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
-    implements _i3.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_74(
+class _FakeOpenIdCredentials_74 extends _i1.SmartFake
+    implements _i4.OpenIdCredentials {
+  _FakeOpenIdCredentials_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -838,9 +840,20 @@ class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_75 extends _i1.SmartFake
-    implements _i3.CreateContentResponse {
-  _FakeCreateContentResponse_75(
+class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
+    implements _i4.SearchUserDirectoryResponse {
+  _FakeSearchUserDirectoryResponse_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeCreateContentResponse_76 extends _i1.SmartFake
+    implements _i4.CreateContentResponse {
+  _FakeCreateContentResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,7 +865,7 @@ class _FakeCreateContentResponse_75 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -867,30 +880,43 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as _i2.CallPushRuleManager);
 
   @override
+  _i3.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i3.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
       ) as String);
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get isLoggedIn => (super.noSuchMethod(
@@ -907,69 +933,69 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  _i4.UiaService get uia => (super.noSuchMethod(
+  _i5.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_2(
+        returnValue: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_2(
+        returnValueForMissingStub: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i4.UiaService);
+      ) as _i5.UiaService);
 
   @override
-  _i5.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i6.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_3(
+        returnValue: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_3(
+        returnValueForMissingStub: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i5.ChatBackupService);
+      ) as _i6.ChatBackupService);
 
   @override
-  _i6.SelectionService get selection => (super.noSuchMethod(
+  _i7.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_4(
+        returnValue: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_4(
+        returnValueForMissingStub: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i6.SelectionService);
+      ) as _i7.SelectionService);
 
   @override
-  _i7.SyncService get sync => (super.noSuchMethod(
+  _i8.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_5(
+        returnValue: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_5(
+        returnValueForMissingStub: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i7.SyncService);
+      ) as _i8.SyncService);
 
   @override
-  _i8.AuthService get auth => (super.noSuchMethod(
+  _i9.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_6(
+        returnValue: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_6(
+        returnValueForMissingStub: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i8.AuthService);
+      ) as _i9.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -988,6 +1014,15 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
+  set keyMirror(_i3.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -997,7 +1032,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set uia(_i4.UiaService? value) => super.noSuchMethod(
+  set uia(_i5.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -1006,7 +1041,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set chatBackup(_i5.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i6.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -1015,7 +1050,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set selection(_i6.SelectionService? value) => super.noSuchMethod(
+  set selection(_i7.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -1024,7 +1059,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set sync(_i7.SyncService? value) => super.noSuchMethod(
+  set sync(_i8.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -1033,7 +1068,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set auth(_i8.AuthService? value) => super.noSuchMethod(
+  set auth(_i9.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -1049,14 +1084,14 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  _i11.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1086,7 +1121,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i15.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i16.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1096,18 +1131,18 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i12.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<bool> login({
+  _i12.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1122,12 +1157,12 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<bool> completeSsoLogin({
+  _i12.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1140,13 +1175,13 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> completeRegistration(
-    _i3.RegisterResponse? response, {
+  _i12.Future<void> completeRegistration(
+    _i4.RegisterResponse? response, {
     String? password,
   }) =>
       (super.noSuchMethod(
@@ -1155,32 +1190,32 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> logout() => (super.noSuchMethod(
+  _i12.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i12.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  void addListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1189,7 +1224,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void removeListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1198,17 +1233,17 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i16.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i17.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1219,7 +1254,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i16.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i17.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1256,26 +1291,26 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<bool> didPushRouteInformation(
-          _i17.RouteInformation? routeInformation) =>
+  _i12.Future<bool> didPushRouteInformation(
+          _i18.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1305,7 +1340,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i15.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i16.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1314,7 +1349,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i15.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i16.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1323,16 +1358,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<_i15.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i12.Future<_i16.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
-      ) as _i11.Future<_i15.AppExitResponse>);
+            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
+      ) as _i12.Future<_i16.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1356,26 +1391,26 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
 /// A class which mocks [Room].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockRoom extends _i1.Mock implements _i3.Room {
+class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
       ) as String);
 
   @override
-  _i3.Membership get membership => (super.noSuchMethod(
+  _i4.Membership get membership => (super.noSuchMethod(
         Invocation.getter(#membership),
-        returnValue: _i3.Membership.ban,
-        returnValueForMissingStub: _i3.Membership.ban,
-      ) as _i3.Membership);
+        returnValue: _i4.Membership.ban,
+        returnValueForMissingStub: _i4.Membership.ban,
+      ) as _i4.Membership);
 
   @override
   int get notificationCount => (super.noSuchMethod(
@@ -1392,47 +1427,47 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i3.RoomSummary get summary => (super.noSuchMethod(
+  _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_7(
+        returnValue: _FakeRoomSummary_8(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_7(
+        returnValueForMissingStub: _FakeRoomSummary_8(
           this,
           Invocation.getter(#summary),
         ),
-      ) as _i3.RoomSummary);
+      ) as _i4.RoomSummary);
 
   @override
-  Map<String, Map<String, _i3.StrippedStateEvent>> get states =>
+  Map<String, Map<String, _i4.StrippedStateEvent>> get states =>
       (super.noSuchMethod(
         Invocation.getter(#states),
-        returnValue: <String, Map<String, _i3.StrippedStateEvent>>{},
+        returnValue: <String, Map<String, _i4.StrippedStateEvent>>{},
         returnValueForMissingStub: <String,
-            Map<String, _i3.StrippedStateEvent>>{},
-      ) as Map<String, Map<String, _i3.StrippedStateEvent>>);
+            Map<String, _i4.StrippedStateEvent>>{},
+      ) as Map<String, Map<String, _i4.StrippedStateEvent>>);
 
   @override
-  Map<String, _i3.BasicEvent> get ephemerals => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get ephemerals => (super.noSuchMethod(
         Invocation.getter(#ephemerals),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  Map<String, _i3.BasicEvent> get roomAccountData => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get roomAccountData => (super.noSuchMethod(
         Invocation.getter(#roomAccountData),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i11.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i12.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i11.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i11.Completer<dynamic>>[],
-      ) as List<_i11.Completer<dynamic>>);
+        returnValue: <_i12.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i12.Completer<dynamic>>[],
+      ) as List<_i12.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1451,51 +1486,51 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i9.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i10.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i9.CachedStreamController<String> get onSessionKeyReceived =>
+  _i10.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1511,11 +1546,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1524,11 +1559,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1542,24 +1577,24 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i3.User> get typingUsers => (super.noSuchMethod(
+  List<_i4.User> get typingUsers => (super.noSuchMethod(
         Invocation.getter(#typingUsers),
-        returnValue: <_i3.User>[],
-        returnValueForMissingStub: <_i3.User>[],
-      ) as List<_i3.User>);
+        returnValue: <_i4.User>[],
+        returnValueForMissingStub: <_i4.User>[],
+      ) as List<_i4.User>);
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get isAbandonedDMRoom => (super.noSuchMethod(
@@ -1571,11 +1606,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1584,22 +1619,22 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_9(
+        returnValue: _FakeDateTime_10(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_9(
+        returnValueForMissingStub: _FakeDateTime_10(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
       ) as DateTime);
 
   @override
-  Map<String, _i3.Tag> get tags => (super.noSuchMethod(
+  Map<String, _i4.Tag> get tags => (super.noSuchMethod(
         Invocation.getter(#tags),
-        returnValue: <String, _i3.Tag>{},
-        returnValueForMissingStub: <String, _i3.Tag>{},
-      ) as Map<String, _i3.Tag>);
+        returnValue: <String, _i4.Tag>{},
+        returnValueForMissingStub: <String, _i4.Tag>{},
+      ) as Map<String, _i4.Tag>);
 
   @override
   bool get markedUnread => (super.noSuchMethod(
@@ -1616,17 +1651,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.LatestReceiptState get receiptState => (super.noSuchMethod(
+  _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_10(
+        returnValue: _FakeLatestReceiptState_11(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_10(
+        returnValueForMissingStub: _FakeLatestReceiptState_11(
           this,
           Invocation.getter(#receiptState),
         ),
-      ) as _i3.LatestReceiptState);
+      ) as _i4.LatestReceiptState);
 
   @override
   bool get isUnread => (super.noSuchMethod(
@@ -1643,18 +1678,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i11.Future<_i3.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i12.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -1664,20 +1699,20 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  Map<String, _i3.MatrixFile> get sendingFilePlaceholders =>
+  Map<String, _i4.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
-        returnValue: <String, _i3.MatrixFile>{},
-        returnValueForMissingStub: <String, _i3.MatrixFile>{},
-      ) as Map<String, _i3.MatrixFile>);
+        returnValue: <String, _i4.MatrixFile>{},
+        returnValueForMissingStub: <String, _i4.MatrixFile>{},
+      ) as Map<String, _i4.MatrixFile>);
 
   @override
-  Map<String, _i3.MatrixImageFile> get sendingFileThumbnails =>
+  Map<String, _i4.MatrixImageFile> get sendingFileThumbnails =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFileThumbnails),
-        returnValue: <String, _i3.MatrixImageFile>{},
-        returnValueForMissingStub: <String, _i3.MatrixImageFile>{},
-      ) as Map<String, _i3.MatrixImageFile>);
+        returnValue: <String, _i4.MatrixImageFile>{},
+        returnValueForMissingStub: <String, _i4.MatrixImageFile>{},
+      ) as Map<String, _i4.MatrixImageFile>);
 
   @override
   bool get isFederated => (super.noSuchMethod(
@@ -1778,11 +1813,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.PushRuleState get pushRuleState => (super.noSuchMethod(
+  _i4.PushRuleState get pushRuleState => (super.noSuchMethod(
         Invocation.getter(#pushRuleState),
-        returnValue: _i3.PushRuleState.notify,
-        returnValueForMissingStub: _i3.PushRuleState.notify,
-      ) as _i3.PushRuleState);
+        returnValue: _i4.PushRuleState.notify,
+        returnValueForMissingStub: _i4.PushRuleState.notify,
+      ) as _i4.PushRuleState);
 
   @override
   bool get canChangeJoinRules => (super.noSuchMethod(
@@ -1792,11 +1827,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.GuestAccess get guestAccess => (super.noSuchMethod(
+  _i4.GuestAccess get guestAccess => (super.noSuchMethod(
         Invocation.getter(#guestAccess),
-        returnValue: _i3.GuestAccess.canJoin,
-        returnValueForMissingStub: _i3.GuestAccess.canJoin,
-      ) as _i3.GuestAccess);
+        returnValue: _i4.GuestAccess.canJoin,
+        returnValueForMissingStub: _i4.GuestAccess.canJoin,
+      ) as _i4.GuestAccess);
 
   @override
   bool get canChangeGuestAccess => (super.noSuchMethod(
@@ -1834,21 +1869,21 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i19.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i18.SpaceParent>[],
-        returnValueForMissingStub: <_i18.SpaceParent>[],
-      ) as List<_i18.SpaceParent>);
+        returnValue: <_i19.SpaceParent>[],
+        returnValueForMissingStub: <_i19.SpaceParent>[],
+      ) as List<_i19.SpaceParent>);
 
   @override
-  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i19.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i18.SpaceChild>[],
-        returnValueForMissingStub: <_i18.SpaceChild>[],
-      ) as List<_i18.SpaceChild>);
+        returnValue: <_i19.SpaceChild>[],
+        returnValueForMissingStub: <_i19.SpaceChild>[],
+      ) as List<_i19.SpaceChild>);
 
   @override
-  set membership(_i3.Membership? value) => super.noSuchMethod(
+  set membership(_i4.Membership? value) => super.noSuchMethod(
         Invocation.setter(
           #membership,
           value,
@@ -1884,7 +1919,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set summary(_i3.RoomSummary? value) => super.noSuchMethod(
+  set summary(_i4.RoomSummary? value) => super.noSuchMethod(
         Invocation.setter(
           #summary,
           value,
@@ -1893,7 +1928,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set states(Map<String, Map<String, _i3.StrippedStateEvent>>? value) =>
+  set states(Map<String, Map<String, _i4.StrippedStateEvent>>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #states,
@@ -1903,7 +1938,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set ephemerals(Map<String, _i3.BasicEvent>? value) => super.noSuchMethod(
+  set ephemerals(Map<String, _i4.BasicEvent>? value) => super.noSuchMethod(
         Invocation.setter(
           #ephemerals,
           value,
@@ -1912,7 +1947,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set roomAccountData(Map<String, _i3.BasicEvent>? value) => super.noSuchMethod(
+  set roomAccountData(Map<String, _i4.BasicEvent>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomAccountData,
           value,
@@ -1930,7 +1965,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set lastEvent(_i3.Event? value) => super.noSuchMethod(
+  set lastEvent(_i4.Event? value) => super.noSuchMethod(
         Invocation.setter(
           #lastEvent,
           value,
@@ -1939,7 +1974,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set receiptState(_i3.LatestReceiptState? value) => super.noSuchMethod(
+  set receiptState(_i4.LatestReceiptState? value) => super.noSuchMethod(
         Invocation.setter(
           #receiptState,
           value,
@@ -1958,17 +1993,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i11.Future<void> postLoad() => (super.noSuchMethod(
+  _i12.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i3.StrippedStateEvent? getState(
+  _i4.StrippedStateEvent? getState(
     String? typeKey, [
     String? stateKey = '',
   ]) =>
@@ -1981,10 +2016,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.StrippedStateEvent?);
+      ) as _i4.StrippedStateEvent?);
 
   @override
-  void setState(_i3.StrippedStateEvent? state) => super.noSuchMethod(
+  void setState(_i4.StrippedStateEvent? state) => super.noSuchMethod(
         Invocation.method(
           #setState,
           [state],
@@ -1993,33 +2028,33 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  _i11.Future<List<_i3.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i12.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
+        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
-      ) as _i11.Future<List<_i3.User>>);
+            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i12.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
-          [_i3.MatrixLocalizations? i18n =
-              const _i3.MatrixDefaultLocalizations()]) =>
+          [_i4.MatrixLocalizations? i18n =
+              const _i4.MatrixDefaultLocalizations()]) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2029,18 +2064,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as String);
 
   @override
-  _i11.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i12.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Event?> refreshLastEvent(
+  _i12.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2048,12 +2083,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
-  void setEphemeral(_i3.BasicEvent? ephemeral) => super.noSuchMethod(
+  void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
         Invocation.method(
           #setEphemeral,
           [ephemeral],
@@ -2062,12 +2097,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  _i11.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i12.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2075,22 +2110,22 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i12.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2098,17 +2133,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> addTag(
+  _i12.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2118,27 +2153,27 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i12.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i12.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2146,43 +2181,43 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i12.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i12.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i12.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2190,14 +2225,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2209,10 +2244,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as String?);
 
   @override
-  _i11.Future<String?> sendTextEvent(
+  _i12.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     bool? parseMarkdown = true,
     bool? parseCommands = true,
@@ -2241,12 +2276,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendReaction(
+  _i12.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2260,12 +2295,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendLocation(
+  _i12.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2279,18 +2314,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendFileEvent(
-    _i3.MatrixFile? file, {
+  _i12.Future<String?> sendFileEvent(
+    _i4.MatrixFile? file, {
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     int? shrinkImageMaxDimension,
-    _i3.MatrixImageFile? thumbnail,
+    _i4.MatrixImageFile? thumbnail,
     Map<String, dynamic>? extraContent,
     String? threadRootEventId,
     String? threadLastEventId,
@@ -2312,29 +2347,29 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<_i3.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i12.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i11.Future<_i3.EncryptionHealthState>.value(
-            _i3.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i11.Future<_i3.EncryptionHealthState>.value(
-            _i3.EncryptionHealthState.allVerified),
-      ) as _i11.Future<_i3.EncryptionHealthState>);
+        returnValue: _i12.Future<_i4.EncryptionHealthState>.value(
+            _i4.EncryptionHealthState.allVerified),
+        returnValueForMissingStub: _i12.Future<_i4.EncryptionHealthState>.value(
+            _i4.EncryptionHealthState.allVerified),
+      ) as _i12.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i11.Future<String?> sendEvent(
+  _i12.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     String? threadRootEventId,
     String? threadLastEventId,
@@ -2354,73 +2389,73 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i12.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> leave() => (super.noSuchMethod(
+  _i12.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> forget() => (super.noSuchMethod(
+  _i12.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> setPower(
+  _i12.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2432,7 +2467,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             power,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2443,7 +2478,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2453,10 +2488,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> invite(
+  _i12.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2466,16 +2501,16 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<int> requestHistory({
+  _i12.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
-    dynamic direction = _i3.Direction.b,
-    _i3.StateFilter? filter,
+    dynamic direction = _i4.Direction.b,
+    _i4.StateFilter? filter,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2488,32 +2523,32 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<int>.value(0),
-        returnValueForMissingStub: _i11.Future<int>.value(0),
-      ) as _i11.Future<int>);
+        returnValue: _i12.Future<int>.value(0),
+        returnValueForMissingStub: _i12.Future<int>.value(0),
+      ) as _i12.Future<int>);
 
   @override
-  _i11.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i12.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setReadMarker(
+  _i12.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2527,25 +2562,25 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #public: public,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
+  _i12.Future<_i20.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i11.Future<_i19.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i11.Future<_i19.TimelineChunk?>.value(),
-      ) as _i11.Future<_i19.TimelineChunk?>);
+        returnValue: _i12.Future<_i20.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i12.Future<_i20.TimelineChunk?>.value(),
+      ) as _i12.Future<_i20.TimelineChunk?>);
 
   @override
-  _i11.Future<void> postReceipt(
+  _i12.Future<void> postReceipt(
     String? eventId, {
-    _i3.ReceiptType? type = _i3.ReceiptType.mRead,
+    _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2553,12 +2588,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Timeline> getTimeline({
+  _i12.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2581,7 +2616,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i11.Future<_i3.Timeline>.value(_FakeTimeline_12(
+        returnValue: _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
           this,
           Invocation.method(
             #getTimeline,
@@ -2598,7 +2633,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Timeline>.value(_FakeTimeline_12(
+            _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
           this,
           Invocation.method(
             #getTimeline,
@@ -2614,30 +2649,30 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Timeline>);
+      ) as _i12.Future<_i4.Timeline>);
 
   @override
-  List<_i3.User> getParticipants(
-          [List<_i3.Membership>? membershipFilter = const [
-            _i3.Membership.join,
-            _i3.Membership.invite,
-            _i3.Membership.knock,
+  List<_i4.User> getParticipants(
+          [List<_i4.Membership>? membershipFilter = const [
+            _i4.Membership.join,
+            _i4.Membership.invite,
+            _i4.Membership.knock,
           ]]) =>
       (super.noSuchMethod(
         Invocation.method(
           #getParticipants,
           [membershipFilter],
         ),
-        returnValue: <_i3.User>[],
-        returnValueForMissingStub: <_i3.User>[],
-      ) as List<_i3.User>);
+        returnValue: <_i4.User>[],
+        returnValueForMissingStub: <_i4.User>[],
+      ) as List<_i4.User>);
 
   @override
-  _i11.Future<List<_i3.User>> requestParticipants([
-    List<_i3.Membership>? membershipFilter = const [
-      _i3.Membership.join,
-      _i3.Membership.invite,
-      _i3.Membership.knock,
+  _i12.Future<List<_i4.User>> requestParticipants([
+    List<_i4.Membership>? membershipFilter = const [
+      _i4.Membership.join,
+      _i4.Membership.invite,
+      _i4.Membership.knock,
     ],
     bool? suppressWarning = false,
     bool? cache,
@@ -2651,58 +2686,58 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             cache,
           ],
         ),
-        returnValue: _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
+        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
-      ) as _i11.Future<List<_i3.User>>);
+            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i12.Future<List<_i4.User>>);
 
   @override
-  _i3.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
+  _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
         Invocation.method(
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_13(
+        returnValue: _FakeUser_14(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_13(
+        returnValueForMissingStub: _FakeUser_14(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-      ) as _i3.User);
+      ) as _i4.User);
 
   @override
-  _i3.User unsafeGetUserFromMemoryOrFallback(String? mxID) =>
+  _i4.User unsafeGetUserFromMemoryOrFallback(String? mxID) =>
       (super.noSuchMethod(
         Invocation.method(
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_13(
+        returnValue: _FakeUser_14(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_13(
+        returnValueForMissingStub: _FakeUser_14(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-      ) as _i3.User);
+      ) as _i4.User);
 
   @override
-  _i11.Future<_i3.User?> requestUser(
+  _i12.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2718,19 +2753,19 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i11.Future<_i3.User?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.User?>.value(),
-      ) as _i11.Future<_i3.User?>);
+        returnValue: _i12.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.User?>.value(),
+      ) as _i12.Future<_i4.User?>);
 
   @override
-  _i11.Future<_i3.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i12.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2743,12 +2778,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i11.Future<String> setAvatar(_i3.MatrixFile? file) => (super.noSuchMethod(
+  _i12.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2756,14 +2791,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2786,14 +2821,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i11.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i12.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -2832,18 +2867,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i11.Future<void> setPushRuleState(_i3.PushRuleState? newState) =>
+  _i12.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEvent(
+  _i12.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -2857,12 +2892,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> setTyping(
+  _i12.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -2872,13 +2907,13 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setJoinRules(
-    _i3.JoinRules? joinRules, {
+  _i12.Future<void> setJoinRules(
+    _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
   }) =>
@@ -2891,59 +2926,59 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setGuestAccess(_i3.GuestAccess? guestAccess) =>
+  _i12.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setHistoryVisibility(
-          _i3.HistoryVisibility? historyVisibility) =>
+  _i12.Future<void> setHistoryVisibility(
+          _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i12.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i12.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i11.Future<List<_i3.DeviceKeys>>.value(<_i3.DeviceKeys>[]),
+            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.DeviceKeys>>.value(<_i3.DeviceKeys>[]),
-      ) as _i11.Future<List<_i3.DeviceKeys>>);
+            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i12.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i11.Future<void> requestSessionKey(
+  _i12.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -2955,12 +2990,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             senderKey,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setSpaceChild(
+  _i12.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -2976,51 +3011,51 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i12.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i11.Future<Uri>);
+      ) as _i12.Future<Uri>);
 
   @override
-  _i11.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i12.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<
+  _i12.Future<
       ({
-        List<_i3.Event> events,
+        List<_i4.Event> events,
         String? nextBatch,
         DateTime? searchedUntil
       })> searchEvents({
     String? searchTerm,
-    bool Function(_i3.Event)? searchFunc,
+    bool Function(_i4.Event)? searchFunc,
     String? nextBatch,
     int? limit = 1000,
     Set<String>? includeEventTypes = const {
@@ -3040,23 +3075,23 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i11.Future<
+        returnValue: _i12.Future<
                 ({
-                  List<_i3.Event> events,
+                  List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
-            (events: <_i3.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i11.Future<
+            (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
+        returnValueForMissingStub: _i12.Future<
                 ({
-                  List<_i3.Event> events,
+                  List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
-            (events: <_i3.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i11.Future<
+            (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
+      ) as _i12.Future<
           ({
-            List<_i3.Event> events,
+            List<_i4.Event> events,
             String? nextBatch,
             DateTime? searchedUntil
           })>);
@@ -3065,27 +3100,27 @@ class MockRoom extends _i1.Mock implements _i3.Room {
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockClient extends _i1.Mock implements _i3.Client {
+class MockClient extends _i1.Mock implements _i4.Client {
   @override
-  _i3.DatabaseApi get database => (super.noSuchMethod(
+  _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_15(
+        returnValue: _FakeDatabaseApi_16(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_15(
+        returnValueForMissingStub: _FakeDatabaseApi_16(
           this,
           Invocation.getter(#database),
         ),
-      ) as _i3.DatabaseApi);
+      ) as _i4.DatabaseApi);
 
   @override
-  Set<_i20.KeyVerificationMethod> get verificationMethods =>
+  Set<_i21.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i20.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
-      ) as Set<_i20.KeyVerificationMethod>);
+        returnValue: <_i21.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i21.KeyVerificationMethod>{},
+      ) as Set<_i21.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3130,44 +3165,44 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  _i3.ShareKeysWith get shareKeysWith => (super.noSuchMethod(
+  _i4.ShareKeysWith get shareKeysWith => (super.noSuchMethod(
         Invocation.getter(#shareKeysWith),
-        returnValue: _i3.ShareKeysWith.all,
-        returnValueForMissingStub: _i3.ShareKeysWith.all,
-      ) as _i3.ShareKeysWith);
+        returnValue: _i4.ShareKeysWith.all,
+        returnValueForMissingStub: _i4.ShareKeysWith.all,
+      ) as _i4.ShareKeysWith);
 
   @override
-  Map<String, _i3.CommandExecutionCallback> get commands => (super.noSuchMethod(
+  Map<String, _i4.CommandExecutionCallback> get commands => (super.noSuchMethod(
         Invocation.getter(#commands),
-        returnValue: <String, _i3.CommandExecutionCallback>{},
-        returnValueForMissingStub: <String, _i3.CommandExecutionCallback>{},
-      ) as Map<String, _i3.CommandExecutionCallback>);
+        returnValue: <String, _i4.CommandExecutionCallback>{},
+        returnValueForMissingStub: <String, _i4.CommandExecutionCallback>{},
+      ) as Map<String, _i4.CommandExecutionCallback>);
 
   @override
-  _i3.Filter get syncFilter => (super.noSuchMethod(
+  _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_16(
+        returnValue: _FakeFilter_17(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_16(
+        returnValueForMissingStub: _FakeFilter_17(
           this,
           Invocation.getter(#syncFilter),
         ),
-      ) as _i3.Filter);
+      ) as _i4.Filter);
 
   @override
-  _i3.NativeImplementations get nativeImplementations => (super.noSuchMethod(
+  _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_17(
+        returnValue: _FakeNativeImplementations_18(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_17(
+        returnValueForMissingStub: _FakeNativeImplementations_18(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-      ) as _i3.NativeImplementations);
+      ) as _i4.NativeImplementations);
 
   @override
   bool get convertLinebreaksInFormatting => (super.noSuchMethod(
@@ -3179,11 +3214,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_18(
+        returnValue: _FakeDuration_19(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_18(
+        returnValueForMissingStub: _FakeDuration_19(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3192,11 +3227,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_18(
+        returnValue: _FakeDuration_19(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_18(
+        returnValueForMissingStub: _FakeDuration_19(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3205,36 +3240,36 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
       ) as String);
 
   @override
-  _i3.LoginState get loginState => (super.noSuchMethod(
+  _i4.LoginState get loginState => (super.noSuchMethod(
         Invocation.getter(#loginState),
-        returnValue: _i3.LoginState.loggedIn,
-        returnValueForMissingStub: _i3.LoginState.loggedIn,
-      ) as _i3.LoginState);
+        returnValue: _i4.LoginState.loggedIn,
+        returnValueForMissingStub: _i4.LoginState.loggedIn,
+      ) as _i4.LoginState);
 
   @override
-  List<_i3.Room> get rooms => (super.noSuchMethod(
+  List<_i4.Room> get rooms => (super.noSuchMethod(
         Invocation.getter(#rooms),
-        returnValue: <_i3.Room>[],
-        returnValueForMissingStub: <_i3.Room>[],
-      ) as List<_i3.Room>);
+        returnValue: <_i4.Room>[],
+        returnValueForMissingStub: <_i4.Room>[],
+      ) as List<_i4.Room>);
 
   @override
-  List<_i3.ArchivedRoom> get archivedRooms => (super.noSuchMethod(
+  List<_i4.ArchivedRoom> get archivedRooms => (super.noSuchMethod(
         Invocation.getter(#archivedRooms),
-        returnValue: <_i3.ArchivedRoom>[],
-        returnValueForMissingStub: <_i3.ArchivedRoom>[],
-      ) as List<_i3.ArchivedRoom>);
+        returnValue: <_i4.ArchivedRoom>[],
+        returnValueForMissingStub: <_i4.ArchivedRoom>[],
+      ) as List<_i4.ArchivedRoom>);
 
   @override
   bool get enableDehydratedDevices => (super.noSuchMethod(
@@ -3246,11 +3281,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3280,11 +3315,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3293,11 +3328,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3311,31 +3346,31 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  Map<String, _i3.BasicEvent> get accountData => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get accountData => (super.noSuchMethod(
         Invocation.getter(#accountData),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  _i3.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
+  _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_19(
+        returnValue: _FakePushruleEvaluator_20(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_19(
+        returnValueForMissingStub: _FakePushruleEvaluator_20(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-      ) as _i3.PushruleEvaluator);
+      ) as _i4.PushruleEvaluator);
 
   @override
-  Map<String, _i3.CachedPresence> get presences => (super.noSuchMethod(
+  Map<String, _i4.CachedPresence> get presences => (super.noSuchMethod(
         Invocation.getter(#presences),
-        returnValue: <String, _i3.CachedPresence>{},
-        returnValueForMissingStub: <String, _i3.CachedPresence>{},
-      ) as Map<String, _i3.CachedPresence>);
+        returnValue: <String, _i4.CachedPresence>{},
+        returnValueForMissingStub: <String, _i4.CachedPresence>{},
+      ) as Map<String, _i4.CachedPresence>);
 
   @override
   Map<String, List<String>> get directChats => (super.noSuchMethod(
@@ -3345,333 +3380,333 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i11.Future<_i3.Profile> get ownProfile => (super.noSuchMethod(
+  _i12.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i9.CachedStreamController<String> get onUserProfileUpdate =>
+  _i10.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i11.Future<List<_i3.Room>> get archive => (super.noSuchMethod(
+  _i12.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
+        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
-      ) as _i11.Future<List<_i3.Room>>);
+            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i12.Future<List<_i4.Room>>);
 
   @override
-  _i9.CachedStreamController<_i3.EventUpdate> get onEvent =>
+  _i10.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.EventUpdate>(
+        returnValue: _FakeCachedStreamController_9<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.EventUpdate>(
+            _FakeCachedStreamController_9<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.EventUpdate>);
+      ) as _i10.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onTimelineEvent =>
+  _i10.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onHistoryEvent =>
+  _i10.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onNotification =>
+  _i10.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.ToDeviceEvent> get onToDeviceEvent =>
+  _i10.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.ToDeviceEvent>(
+            _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.ToDeviceEvent>);
+      ) as _i10.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i9.CachedStreamController<List<_i3.BasicEventWithSender>> get onCallEvents =>
-      (super.noSuchMethod(
-        Invocation.getter(#onCallEvents),
-        returnValue:
-            _FakeCachedStreamController_8<List<_i3.BasicEventWithSender>>(
-          this,
-          Invocation.getter(#onCallEvents),
-        ),
-        returnValueForMissingStub:
-            _FakeCachedStreamController_8<List<_i3.BasicEventWithSender>>(
-          this,
-          Invocation.getter(#onCallEvents),
-        ),
-      ) as _i9.CachedStreamController<List<_i3.BasicEventWithSender>>);
+  _i10.CachedStreamController<List<_i4.BasicEventWithSender>>
+      get onCallEvents => (super.noSuchMethod(
+            Invocation.getter(#onCallEvents),
+            returnValue:
+                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+              this,
+              Invocation.getter(#onCallEvents),
+            ),
+            returnValueForMissingStub:
+                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+              this,
+              Invocation.getter(#onCallEvents),
+            ),
+          ) as _i10.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i9.CachedStreamController<_i3.LoginState> get onLoginStateChanged =>
+  _i10.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_8<_i3.LoginState>(
+        returnValue: _FakeCachedStreamController_9<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.LoginState>(
+            _FakeCachedStreamController_9<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i9.CachedStreamController<_i3.LoginState>);
+      ) as _i10.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i9.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i10.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_8<bool>(
+        returnValue: _FakeCachedStreamController_9<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i9.CachedStreamController<bool>);
+      ) as _i10.CachedStreamController<bool>);
 
   @override
-  _i9.CachedStreamController<_i3.SdkError> get onEncryptionError =>
+  _i10.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_8<_i3.SdkError>(
+        returnValue: _FakeCachedStreamController_9<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i9.CachedStreamController<_i3.SdkError>);
+      ) as _i10.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i9.CachedStreamController<_i3.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i10.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_8<_i3.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_9<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.SyncUpdate>(
+            _FakeCachedStreamController_9<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i9.CachedStreamController<_i3.SyncUpdate>);
+      ) as _i10.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.SyncStatusUpdate> get onSyncStatus =>
+  _i10.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_8<_i3.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.SyncStatusUpdate>(
+            _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i9.CachedStreamController<_i3.SyncStatusUpdate>);
+      ) as _i10.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.Presence> get onPresence =>
+  _i10.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_8<_i3.Presence>(
+        returnValue: _FakeCachedStreamController_9<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i9.CachedStreamController<_i3.Presence>);
+      ) as _i10.CachedStreamController<_i4.Presence>);
 
   @override
-  _i9.CachedStreamController<_i3.CachedPresence> get onPresenceChanged =>
+  _i10.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_8<_i3.CachedPresence>(
+        returnValue: _FakeCachedStreamController_9<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.CachedPresence>(
+            _FakeCachedStreamController_9<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i9.CachedStreamController<_i3.CachedPresence>);
+      ) as _i10.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i9.CachedStreamController<_i3.BasicEvent> get onAccountData =>
+  _i10.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_8<_i3.BasicEvent>(
+        returnValue: _FakeCachedStreamController_9<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.BasicEvent>(
+            _FakeCachedStreamController_9<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i9.CachedStreamController<_i3.BasicEvent>);
+      ) as _i10.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i9.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
+  _i10.CachedStreamController<_i21.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
+            _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i9.CachedStreamController<_i20.RoomKeyRequest>);
+      ) as _i10.CachedStreamController<_i21.RoomKeyRequest>);
 
   @override
-  _i9.CachedStreamController<_i20.KeyVerification>
+  _i10.CachedStreamController<_i21.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_8<_i20.KeyVerification>(
+            returnValue: _FakeCachedStreamController_9<_i21.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_8<_i20.KeyVerification>(
+                _FakeCachedStreamController_9<_i21.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i9.CachedStreamController<_i20.KeyVerification>);
+          ) as _i10.CachedStreamController<_i21.KeyVerification>);
 
   @override
-  _i9.CachedStreamController<_i3.UiaRequest<dynamic>> get onUiaRequest =>
+  _i10.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_8<_i3.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i9.CachedStreamController<_i3.UiaRequest<dynamic>>);
+      ) as _i10.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onGroupMember =>
+  _i10.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<String> get onCancelSendEvent =>
+  _i10.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i9.CachedStreamController<({String roomId, _i3.StrippedStateEvent state})>
+  _i10.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_8<
-                ({String roomId, _i3.StrippedStateEvent state})>(
+            returnValue: _FakeCachedStreamController_9<
+                ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_8<
-                ({String roomId, _i3.StrippedStateEvent state})>(
+            returnValueForMissingStub: _FakeCachedStreamController_9<
+                ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i9.CachedStreamController<
-              ({String roomId, _i3.StrippedStateEvent state})>);
+          ) as _i10.CachedStreamController<
+              ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
   int get syncErrorTimeoutSec => (super.noSuchMethod(
@@ -3690,11 +3725,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_9(
+        returnValue: _FakeDateTime_10(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_9(
+        returnValueForMissingStub: _FakeDateTime_10(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3715,33 +3750,33 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  _i3.RoomSorter get sortRoomsBy => (super.noSuchMethod(
+  _i4.RoomSorter get sortRoomsBy => (super.noSuchMethod(
         Invocation.getter(#sortRoomsBy),
         returnValue: (
-          _i3.Room a,
-          _i3.Room b,
+          _i4.Room a,
+          _i4.Room b,
         ) =>
             0,
         returnValueForMissingStub: (
-          _i3.Room a,
-          _i3.Room b,
+          _i4.Room a,
+          _i4.Room b,
         ) =>
             0,
-      ) as _i3.RoomSorter);
+      ) as _i4.RoomSorter);
 
   @override
-  Map<String, _i3.DeviceKeysList> get userDeviceKeys => (super.noSuchMethod(
+  Map<String, _i4.DeviceKeysList> get userDeviceKeys => (super.noSuchMethod(
         Invocation.getter(#userDeviceKeys),
-        returnValue: <String, _i3.DeviceKeysList>{},
-        returnValueForMissingStub: <String, _i3.DeviceKeysList>{},
-      ) as Map<String, _i3.DeviceKeysList>);
+        returnValue: <String, _i4.DeviceKeysList>{},
+        returnValueForMissingStub: <String, _i4.DeviceKeysList>{},
+      ) as Map<String, _i4.DeviceKeysList>);
 
   @override
-  List<_i3.DeviceKeys> get unverifiedDevices => (super.noSuchMethod(
+  List<_i4.DeviceKeys> get unverifiedDevices => (super.noSuchMethod(
         Invocation.getter(#unverifiedDevices),
-        returnValue: <_i3.DeviceKeys>[],
-        returnValueForMissingStub: <_i3.DeviceKeys>[],
-      ) as List<_i3.DeviceKeys>);
+        returnValue: <_i4.DeviceKeys>[],
+        returnValueForMissingStub: <_i4.DeviceKeys>[],
+      ) as List<_i4.DeviceKeys>);
 
   @override
   bool get allPushNotificationsMuted => (super.noSuchMethod(
@@ -3758,7 +3793,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as List<String>);
 
   @override
-  set database(_i3.DatabaseApi? db) => super.noSuchMethod(
+  set database(_i4.DatabaseApi? db) => super.noSuchMethod(
         Invocation.setter(
           #database,
           db,
@@ -3767,7 +3802,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i21.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3813,7 +3848,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set shareKeysWith(_i3.ShareKeysWith? value) => super.noSuchMethod(
+  set shareKeysWith(_i4.ShareKeysWith? value) => super.noSuchMethod(
         Invocation.setter(
           #shareKeysWith,
           value,
@@ -3822,7 +3857,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set onSoftLogout(_i11.Future<void> Function(_i3.Client)? value) =>
+  set onSoftLogout(_i12.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3833,8 +3868,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
 
   @override
   set customImageResizer(
-          _i11.Future<_i3.MatrixImageFileResizedResponse?> Function(
-                  _i3.MatrixImageFileResizeArguments)?
+          _i12.Future<_i4.MatrixImageFileResizedResponse?> Function(
+                  _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
         Invocation.setter(
@@ -3872,7 +3907,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set rooms(List<_i3.Room>? newList) => super.noSuchMethod(
+  set rooms(List<_i4.Room>? newList) => super.noSuchMethod(
         Invocation.setter(
           #rooms,
           newList,
@@ -3881,7 +3916,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set presences(Map<String, _i3.CachedPresence>? value) => super.noSuchMethod(
+  set presences(Map<String, _i4.CachedPresence>? value) => super.noSuchMethod(
         Invocation.setter(
           #presences,
           value,
@@ -3908,7 +3943,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set syncPresence(_i3.PresenceType? value) => super.noSuchMethod(
+  set syncPresence(_i4.PresenceType? value) => super.noSuchMethod(
         Invocation.setter(
           #syncPresence,
           value,
@@ -3944,7 +3979,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -3953,7 +3988,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set roomsLoading(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -3962,7 +3997,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set firstSyncReceived(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -3989,20 +4024,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i10.Client get httpClient => (super.noSuchMethod(
+  _i11.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_21(
+        returnValue: _FakeClient_22(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_21(
+        returnValueForMissingStub: _FakeClient_22(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i10.Client);
+      ) as _i11.Client);
 
   @override
-  set httpClient(_i10.Client? value) => super.noSuchMethod(
+  set httpClient(_i11.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4029,7 +4064,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<void> refreshAccessToken(
+  _i12.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4037,9 +4072,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4057,14 +4092,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4074,22 +4109,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as String);
 
   @override
-  _i3.Room? getRoomByAlias(String? alias) => (super.noSuchMethod(
+  _i4.Room? getRoomByAlias(String? alias) => (super.noSuchMethod(
         Invocation.method(
           #getRoomByAlias,
           [alias],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.Room?);
+      ) as _i4.Room?);
 
   @override
-  _i3.Room? getRoomById(String? id) => (super.noSuchMethod(
+  _i4.Room? getRoomById(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getRoomById,
           [id],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.Room?);
+      ) as _i4.Room?);
 
   @override
   String? getDirectChatFromUserId(String? userId) => (super.noSuchMethod(
@@ -4101,38 +4136,38 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as String?);
 
   @override
-  _i11.Future<_i3.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i12.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i11.Future<_i3.DiscoveryInformation>);
+      ) as _i12.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i11.Future<
+  _i12.Future<
       (
-        _i3.DiscoveryInformation?,
-        _i3.GetVersionsResponse,
-        List<_i3.LoginFlow>,
-        _i3.GetAuthMetadataResponse?
+        _i4.DiscoveryInformation?,
+        _i4.GetVersionsResponse,
+        List<_i4.LoginFlow>,
+        _i4.GetAuthMetadataResponse?
       )> checkHomeserver(
     Uri? homeserverUrl, {
     bool? checkWellKnown = true,
@@ -4149,15 +4184,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i11.Future<
+        returnValue: _i12.Future<
             (
-              _i3.DiscoveryInformation?,
-              _i3.GetVersionsResponse,
-              List<_i3.LoginFlow>,
-              _i3.GetAuthMetadataResponse?
+              _i4.DiscoveryInformation?,
+              _i4.GetVersionsResponse,
+              List<_i4.LoginFlow>,
+              _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_23(
+          _FakeGetVersionsResponse_24(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4169,18 +4204,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
           ),
-          <_i3.LoginFlow>[],
+          <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i11.Future<
+        returnValueForMissingStub: _i12.Future<
             (
-              _i3.DiscoveryInformation?,
-              _i3.GetVersionsResponse,
-              List<_i3.LoginFlow>,
-              _i3.GetAuthMetadataResponse?
+              _i4.DiscoveryInformation?,
+              _i4.GetVersionsResponse,
+              List<_i4.LoginFlow>,
+              _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_23(
+          _FakeGetVersionsResponse_24(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4192,19 +4227,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
           ),
-          <_i3.LoginFlow>[],
+          <_i4.LoginFlow>[],
           null
         )),
-      ) as _i11.Future<
+      ) as _i12.Future<
           (
-            _i3.DiscoveryInformation?,
-            _i3.GetVersionsResponse,
-            List<_i3.LoginFlow>,
-            _i3.GetAuthMetadataResponse?
+            _i4.DiscoveryInformation?,
+            _i4.GetVersionsResponse,
+            List<_i4.LoginFlow>,
+            _i4.GetAuthMetadataResponse?
           )>);
 
   @override
-  _i11.Future<_i3.DiscoveryInformation> getWellknown({
+  _i12.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4217,8 +4252,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getWellknown,
@@ -4229,8 +4264,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getWellknown,
@@ -4241,19 +4276,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.DiscoveryInformation>);
+      ) as _i12.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i11.Future<_i3.RegisterResponse> register({
+  _i12.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
     String? initialDeviceDisplayName,
     bool? inhibitLogin,
     bool? refreshToken,
-    _i3.AuthenticationData? auth,
-    _i3.AccountKind? kind,
-    void Function(_i3.InitState)? onInitStateChanged,
+    _i4.AuthenticationData? auth,
+    _i4.AccountKind? kind,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4272,7 +4307,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<_i3.RegisterResponse>.value(_FakeRegisterResponse_24(
+            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
           this,
           Invocation.method(
             #register,
@@ -4291,7 +4326,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RegisterResponse>.value(_FakeRegisterResponse_24(
+            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
           this,
           Invocation.method(
             #register,
@@ -4309,12 +4344,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RegisterResponse>);
+      ) as _i12.Future<_i4.RegisterResponse>);
 
   @override
-  _i11.Future<_i3.LoginResponse> login(
+  _i12.Future<_i4.LoginResponse> login(
     String? type, {
-    _i3.AuthenticationIdentifier? identifier,
+    _i4.AuthenticationIdentifier? identifier,
     String? password,
     String? token,
     String? deviceId,
@@ -4323,7 +4358,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? user,
     String? medium,
     String? address,
-    void Function(_i3.InitState)? onInitStateChanged,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4342,7 +4377,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i11.Future<_i3.LoginResponse>.value(_FakeLoginResponse_25(
+        returnValue: _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
           this,
           Invocation.method(
             #login,
@@ -4362,7 +4397,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.LoginResponse>.value(_FakeLoginResponse_25(
+            _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
           this,
           Invocation.method(
             #login,
@@ -4381,10 +4416,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.LoginResponse>);
+      ) as _i12.Future<_i4.LoginResponse>);
 
   @override
-  _i11.Future<_i3.GetAuthMetadataResponse> getAuthMetadata({
+  _i12.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4397,8 +4432,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_26(
+        returnValue: _i12.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_27(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4410,8 +4445,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_26(
+            _i12.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_27(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4422,80 +4457,80 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetAuthMetadataResponse>);
+      ) as _i12.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i11.Future<void> logout() => (super.noSuchMethod(
+  _i12.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> logoutAll() => (super.noSuchMethod(
+  _i12.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<T> uiaRequestBackground<T>(
-          _i11.Future<T> Function(_i3.AuthenticationData?)? request) =>
+  _i12.Future<T> uiaRequestBackground<T>(
+          _i12.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i11.Future<T>.value(v),
+              (T v) => _i12.Future<T>.value(v),
             ) ??
-            _FakeFuture_27<T>(
+            _FakeFuture_28<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i11.Future<T>.value(v),
+              (T v) => _i12.Future<T>.value(v),
             ) ??
-            _FakeFuture_27<T>(
+            _FakeFuture_28<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i11.Future<T>);
+      ) as _i12.Future<T>);
 
   @override
-  _i11.Future<String> startDirectChat(
+  _i12.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
-    List<_i3.StateEvent>? initialState,
+    List<_i4.StateEvent>? initialState,
     bool? waitForSync = true,
     Map<String, dynamic>? powerLevelContentOverride,
-    _i3.CreateRoomPreset? preset = _i3.CreateRoomPreset.trustedPrivateChat,
+    _i4.CreateRoomPreset? preset = _i4.CreateRoomPreset.trustedPrivateChat,
     bool? skipExistingChat = false,
   }) =>
       (super.noSuchMethod(
@@ -4511,7 +4546,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4527,7 +4562,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4542,17 +4577,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<String> createGroupChat({
+  _i12.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
-    _i3.CreateRoomPreset? preset = _i3.CreateRoomPreset.privateChat,
-    List<_i3.StateEvent>? initialState,
-    _i3.Visibility? visibility,
-    _i3.HistoryVisibility? historyVisibility,
+    _i4.CreateRoomPreset? preset = _i4.CreateRoomPreset.privateChat,
+    List<_i4.StateEvent>? initialState,
+    _i4.Visibility? visibility,
+    _i4.HistoryVisibility? historyVisibility,
     bool? waitForSync = true,
     bool? groupCall = false,
     bool? federated = true,
@@ -4576,7 +4611,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4597,7 +4632,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4617,10 +4652,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> waitForRoomInSync(
+  _i12.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4636,7 +4671,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4649,7 +4684,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4661,27 +4696,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i12.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<String> createSpace({
+  _i12.Future<String> createSpace({
     String? name,
     String? topic,
-    _i3.Visibility? visibility = _i3.Visibility.public,
+    _i4.Visibility? visibility = _i4.Visibility.public,
     String? spaceAliasName,
     List<String>? invite,
-    List<_i3.Invite3pid>? invite3pid,
+    List<_i4.Invite3pid>? invite3pid,
     String? roomVersion,
     bool? waitForSync = false,
   }) =>
@@ -4700,7 +4735,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4718,7 +4753,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4735,10 +4770,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.Profile> fetchOwnProfileFromServer(
+  _i12.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4746,7 +4781,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4755,7 +4790,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4763,10 +4798,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i11.Future<_i3.Profile> fetchOwnProfile({
+  _i12.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4779,7 +4814,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4791,7 +4826,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4802,10 +4837,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i11.Future<_i3.CachedProfileInformation> getUserProfile(
+  _i12.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4819,8 +4854,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i11.Future<_i3.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_28(
+        returnValue: _i12.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_29(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4832,8 +4867,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_28(
+            _i12.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_29(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4844,10 +4879,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.CachedProfileInformation>);
+      ) as _i12.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i11.Future<_i3.Profile> getProfileFromUserId(
+  _i12.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4865,7 +4900,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4879,7 +4914,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4892,17 +4927,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i3.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
+  _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getArchiveRoomFromCache,
           [roomId],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.ArchivedRoom?);
+      ) as _i4.ArchivedRoom?);
 
   @override
   void clearArchivesFromCache() => super.noSuchMethod(
@@ -4914,31 +4949,31 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<List<_i3.Room>> loadArchive() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
+        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
-      ) as _i11.Future<List<_i3.Room>>);
+            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i12.Future<List<_i4.Room>>);
 
   @override
-  _i11.Future<List<_i3.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i12.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i11.Future<List<_i3.ArchivedRoom>>.value(<_i3.ArchivedRoom>[]),
+            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ArchivedRoom>>.value(<_i3.ArchivedRoom>[]),
-      ) as _i11.Future<List<_i3.ArchivedRoom>>);
+            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i12.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i11.Future<_i3.GetVersionsResponse> getVersions({
+  _i12.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4951,8 +4986,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_23(
+        returnValue: _i12.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_24(
           this,
           Invocation.method(
             #getVersions,
@@ -4963,8 +4998,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_23(
+        returnValueForMissingStub: _i12.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_24(
           this,
           Invocation.method(
             #getVersions,
@@ -4975,20 +5010,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetVersionsResponse>);
+      ) as _i12.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i11.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i12.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<_i3.MediaConfig> getConfig({
+  _i12.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5001,7 +5036,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfig,
@@ -5013,7 +5048,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfig,
@@ -5024,10 +5059,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.MediaConfig>);
+      ) as _i12.Future<_i4.MediaConfig>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContent(
+  _i12.Future<_i13.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5047,7 +5082,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContent,
@@ -5063,7 +5098,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContent,
@@ -5078,10 +5113,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentOverrideName(
+  _i12.Future<_i13.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5103,7 +5138,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5120,7 +5155,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5136,15 +5171,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentThumbnail(
+  _i12.Future<_i13.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
     int? height, {
-    _i3.Method? method,
+    _i4.Method? method,
     bool? allowRemote,
     int? timeoutMs,
     bool? allowRedirect,
@@ -5167,7 +5202,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5187,7 +5222,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5206,10 +5241,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i3.PreviewForUrl> getUrlPreview(
+  _i12.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5219,7 +5254,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5228,7 +5263,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5236,11 +5271,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i11.Future<_i3.PreviewForUrl>);
+      ) as _i12.Future<_i4.PreviewForUrl>);
 
   @override
-  _i11.Future<Uri> uploadContent(
-    _i21.Uint8List? file, {
+  _i12.Future<Uri> uploadContent(
+    _i22.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5253,7 +5288,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #uploadContent,
@@ -5264,7 +5299,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #uploadContent,
@@ -5275,10 +5310,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<Uri>);
+      ) as _i12.Future<Uri>);
 
   @override
-  _i11.Future<void> setTyping(
+  _i12.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5294,43 +5329,43 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> exportDump() => (super.noSuchMethod(
+  _i12.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i12.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> setAvatar(_i3.MatrixFile? file) => (super.noSuchMethod(
+  _i12.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Event?> getEventByPushNotification(
-    _i3.PushNotification? notification, {
+  _i12.Future<_i4.Event?> getEventByPushNotification(
+    _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
     bool? returnNullIfSeen = true,
@@ -5345,12 +5380,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
-  _i11.Future<void> init({
+  _i12.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5363,7 +5398,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     bool? waitForFirstSync = true,
     bool? waitUntilLoadCompletedLoaded = true,
     void Function()? onMigration,
-    void Function(_i3.InitState)? onInitStateChanged,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5385,9 +5420,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5399,42 +5434,42 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<void> clear() => (super.noSuchMethod(
+  _i12.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i12.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ensureNotSoftLoggedOut(
+  _i12.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> handleSync(
-    _i3.SyncUpdate? sync, {
-    _i3.Direction? direction,
+  _i12.Future<void> handleSync(
+    _i4.SyncUpdate? sync, {
+    _i4.Direction? direction,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5442,44 +5477,44 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i3.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
+  _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeysByCurve25519Key,
           [senderKey],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.DeviceKeys?);
+      ) as _i4.DeviceKeys?);
 
   @override
-  _i11.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i12.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i12.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDevice(
+  _i12.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5493,12 +5528,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             messages,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDevicesOfUserIds(
+  _i12.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5514,13 +5549,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDeviceEncrypted(
-    List<_i3.DeviceKeys>? deviceKeys,
+  _i12.Future<void> sendToDeviceEncrypted(
+    List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
     String? messageId,
@@ -5539,13 +5574,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDeviceEncryptedChunked(
-    List<_i3.DeviceKeys>? deviceKeys,
+  _i12.Future<void> sendToDeviceEncryptedChunked(
+    List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
   ) =>
@@ -5558,28 +5593,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
             message,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i12.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> joinRoom(
+  _i12.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
     String? reason,
-    _i3.ThirdPartySigned? thirdPartySigned,
+    _i4.ThirdPartySigned? thirdPartySigned,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5592,7 +5627,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5606,7 +5641,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5619,13 +5654,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> changePassword(
+  _i12.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
     bool? logoutDevices,
   }) =>
       (super.noSuchMethod(
@@ -5638,22 +5673,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> clearCache() => (super.noSuchMethod(
+  _i12.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ignoreUser(
+  _i12.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5663,22 +5698,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i12.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.CachedPresence> fetchCurrentPresence(
+  _i12.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5689,7 +5724,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i11.Future<_i3.CachedPresence>.value(_FakeCachedPresence_32(
+            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5698,7 +5733,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.CachedPresence>.value(_FakeCachedPresence_32(
+            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5706,32 +5741,32 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i11.Future<_i3.CachedPresence>);
+      ) as _i12.Future<_i4.CachedPresence>);
 
   @override
-  _i11.Future<void> abortSync() => (super.noSuchMethod(
+  _i12.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i12.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEventWithMetadata(
+  _i12.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5751,14 +5786,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i10.BaseResponse? response,
-    _i21.Uint8List? body,
+    _i11.BaseResponse? response,
+    _i22.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5790,8 +5825,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as Never);
 
   @override
-  _i11.Future<Map<String, Object?>> request(
-    _i3.RequestType? type,
+  _i12.Future<Map<String, Object?>> request(
+    _i4.RequestType? type,
     String? action, {
     dynamic data = '',
     String? contentType = 'application/json',
@@ -5811,14 +5846,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> postPusher(
-    _i3.Pusher? pusher, {
+  _i12.Future<void> postPusher(
+    _i4.Pusher? pusher, {
     bool? append,
   }) =>
       (super.noSuchMethod(
@@ -5827,57 +5862,57 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deletePusher(_i3.PusherId? pusher) => (super.noSuchMethod(
+  _i12.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i12.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i12.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i11.Future<_i3.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_33(
+        returnValue: _i12.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_34(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_33(
+        returnValueForMissingStub: _i12.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_34(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.TurnServerCredentials>);
+      ) as _i12.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5891,8 +5926,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5904,8 +5939,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5916,14 +5951,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
-    _i3.KeyBackupData? data,
+    _i4.KeyBackupData? data,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5935,8 +5970,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             data,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5949,8 +5984,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5962,10 +5997,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.KeyBackupData> getRoomKeysBySessionId(
+  _i12.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5979,7 +6014,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -5991,7 +6026,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6002,17 +6037,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.KeyBackupData>);
+      ) as _i12.Future<_i4.KeyBackupData>);
 
   @override
-  _i11.Future<_i3.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i12.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i11.Future<_i3.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_36(
+        returnValue: _i12.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_37(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6020,18 +6055,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_36(
+            _i12.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_37(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.GetWellknownSupportResponse>);
+      ) as _i12.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i11.Future<int> pingAppservice(
+  _i12.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6041,21 +6076,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i11.Future<int>.value(0),
-        returnValueForMissingStub: _i11.Future<int>.value(0),
-      ) as _i11.Future<int>);
+        returnValue: _i12.Future<int>.value(0),
+        returnValueForMissingStub: _i12.Future<int>.value(0),
+      ) as _i12.Future<int>);
 
   @override
-  _i11.Future<_i3.GenerateLoginTokenResponse> generateLoginToken(
-          {_i3.AuthenticationData? auth}) =>
+  _i12.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+          {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
           #generateLoginToken,
           [],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<_i3.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_37(
+        returnValue: _i12.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_38(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6064,8 +6099,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_37(
+            _i12.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_38(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6073,15 +6108,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i11.Future<_i3.GenerateLoginTokenResponse>);
+      ) as _i12.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i11.Future<_i3.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i12.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6089,17 +6124,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.MediaConfig>);
+      ) as _i12.Future<_i4.MediaConfig>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentAuthed(
+  _i12.Future<_i13.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6113,7 +6148,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6125,7 +6160,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6136,10 +6171,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentOverrideNameAuthed(
+  _i12.Future<_i13.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6155,7 +6190,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6168,7 +6203,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6180,10 +6215,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i3.PreviewForUrl> getUrlPreviewAuthed(
+  _i12.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6193,7 +6228,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6202,7 +6237,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6210,15 +6245,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i11.Future<_i3.PreviewForUrl>);
+      ) as _i12.Future<_i4.PreviewForUrl>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentThumbnailAuthed(
+  _i12.Future<_i13.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
     int? height, {
-    _i3.Method? method,
+    _i4.Method? method,
     int? timeoutMs,
     bool? animated,
   }) =>
@@ -6237,7 +6272,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6255,7 +6290,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6272,21 +6307,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<bool> registrationTokenValidity(String? token) =>
+  _i12.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<_i3.GetRoomSummaryResponse$3> getRoomSummary(
+  _i12.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6296,8 +6331,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i11.Future<_i3.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_38(
+        returnValue: _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_39(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6306,8 +6341,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_38(
+            _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_39(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6315,10 +6350,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#via: via},
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomSummaryResponse$3>);
+      ) as _i12.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i11.Future<_i3.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i12.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6336,8 +6371,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #from: from,
           },
         ),
-        returnValue: _i11.Future<_i3.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_39(
+        returnValue: _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_40(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6351,8 +6386,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_39(
+            _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_40(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6365,16 +6400,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetSpaceHierarchyResponse>);
+      ) as _i12.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsResponse> getRelatingEvents(
+  _i12.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
       (super.noSuchMethod(
@@ -6392,8 +6427,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i11.Future<_i3.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_40(
+        returnValue: _i12.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_41(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6411,8 +6446,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_40(
+            _i12.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_41(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6429,10 +6464,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetRelatingEventsResponse>);
+      ) as _i12.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>
+  _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6440,7 +6475,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
           (super.noSuchMethod(
@@ -6460,8 +6495,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
             returnValue:
-                _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_41(
+                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6480,8 +6515,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_41(
+                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6499,10 +6534,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-          ) as _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i12.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6511,7 +6546,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
           (super.noSuchMethod(
@@ -6531,9 +6566,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i11.Future<
-                    _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+            returnValue: _i12.Future<
+                    _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6552,9 +6587,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i11.Future<
-                    _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+            returnValueForMissingStub: _i12.Future<
+                    _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6573,13 +6608,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-          ) as _i11
-              .Future<_i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
+          ) as _i12
+              .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i11.Future<_i3.GetThreadRootsResponse> getThreadRoots(
+  _i12.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
-    _i3.Include? include,
+    _i4.Include? include,
     int? limit,
     String? from,
   }) =>
@@ -6593,8 +6628,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #from: from,
           },
         ),
-        returnValue: _i11.Future<_i3.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_43(
+        returnValue: _i12.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_44(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6607,8 +6642,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_43(
+            _i12.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_44(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6620,13 +6655,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetThreadRootsResponse>);
+      ) as _i12.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i11.Future<_i3.GetEventByTimestampResponse> getEventByTimestamp(
+  _i12.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6637,8 +6672,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             dir,
           ],
         ),
-        returnValue: _i11.Future<_i3.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_44(
+        returnValue: _i12.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_45(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6650,8 +6685,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_44(
+            _i12.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_45(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6662,36 +6697,36 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.GetEventByTimestampResponse>);
+      ) as _i12.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i12.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyIdentifier>?>.value(),
-      ) as _i11.Future<List<_i3.ThirdPartyIdentifier>?>);
+            _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i12.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i11.Future<Uri?> post3PIDs(_i3.ThreePidCredentials? threePidCreds) =>
+  _i12.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i11.Future<Uri?>.value(),
-        returnValueForMissingStub: _i11.Future<Uri?>.value(),
-      ) as _i11.Future<Uri?>);
+        returnValue: _i12.Future<Uri?>.value(),
+        returnValueForMissingStub: _i12.Future<Uri?>.value(),
+      ) as _i12.Future<Uri?>);
 
   @override
-  _i11.Future<void> add3PID(
+  _i12.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6702,12 +6737,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> bind3PID(
+  _i12.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6723,14 +6758,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             sid,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> delete3pidFromAccount(
+  _i12.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
-    _i3.ThirdPartyIdentifierMedium? medium, {
+    _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
   }) =>
       (super.noSuchMethod(
@@ -6742,14 +6777,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6771,8 +6806,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6788,8 +6823,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6805,10 +6840,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6832,8 +6867,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6850,8 +6885,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6868,12 +6903,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> unbind3pidFromAccount(
+  _i12.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
-    _i3.ThirdPartyIdentifierMedium? medium, {
+    _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
   }) =>
       (super.noSuchMethod(
@@ -6885,15 +6920,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> deactivateAccount({
-    _i3.AuthenticationData? auth,
+  _i12.Future<_i4.IdServerUnbindResult> deactivateAccount({
+    _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
   }) =>
@@ -6907,14 +6942,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6936,8 +6971,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -6953,8 +6988,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -6970,10 +7005,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6997,8 +7032,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7015,8 +7050,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7033,16 +7068,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i12.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i11.Future<_i3.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
+            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7050,22 +7085,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
+            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.TokenOwnerInfo>);
+      ) as _i12.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i11.Future<_i3.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i12.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i11.Future<_i3.WhoIsInfo>.value(_FakeWhoIsInfo_47(
+        returnValue: _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7073,22 +7108,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.WhoIsInfo>.value(_FakeWhoIsInfo_47(
+            _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i11.Future<_i3.WhoIsInfo>);
+      ) as _i12.Future<_i4.WhoIsInfo>);
 
   @override
-  _i11.Future<_i3.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i12.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i11.Future<_i3.Capabilities>.value(_FakeCapabilities_48(
+        returnValue: _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7096,29 +7131,29 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Capabilities>.value(_FakeCapabilities_48(
+            _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.Capabilities>);
+      ) as _i12.Future<_i4.Capabilities>);
 
   @override
-  _i11.Future<String> createRoom({
+  _i12.Future<String> createRoom({
     Map<String, Object?>? creationContent,
-    List<_i3.StateEvent>? initialState,
+    List<_i4.StateEvent>? initialState,
     List<String>? invite,
-    List<_i3.Invite3pid>? invite3pid,
+    List<_i4.Invite3pid>? invite3pid,
     bool? isDirect,
     String? name,
     Map<String, Object?>? powerLevelContentOverride,
-    _i3.CreateRoomPreset? preset,
+    _i4.CreateRoomPreset? preset,
     String? roomAliasName,
     String? roomVersion,
     String? topic,
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7139,7 +7174,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7161,7 +7196,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7182,12 +7217,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> deleteDevices(
+  _i12.Future<void> deleteDevices(
     List<String>? devices, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7195,24 +7230,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.Device>?> getDevices() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Device>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.Device>?>.value(),
-      ) as _i11.Future<List<_i3.Device>?>);
+        returnValue: _i12.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.Device>?>.value(),
+      ) as _i12.Future<List<_i4.Device>?>);
 
   @override
-  _i11.Future<void> deleteDevice(
+  _i12.Future<void> deleteDevice(
     String? deviceId, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7220,34 +7255,34 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i12.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i11.Future<_i3.Device>.value(_FakeDevice_49(
+        returnValue: _i12.Future<_i4.Device>.value(_FakeDevice_50(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.Device>.value(_FakeDevice_49(
+        returnValueForMissingStub: _i12.Future<_i4.Device>.value(_FakeDevice_50(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i11.Future<_i3.Device>);
+      ) as _i12.Future<_i4.Device>);
 
   @override
-  _i11.Future<void> updateDevice(
+  _i12.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7257,15 +7292,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i12.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7277,26 +7312,26 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i12.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i11.Future<_i3.Visibility?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Visibility?>.value(),
-      ) as _i11.Future<_i3.Visibility?>);
+        returnValue: _i12.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Visibility?>.value(),
+      ) as _i12.Future<_i4.Visibility?>);
 
   @override
-  _i11.Future<void> setRoomVisibilityOnDirectory(
+  _i12.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7304,30 +7339,30 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i12.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i12.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i11.Future<_i3.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_50(
+        returnValue: _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_51(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7335,18 +7370,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_50(
+            _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_51(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomIdByAliasResponse>);
+      ) as _i12.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i11.Future<void> setRoomAlias(
+  _i12.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7358,12 +7393,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             roomId,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetEventsResponse> getEvents({
+  _i12.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7377,7 +7412,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<_i3.GetEventsResponse>.value(_FakeGetEventsResponse_51(
+            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
           this,
           Invocation.method(
             #getEvents,
@@ -7389,7 +7424,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetEventsResponse>.value(_FakeGetEventsResponse_51(
+            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
           this,
           Invocation.method(
             #getEvents,
@@ -7400,10 +7435,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetEventsResponse>);
+      ) as _i12.Future<_i4.GetEventsResponse>);
 
   @override
-  _i11.Future<_i3.PeekEventsResponse> peekEvents({
+  _i12.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7418,8 +7453,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i11.Future<_i3.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_52(
+        returnValue: _i12.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_53(
           this,
           Invocation.method(
             #peekEvents,
@@ -7431,8 +7466,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_52(
+        returnValueForMissingStub: _i12.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_53(
           this,
           Invocation.method(
             #peekEvents,
@@ -7444,16 +7479,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.PeekEventsResponse>);
+      ) as _i12.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i11.Future<_i3.MatrixEvent> getOneEvent(String? eventId) =>
+  _i12.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7461,27 +7496,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i11.Future<_i3.MatrixEvent>);
+      ) as _i12.Future<_i4.MatrixEvent>);
 
   @override
-  _i11.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i12.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i11.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i11.Future<List<String>>.value(<String>[]),
-      ) as _i11.Future<List<String>>);
+        returnValue: _i12.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
+      ) as _i12.Future<List<String>>);
 
   @override
-  _i11.Future<_i3.GetKeysChangesResponse> getKeysChanges(
+  _i12.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7493,8 +7528,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             to,
           ],
         ),
-        returnValue: _i11.Future<_i3.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_54(
+        returnValue: _i12.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_55(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7505,8 +7540,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_54(
+            _i12.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_55(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7516,10 +7551,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.GetKeysChangesResponse>);
+      ) as _i12.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i11.Future<_i3.ClaimKeysResponse> claimKeys(
+  _i12.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7530,7 +7565,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i11.Future<_i3.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
+            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
           this,
           Invocation.method(
             #claimKeys,
@@ -7539,7 +7574,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
+            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
           this,
           Invocation.method(
             #claimKeys,
@@ -7547,14 +7582,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i11.Future<_i3.ClaimKeysResponse>);
+      ) as _i12.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i11.Future<void> uploadCrossSigningKeys({
-    _i3.AuthenticationData? auth,
-    _i3.MatrixCrossSigningKey? masterKey,
-    _i3.MatrixCrossSigningKey? selfSigningKey,
-    _i3.MatrixCrossSigningKey? userSigningKey,
+  _i12.Future<void> uploadCrossSigningKeys({
+    _i4.AuthenticationData? auth,
+    _i4.MatrixCrossSigningKey? masterKey,
+    _i4.MatrixCrossSigningKey? selfSigningKey,
+    _i4.MatrixCrossSigningKey? userSigningKey,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7567,12 +7602,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.QueryKeysResponse> queryKeys(
+  _i12.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7583,7 +7618,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i11.Future<_i3.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
+            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
           this,
           Invocation.method(
             #queryKeys,
@@ -7592,7 +7627,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
+            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
           this,
           Invocation.method(
             #queryKeys,
@@ -7600,10 +7635,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i11.Future<_i3.QueryKeysResponse>);
+      ) as _i12.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i11.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7611,15 +7646,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i11.Future<
+            returnValue: _i12.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i11.Future<
+            returnValueForMissingStub: _i12.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i11.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i11.Future<Map<String, int>> uploadKeys({
-    _i3.MatrixDeviceKeys? deviceKeys,
+  _i12.Future<Map<String, int>> uploadKeys({
+    _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
   }) =>
@@ -7633,13 +7668,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i11.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i12.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i11.Future<Map<String, int>>);
+            _i12.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i12.Future<Map<String, int>>);
 
   @override
-  _i11.Future<String> knockRoom(
+  _i12.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7653,7 +7688,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7665,7 +7700,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7676,20 +7711,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<List<_i3.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i12.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.LoginFlow>?>.value(),
-      ) as _i11.Future<List<_i3.LoginFlow>?>);
+        returnValue: _i12.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i12.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i11.Future<_i3.GetNotificationsResponse> getNotifications({
+  _i12.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7704,8 +7739,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #only: only,
           },
         ),
-        returnValue: _i11.Future<_i3.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_57(
+        returnValue: _i12.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_58(
           this,
           Invocation.method(
             #getNotifications,
@@ -7718,8 +7753,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_57(
+            _i12.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_58(
           this,
           Invocation.method(
             #getNotifications,
@@ -7731,37 +7766,37 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetNotificationsResponse>);
+      ) as _i12.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i11.Future<_i3.GetPresenceResponse> getPresence(String? userId) =>
+  _i12.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i11.Future<_i3.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_58(
+        returnValue: _i12.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_59(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_58(
+        returnValueForMissingStub: _i12.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_59(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i11.Future<_i3.GetPresenceResponse>);
+      ) as _i12.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i11.Future<void> setPresence(
+  _i12.Future<void> setPresence(
     String? userId,
-    _i3.PresenceType? presence, {
+    _i4.PresenceType? presence, {
     String? statusMsg,
   }) =>
       (super.noSuchMethod(
@@ -7773,12 +7808,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, Object?>> deleteProfileField(
+  _i12.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7791,13 +7826,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getProfileField(
+  _i12.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7810,13 +7845,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<Map<String, Object?>> setProfileField(
+  _i12.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7831,13 +7866,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.GetPublicRoomsResponse> getPublicRooms({
+  _i12.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7852,8 +7887,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #server: server,
           },
         ),
-        returnValue: _i11.Future<_i3.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_59(
+        returnValue: _i12.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_60(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7866,8 +7901,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_59(
+            _i12.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_60(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7879,12 +7914,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetPublicRoomsResponse>);
+      ) as _i12.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i11.Future<_i3.QueryPublicRoomsResponse> queryPublicRooms({
+  _i12.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
-    _i3.PublicRoomQueryFilter? filter,
+    _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
     int? limit,
     String? since,
@@ -7903,8 +7938,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i11.Future<_i3.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_60(
+        returnValue: _i12.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_61(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7920,8 +7955,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_60(
+            _i12.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_61(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7936,25 +7971,25 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.QueryPublicRoomsResponse>);
+      ) as _i12.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i11.Future<List<_i3.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Pusher>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.Pusher>?>.value(),
-      ) as _i11.Future<List<_i3.Pusher>?>);
+        returnValue: _i12.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.Pusher>?>.value(),
+      ) as _i12.Future<List<_i4.Pusher>?>);
 
   @override
-  _i11.Future<_i3.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i12.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i11.Future<_i3.PushRuleSet>.value(_FakePushRuleSet_61(
+        returnValue: _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
           this,
           Invocation.method(
             #getPushRules,
@@ -7962,24 +7997,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PushRuleSet>.value(_FakePushRuleSet_61(
+            _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.PushRuleSet>);
+      ) as _i12.Future<_i4.PushRuleSet>);
 
   @override
-  _i11.Future<_i3.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i12.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i11.Future<_i3.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_62(
+        returnValue: _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_63(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -7987,19 +8022,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_62(
+            _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_63(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.GetPushRulesGlobalResponse>);
+      ) as _i12.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i11.Future<void> deletePushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> deletePushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8010,13 +8045,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.PushRule> getPushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<_i4.PushRule> getPushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8027,7 +8062,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<_i3.PushRule>.value(_FakePushRule_63(
+        returnValue: _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
           this,
           Invocation.method(
             #getPushRule,
@@ -8038,7 +8073,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PushRule>.value(_FakePushRule_63(
+            _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
           this,
           Invocation.method(
             #getPushRule,
@@ -8048,16 +8083,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.PushRule>);
+      ) as _i12.Future<_i4.PushRule>);
 
   @override
-  _i11.Future<void> setPushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
     String? before,
     String? after,
-    List<_i3.PushCondition>? conditions,
+    List<_i4.PushCondition>? conditions,
     String? pattern,
   }) =>
       (super.noSuchMethod(
@@ -8075,13 +8110,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<Object?>> getPushRuleActions(
-    _i3.PushRuleKind? kind,
+  _i12.Future<List<Object?>> getPushRuleActions(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8092,14 +8127,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i12.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i11.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i11.Future<List<Object?>>);
+            _i12.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i12.Future<List<Object?>>);
 
   @override
-  _i11.Future<void> setPushRuleActions(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRuleActions(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
   ) =>
@@ -8112,13 +8147,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             actions,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<bool> isPushRuleEnabled(
-    _i3.PushRuleKind? kind,
+  _i12.Future<bool> isPushRuleEnabled(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8129,13 +8164,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> setPushRuleEnabled(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRuleEnabled(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
   ) =>
@@ -8148,19 +8183,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
             enabled,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.RefreshResponse> refresh(String? refreshToken) =>
+  _i12.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i11.Future<_i3.RefreshResponse>.value(_FakeRefreshResponse_64(
+            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
           this,
           Invocation.method(
             #refresh,
@@ -8168,28 +8203,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RefreshResponse>.value(_FakeRefreshResponse_64(
+            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i11.Future<_i3.RefreshResponse>);
+      ) as _i12.Future<_i4.RefreshResponse>);
 
   @override
-  _i11.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i12.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i11.Future<bool?>.value(),
-        returnValueForMissingStub: _i11.Future<bool?>.value(),
-      ) as _i11.Future<bool?>);
+        returnValue: _i12.Future<bool?>.value(),
+        returnValueForMissingStub: _i12.Future<bool?>.value(),
+      ) as _i12.Future<bool?>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8211,8 +8246,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8228,8 +8263,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8245,10 +8280,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8272,8 +8307,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8290,8 +8325,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8308,17 +8343,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8326,23 +8361,23 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i12.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i11.Future<_i3.RoomKeys>.value(_FakeRoomKeys_65(
+        returnValue: _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8350,19 +8385,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeys>.value(_FakeRoomKeys_65(
+            _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeys>);
+      ) as _i12.Future<_i4.RoomKeys>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeys(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
-    _i3.RoomKeys? body,
+    _i4.RoomKeys? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8372,8 +8407,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8384,8 +8419,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8395,10 +8430,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8410,8 +8445,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8422,8 +8457,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8433,10 +8468,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeyBackup> getRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8448,7 +8483,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
+        returnValue: _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8459,7 +8494,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
+            _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8469,13 +8504,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeyBackup>);
+      ) as _i12.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
-    _i3.RoomKeyBackup? body,
+    _i4.RoomKeyBackup? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8486,8 +8521,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8499,8 +8534,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8511,10 +8546,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8528,8 +8563,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8541,8 +8576,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8553,10 +8588,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.KeyBackupData> getRoomKeyBySessionId(
+  _i12.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8570,7 +8605,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8582,7 +8617,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8593,14 +8628,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.KeyBackupData>);
+      ) as _i12.Future<_i4.KeyBackupData>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
-    _i3.KeyBackupData? body,
+    _i4.KeyBackupData? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8612,8 +8647,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8626,8 +8661,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8639,18 +8674,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>
+  _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_67(
+                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_68(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8658,19 +8693,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_67(
+                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_68(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>);
+          ) as _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i11.Future<String> postRoomKeysVersion(
-    _i3.BackupAlgorithm? algorithm,
+  _i12.Future<String> postRoomKeysVersion(
+    _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
       (super.noSuchMethod(
@@ -8681,7 +8716,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             authData,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8692,7 +8727,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8702,29 +8737,29 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i12.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i12.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i11.Future<_i3.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_68(
+        returnValue: _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_69(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8732,20 +8767,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_68(
+            _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_69(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomKeysVersionResponse>);
+      ) as _i12.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i12.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
-    _i3.BackupAlgorithm? algorithm,
+    _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
       (super.noSuchMethod(
@@ -8758,24 +8793,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i12.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i11.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i11.Future<List<String>>.value(<String>[]),
-      ) as _i11.Future<List<String>>);
+        returnValue: _i12.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
+      ) as _i12.Future<List<String>>);
 
   @override
-  _i11.Future<void> ban(
+  _i12.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8789,12 +8824,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.EventContext> getEventContext(
+  _i12.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8812,7 +8847,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<_i3.EventContext>.value(_FakeEventContext_69(
+        returnValue: _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
           this,
           Invocation.method(
             #getEventContext,
@@ -8827,7 +8862,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.EventContext>.value(_FakeEventContext_69(
+            _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
           this,
           Invocation.method(
             #getEventContext,
@@ -8841,10 +8876,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.EventContext>);
+      ) as _i12.Future<_i4.EventContext>);
 
   @override
-  _i11.Future<_i3.MatrixEvent> getOneRoomEvent(
+  _i12.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8856,7 +8891,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             eventId,
           ],
         ),
-        returnValue: _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8867,7 +8902,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8877,22 +8912,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.MatrixEvent>);
+      ) as _i12.Future<_i4.MatrixEvent>);
 
   @override
-  _i11.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i12.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> inviteBy3PID(
+  _i12.Future<void> inviteBy3PID(
     String? roomId,
-    _i3.Invite3pid? body,
+    _i4.Invite3pid? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8902,12 +8937,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> inviteUser(
+  _i12.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8921,15 +8956,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> joinRoomById(
+  _i12.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
-    _i3.ThirdPartySigned? thirdPartySigned,
+    _i4.ThirdPartySigned? thirdPartySigned,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8940,7 +8975,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8952,7 +8987,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8963,23 +8998,23 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<Map<String, _i3.RoomMember>?> getJoinedMembersByRoom(
+  _i12.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i11.Future<Map<String, _i3.RoomMember>?>.value(),
+        returnValue: _i12.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i11.Future<Map<String, _i3.RoomMember>?>.value(),
-      ) as _i11.Future<Map<String, _i3.RoomMember>?>);
+            _i12.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i12.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i11.Future<void> kick(
+  _i12.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8993,12 +9028,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> leaveRoom(
+  _i12.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9008,16 +9043,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.MatrixEvent>?> getMembersByRoom(
+  _i12.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
-    _i3.Membership? membership,
-    _i3.Membership? notMembership,
+    _i4.Membership? membership,
+    _i4.Membership? notMembership,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9029,14 +9064,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i11.Future<List<_i3.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.MatrixEvent>?>.value(),
-      ) as _i11.Future<List<_i3.MatrixEvent>?>);
+        returnValue: _i12.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i12.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i11.Future<_i3.GetRoomEventsResponse> getRoomEvents(
+  _i12.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
-    _i3.Direction? dir, {
+    _i4.Direction? dir, {
     String? from,
     String? to,
     int? limit,
@@ -9056,8 +9091,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<_i3.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_70(
+        returnValue: _i12.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_71(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9073,8 +9108,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_70(
+        returnValueForMissingStub: _i12.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_71(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9090,10 +9125,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomEventsResponse>);
+      ) as _i12.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i11.Future<void> setReadMarker(
+  _i12.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9109,14 +9144,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> postReceipt(
+  _i12.Future<void> postReceipt(
     String? roomId,
-    _i3.ReceiptType? receiptType,
+    _i4.ReceiptType? receiptType,
     String? eventId, {
     String? threadId,
   }) =>
@@ -9130,12 +9165,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEvent(
+  _i12.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9151,12 +9186,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> reportRoom(
+  _i12.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9168,12 +9203,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             reason,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> reportEvent(
+  _i12.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9191,12 +9226,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #score: score,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> sendMessage(
+  _i12.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9212,7 +9247,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9225,7 +9260,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9237,27 +9272,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<List<_i3.MatrixEvent>> getRoomState(String? roomId) =>
+  _i12.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i11.Future<List<_i3.MatrixEvent>>.value(<_i3.MatrixEvent>[]),
+            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.MatrixEvent>>.value(<_i3.MatrixEvent>[]),
-      ) as _i11.Future<List<_i3.MatrixEvent>>);
+            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i12.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i12.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
-    _i3.Format? format,
+    _i4.Format? format,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9270,13 +9305,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#format: format},
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<String> setRoomStateWithKey(
+  _i12.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9292,7 +9327,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9305,7 +9340,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9317,10 +9352,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> unban(
+  _i12.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9334,12 +9369,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> upgradeRoom(
+  _i12.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9353,7 +9388,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9365,7 +9400,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9376,11 +9411,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.SearchResults> search(
-    _i3.Categories? searchCategories, {
+  _i12.Future<_i4.SearchResults> search(
+    _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
       (super.noSuchMethod(
@@ -9389,7 +9424,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i11.Future<_i3.SearchResults>.value(_FakeSearchResults_71(
+        returnValue: _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
           this,
           Invocation.method(
             #search,
@@ -9398,7 +9433,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SearchResults>.value(_FakeSearchResults_71(
+            _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
           this,
           Invocation.method(
             #search,
@@ -9406,14 +9441,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i11.Future<_i3.SearchResults>);
+      ) as _i12.Future<_i4.SearchResults>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> sync({
+  _i12.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
-    _i3.PresenceType? setPresence,
+    _i4.PresenceType? setPresence,
     int? timeout,
     bool? useStateAfter,
   }) =>
@@ -9430,7 +9465,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #sync,
@@ -9446,7 +9481,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #sync,
@@ -9461,22 +9496,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<List<_i3.Location>> queryLocationByAlias(String? alias) =>
+  _i12.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
+        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
-      ) as _i11.Future<List<_i3.Location>>);
+            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i12.Future<List<_i4.Location>>);
 
   @override
-  _i11.Future<List<_i3.Location>> queryLocationByProtocol(
+  _i12.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9486,21 +9521,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
+        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
-      ) as _i11.Future<List<_i3.Location>>);
+            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i12.Future<List<_i4.Location>>);
 
   @override
-  _i11.Future<_i3.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i12.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i11.Future<_i3.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_72(
+        returnValue: _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_73(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9508,45 +9543,45 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_72(
+            _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_73(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i11.Future<_i3.GetProtocolMetadataResponse$2>);
+      ) as _i12.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i11.Future<Map<String, _i3.GetProtocolsResponse$2>> getProtocols() =>
+  _i12.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>.value(
-            <String, _i3.GetProtocolsResponse$2>{}),
+        returnValue: _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>.value(
-                <String, _i3.GetProtocolsResponse$2>{}),
-      ) as _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>);
+            _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+                <String, _i4.GetProtocolsResponse$2>{}),
+      ) as _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
-      ) as _i11.Future<List<_i3.ThirdPartyUser>>);
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyUser>> queryUserByProtocol(
+  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9557,13 +9592,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
-      ) as _i11.Future<List<_i3.ThirdPartyUser>>);
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getAccountData(
+  _i12.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9576,13 +9611,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> setAccountData(
+  _i12.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9596,14 +9631,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> defineFilter(
+  _i12.Future<String> defineFilter(
     String? userId,
-    _i3.Filter? body,
+    _i4.Filter? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9613,7 +9648,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9624,7 +9659,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9634,10 +9669,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.Filter> getFilter(
+  _i12.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9649,7 +9684,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             filterId,
           ],
         ),
-        returnValue: _i11.Future<_i3.Filter>.value(_FakeFilter_16(
+        returnValue: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
           this,
           Invocation.method(
             #getFilter,
@@ -9659,7 +9694,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.Filter>.value(_FakeFilter_16(
+        returnValueForMissingStub: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
           this,
           Invocation.method(
             #getFilter,
@@ -9669,10 +9704,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.Filter>);
+      ) as _i12.Future<_i4.Filter>);
 
   @override
-  _i11.Future<_i3.OpenIdCredentials> requestOpenIdToken(
+  _i12.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9685,7 +9720,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<_i3.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
+            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9696,7 +9731,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
+            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9706,10 +9741,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.OpenIdCredentials>);
+      ) as _i12.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i11.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i12.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9724,13 +9759,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> setAccountDataPerRoom(
+  _i12.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9746,12 +9781,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, _i3.Tag>?> getRoomTags(
+  _i12.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9763,12 +9798,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             roomId,
           ],
         ),
-        returnValue: _i11.Future<Map<String, _i3.Tag>?>.value(),
-        returnValueForMissingStub: _i11.Future<Map<String, _i3.Tag>?>.value(),
-      ) as _i11.Future<Map<String, _i3.Tag>?>);
+        returnValue: _i12.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i12.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i12.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i11.Future<void> deleteRoomTag(
+  _i12.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9782,16 +9817,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             tag,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setRoomTag(
+  _i12.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
-    _i3.Tag? body,
+    _i4.Tag? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9803,12 +9838,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.SearchUserDirectoryResponse> searchUserDirectory(
+  _i12.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9818,8 +9853,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i11.Future<_i3.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_74(
+        returnValue: _i12.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_75(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9828,8 +9863,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_74(
+            _i12.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_75(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9837,10 +9872,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i11.Future<_i3.SearchUserDirectoryResponse>);
+      ) as _i12.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> reportUser(
+  _i12.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9853,40 +9888,40 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i12.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i11.Future<_i3.CreateContentResponse>.value(
-            _FakeCreateContentResponse_75(
+        returnValue: _i12.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_76(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.CreateContentResponse>.value(
-            _FakeCreateContentResponse_75(
+        returnValueForMissingStub: _i12.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_76(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.CreateContentResponse>);
+      ) as _i12.Future<_i4.CreateContentResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> uploadContentToMXC(
+  _i12.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i21.Uint8List? body, {
+    _i22.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -9904,8 +9939,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 }

--- a/test/widgets/add_room_to_space_dialog_test.mocks.dart
+++ b/test/widgets/add_room_to_space_dialog_test.mocks.dart
@@ -3,31 +3,33 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i11;
-import 'dart:typed_data' as _i21;
-import 'dart:ui' as _i15;
+import 'dart:async' as _i12;
+import 'dart:typed_data' as _i22;
+import 'dart:ui' as _i16;
 
-import 'package:flutter/services.dart' as _i16;
-import 'package:flutter/widgets.dart' as _i17;
-import 'package:http/http.dart' as _i10;
-import 'package:kohera/core/services/matrix_service.dart' as _i13;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
+import 'package:flutter/services.dart' as _i17;
+import 'package:flutter/widgets.dart' as _i18;
+import 'package:http/http.dart' as _i11;
+import 'package:kohera/core/services/matrix_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i5;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i7;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i4;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i7;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
-import 'package:matrix/encryption.dart' as _i20;
-import 'package:matrix/matrix.dart' as _i3;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i12;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i9;
-import 'package:matrix/src/utils/space_child.dart' as _i18;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i3;
+import 'package:matrix/encryption.dart' as _i21;
+import 'package:matrix/matrix.dart' as _i4;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i13;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i20;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i10;
+import 'package:matrix/src/utils/space_child.dart' as _i19;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -55,8 +57,9 @@ class _FakeCallPushRuleManager_0 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
-  _FakeClient_1(
+class _FakeMegolmKeyMirror_1 extends _i1.SmartFake
+    implements _i3.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_1(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -65,8 +68,8 @@ class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
         );
 }
 
-class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
-  _FakeUiaService_2(
+class _FakeClient_2 extends _i1.SmartFake implements _i4.Client {
+  _FakeClient_2(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -75,9 +78,8 @@ class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
         );
 }
 
-class _FakeChatBackupService_3 extends _i1.SmartFake
-    implements _i5.ChatBackupService {
-  _FakeChatBackupService_3(
+class _FakeUiaService_3 extends _i1.SmartFake implements _i5.UiaService {
+  _FakeUiaService_3(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -86,9 +88,9 @@ class _FakeChatBackupService_3 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_4 extends _i1.SmartFake
-    implements _i6.SelectionService {
-  _FakeSelectionService_4(
+class _FakeChatBackupService_4 extends _i1.SmartFake
+    implements _i6.ChatBackupService {
+  _FakeChatBackupService_4(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -97,8 +99,9 @@ class _FakeSelectionService_4 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
-  _FakeSyncService_5(
+class _FakeSelectionService_5 extends _i1.SmartFake
+    implements _i7.SelectionService {
+  _FakeSelectionService_5(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -107,8 +110,8 @@ class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
         );
 }
 
-class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
-  _FakeAuthService_6(
+class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
+  _FakeSyncService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -117,8 +120,8 @@ class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
         );
 }
 
-class _FakeRoomSummary_7 extends _i1.SmartFake implements _i3.RoomSummary {
-  _FakeRoomSummary_7(
+class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
+  _FakeAuthService_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -127,9 +130,8 @@ class _FakeRoomSummary_7 extends _i1.SmartFake implements _i3.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_8<T> extends _i1.SmartFake
-    implements _i9.CachedStreamController<T> {
-  _FakeCachedStreamController_8(
+class _FakeRoomSummary_8 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -138,8 +140,9 @@ class _FakeCachedStreamController_8<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_9 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_9(
+class _FakeCachedStreamController_9<T> extends _i1.SmartFake
+    implements _i10.CachedStreamController<T> {
+  _FakeCachedStreamController_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -148,9 +151,8 @@ class _FakeDateTime_9 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_10 extends _i1.SmartFake
-    implements _i3.LatestReceiptState {
-  _FakeLatestReceiptState_10(
+class _FakeDateTime_10 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -159,8 +161,9 @@ class _FakeLatestReceiptState_10 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_11 extends _i1.SmartFake implements _i3.SyncUpdate {
-  _FakeSyncUpdate_11(
+class _FakeLatestReceiptState_11 extends _i1.SmartFake
+    implements _i4.LatestReceiptState {
+  _FakeLatestReceiptState_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -169,8 +172,8 @@ class _FakeSyncUpdate_11 extends _i1.SmartFake implements _i3.SyncUpdate {
         );
 }
 
-class _FakeTimeline_12 extends _i1.SmartFake implements _i3.Timeline {
-  _FakeTimeline_12(
+class _FakeSyncUpdate_12 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -179,8 +182,8 @@ class _FakeTimeline_12 extends _i1.SmartFake implements _i3.Timeline {
         );
 }
 
-class _FakeUser_13 extends _i1.SmartFake implements _i3.User {
-  _FakeUser_13(
+class _FakeTimeline_13 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -189,8 +192,8 @@ class _FakeUser_13 extends _i1.SmartFake implements _i3.User {
         );
 }
 
-class _FakeUri_14 extends _i1.SmartFake implements Uri {
-  _FakeUri_14(
+class _FakeUser_14 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -199,8 +202,8 @@ class _FakeUri_14 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_15 extends _i1.SmartFake implements _i3.DatabaseApi {
-  _FakeDatabaseApi_15(
+class _FakeUri_15 extends _i1.SmartFake implements Uri {
+  _FakeUri_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -209,8 +212,8 @@ class _FakeDatabaseApi_15 extends _i1.SmartFake implements _i3.DatabaseApi {
         );
 }
 
-class _FakeFilter_16 extends _i1.SmartFake implements _i3.Filter {
-  _FakeFilter_16(
+class _FakeDatabaseApi_16 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -219,9 +222,8 @@ class _FakeFilter_16 extends _i1.SmartFake implements _i3.Filter {
         );
 }
 
-class _FakeNativeImplementations_17 extends _i1.SmartFake
-    implements _i3.NativeImplementations {
-  _FakeNativeImplementations_17(
+class _FakeFilter_17 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -230,8 +232,9 @@ class _FakeNativeImplementations_17 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_18 extends _i1.SmartFake implements Duration {
-  _FakeDuration_18(
+class _FakeNativeImplementations_18 extends _i1.SmartFake
+    implements _i4.NativeImplementations {
+  _FakeNativeImplementations_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -240,9 +243,8 @@ class _FakeDuration_18 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_19 extends _i1.SmartFake
-    implements _i3.PushruleEvaluator {
-  _FakePushruleEvaluator_19(
+class _FakeDuration_19 extends _i1.SmartFake implements Duration {
+  _FakeDuration_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -251,8 +253,9 @@ class _FakePushruleEvaluator_19 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_20 extends _i1.SmartFake implements _i3.Profile {
-  _FakeProfile_20(
+class _FakePushruleEvaluator_20 extends _i1.SmartFake
+    implements _i4.PushruleEvaluator {
+  _FakePushruleEvaluator_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -261,8 +264,8 @@ class _FakeProfile_20 extends _i1.SmartFake implements _i3.Profile {
         );
 }
 
-class _FakeClient_21 extends _i1.SmartFake implements _i10.Client {
-  _FakeClient_21(
+class _FakeProfile_21 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -271,9 +274,8 @@ class _FakeClient_21 extends _i1.SmartFake implements _i10.Client {
         );
 }
 
-class _FakeDiscoveryInformation_22 extends _i1.SmartFake
-    implements _i3.DiscoveryInformation {
-  _FakeDiscoveryInformation_22(
+class _FakeClient_22 extends _i1.SmartFake implements _i11.Client {
+  _FakeClient_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -282,9 +284,9 @@ class _FakeDiscoveryInformation_22 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_23 extends _i1.SmartFake
-    implements _i3.GetVersionsResponse {
-  _FakeGetVersionsResponse_23(
+class _FakeDiscoveryInformation_23 extends _i1.SmartFake
+    implements _i4.DiscoveryInformation {
+  _FakeDiscoveryInformation_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -293,9 +295,9 @@ class _FakeGetVersionsResponse_23 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_24 extends _i1.SmartFake
-    implements _i3.RegisterResponse {
-  _FakeRegisterResponse_24(
+class _FakeGetVersionsResponse_24 extends _i1.SmartFake
+    implements _i4.GetVersionsResponse {
+  _FakeGetVersionsResponse_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -304,8 +306,9 @@ class _FakeRegisterResponse_24 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_25 extends _i1.SmartFake implements _i3.LoginResponse {
-  _FakeLoginResponse_25(
+class _FakeRegisterResponse_25 extends _i1.SmartFake
+    implements _i4.RegisterResponse {
+  _FakeRegisterResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -314,9 +317,8 @@ class _FakeLoginResponse_25 extends _i1.SmartFake implements _i3.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_26 extends _i1.SmartFake
-    implements _i3.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_26(
+class _FakeLoginResponse_26 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -325,8 +327,9 @@ class _FakeGetAuthMetadataResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_27<T1> extends _i1.SmartFake implements _i11.Future<T1> {
-  _FakeFuture_27(
+class _FakeGetAuthMetadataResponse_27 extends _i1.SmartFake
+    implements _i4.GetAuthMetadataResponse {
+  _FakeGetAuthMetadataResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -335,9 +338,8 @@ class _FakeFuture_27<T1> extends _i1.SmartFake implements _i11.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_28 extends _i1.SmartFake
-    implements _i3.CachedProfileInformation {
-  _FakeCachedProfileInformation_28(
+class _FakeFuture_28<T1> extends _i1.SmartFake implements _i12.Future<T1> {
+  _FakeFuture_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -346,8 +348,9 @@ class _FakeCachedProfileInformation_28 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_29 extends _i1.SmartFake implements _i3.MediaConfig {
-  _FakeMediaConfig_29(
+class _FakeCachedProfileInformation_29 extends _i1.SmartFake
+    implements _i4.CachedProfileInformation {
+  _FakeCachedProfileInformation_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -356,8 +359,8 @@ class _FakeMediaConfig_29 extends _i1.SmartFake implements _i3.MediaConfig {
         );
 }
 
-class _FakeFileResponse_30 extends _i1.SmartFake implements _i12.FileResponse {
-  _FakeFileResponse_30(
+class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -366,8 +369,8 @@ class _FakeFileResponse_30 extends _i1.SmartFake implements _i12.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_31 extends _i1.SmartFake implements _i3.PreviewForUrl {
-  _FakePreviewForUrl_31(
+class _FakeFileResponse_31 extends _i1.SmartFake implements _i13.FileResponse {
+  _FakeFileResponse_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -376,9 +379,8 @@ class _FakePreviewForUrl_31 extends _i1.SmartFake implements _i3.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_32 extends _i1.SmartFake
-    implements _i3.CachedPresence {
-  _FakeCachedPresence_32(
+class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -387,9 +389,9 @@ class _FakeCachedPresence_32 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_33 extends _i1.SmartFake
-    implements _i3.TurnServerCredentials {
-  _FakeTurnServerCredentials_33(
+class _FakeCachedPresence_33 extends _i1.SmartFake
+    implements _i4.CachedPresence {
+  _FakeCachedPresence_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -398,9 +400,9 @@ class _FakeTurnServerCredentials_33 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
-    implements _i3.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_34(
+class _FakeTurnServerCredentials_34 extends _i1.SmartFake
+    implements _i4.TurnServerCredentials {
+  _FakeTurnServerCredentials_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -409,8 +411,9 @@ class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i3.KeyBackupData {
-  _FakeKeyBackupData_35(
+class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
+    implements _i4.RoomKeysUpdateResponse {
+  _FakeRoomKeysUpdateResponse_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -419,9 +422,8 @@ class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i3.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
-    implements _i3.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_36(
+class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -430,9 +432,9 @@ class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
-    implements _i3.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_37(
+class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
+    implements _i4.GetWellknownSupportResponse {
+  _FakeGetWellknownSupportResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -441,9 +443,9 @@ class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
-    implements _i3.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_38(
+class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
+    implements _i4.GenerateLoginTokenResponse {
+  _FakeGenerateLoginTokenResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -452,9 +454,9 @@ class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
-    implements _i3.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_39(
+class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
+    implements _i4.GetRoomSummaryResponse$3 {
+  _FakeGetRoomSummaryResponse$3_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -463,9 +465,9 @@ class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
-    implements _i3.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_40(
+class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
+    implements _i4.GetSpaceHierarchyResponse {
+  _FakeGetSpaceHierarchyResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -474,9 +476,9 @@ class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
-    implements _i3.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_41(
+class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
+    implements _i4.GetRelatingEventsResponse {
+  _FakeGetRelatingEventsResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -485,9 +487,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
-    .SmartFake implements _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
+    implements _i4.GetRelatingEventsWithRelTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -496,9 +498,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
-    implements _i3.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_43(
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
+    .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -507,9 +509,9 @@ class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
-    implements _i3.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_44(
+class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
+    implements _i4.GetThreadRootsResponse {
+  _FakeGetThreadRootsResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -518,9 +520,9 @@ class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_45 extends _i1.SmartFake
-    implements _i3.RequestTokenResponse {
-  _FakeRequestTokenResponse_45(
+class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
+    implements _i4.GetEventByTimestampResponse {
+  _FakeGetEventByTimestampResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -529,9 +531,9 @@ class _FakeRequestTokenResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
-    implements _i3.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_46(
+class _FakeRequestTokenResponse_46 extends _i1.SmartFake
+    implements _i4.RequestTokenResponse {
+  _FakeRequestTokenResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -540,8 +542,9 @@ class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i3.WhoIsInfo {
-  _FakeWhoIsInfo_47(
+class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
+    implements _i4.TokenOwnerInfo {
+  _FakeTokenOwnerInfo_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -550,8 +553,8 @@ class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i3.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_48 extends _i1.SmartFake implements _i3.Capabilities {
-  _FakeCapabilities_48(
+class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -560,8 +563,8 @@ class _FakeCapabilities_48 extends _i1.SmartFake implements _i3.Capabilities {
         );
 }
 
-class _FakeDevice_49 extends _i1.SmartFake implements _i3.Device {
-  _FakeDevice_49(
+class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -570,9 +573,8 @@ class _FakeDevice_49 extends _i1.SmartFake implements _i3.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
-    implements _i3.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_50(
+class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -581,9 +583,9 @@ class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_51 extends _i1.SmartFake
-    implements _i3.GetEventsResponse {
-  _FakeGetEventsResponse_51(
+class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
+    implements _i4.GetRoomIdByAliasResponse {
+  _FakeGetRoomIdByAliasResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -592,9 +594,9 @@ class _FakeGetEventsResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_52 extends _i1.SmartFake
-    implements _i3.PeekEventsResponse {
-  _FakePeekEventsResponse_52(
+class _FakeGetEventsResponse_52 extends _i1.SmartFake
+    implements _i4.GetEventsResponse {
+  _FakeGetEventsResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -603,8 +605,9 @@ class _FakePeekEventsResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i3.MatrixEvent {
-  _FakeMatrixEvent_53(
+class _FakePeekEventsResponse_53 extends _i1.SmartFake
+    implements _i4.PeekEventsResponse {
+  _FakePeekEventsResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -613,9 +616,8 @@ class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i3.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
-    implements _i3.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_54(
+class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -624,9 +626,9 @@ class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_55 extends _i1.SmartFake
-    implements _i3.ClaimKeysResponse {
-  _FakeClaimKeysResponse_55(
+class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
+    implements _i4.GetKeysChangesResponse {
+  _FakeGetKeysChangesResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -635,9 +637,9 @@ class _FakeClaimKeysResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_56 extends _i1.SmartFake
-    implements _i3.QueryKeysResponse {
-  _FakeQueryKeysResponse_56(
+class _FakeClaimKeysResponse_56 extends _i1.SmartFake
+    implements _i4.ClaimKeysResponse {
+  _FakeClaimKeysResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -646,9 +648,9 @@ class _FakeQueryKeysResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
-    implements _i3.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_57(
+class _FakeQueryKeysResponse_57 extends _i1.SmartFake
+    implements _i4.QueryKeysResponse {
+  _FakeQueryKeysResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -657,9 +659,9 @@ class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_58 extends _i1.SmartFake
-    implements _i3.GetPresenceResponse {
-  _FakeGetPresenceResponse_58(
+class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
+    implements _i4.GetNotificationsResponse {
+  _FakeGetNotificationsResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -668,9 +670,9 @@ class _FakeGetPresenceResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
-    implements _i3.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_59(
+class _FakeGetPresenceResponse_59 extends _i1.SmartFake
+    implements _i4.GetPresenceResponse {
+  _FakeGetPresenceResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -679,9 +681,9 @@ class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
-    implements _i3.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_60(
+class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
+    implements _i4.GetPublicRoomsResponse {
+  _FakeGetPublicRoomsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -690,8 +692,9 @@ class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_61 extends _i1.SmartFake implements _i3.PushRuleSet {
-  _FakePushRuleSet_61(
+class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
+    implements _i4.QueryPublicRoomsResponse {
+  _FakeQueryPublicRoomsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -700,9 +703,8 @@ class _FakePushRuleSet_61 extends _i1.SmartFake implements _i3.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
-    implements _i3.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_62(
+class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -711,8 +713,9 @@ class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_63 extends _i1.SmartFake implements _i3.PushRule {
-  _FakePushRule_63(
+class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
+    implements _i4.GetPushRulesGlobalResponse {
+  _FakeGetPushRulesGlobalResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -721,9 +724,8 @@ class _FakePushRule_63 extends _i1.SmartFake implements _i3.PushRule {
         );
 }
 
-class _FakeRefreshResponse_64 extends _i1.SmartFake
-    implements _i3.RefreshResponse {
-  _FakeRefreshResponse_64(
+class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -732,8 +734,9 @@ class _FakeRefreshResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_65 extends _i1.SmartFake implements _i3.RoomKeys {
-  _FakeRoomKeys_65(
+class _FakeRefreshResponse_65 extends _i1.SmartFake
+    implements _i4.RefreshResponse {
+  _FakeRefreshResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -742,8 +745,8 @@ class _FakeRoomKeys_65 extends _i1.SmartFake implements _i3.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i3.RoomKeyBackup {
-  _FakeRoomKeyBackup_66(
+class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -752,9 +755,8 @@ class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i3.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
-    implements _i3.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_67(
+class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -763,9 +765,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
-    implements _i3.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_68(
+class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
+    implements _i4.GetRoomKeysVersionCurrentResponse {
+  _FakeGetRoomKeysVersionCurrentResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -774,8 +776,9 @@ class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_69 extends _i1.SmartFake implements _i3.EventContext {
-  _FakeEventContext_69(
+class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
+    implements _i4.GetRoomKeysVersionResponse {
+  _FakeGetRoomKeysVersionResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -784,9 +787,8 @@ class _FakeEventContext_69 extends _i1.SmartFake implements _i3.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
-    implements _i3.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_70(
+class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -795,8 +797,9 @@ class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_71 extends _i1.SmartFake implements _i3.SearchResults {
-  _FakeSearchResults_71(
+class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
+    implements _i4.GetRoomEventsResponse {
+  _FakeGetRoomEventsResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -805,9 +808,8 @@ class _FakeSearchResults_71 extends _i1.SmartFake implements _i3.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
-    implements _i3.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_72(
+class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -816,9 +818,9 @@ class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_73 extends _i1.SmartFake
-    implements _i3.OpenIdCredentials {
-  _FakeOpenIdCredentials_73(
+class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
+    implements _i4.GetProtocolMetadataResponse$2 {
+  _FakeGetProtocolMetadataResponse$2_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -827,9 +829,9 @@ class _FakeOpenIdCredentials_73 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
-    implements _i3.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_74(
+class _FakeOpenIdCredentials_74 extends _i1.SmartFake
+    implements _i4.OpenIdCredentials {
+  _FakeOpenIdCredentials_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -838,9 +840,20 @@ class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_75 extends _i1.SmartFake
-    implements _i3.CreateContentResponse {
-  _FakeCreateContentResponse_75(
+class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
+    implements _i4.SearchUserDirectoryResponse {
+  _FakeSearchUserDirectoryResponse_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeCreateContentResponse_76 extends _i1.SmartFake
+    implements _i4.CreateContentResponse {
+  _FakeCreateContentResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,7 +865,7 @@ class _FakeCreateContentResponse_75 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -867,30 +880,43 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as _i2.CallPushRuleManager);
 
   @override
+  _i3.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i3.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
       ) as String);
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get isLoggedIn => (super.noSuchMethod(
@@ -907,69 +933,69 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  _i4.UiaService get uia => (super.noSuchMethod(
+  _i5.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_2(
+        returnValue: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_2(
+        returnValueForMissingStub: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i4.UiaService);
+      ) as _i5.UiaService);
 
   @override
-  _i5.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i6.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_3(
+        returnValue: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_3(
+        returnValueForMissingStub: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i5.ChatBackupService);
+      ) as _i6.ChatBackupService);
 
   @override
-  _i6.SelectionService get selection => (super.noSuchMethod(
+  _i7.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_4(
+        returnValue: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_4(
+        returnValueForMissingStub: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i6.SelectionService);
+      ) as _i7.SelectionService);
 
   @override
-  _i7.SyncService get sync => (super.noSuchMethod(
+  _i8.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_5(
+        returnValue: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_5(
+        returnValueForMissingStub: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i7.SyncService);
+      ) as _i8.SyncService);
 
   @override
-  _i8.AuthService get auth => (super.noSuchMethod(
+  _i9.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_6(
+        returnValue: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_6(
+        returnValueForMissingStub: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i8.AuthService);
+      ) as _i9.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -988,6 +1014,15 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
+  set keyMirror(_i3.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -997,7 +1032,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set uia(_i4.UiaService? value) => super.noSuchMethod(
+  set uia(_i5.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -1006,7 +1041,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set chatBackup(_i5.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i6.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -1015,7 +1050,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set selection(_i6.SelectionService? value) => super.noSuchMethod(
+  set selection(_i7.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -1024,7 +1059,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set sync(_i7.SyncService? value) => super.noSuchMethod(
+  set sync(_i8.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -1033,7 +1068,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set auth(_i8.AuthService? value) => super.noSuchMethod(
+  set auth(_i9.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -1049,14 +1084,14 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  _i11.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1086,7 +1121,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i15.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i16.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1096,18 +1131,18 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i12.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<bool> login({
+  _i12.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1122,12 +1157,12 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<bool> completeSsoLogin({
+  _i12.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1140,13 +1175,13 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> completeRegistration(
-    _i3.RegisterResponse? response, {
+  _i12.Future<void> completeRegistration(
+    _i4.RegisterResponse? response, {
     String? password,
   }) =>
       (super.noSuchMethod(
@@ -1155,32 +1190,32 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> logout() => (super.noSuchMethod(
+  _i12.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i12.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  void addListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1189,7 +1224,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void removeListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1198,17 +1233,17 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i16.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i17.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1219,7 +1254,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i16.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i17.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1256,26 +1291,26 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<bool> didPushRouteInformation(
-          _i17.RouteInformation? routeInformation) =>
+  _i12.Future<bool> didPushRouteInformation(
+          _i18.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1305,7 +1340,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i15.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i16.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1314,7 +1349,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i15.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i16.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1323,16 +1358,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<_i15.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i12.Future<_i16.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
-      ) as _i11.Future<_i15.AppExitResponse>);
+            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
+      ) as _i12.Future<_i16.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1356,26 +1391,26 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
 /// A class which mocks [Room].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockRoom extends _i1.Mock implements _i3.Room {
+class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
       ) as String);
 
   @override
-  _i3.Membership get membership => (super.noSuchMethod(
+  _i4.Membership get membership => (super.noSuchMethod(
         Invocation.getter(#membership),
-        returnValue: _i3.Membership.ban,
-        returnValueForMissingStub: _i3.Membership.ban,
-      ) as _i3.Membership);
+        returnValue: _i4.Membership.ban,
+        returnValueForMissingStub: _i4.Membership.ban,
+      ) as _i4.Membership);
 
   @override
   int get notificationCount => (super.noSuchMethod(
@@ -1392,47 +1427,47 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i3.RoomSummary get summary => (super.noSuchMethod(
+  _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_7(
+        returnValue: _FakeRoomSummary_8(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_7(
+        returnValueForMissingStub: _FakeRoomSummary_8(
           this,
           Invocation.getter(#summary),
         ),
-      ) as _i3.RoomSummary);
+      ) as _i4.RoomSummary);
 
   @override
-  Map<String, Map<String, _i3.StrippedStateEvent>> get states =>
+  Map<String, Map<String, _i4.StrippedStateEvent>> get states =>
       (super.noSuchMethod(
         Invocation.getter(#states),
-        returnValue: <String, Map<String, _i3.StrippedStateEvent>>{},
+        returnValue: <String, Map<String, _i4.StrippedStateEvent>>{},
         returnValueForMissingStub: <String,
-            Map<String, _i3.StrippedStateEvent>>{},
-      ) as Map<String, Map<String, _i3.StrippedStateEvent>>);
+            Map<String, _i4.StrippedStateEvent>>{},
+      ) as Map<String, Map<String, _i4.StrippedStateEvent>>);
 
   @override
-  Map<String, _i3.BasicEvent> get ephemerals => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get ephemerals => (super.noSuchMethod(
         Invocation.getter(#ephemerals),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  Map<String, _i3.BasicEvent> get roomAccountData => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get roomAccountData => (super.noSuchMethod(
         Invocation.getter(#roomAccountData),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i11.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i12.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i11.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i11.Completer<dynamic>>[],
-      ) as List<_i11.Completer<dynamic>>);
+        returnValue: <_i12.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i12.Completer<dynamic>>[],
+      ) as List<_i12.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1451,51 +1486,51 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i9.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i10.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i9.CachedStreamController<String> get onSessionKeyReceived =>
+  _i10.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1511,11 +1546,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1524,11 +1559,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1542,24 +1577,24 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i3.User> get typingUsers => (super.noSuchMethod(
+  List<_i4.User> get typingUsers => (super.noSuchMethod(
         Invocation.getter(#typingUsers),
-        returnValue: <_i3.User>[],
-        returnValueForMissingStub: <_i3.User>[],
-      ) as List<_i3.User>);
+        returnValue: <_i4.User>[],
+        returnValueForMissingStub: <_i4.User>[],
+      ) as List<_i4.User>);
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get isAbandonedDMRoom => (super.noSuchMethod(
@@ -1571,11 +1606,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1584,22 +1619,22 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_9(
+        returnValue: _FakeDateTime_10(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_9(
+        returnValueForMissingStub: _FakeDateTime_10(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
       ) as DateTime);
 
   @override
-  Map<String, _i3.Tag> get tags => (super.noSuchMethod(
+  Map<String, _i4.Tag> get tags => (super.noSuchMethod(
         Invocation.getter(#tags),
-        returnValue: <String, _i3.Tag>{},
-        returnValueForMissingStub: <String, _i3.Tag>{},
-      ) as Map<String, _i3.Tag>);
+        returnValue: <String, _i4.Tag>{},
+        returnValueForMissingStub: <String, _i4.Tag>{},
+      ) as Map<String, _i4.Tag>);
 
   @override
   bool get markedUnread => (super.noSuchMethod(
@@ -1616,17 +1651,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.LatestReceiptState get receiptState => (super.noSuchMethod(
+  _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_10(
+        returnValue: _FakeLatestReceiptState_11(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_10(
+        returnValueForMissingStub: _FakeLatestReceiptState_11(
           this,
           Invocation.getter(#receiptState),
         ),
-      ) as _i3.LatestReceiptState);
+      ) as _i4.LatestReceiptState);
 
   @override
   bool get isUnread => (super.noSuchMethod(
@@ -1643,18 +1678,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i11.Future<_i3.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i12.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -1664,20 +1699,20 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  Map<String, _i3.MatrixFile> get sendingFilePlaceholders =>
+  Map<String, _i4.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
-        returnValue: <String, _i3.MatrixFile>{},
-        returnValueForMissingStub: <String, _i3.MatrixFile>{},
-      ) as Map<String, _i3.MatrixFile>);
+        returnValue: <String, _i4.MatrixFile>{},
+        returnValueForMissingStub: <String, _i4.MatrixFile>{},
+      ) as Map<String, _i4.MatrixFile>);
 
   @override
-  Map<String, _i3.MatrixImageFile> get sendingFileThumbnails =>
+  Map<String, _i4.MatrixImageFile> get sendingFileThumbnails =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFileThumbnails),
-        returnValue: <String, _i3.MatrixImageFile>{},
-        returnValueForMissingStub: <String, _i3.MatrixImageFile>{},
-      ) as Map<String, _i3.MatrixImageFile>);
+        returnValue: <String, _i4.MatrixImageFile>{},
+        returnValueForMissingStub: <String, _i4.MatrixImageFile>{},
+      ) as Map<String, _i4.MatrixImageFile>);
 
   @override
   bool get isFederated => (super.noSuchMethod(
@@ -1778,11 +1813,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.PushRuleState get pushRuleState => (super.noSuchMethod(
+  _i4.PushRuleState get pushRuleState => (super.noSuchMethod(
         Invocation.getter(#pushRuleState),
-        returnValue: _i3.PushRuleState.notify,
-        returnValueForMissingStub: _i3.PushRuleState.notify,
-      ) as _i3.PushRuleState);
+        returnValue: _i4.PushRuleState.notify,
+        returnValueForMissingStub: _i4.PushRuleState.notify,
+      ) as _i4.PushRuleState);
 
   @override
   bool get canChangeJoinRules => (super.noSuchMethod(
@@ -1792,11 +1827,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.GuestAccess get guestAccess => (super.noSuchMethod(
+  _i4.GuestAccess get guestAccess => (super.noSuchMethod(
         Invocation.getter(#guestAccess),
-        returnValue: _i3.GuestAccess.canJoin,
-        returnValueForMissingStub: _i3.GuestAccess.canJoin,
-      ) as _i3.GuestAccess);
+        returnValue: _i4.GuestAccess.canJoin,
+        returnValueForMissingStub: _i4.GuestAccess.canJoin,
+      ) as _i4.GuestAccess);
 
   @override
   bool get canChangeGuestAccess => (super.noSuchMethod(
@@ -1834,21 +1869,21 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i19.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i18.SpaceParent>[],
-        returnValueForMissingStub: <_i18.SpaceParent>[],
-      ) as List<_i18.SpaceParent>);
+        returnValue: <_i19.SpaceParent>[],
+        returnValueForMissingStub: <_i19.SpaceParent>[],
+      ) as List<_i19.SpaceParent>);
 
   @override
-  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i19.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i18.SpaceChild>[],
-        returnValueForMissingStub: <_i18.SpaceChild>[],
-      ) as List<_i18.SpaceChild>);
+        returnValue: <_i19.SpaceChild>[],
+        returnValueForMissingStub: <_i19.SpaceChild>[],
+      ) as List<_i19.SpaceChild>);
 
   @override
-  set membership(_i3.Membership? value) => super.noSuchMethod(
+  set membership(_i4.Membership? value) => super.noSuchMethod(
         Invocation.setter(
           #membership,
           value,
@@ -1884,7 +1919,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set summary(_i3.RoomSummary? value) => super.noSuchMethod(
+  set summary(_i4.RoomSummary? value) => super.noSuchMethod(
         Invocation.setter(
           #summary,
           value,
@@ -1893,7 +1928,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set states(Map<String, Map<String, _i3.StrippedStateEvent>>? value) =>
+  set states(Map<String, Map<String, _i4.StrippedStateEvent>>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #states,
@@ -1903,7 +1938,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set ephemerals(Map<String, _i3.BasicEvent>? value) => super.noSuchMethod(
+  set ephemerals(Map<String, _i4.BasicEvent>? value) => super.noSuchMethod(
         Invocation.setter(
           #ephemerals,
           value,
@@ -1912,7 +1947,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set roomAccountData(Map<String, _i3.BasicEvent>? value) => super.noSuchMethod(
+  set roomAccountData(Map<String, _i4.BasicEvent>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomAccountData,
           value,
@@ -1930,7 +1965,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set lastEvent(_i3.Event? value) => super.noSuchMethod(
+  set lastEvent(_i4.Event? value) => super.noSuchMethod(
         Invocation.setter(
           #lastEvent,
           value,
@@ -1939,7 +1974,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set receiptState(_i3.LatestReceiptState? value) => super.noSuchMethod(
+  set receiptState(_i4.LatestReceiptState? value) => super.noSuchMethod(
         Invocation.setter(
           #receiptState,
           value,
@@ -1958,17 +1993,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i11.Future<void> postLoad() => (super.noSuchMethod(
+  _i12.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i3.StrippedStateEvent? getState(
+  _i4.StrippedStateEvent? getState(
     String? typeKey, [
     String? stateKey = '',
   ]) =>
@@ -1981,10 +2016,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.StrippedStateEvent?);
+      ) as _i4.StrippedStateEvent?);
 
   @override
-  void setState(_i3.StrippedStateEvent? state) => super.noSuchMethod(
+  void setState(_i4.StrippedStateEvent? state) => super.noSuchMethod(
         Invocation.method(
           #setState,
           [state],
@@ -1993,33 +2028,33 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  _i11.Future<List<_i3.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i12.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
+        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
-      ) as _i11.Future<List<_i3.User>>);
+            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i12.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
-          [_i3.MatrixLocalizations? i18n =
-              const _i3.MatrixDefaultLocalizations()]) =>
+          [_i4.MatrixLocalizations? i18n =
+              const _i4.MatrixDefaultLocalizations()]) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2029,18 +2064,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as String);
 
   @override
-  _i11.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i12.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Event?> refreshLastEvent(
+  _i12.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2048,12 +2083,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
-  void setEphemeral(_i3.BasicEvent? ephemeral) => super.noSuchMethod(
+  void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
         Invocation.method(
           #setEphemeral,
           [ephemeral],
@@ -2062,12 +2097,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  _i11.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i12.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2075,22 +2110,22 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i12.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2098,17 +2133,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> addTag(
+  _i12.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2118,27 +2153,27 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i12.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i12.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2146,43 +2181,43 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i12.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i12.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i12.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2190,14 +2225,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2209,10 +2244,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as String?);
 
   @override
-  _i11.Future<String?> sendTextEvent(
+  _i12.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     bool? parseMarkdown = true,
     bool? parseCommands = true,
@@ -2241,12 +2276,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendReaction(
+  _i12.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2260,12 +2295,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendLocation(
+  _i12.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2279,18 +2314,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendFileEvent(
-    _i3.MatrixFile? file, {
+  _i12.Future<String?> sendFileEvent(
+    _i4.MatrixFile? file, {
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     int? shrinkImageMaxDimension,
-    _i3.MatrixImageFile? thumbnail,
+    _i4.MatrixImageFile? thumbnail,
     Map<String, dynamic>? extraContent,
     String? threadRootEventId,
     String? threadLastEventId,
@@ -2312,29 +2347,29 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<_i3.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i12.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i11.Future<_i3.EncryptionHealthState>.value(
-            _i3.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i11.Future<_i3.EncryptionHealthState>.value(
-            _i3.EncryptionHealthState.allVerified),
-      ) as _i11.Future<_i3.EncryptionHealthState>);
+        returnValue: _i12.Future<_i4.EncryptionHealthState>.value(
+            _i4.EncryptionHealthState.allVerified),
+        returnValueForMissingStub: _i12.Future<_i4.EncryptionHealthState>.value(
+            _i4.EncryptionHealthState.allVerified),
+      ) as _i12.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i11.Future<String?> sendEvent(
+  _i12.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     String? threadRootEventId,
     String? threadLastEventId,
@@ -2354,73 +2389,73 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i12.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> leave() => (super.noSuchMethod(
+  _i12.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> forget() => (super.noSuchMethod(
+  _i12.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> setPower(
+  _i12.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2432,7 +2467,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             power,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2443,7 +2478,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2453,10 +2488,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> invite(
+  _i12.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2466,16 +2501,16 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<int> requestHistory({
+  _i12.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
-    dynamic direction = _i3.Direction.b,
-    _i3.StateFilter? filter,
+    dynamic direction = _i4.Direction.b,
+    _i4.StateFilter? filter,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2488,32 +2523,32 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<int>.value(0),
-        returnValueForMissingStub: _i11.Future<int>.value(0),
-      ) as _i11.Future<int>);
+        returnValue: _i12.Future<int>.value(0),
+        returnValueForMissingStub: _i12.Future<int>.value(0),
+      ) as _i12.Future<int>);
 
   @override
-  _i11.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i12.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setReadMarker(
+  _i12.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2527,25 +2562,25 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #public: public,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
+  _i12.Future<_i20.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i11.Future<_i19.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i11.Future<_i19.TimelineChunk?>.value(),
-      ) as _i11.Future<_i19.TimelineChunk?>);
+        returnValue: _i12.Future<_i20.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i12.Future<_i20.TimelineChunk?>.value(),
+      ) as _i12.Future<_i20.TimelineChunk?>);
 
   @override
-  _i11.Future<void> postReceipt(
+  _i12.Future<void> postReceipt(
     String? eventId, {
-    _i3.ReceiptType? type = _i3.ReceiptType.mRead,
+    _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2553,12 +2588,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Timeline> getTimeline({
+  _i12.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2581,7 +2616,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i11.Future<_i3.Timeline>.value(_FakeTimeline_12(
+        returnValue: _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
           this,
           Invocation.method(
             #getTimeline,
@@ -2598,7 +2633,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Timeline>.value(_FakeTimeline_12(
+            _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
           this,
           Invocation.method(
             #getTimeline,
@@ -2614,30 +2649,30 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Timeline>);
+      ) as _i12.Future<_i4.Timeline>);
 
   @override
-  List<_i3.User> getParticipants(
-          [List<_i3.Membership>? membershipFilter = const [
-            _i3.Membership.join,
-            _i3.Membership.invite,
-            _i3.Membership.knock,
+  List<_i4.User> getParticipants(
+          [List<_i4.Membership>? membershipFilter = const [
+            _i4.Membership.join,
+            _i4.Membership.invite,
+            _i4.Membership.knock,
           ]]) =>
       (super.noSuchMethod(
         Invocation.method(
           #getParticipants,
           [membershipFilter],
         ),
-        returnValue: <_i3.User>[],
-        returnValueForMissingStub: <_i3.User>[],
-      ) as List<_i3.User>);
+        returnValue: <_i4.User>[],
+        returnValueForMissingStub: <_i4.User>[],
+      ) as List<_i4.User>);
 
   @override
-  _i11.Future<List<_i3.User>> requestParticipants([
-    List<_i3.Membership>? membershipFilter = const [
-      _i3.Membership.join,
-      _i3.Membership.invite,
-      _i3.Membership.knock,
+  _i12.Future<List<_i4.User>> requestParticipants([
+    List<_i4.Membership>? membershipFilter = const [
+      _i4.Membership.join,
+      _i4.Membership.invite,
+      _i4.Membership.knock,
     ],
     bool? suppressWarning = false,
     bool? cache,
@@ -2651,58 +2686,58 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             cache,
           ],
         ),
-        returnValue: _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
+        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
-      ) as _i11.Future<List<_i3.User>>);
+            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i12.Future<List<_i4.User>>);
 
   @override
-  _i3.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
+  _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
         Invocation.method(
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_13(
+        returnValue: _FakeUser_14(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_13(
+        returnValueForMissingStub: _FakeUser_14(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-      ) as _i3.User);
+      ) as _i4.User);
 
   @override
-  _i3.User unsafeGetUserFromMemoryOrFallback(String? mxID) =>
+  _i4.User unsafeGetUserFromMemoryOrFallback(String? mxID) =>
       (super.noSuchMethod(
         Invocation.method(
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_13(
+        returnValue: _FakeUser_14(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_13(
+        returnValueForMissingStub: _FakeUser_14(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-      ) as _i3.User);
+      ) as _i4.User);
 
   @override
-  _i11.Future<_i3.User?> requestUser(
+  _i12.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2718,19 +2753,19 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i11.Future<_i3.User?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.User?>.value(),
-      ) as _i11.Future<_i3.User?>);
+        returnValue: _i12.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.User?>.value(),
+      ) as _i12.Future<_i4.User?>);
 
   @override
-  _i11.Future<_i3.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i12.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2743,12 +2778,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i11.Future<String> setAvatar(_i3.MatrixFile? file) => (super.noSuchMethod(
+  _i12.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2756,14 +2791,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2786,14 +2821,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i11.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i12.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -2832,18 +2867,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i11.Future<void> setPushRuleState(_i3.PushRuleState? newState) =>
+  _i12.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEvent(
+  _i12.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -2857,12 +2892,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> setTyping(
+  _i12.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -2872,13 +2907,13 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setJoinRules(
-    _i3.JoinRules? joinRules, {
+  _i12.Future<void> setJoinRules(
+    _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
   }) =>
@@ -2891,59 +2926,59 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setGuestAccess(_i3.GuestAccess? guestAccess) =>
+  _i12.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setHistoryVisibility(
-          _i3.HistoryVisibility? historyVisibility) =>
+  _i12.Future<void> setHistoryVisibility(
+          _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i12.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i12.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i11.Future<List<_i3.DeviceKeys>>.value(<_i3.DeviceKeys>[]),
+            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.DeviceKeys>>.value(<_i3.DeviceKeys>[]),
-      ) as _i11.Future<List<_i3.DeviceKeys>>);
+            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i12.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i11.Future<void> requestSessionKey(
+  _i12.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -2955,12 +2990,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             senderKey,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setSpaceChild(
+  _i12.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -2976,51 +3011,51 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i12.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i11.Future<Uri>);
+      ) as _i12.Future<Uri>);
 
   @override
-  _i11.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i12.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<
+  _i12.Future<
       ({
-        List<_i3.Event> events,
+        List<_i4.Event> events,
         String? nextBatch,
         DateTime? searchedUntil
       })> searchEvents({
     String? searchTerm,
-    bool Function(_i3.Event)? searchFunc,
+    bool Function(_i4.Event)? searchFunc,
     String? nextBatch,
     int? limit = 1000,
     Set<String>? includeEventTypes = const {
@@ -3040,23 +3075,23 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i11.Future<
+        returnValue: _i12.Future<
                 ({
-                  List<_i3.Event> events,
+                  List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
-            (events: <_i3.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i11.Future<
+            (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
+        returnValueForMissingStub: _i12.Future<
                 ({
-                  List<_i3.Event> events,
+                  List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
-            (events: <_i3.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i11.Future<
+            (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
+      ) as _i12.Future<
           ({
-            List<_i3.Event> events,
+            List<_i4.Event> events,
             String? nextBatch,
             DateTime? searchedUntil
           })>);
@@ -3065,27 +3100,27 @@ class MockRoom extends _i1.Mock implements _i3.Room {
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockClient extends _i1.Mock implements _i3.Client {
+class MockClient extends _i1.Mock implements _i4.Client {
   @override
-  _i3.DatabaseApi get database => (super.noSuchMethod(
+  _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_15(
+        returnValue: _FakeDatabaseApi_16(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_15(
+        returnValueForMissingStub: _FakeDatabaseApi_16(
           this,
           Invocation.getter(#database),
         ),
-      ) as _i3.DatabaseApi);
+      ) as _i4.DatabaseApi);
 
   @override
-  Set<_i20.KeyVerificationMethod> get verificationMethods =>
+  Set<_i21.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i20.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
-      ) as Set<_i20.KeyVerificationMethod>);
+        returnValue: <_i21.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i21.KeyVerificationMethod>{},
+      ) as Set<_i21.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3130,44 +3165,44 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  _i3.ShareKeysWith get shareKeysWith => (super.noSuchMethod(
+  _i4.ShareKeysWith get shareKeysWith => (super.noSuchMethod(
         Invocation.getter(#shareKeysWith),
-        returnValue: _i3.ShareKeysWith.all,
-        returnValueForMissingStub: _i3.ShareKeysWith.all,
-      ) as _i3.ShareKeysWith);
+        returnValue: _i4.ShareKeysWith.all,
+        returnValueForMissingStub: _i4.ShareKeysWith.all,
+      ) as _i4.ShareKeysWith);
 
   @override
-  Map<String, _i3.CommandExecutionCallback> get commands => (super.noSuchMethod(
+  Map<String, _i4.CommandExecutionCallback> get commands => (super.noSuchMethod(
         Invocation.getter(#commands),
-        returnValue: <String, _i3.CommandExecutionCallback>{},
-        returnValueForMissingStub: <String, _i3.CommandExecutionCallback>{},
-      ) as Map<String, _i3.CommandExecutionCallback>);
+        returnValue: <String, _i4.CommandExecutionCallback>{},
+        returnValueForMissingStub: <String, _i4.CommandExecutionCallback>{},
+      ) as Map<String, _i4.CommandExecutionCallback>);
 
   @override
-  _i3.Filter get syncFilter => (super.noSuchMethod(
+  _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_16(
+        returnValue: _FakeFilter_17(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_16(
+        returnValueForMissingStub: _FakeFilter_17(
           this,
           Invocation.getter(#syncFilter),
         ),
-      ) as _i3.Filter);
+      ) as _i4.Filter);
 
   @override
-  _i3.NativeImplementations get nativeImplementations => (super.noSuchMethod(
+  _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_17(
+        returnValue: _FakeNativeImplementations_18(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_17(
+        returnValueForMissingStub: _FakeNativeImplementations_18(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-      ) as _i3.NativeImplementations);
+      ) as _i4.NativeImplementations);
 
   @override
   bool get convertLinebreaksInFormatting => (super.noSuchMethod(
@@ -3179,11 +3214,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_18(
+        returnValue: _FakeDuration_19(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_18(
+        returnValueForMissingStub: _FakeDuration_19(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3192,11 +3227,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_18(
+        returnValue: _FakeDuration_19(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_18(
+        returnValueForMissingStub: _FakeDuration_19(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3205,36 +3240,36 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
       ) as String);
 
   @override
-  _i3.LoginState get loginState => (super.noSuchMethod(
+  _i4.LoginState get loginState => (super.noSuchMethod(
         Invocation.getter(#loginState),
-        returnValue: _i3.LoginState.loggedIn,
-        returnValueForMissingStub: _i3.LoginState.loggedIn,
-      ) as _i3.LoginState);
+        returnValue: _i4.LoginState.loggedIn,
+        returnValueForMissingStub: _i4.LoginState.loggedIn,
+      ) as _i4.LoginState);
 
   @override
-  List<_i3.Room> get rooms => (super.noSuchMethod(
+  List<_i4.Room> get rooms => (super.noSuchMethod(
         Invocation.getter(#rooms),
-        returnValue: <_i3.Room>[],
-        returnValueForMissingStub: <_i3.Room>[],
-      ) as List<_i3.Room>);
+        returnValue: <_i4.Room>[],
+        returnValueForMissingStub: <_i4.Room>[],
+      ) as List<_i4.Room>);
 
   @override
-  List<_i3.ArchivedRoom> get archivedRooms => (super.noSuchMethod(
+  List<_i4.ArchivedRoom> get archivedRooms => (super.noSuchMethod(
         Invocation.getter(#archivedRooms),
-        returnValue: <_i3.ArchivedRoom>[],
-        returnValueForMissingStub: <_i3.ArchivedRoom>[],
-      ) as List<_i3.ArchivedRoom>);
+        returnValue: <_i4.ArchivedRoom>[],
+        returnValueForMissingStub: <_i4.ArchivedRoom>[],
+      ) as List<_i4.ArchivedRoom>);
 
   @override
   bool get enableDehydratedDevices => (super.noSuchMethod(
@@ -3246,11 +3281,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3280,11 +3315,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3293,11 +3328,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3311,31 +3346,31 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  Map<String, _i3.BasicEvent> get accountData => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get accountData => (super.noSuchMethod(
         Invocation.getter(#accountData),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  _i3.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
+  _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_19(
+        returnValue: _FakePushruleEvaluator_20(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_19(
+        returnValueForMissingStub: _FakePushruleEvaluator_20(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-      ) as _i3.PushruleEvaluator);
+      ) as _i4.PushruleEvaluator);
 
   @override
-  Map<String, _i3.CachedPresence> get presences => (super.noSuchMethod(
+  Map<String, _i4.CachedPresence> get presences => (super.noSuchMethod(
         Invocation.getter(#presences),
-        returnValue: <String, _i3.CachedPresence>{},
-        returnValueForMissingStub: <String, _i3.CachedPresence>{},
-      ) as Map<String, _i3.CachedPresence>);
+        returnValue: <String, _i4.CachedPresence>{},
+        returnValueForMissingStub: <String, _i4.CachedPresence>{},
+      ) as Map<String, _i4.CachedPresence>);
 
   @override
   Map<String, List<String>> get directChats => (super.noSuchMethod(
@@ -3345,333 +3380,333 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i11.Future<_i3.Profile> get ownProfile => (super.noSuchMethod(
+  _i12.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i9.CachedStreamController<String> get onUserProfileUpdate =>
+  _i10.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i11.Future<List<_i3.Room>> get archive => (super.noSuchMethod(
+  _i12.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
+        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
-      ) as _i11.Future<List<_i3.Room>>);
+            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i12.Future<List<_i4.Room>>);
 
   @override
-  _i9.CachedStreamController<_i3.EventUpdate> get onEvent =>
+  _i10.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.EventUpdate>(
+        returnValue: _FakeCachedStreamController_9<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.EventUpdate>(
+            _FakeCachedStreamController_9<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.EventUpdate>);
+      ) as _i10.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onTimelineEvent =>
+  _i10.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onHistoryEvent =>
+  _i10.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onNotification =>
+  _i10.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.ToDeviceEvent> get onToDeviceEvent =>
+  _i10.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.ToDeviceEvent>(
+            _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.ToDeviceEvent>);
+      ) as _i10.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i9.CachedStreamController<List<_i3.BasicEventWithSender>> get onCallEvents =>
-      (super.noSuchMethod(
-        Invocation.getter(#onCallEvents),
-        returnValue:
-            _FakeCachedStreamController_8<List<_i3.BasicEventWithSender>>(
-          this,
-          Invocation.getter(#onCallEvents),
-        ),
-        returnValueForMissingStub:
-            _FakeCachedStreamController_8<List<_i3.BasicEventWithSender>>(
-          this,
-          Invocation.getter(#onCallEvents),
-        ),
-      ) as _i9.CachedStreamController<List<_i3.BasicEventWithSender>>);
+  _i10.CachedStreamController<List<_i4.BasicEventWithSender>>
+      get onCallEvents => (super.noSuchMethod(
+            Invocation.getter(#onCallEvents),
+            returnValue:
+                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+              this,
+              Invocation.getter(#onCallEvents),
+            ),
+            returnValueForMissingStub:
+                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+              this,
+              Invocation.getter(#onCallEvents),
+            ),
+          ) as _i10.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i9.CachedStreamController<_i3.LoginState> get onLoginStateChanged =>
+  _i10.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_8<_i3.LoginState>(
+        returnValue: _FakeCachedStreamController_9<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.LoginState>(
+            _FakeCachedStreamController_9<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i9.CachedStreamController<_i3.LoginState>);
+      ) as _i10.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i9.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i10.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_8<bool>(
+        returnValue: _FakeCachedStreamController_9<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i9.CachedStreamController<bool>);
+      ) as _i10.CachedStreamController<bool>);
 
   @override
-  _i9.CachedStreamController<_i3.SdkError> get onEncryptionError =>
+  _i10.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_8<_i3.SdkError>(
+        returnValue: _FakeCachedStreamController_9<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i9.CachedStreamController<_i3.SdkError>);
+      ) as _i10.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i9.CachedStreamController<_i3.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i10.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_8<_i3.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_9<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.SyncUpdate>(
+            _FakeCachedStreamController_9<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i9.CachedStreamController<_i3.SyncUpdate>);
+      ) as _i10.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.SyncStatusUpdate> get onSyncStatus =>
+  _i10.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_8<_i3.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.SyncStatusUpdate>(
+            _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i9.CachedStreamController<_i3.SyncStatusUpdate>);
+      ) as _i10.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.Presence> get onPresence =>
+  _i10.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_8<_i3.Presence>(
+        returnValue: _FakeCachedStreamController_9<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i9.CachedStreamController<_i3.Presence>);
+      ) as _i10.CachedStreamController<_i4.Presence>);
 
   @override
-  _i9.CachedStreamController<_i3.CachedPresence> get onPresenceChanged =>
+  _i10.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_8<_i3.CachedPresence>(
+        returnValue: _FakeCachedStreamController_9<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.CachedPresence>(
+            _FakeCachedStreamController_9<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i9.CachedStreamController<_i3.CachedPresence>);
+      ) as _i10.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i9.CachedStreamController<_i3.BasicEvent> get onAccountData =>
+  _i10.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_8<_i3.BasicEvent>(
+        returnValue: _FakeCachedStreamController_9<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.BasicEvent>(
+            _FakeCachedStreamController_9<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i9.CachedStreamController<_i3.BasicEvent>);
+      ) as _i10.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i9.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
+  _i10.CachedStreamController<_i21.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
+            _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i9.CachedStreamController<_i20.RoomKeyRequest>);
+      ) as _i10.CachedStreamController<_i21.RoomKeyRequest>);
 
   @override
-  _i9.CachedStreamController<_i20.KeyVerification>
+  _i10.CachedStreamController<_i21.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_8<_i20.KeyVerification>(
+            returnValue: _FakeCachedStreamController_9<_i21.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_8<_i20.KeyVerification>(
+                _FakeCachedStreamController_9<_i21.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i9.CachedStreamController<_i20.KeyVerification>);
+          ) as _i10.CachedStreamController<_i21.KeyVerification>);
 
   @override
-  _i9.CachedStreamController<_i3.UiaRequest<dynamic>> get onUiaRequest =>
+  _i10.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_8<_i3.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i9.CachedStreamController<_i3.UiaRequest<dynamic>>);
+      ) as _i10.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onGroupMember =>
+  _i10.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<String> get onCancelSendEvent =>
+  _i10.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i9.CachedStreamController<({String roomId, _i3.StrippedStateEvent state})>
+  _i10.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_8<
-                ({String roomId, _i3.StrippedStateEvent state})>(
+            returnValue: _FakeCachedStreamController_9<
+                ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_8<
-                ({String roomId, _i3.StrippedStateEvent state})>(
+            returnValueForMissingStub: _FakeCachedStreamController_9<
+                ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i9.CachedStreamController<
-              ({String roomId, _i3.StrippedStateEvent state})>);
+          ) as _i10.CachedStreamController<
+              ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
   int get syncErrorTimeoutSec => (super.noSuchMethod(
@@ -3690,11 +3725,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_9(
+        returnValue: _FakeDateTime_10(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_9(
+        returnValueForMissingStub: _FakeDateTime_10(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3715,33 +3750,33 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  _i3.RoomSorter get sortRoomsBy => (super.noSuchMethod(
+  _i4.RoomSorter get sortRoomsBy => (super.noSuchMethod(
         Invocation.getter(#sortRoomsBy),
         returnValue: (
-          _i3.Room a,
-          _i3.Room b,
+          _i4.Room a,
+          _i4.Room b,
         ) =>
             0,
         returnValueForMissingStub: (
-          _i3.Room a,
-          _i3.Room b,
+          _i4.Room a,
+          _i4.Room b,
         ) =>
             0,
-      ) as _i3.RoomSorter);
+      ) as _i4.RoomSorter);
 
   @override
-  Map<String, _i3.DeviceKeysList> get userDeviceKeys => (super.noSuchMethod(
+  Map<String, _i4.DeviceKeysList> get userDeviceKeys => (super.noSuchMethod(
         Invocation.getter(#userDeviceKeys),
-        returnValue: <String, _i3.DeviceKeysList>{},
-        returnValueForMissingStub: <String, _i3.DeviceKeysList>{},
-      ) as Map<String, _i3.DeviceKeysList>);
+        returnValue: <String, _i4.DeviceKeysList>{},
+        returnValueForMissingStub: <String, _i4.DeviceKeysList>{},
+      ) as Map<String, _i4.DeviceKeysList>);
 
   @override
-  List<_i3.DeviceKeys> get unverifiedDevices => (super.noSuchMethod(
+  List<_i4.DeviceKeys> get unverifiedDevices => (super.noSuchMethod(
         Invocation.getter(#unverifiedDevices),
-        returnValue: <_i3.DeviceKeys>[],
-        returnValueForMissingStub: <_i3.DeviceKeys>[],
-      ) as List<_i3.DeviceKeys>);
+        returnValue: <_i4.DeviceKeys>[],
+        returnValueForMissingStub: <_i4.DeviceKeys>[],
+      ) as List<_i4.DeviceKeys>);
 
   @override
   bool get allPushNotificationsMuted => (super.noSuchMethod(
@@ -3758,7 +3793,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as List<String>);
 
   @override
-  set database(_i3.DatabaseApi? db) => super.noSuchMethod(
+  set database(_i4.DatabaseApi? db) => super.noSuchMethod(
         Invocation.setter(
           #database,
           db,
@@ -3767,7 +3802,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i21.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3813,7 +3848,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set shareKeysWith(_i3.ShareKeysWith? value) => super.noSuchMethod(
+  set shareKeysWith(_i4.ShareKeysWith? value) => super.noSuchMethod(
         Invocation.setter(
           #shareKeysWith,
           value,
@@ -3822,7 +3857,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set onSoftLogout(_i11.Future<void> Function(_i3.Client)? value) =>
+  set onSoftLogout(_i12.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3833,8 +3868,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
 
   @override
   set customImageResizer(
-          _i11.Future<_i3.MatrixImageFileResizedResponse?> Function(
-                  _i3.MatrixImageFileResizeArguments)?
+          _i12.Future<_i4.MatrixImageFileResizedResponse?> Function(
+                  _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
         Invocation.setter(
@@ -3872,7 +3907,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set rooms(List<_i3.Room>? newList) => super.noSuchMethod(
+  set rooms(List<_i4.Room>? newList) => super.noSuchMethod(
         Invocation.setter(
           #rooms,
           newList,
@@ -3881,7 +3916,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set presences(Map<String, _i3.CachedPresence>? value) => super.noSuchMethod(
+  set presences(Map<String, _i4.CachedPresence>? value) => super.noSuchMethod(
         Invocation.setter(
           #presences,
           value,
@@ -3908,7 +3943,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set syncPresence(_i3.PresenceType? value) => super.noSuchMethod(
+  set syncPresence(_i4.PresenceType? value) => super.noSuchMethod(
         Invocation.setter(
           #syncPresence,
           value,
@@ -3944,7 +3979,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -3953,7 +3988,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set roomsLoading(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -3962,7 +3997,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set firstSyncReceived(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -3989,20 +4024,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i10.Client get httpClient => (super.noSuchMethod(
+  _i11.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_21(
+        returnValue: _FakeClient_22(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_21(
+        returnValueForMissingStub: _FakeClient_22(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i10.Client);
+      ) as _i11.Client);
 
   @override
-  set httpClient(_i10.Client? value) => super.noSuchMethod(
+  set httpClient(_i11.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4029,7 +4064,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<void> refreshAccessToken(
+  _i12.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4037,9 +4072,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4057,14 +4092,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4074,22 +4109,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as String);
 
   @override
-  _i3.Room? getRoomByAlias(String? alias) => (super.noSuchMethod(
+  _i4.Room? getRoomByAlias(String? alias) => (super.noSuchMethod(
         Invocation.method(
           #getRoomByAlias,
           [alias],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.Room?);
+      ) as _i4.Room?);
 
   @override
-  _i3.Room? getRoomById(String? id) => (super.noSuchMethod(
+  _i4.Room? getRoomById(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getRoomById,
           [id],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.Room?);
+      ) as _i4.Room?);
 
   @override
   String? getDirectChatFromUserId(String? userId) => (super.noSuchMethod(
@@ -4101,38 +4136,38 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as String?);
 
   @override
-  _i11.Future<_i3.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i12.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i11.Future<_i3.DiscoveryInformation>);
+      ) as _i12.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i11.Future<
+  _i12.Future<
       (
-        _i3.DiscoveryInformation?,
-        _i3.GetVersionsResponse,
-        List<_i3.LoginFlow>,
-        _i3.GetAuthMetadataResponse?
+        _i4.DiscoveryInformation?,
+        _i4.GetVersionsResponse,
+        List<_i4.LoginFlow>,
+        _i4.GetAuthMetadataResponse?
       )> checkHomeserver(
     Uri? homeserverUrl, {
     bool? checkWellKnown = true,
@@ -4149,15 +4184,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i11.Future<
+        returnValue: _i12.Future<
             (
-              _i3.DiscoveryInformation?,
-              _i3.GetVersionsResponse,
-              List<_i3.LoginFlow>,
-              _i3.GetAuthMetadataResponse?
+              _i4.DiscoveryInformation?,
+              _i4.GetVersionsResponse,
+              List<_i4.LoginFlow>,
+              _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_23(
+          _FakeGetVersionsResponse_24(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4169,18 +4204,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
           ),
-          <_i3.LoginFlow>[],
+          <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i11.Future<
+        returnValueForMissingStub: _i12.Future<
             (
-              _i3.DiscoveryInformation?,
-              _i3.GetVersionsResponse,
-              List<_i3.LoginFlow>,
-              _i3.GetAuthMetadataResponse?
+              _i4.DiscoveryInformation?,
+              _i4.GetVersionsResponse,
+              List<_i4.LoginFlow>,
+              _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_23(
+          _FakeGetVersionsResponse_24(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4192,19 +4227,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
           ),
-          <_i3.LoginFlow>[],
+          <_i4.LoginFlow>[],
           null
         )),
-      ) as _i11.Future<
+      ) as _i12.Future<
           (
-            _i3.DiscoveryInformation?,
-            _i3.GetVersionsResponse,
-            List<_i3.LoginFlow>,
-            _i3.GetAuthMetadataResponse?
+            _i4.DiscoveryInformation?,
+            _i4.GetVersionsResponse,
+            List<_i4.LoginFlow>,
+            _i4.GetAuthMetadataResponse?
           )>);
 
   @override
-  _i11.Future<_i3.DiscoveryInformation> getWellknown({
+  _i12.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4217,8 +4252,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getWellknown,
@@ -4229,8 +4264,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getWellknown,
@@ -4241,19 +4276,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.DiscoveryInformation>);
+      ) as _i12.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i11.Future<_i3.RegisterResponse> register({
+  _i12.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
     String? initialDeviceDisplayName,
     bool? inhibitLogin,
     bool? refreshToken,
-    _i3.AuthenticationData? auth,
-    _i3.AccountKind? kind,
-    void Function(_i3.InitState)? onInitStateChanged,
+    _i4.AuthenticationData? auth,
+    _i4.AccountKind? kind,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4272,7 +4307,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<_i3.RegisterResponse>.value(_FakeRegisterResponse_24(
+            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
           this,
           Invocation.method(
             #register,
@@ -4291,7 +4326,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RegisterResponse>.value(_FakeRegisterResponse_24(
+            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
           this,
           Invocation.method(
             #register,
@@ -4309,12 +4344,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RegisterResponse>);
+      ) as _i12.Future<_i4.RegisterResponse>);
 
   @override
-  _i11.Future<_i3.LoginResponse> login(
+  _i12.Future<_i4.LoginResponse> login(
     String? type, {
-    _i3.AuthenticationIdentifier? identifier,
+    _i4.AuthenticationIdentifier? identifier,
     String? password,
     String? token,
     String? deviceId,
@@ -4323,7 +4358,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? user,
     String? medium,
     String? address,
-    void Function(_i3.InitState)? onInitStateChanged,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4342,7 +4377,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i11.Future<_i3.LoginResponse>.value(_FakeLoginResponse_25(
+        returnValue: _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
           this,
           Invocation.method(
             #login,
@@ -4362,7 +4397,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.LoginResponse>.value(_FakeLoginResponse_25(
+            _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
           this,
           Invocation.method(
             #login,
@@ -4381,10 +4416,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.LoginResponse>);
+      ) as _i12.Future<_i4.LoginResponse>);
 
   @override
-  _i11.Future<_i3.GetAuthMetadataResponse> getAuthMetadata({
+  _i12.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4397,8 +4432,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_26(
+        returnValue: _i12.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_27(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4410,8 +4445,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_26(
+            _i12.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_27(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4422,80 +4457,80 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetAuthMetadataResponse>);
+      ) as _i12.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i11.Future<void> logout() => (super.noSuchMethod(
+  _i12.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> logoutAll() => (super.noSuchMethod(
+  _i12.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<T> uiaRequestBackground<T>(
-          _i11.Future<T> Function(_i3.AuthenticationData?)? request) =>
+  _i12.Future<T> uiaRequestBackground<T>(
+          _i12.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i11.Future<T>.value(v),
+              (T v) => _i12.Future<T>.value(v),
             ) ??
-            _FakeFuture_27<T>(
+            _FakeFuture_28<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i11.Future<T>.value(v),
+              (T v) => _i12.Future<T>.value(v),
             ) ??
-            _FakeFuture_27<T>(
+            _FakeFuture_28<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i11.Future<T>);
+      ) as _i12.Future<T>);
 
   @override
-  _i11.Future<String> startDirectChat(
+  _i12.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
-    List<_i3.StateEvent>? initialState,
+    List<_i4.StateEvent>? initialState,
     bool? waitForSync = true,
     Map<String, dynamic>? powerLevelContentOverride,
-    _i3.CreateRoomPreset? preset = _i3.CreateRoomPreset.trustedPrivateChat,
+    _i4.CreateRoomPreset? preset = _i4.CreateRoomPreset.trustedPrivateChat,
     bool? skipExistingChat = false,
   }) =>
       (super.noSuchMethod(
@@ -4511,7 +4546,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4527,7 +4562,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4542,17 +4577,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<String> createGroupChat({
+  _i12.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
-    _i3.CreateRoomPreset? preset = _i3.CreateRoomPreset.privateChat,
-    List<_i3.StateEvent>? initialState,
-    _i3.Visibility? visibility,
-    _i3.HistoryVisibility? historyVisibility,
+    _i4.CreateRoomPreset? preset = _i4.CreateRoomPreset.privateChat,
+    List<_i4.StateEvent>? initialState,
+    _i4.Visibility? visibility,
+    _i4.HistoryVisibility? historyVisibility,
     bool? waitForSync = true,
     bool? groupCall = false,
     bool? federated = true,
@@ -4576,7 +4611,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4597,7 +4632,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4617,10 +4652,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> waitForRoomInSync(
+  _i12.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4636,7 +4671,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4649,7 +4684,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4661,27 +4696,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i12.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<String> createSpace({
+  _i12.Future<String> createSpace({
     String? name,
     String? topic,
-    _i3.Visibility? visibility = _i3.Visibility.public,
+    _i4.Visibility? visibility = _i4.Visibility.public,
     String? spaceAliasName,
     List<String>? invite,
-    List<_i3.Invite3pid>? invite3pid,
+    List<_i4.Invite3pid>? invite3pid,
     String? roomVersion,
     bool? waitForSync = false,
   }) =>
@@ -4700,7 +4735,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4718,7 +4753,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4735,10 +4770,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.Profile> fetchOwnProfileFromServer(
+  _i12.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4746,7 +4781,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4755,7 +4790,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4763,10 +4798,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i11.Future<_i3.Profile> fetchOwnProfile({
+  _i12.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4779,7 +4814,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4791,7 +4826,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4802,10 +4837,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i11.Future<_i3.CachedProfileInformation> getUserProfile(
+  _i12.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4819,8 +4854,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i11.Future<_i3.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_28(
+        returnValue: _i12.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_29(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4832,8 +4867,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_28(
+            _i12.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_29(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4844,10 +4879,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.CachedProfileInformation>);
+      ) as _i12.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i11.Future<_i3.Profile> getProfileFromUserId(
+  _i12.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4865,7 +4900,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4879,7 +4914,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4892,17 +4927,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i3.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
+  _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getArchiveRoomFromCache,
           [roomId],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.ArchivedRoom?);
+      ) as _i4.ArchivedRoom?);
 
   @override
   void clearArchivesFromCache() => super.noSuchMethod(
@@ -4914,31 +4949,31 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<List<_i3.Room>> loadArchive() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
+        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
-      ) as _i11.Future<List<_i3.Room>>);
+            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i12.Future<List<_i4.Room>>);
 
   @override
-  _i11.Future<List<_i3.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i12.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i11.Future<List<_i3.ArchivedRoom>>.value(<_i3.ArchivedRoom>[]),
+            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ArchivedRoom>>.value(<_i3.ArchivedRoom>[]),
-      ) as _i11.Future<List<_i3.ArchivedRoom>>);
+            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i12.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i11.Future<_i3.GetVersionsResponse> getVersions({
+  _i12.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4951,8 +4986,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_23(
+        returnValue: _i12.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_24(
           this,
           Invocation.method(
             #getVersions,
@@ -4963,8 +4998,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_23(
+        returnValueForMissingStub: _i12.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_24(
           this,
           Invocation.method(
             #getVersions,
@@ -4975,20 +5010,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetVersionsResponse>);
+      ) as _i12.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i11.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i12.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<_i3.MediaConfig> getConfig({
+  _i12.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5001,7 +5036,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfig,
@@ -5013,7 +5048,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfig,
@@ -5024,10 +5059,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.MediaConfig>);
+      ) as _i12.Future<_i4.MediaConfig>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContent(
+  _i12.Future<_i13.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5047,7 +5082,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContent,
@@ -5063,7 +5098,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContent,
@@ -5078,10 +5113,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentOverrideName(
+  _i12.Future<_i13.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5103,7 +5138,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5120,7 +5155,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5136,15 +5171,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentThumbnail(
+  _i12.Future<_i13.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
     int? height, {
-    _i3.Method? method,
+    _i4.Method? method,
     bool? allowRemote,
     int? timeoutMs,
     bool? allowRedirect,
@@ -5167,7 +5202,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5187,7 +5222,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5206,10 +5241,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i3.PreviewForUrl> getUrlPreview(
+  _i12.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5219,7 +5254,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5228,7 +5263,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5236,11 +5271,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i11.Future<_i3.PreviewForUrl>);
+      ) as _i12.Future<_i4.PreviewForUrl>);
 
   @override
-  _i11.Future<Uri> uploadContent(
-    _i21.Uint8List? file, {
+  _i12.Future<Uri> uploadContent(
+    _i22.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5253,7 +5288,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #uploadContent,
@@ -5264,7 +5299,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #uploadContent,
@@ -5275,10 +5310,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<Uri>);
+      ) as _i12.Future<Uri>);
 
   @override
-  _i11.Future<void> setTyping(
+  _i12.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5294,43 +5329,43 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> exportDump() => (super.noSuchMethod(
+  _i12.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i12.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> setAvatar(_i3.MatrixFile? file) => (super.noSuchMethod(
+  _i12.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Event?> getEventByPushNotification(
-    _i3.PushNotification? notification, {
+  _i12.Future<_i4.Event?> getEventByPushNotification(
+    _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
     bool? returnNullIfSeen = true,
@@ -5345,12 +5380,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
-  _i11.Future<void> init({
+  _i12.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5363,7 +5398,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     bool? waitForFirstSync = true,
     bool? waitUntilLoadCompletedLoaded = true,
     void Function()? onMigration,
-    void Function(_i3.InitState)? onInitStateChanged,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5385,9 +5420,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5399,42 +5434,42 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<void> clear() => (super.noSuchMethod(
+  _i12.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i12.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ensureNotSoftLoggedOut(
+  _i12.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> handleSync(
-    _i3.SyncUpdate? sync, {
-    _i3.Direction? direction,
+  _i12.Future<void> handleSync(
+    _i4.SyncUpdate? sync, {
+    _i4.Direction? direction,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5442,44 +5477,44 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i3.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
+  _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeysByCurve25519Key,
           [senderKey],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.DeviceKeys?);
+      ) as _i4.DeviceKeys?);
 
   @override
-  _i11.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i12.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i12.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDevice(
+  _i12.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5493,12 +5528,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             messages,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDevicesOfUserIds(
+  _i12.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5514,13 +5549,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDeviceEncrypted(
-    List<_i3.DeviceKeys>? deviceKeys,
+  _i12.Future<void> sendToDeviceEncrypted(
+    List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
     String? messageId,
@@ -5539,13 +5574,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDeviceEncryptedChunked(
-    List<_i3.DeviceKeys>? deviceKeys,
+  _i12.Future<void> sendToDeviceEncryptedChunked(
+    List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
   ) =>
@@ -5558,28 +5593,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
             message,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i12.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> joinRoom(
+  _i12.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
     String? reason,
-    _i3.ThirdPartySigned? thirdPartySigned,
+    _i4.ThirdPartySigned? thirdPartySigned,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5592,7 +5627,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5606,7 +5641,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5619,13 +5654,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> changePassword(
+  _i12.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
     bool? logoutDevices,
   }) =>
       (super.noSuchMethod(
@@ -5638,22 +5673,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> clearCache() => (super.noSuchMethod(
+  _i12.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ignoreUser(
+  _i12.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5663,22 +5698,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i12.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.CachedPresence> fetchCurrentPresence(
+  _i12.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5689,7 +5724,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i11.Future<_i3.CachedPresence>.value(_FakeCachedPresence_32(
+            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5698,7 +5733,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.CachedPresence>.value(_FakeCachedPresence_32(
+            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5706,32 +5741,32 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i11.Future<_i3.CachedPresence>);
+      ) as _i12.Future<_i4.CachedPresence>);
 
   @override
-  _i11.Future<void> abortSync() => (super.noSuchMethod(
+  _i12.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i12.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEventWithMetadata(
+  _i12.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5751,14 +5786,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i10.BaseResponse? response,
-    _i21.Uint8List? body,
+    _i11.BaseResponse? response,
+    _i22.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5790,8 +5825,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as Never);
 
   @override
-  _i11.Future<Map<String, Object?>> request(
-    _i3.RequestType? type,
+  _i12.Future<Map<String, Object?>> request(
+    _i4.RequestType? type,
     String? action, {
     dynamic data = '',
     String? contentType = 'application/json',
@@ -5811,14 +5846,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> postPusher(
-    _i3.Pusher? pusher, {
+  _i12.Future<void> postPusher(
+    _i4.Pusher? pusher, {
     bool? append,
   }) =>
       (super.noSuchMethod(
@@ -5827,57 +5862,57 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deletePusher(_i3.PusherId? pusher) => (super.noSuchMethod(
+  _i12.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i12.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i12.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i11.Future<_i3.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_33(
+        returnValue: _i12.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_34(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_33(
+        returnValueForMissingStub: _i12.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_34(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.TurnServerCredentials>);
+      ) as _i12.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5891,8 +5926,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5904,8 +5939,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5916,14 +5951,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
-    _i3.KeyBackupData? data,
+    _i4.KeyBackupData? data,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5935,8 +5970,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             data,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5949,8 +5984,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5962,10 +5997,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.KeyBackupData> getRoomKeysBySessionId(
+  _i12.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5979,7 +6014,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -5991,7 +6026,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6002,17 +6037,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.KeyBackupData>);
+      ) as _i12.Future<_i4.KeyBackupData>);
 
   @override
-  _i11.Future<_i3.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i12.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i11.Future<_i3.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_36(
+        returnValue: _i12.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_37(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6020,18 +6055,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_36(
+            _i12.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_37(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.GetWellknownSupportResponse>);
+      ) as _i12.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i11.Future<int> pingAppservice(
+  _i12.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6041,21 +6076,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i11.Future<int>.value(0),
-        returnValueForMissingStub: _i11.Future<int>.value(0),
-      ) as _i11.Future<int>);
+        returnValue: _i12.Future<int>.value(0),
+        returnValueForMissingStub: _i12.Future<int>.value(0),
+      ) as _i12.Future<int>);
 
   @override
-  _i11.Future<_i3.GenerateLoginTokenResponse> generateLoginToken(
-          {_i3.AuthenticationData? auth}) =>
+  _i12.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+          {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
           #generateLoginToken,
           [],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<_i3.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_37(
+        returnValue: _i12.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_38(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6064,8 +6099,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_37(
+            _i12.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_38(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6073,15 +6108,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i11.Future<_i3.GenerateLoginTokenResponse>);
+      ) as _i12.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i11.Future<_i3.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i12.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6089,17 +6124,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.MediaConfig>);
+      ) as _i12.Future<_i4.MediaConfig>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentAuthed(
+  _i12.Future<_i13.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6113,7 +6148,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6125,7 +6160,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6136,10 +6171,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentOverrideNameAuthed(
+  _i12.Future<_i13.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6155,7 +6190,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6168,7 +6203,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6180,10 +6215,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i3.PreviewForUrl> getUrlPreviewAuthed(
+  _i12.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6193,7 +6228,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6202,7 +6237,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6210,15 +6245,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i11.Future<_i3.PreviewForUrl>);
+      ) as _i12.Future<_i4.PreviewForUrl>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentThumbnailAuthed(
+  _i12.Future<_i13.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
     int? height, {
-    _i3.Method? method,
+    _i4.Method? method,
     int? timeoutMs,
     bool? animated,
   }) =>
@@ -6237,7 +6272,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6255,7 +6290,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6272,21 +6307,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<bool> registrationTokenValidity(String? token) =>
+  _i12.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<_i3.GetRoomSummaryResponse$3> getRoomSummary(
+  _i12.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6296,8 +6331,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i11.Future<_i3.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_38(
+        returnValue: _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_39(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6306,8 +6341,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_38(
+            _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_39(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6315,10 +6350,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#via: via},
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomSummaryResponse$3>);
+      ) as _i12.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i11.Future<_i3.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i12.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6336,8 +6371,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #from: from,
           },
         ),
-        returnValue: _i11.Future<_i3.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_39(
+        returnValue: _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_40(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6351,8 +6386,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_39(
+            _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_40(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6365,16 +6400,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetSpaceHierarchyResponse>);
+      ) as _i12.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsResponse> getRelatingEvents(
+  _i12.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
       (super.noSuchMethod(
@@ -6392,8 +6427,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i11.Future<_i3.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_40(
+        returnValue: _i12.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_41(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6411,8 +6446,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_40(
+            _i12.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_41(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6429,10 +6464,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetRelatingEventsResponse>);
+      ) as _i12.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>
+  _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6440,7 +6475,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
           (super.noSuchMethod(
@@ -6460,8 +6495,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
             returnValue:
-                _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_41(
+                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6480,8 +6515,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_41(
+                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6499,10 +6534,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-          ) as _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i12.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6511,7 +6546,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
           (super.noSuchMethod(
@@ -6531,9 +6566,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i11.Future<
-                    _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+            returnValue: _i12.Future<
+                    _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6552,9 +6587,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i11.Future<
-                    _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+            returnValueForMissingStub: _i12.Future<
+                    _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6573,13 +6608,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-          ) as _i11
-              .Future<_i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
+          ) as _i12
+              .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i11.Future<_i3.GetThreadRootsResponse> getThreadRoots(
+  _i12.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
-    _i3.Include? include,
+    _i4.Include? include,
     int? limit,
     String? from,
   }) =>
@@ -6593,8 +6628,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #from: from,
           },
         ),
-        returnValue: _i11.Future<_i3.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_43(
+        returnValue: _i12.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_44(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6607,8 +6642,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_43(
+            _i12.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_44(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6620,13 +6655,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetThreadRootsResponse>);
+      ) as _i12.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i11.Future<_i3.GetEventByTimestampResponse> getEventByTimestamp(
+  _i12.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6637,8 +6672,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             dir,
           ],
         ),
-        returnValue: _i11.Future<_i3.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_44(
+        returnValue: _i12.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_45(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6650,8 +6685,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_44(
+            _i12.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_45(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6662,36 +6697,36 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.GetEventByTimestampResponse>);
+      ) as _i12.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i12.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyIdentifier>?>.value(),
-      ) as _i11.Future<List<_i3.ThirdPartyIdentifier>?>);
+            _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i12.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i11.Future<Uri?> post3PIDs(_i3.ThreePidCredentials? threePidCreds) =>
+  _i12.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i11.Future<Uri?>.value(),
-        returnValueForMissingStub: _i11.Future<Uri?>.value(),
-      ) as _i11.Future<Uri?>);
+        returnValue: _i12.Future<Uri?>.value(),
+        returnValueForMissingStub: _i12.Future<Uri?>.value(),
+      ) as _i12.Future<Uri?>);
 
   @override
-  _i11.Future<void> add3PID(
+  _i12.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6702,12 +6737,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> bind3PID(
+  _i12.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6723,14 +6758,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             sid,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> delete3pidFromAccount(
+  _i12.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
-    _i3.ThirdPartyIdentifierMedium? medium, {
+    _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
   }) =>
       (super.noSuchMethod(
@@ -6742,14 +6777,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6771,8 +6806,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6788,8 +6823,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6805,10 +6840,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6832,8 +6867,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6850,8 +6885,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6868,12 +6903,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> unbind3pidFromAccount(
+  _i12.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
-    _i3.ThirdPartyIdentifierMedium? medium, {
+    _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
   }) =>
       (super.noSuchMethod(
@@ -6885,15 +6920,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> deactivateAccount({
-    _i3.AuthenticationData? auth,
+  _i12.Future<_i4.IdServerUnbindResult> deactivateAccount({
+    _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
   }) =>
@@ -6907,14 +6942,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6936,8 +6971,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -6953,8 +6988,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -6970,10 +7005,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6997,8 +7032,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7015,8 +7050,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7033,16 +7068,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i12.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i11.Future<_i3.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
+            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7050,22 +7085,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
+            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.TokenOwnerInfo>);
+      ) as _i12.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i11.Future<_i3.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i12.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i11.Future<_i3.WhoIsInfo>.value(_FakeWhoIsInfo_47(
+        returnValue: _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7073,22 +7108,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.WhoIsInfo>.value(_FakeWhoIsInfo_47(
+            _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i11.Future<_i3.WhoIsInfo>);
+      ) as _i12.Future<_i4.WhoIsInfo>);
 
   @override
-  _i11.Future<_i3.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i12.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i11.Future<_i3.Capabilities>.value(_FakeCapabilities_48(
+        returnValue: _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7096,29 +7131,29 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Capabilities>.value(_FakeCapabilities_48(
+            _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.Capabilities>);
+      ) as _i12.Future<_i4.Capabilities>);
 
   @override
-  _i11.Future<String> createRoom({
+  _i12.Future<String> createRoom({
     Map<String, Object?>? creationContent,
-    List<_i3.StateEvent>? initialState,
+    List<_i4.StateEvent>? initialState,
     List<String>? invite,
-    List<_i3.Invite3pid>? invite3pid,
+    List<_i4.Invite3pid>? invite3pid,
     bool? isDirect,
     String? name,
     Map<String, Object?>? powerLevelContentOverride,
-    _i3.CreateRoomPreset? preset,
+    _i4.CreateRoomPreset? preset,
     String? roomAliasName,
     String? roomVersion,
     String? topic,
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7139,7 +7174,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7161,7 +7196,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7182,12 +7217,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> deleteDevices(
+  _i12.Future<void> deleteDevices(
     List<String>? devices, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7195,24 +7230,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.Device>?> getDevices() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Device>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.Device>?>.value(),
-      ) as _i11.Future<List<_i3.Device>?>);
+        returnValue: _i12.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.Device>?>.value(),
+      ) as _i12.Future<List<_i4.Device>?>);
 
   @override
-  _i11.Future<void> deleteDevice(
+  _i12.Future<void> deleteDevice(
     String? deviceId, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7220,34 +7255,34 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i12.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i11.Future<_i3.Device>.value(_FakeDevice_49(
+        returnValue: _i12.Future<_i4.Device>.value(_FakeDevice_50(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.Device>.value(_FakeDevice_49(
+        returnValueForMissingStub: _i12.Future<_i4.Device>.value(_FakeDevice_50(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i11.Future<_i3.Device>);
+      ) as _i12.Future<_i4.Device>);
 
   @override
-  _i11.Future<void> updateDevice(
+  _i12.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7257,15 +7292,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i12.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7277,26 +7312,26 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i12.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i11.Future<_i3.Visibility?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Visibility?>.value(),
-      ) as _i11.Future<_i3.Visibility?>);
+        returnValue: _i12.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Visibility?>.value(),
+      ) as _i12.Future<_i4.Visibility?>);
 
   @override
-  _i11.Future<void> setRoomVisibilityOnDirectory(
+  _i12.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7304,30 +7339,30 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i12.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i12.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i11.Future<_i3.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_50(
+        returnValue: _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_51(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7335,18 +7370,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_50(
+            _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_51(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomIdByAliasResponse>);
+      ) as _i12.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i11.Future<void> setRoomAlias(
+  _i12.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7358,12 +7393,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             roomId,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetEventsResponse> getEvents({
+  _i12.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7377,7 +7412,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<_i3.GetEventsResponse>.value(_FakeGetEventsResponse_51(
+            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
           this,
           Invocation.method(
             #getEvents,
@@ -7389,7 +7424,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetEventsResponse>.value(_FakeGetEventsResponse_51(
+            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
           this,
           Invocation.method(
             #getEvents,
@@ -7400,10 +7435,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetEventsResponse>);
+      ) as _i12.Future<_i4.GetEventsResponse>);
 
   @override
-  _i11.Future<_i3.PeekEventsResponse> peekEvents({
+  _i12.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7418,8 +7453,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i11.Future<_i3.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_52(
+        returnValue: _i12.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_53(
           this,
           Invocation.method(
             #peekEvents,
@@ -7431,8 +7466,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_52(
+        returnValueForMissingStub: _i12.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_53(
           this,
           Invocation.method(
             #peekEvents,
@@ -7444,16 +7479,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.PeekEventsResponse>);
+      ) as _i12.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i11.Future<_i3.MatrixEvent> getOneEvent(String? eventId) =>
+  _i12.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7461,27 +7496,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i11.Future<_i3.MatrixEvent>);
+      ) as _i12.Future<_i4.MatrixEvent>);
 
   @override
-  _i11.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i12.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i11.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i11.Future<List<String>>.value(<String>[]),
-      ) as _i11.Future<List<String>>);
+        returnValue: _i12.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
+      ) as _i12.Future<List<String>>);
 
   @override
-  _i11.Future<_i3.GetKeysChangesResponse> getKeysChanges(
+  _i12.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7493,8 +7528,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             to,
           ],
         ),
-        returnValue: _i11.Future<_i3.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_54(
+        returnValue: _i12.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_55(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7505,8 +7540,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_54(
+            _i12.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_55(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7516,10 +7551,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.GetKeysChangesResponse>);
+      ) as _i12.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i11.Future<_i3.ClaimKeysResponse> claimKeys(
+  _i12.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7530,7 +7565,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i11.Future<_i3.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
+            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
           this,
           Invocation.method(
             #claimKeys,
@@ -7539,7 +7574,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
+            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
           this,
           Invocation.method(
             #claimKeys,
@@ -7547,14 +7582,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i11.Future<_i3.ClaimKeysResponse>);
+      ) as _i12.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i11.Future<void> uploadCrossSigningKeys({
-    _i3.AuthenticationData? auth,
-    _i3.MatrixCrossSigningKey? masterKey,
-    _i3.MatrixCrossSigningKey? selfSigningKey,
-    _i3.MatrixCrossSigningKey? userSigningKey,
+  _i12.Future<void> uploadCrossSigningKeys({
+    _i4.AuthenticationData? auth,
+    _i4.MatrixCrossSigningKey? masterKey,
+    _i4.MatrixCrossSigningKey? selfSigningKey,
+    _i4.MatrixCrossSigningKey? userSigningKey,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7567,12 +7602,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.QueryKeysResponse> queryKeys(
+  _i12.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7583,7 +7618,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i11.Future<_i3.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
+            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
           this,
           Invocation.method(
             #queryKeys,
@@ -7592,7 +7627,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
+            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
           this,
           Invocation.method(
             #queryKeys,
@@ -7600,10 +7635,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i11.Future<_i3.QueryKeysResponse>);
+      ) as _i12.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i11.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7611,15 +7646,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i11.Future<
+            returnValue: _i12.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i11.Future<
+            returnValueForMissingStub: _i12.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i11.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i11.Future<Map<String, int>> uploadKeys({
-    _i3.MatrixDeviceKeys? deviceKeys,
+  _i12.Future<Map<String, int>> uploadKeys({
+    _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
   }) =>
@@ -7633,13 +7668,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i11.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i12.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i11.Future<Map<String, int>>);
+            _i12.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i12.Future<Map<String, int>>);
 
   @override
-  _i11.Future<String> knockRoom(
+  _i12.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7653,7 +7688,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7665,7 +7700,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7676,20 +7711,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<List<_i3.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i12.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.LoginFlow>?>.value(),
-      ) as _i11.Future<List<_i3.LoginFlow>?>);
+        returnValue: _i12.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i12.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i11.Future<_i3.GetNotificationsResponse> getNotifications({
+  _i12.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7704,8 +7739,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #only: only,
           },
         ),
-        returnValue: _i11.Future<_i3.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_57(
+        returnValue: _i12.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_58(
           this,
           Invocation.method(
             #getNotifications,
@@ -7718,8 +7753,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_57(
+            _i12.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_58(
           this,
           Invocation.method(
             #getNotifications,
@@ -7731,37 +7766,37 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetNotificationsResponse>);
+      ) as _i12.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i11.Future<_i3.GetPresenceResponse> getPresence(String? userId) =>
+  _i12.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i11.Future<_i3.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_58(
+        returnValue: _i12.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_59(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_58(
+        returnValueForMissingStub: _i12.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_59(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i11.Future<_i3.GetPresenceResponse>);
+      ) as _i12.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i11.Future<void> setPresence(
+  _i12.Future<void> setPresence(
     String? userId,
-    _i3.PresenceType? presence, {
+    _i4.PresenceType? presence, {
     String? statusMsg,
   }) =>
       (super.noSuchMethod(
@@ -7773,12 +7808,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, Object?>> deleteProfileField(
+  _i12.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7791,13 +7826,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getProfileField(
+  _i12.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7810,13 +7845,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<Map<String, Object?>> setProfileField(
+  _i12.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7831,13 +7866,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.GetPublicRoomsResponse> getPublicRooms({
+  _i12.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7852,8 +7887,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #server: server,
           },
         ),
-        returnValue: _i11.Future<_i3.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_59(
+        returnValue: _i12.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_60(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7866,8 +7901,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_59(
+            _i12.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_60(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7879,12 +7914,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetPublicRoomsResponse>);
+      ) as _i12.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i11.Future<_i3.QueryPublicRoomsResponse> queryPublicRooms({
+  _i12.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
-    _i3.PublicRoomQueryFilter? filter,
+    _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
     int? limit,
     String? since,
@@ -7903,8 +7938,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i11.Future<_i3.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_60(
+        returnValue: _i12.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_61(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7920,8 +7955,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_60(
+            _i12.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_61(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7936,25 +7971,25 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.QueryPublicRoomsResponse>);
+      ) as _i12.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i11.Future<List<_i3.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Pusher>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.Pusher>?>.value(),
-      ) as _i11.Future<List<_i3.Pusher>?>);
+        returnValue: _i12.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.Pusher>?>.value(),
+      ) as _i12.Future<List<_i4.Pusher>?>);
 
   @override
-  _i11.Future<_i3.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i12.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i11.Future<_i3.PushRuleSet>.value(_FakePushRuleSet_61(
+        returnValue: _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
           this,
           Invocation.method(
             #getPushRules,
@@ -7962,24 +7997,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PushRuleSet>.value(_FakePushRuleSet_61(
+            _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.PushRuleSet>);
+      ) as _i12.Future<_i4.PushRuleSet>);
 
   @override
-  _i11.Future<_i3.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i12.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i11.Future<_i3.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_62(
+        returnValue: _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_63(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -7987,19 +8022,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_62(
+            _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_63(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.GetPushRulesGlobalResponse>);
+      ) as _i12.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i11.Future<void> deletePushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> deletePushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8010,13 +8045,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.PushRule> getPushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<_i4.PushRule> getPushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8027,7 +8062,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<_i3.PushRule>.value(_FakePushRule_63(
+        returnValue: _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
           this,
           Invocation.method(
             #getPushRule,
@@ -8038,7 +8073,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PushRule>.value(_FakePushRule_63(
+            _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
           this,
           Invocation.method(
             #getPushRule,
@@ -8048,16 +8083,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.PushRule>);
+      ) as _i12.Future<_i4.PushRule>);
 
   @override
-  _i11.Future<void> setPushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
     String? before,
     String? after,
-    List<_i3.PushCondition>? conditions,
+    List<_i4.PushCondition>? conditions,
     String? pattern,
   }) =>
       (super.noSuchMethod(
@@ -8075,13 +8110,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<Object?>> getPushRuleActions(
-    _i3.PushRuleKind? kind,
+  _i12.Future<List<Object?>> getPushRuleActions(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8092,14 +8127,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i12.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i11.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i11.Future<List<Object?>>);
+            _i12.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i12.Future<List<Object?>>);
 
   @override
-  _i11.Future<void> setPushRuleActions(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRuleActions(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
   ) =>
@@ -8112,13 +8147,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             actions,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<bool> isPushRuleEnabled(
-    _i3.PushRuleKind? kind,
+  _i12.Future<bool> isPushRuleEnabled(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8129,13 +8164,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> setPushRuleEnabled(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRuleEnabled(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
   ) =>
@@ -8148,19 +8183,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
             enabled,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.RefreshResponse> refresh(String? refreshToken) =>
+  _i12.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i11.Future<_i3.RefreshResponse>.value(_FakeRefreshResponse_64(
+            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
           this,
           Invocation.method(
             #refresh,
@@ -8168,28 +8203,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RefreshResponse>.value(_FakeRefreshResponse_64(
+            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i11.Future<_i3.RefreshResponse>);
+      ) as _i12.Future<_i4.RefreshResponse>);
 
   @override
-  _i11.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i12.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i11.Future<bool?>.value(),
-        returnValueForMissingStub: _i11.Future<bool?>.value(),
-      ) as _i11.Future<bool?>);
+        returnValue: _i12.Future<bool?>.value(),
+        returnValueForMissingStub: _i12.Future<bool?>.value(),
+      ) as _i12.Future<bool?>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8211,8 +8246,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8228,8 +8263,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8245,10 +8280,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8272,8 +8307,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8290,8 +8325,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8308,17 +8343,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8326,23 +8361,23 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i12.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i11.Future<_i3.RoomKeys>.value(_FakeRoomKeys_65(
+        returnValue: _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8350,19 +8385,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeys>.value(_FakeRoomKeys_65(
+            _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeys>);
+      ) as _i12.Future<_i4.RoomKeys>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeys(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
-    _i3.RoomKeys? body,
+    _i4.RoomKeys? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8372,8 +8407,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8384,8 +8419,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8395,10 +8430,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8410,8 +8445,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8422,8 +8457,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8433,10 +8468,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeyBackup> getRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8448,7 +8483,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
+        returnValue: _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8459,7 +8494,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
+            _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8469,13 +8504,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeyBackup>);
+      ) as _i12.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
-    _i3.RoomKeyBackup? body,
+    _i4.RoomKeyBackup? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8486,8 +8521,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8499,8 +8534,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8511,10 +8546,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8528,8 +8563,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8541,8 +8576,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8553,10 +8588,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.KeyBackupData> getRoomKeyBySessionId(
+  _i12.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8570,7 +8605,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8582,7 +8617,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8593,14 +8628,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.KeyBackupData>);
+      ) as _i12.Future<_i4.KeyBackupData>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
-    _i3.KeyBackupData? body,
+    _i4.KeyBackupData? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8612,8 +8647,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8626,8 +8661,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8639,18 +8674,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>
+  _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_67(
+                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_68(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8658,19 +8693,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_67(
+                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_68(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>);
+          ) as _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i11.Future<String> postRoomKeysVersion(
-    _i3.BackupAlgorithm? algorithm,
+  _i12.Future<String> postRoomKeysVersion(
+    _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
       (super.noSuchMethod(
@@ -8681,7 +8716,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             authData,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8692,7 +8727,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8702,29 +8737,29 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i12.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i12.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i11.Future<_i3.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_68(
+        returnValue: _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_69(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8732,20 +8767,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_68(
+            _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_69(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomKeysVersionResponse>);
+      ) as _i12.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i12.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
-    _i3.BackupAlgorithm? algorithm,
+    _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
       (super.noSuchMethod(
@@ -8758,24 +8793,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i12.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i11.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i11.Future<List<String>>.value(<String>[]),
-      ) as _i11.Future<List<String>>);
+        returnValue: _i12.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
+      ) as _i12.Future<List<String>>);
 
   @override
-  _i11.Future<void> ban(
+  _i12.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8789,12 +8824,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.EventContext> getEventContext(
+  _i12.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8812,7 +8847,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<_i3.EventContext>.value(_FakeEventContext_69(
+        returnValue: _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
           this,
           Invocation.method(
             #getEventContext,
@@ -8827,7 +8862,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.EventContext>.value(_FakeEventContext_69(
+            _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
           this,
           Invocation.method(
             #getEventContext,
@@ -8841,10 +8876,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.EventContext>);
+      ) as _i12.Future<_i4.EventContext>);
 
   @override
-  _i11.Future<_i3.MatrixEvent> getOneRoomEvent(
+  _i12.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8856,7 +8891,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             eventId,
           ],
         ),
-        returnValue: _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8867,7 +8902,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8877,22 +8912,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.MatrixEvent>);
+      ) as _i12.Future<_i4.MatrixEvent>);
 
   @override
-  _i11.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i12.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> inviteBy3PID(
+  _i12.Future<void> inviteBy3PID(
     String? roomId,
-    _i3.Invite3pid? body,
+    _i4.Invite3pid? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8902,12 +8937,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> inviteUser(
+  _i12.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8921,15 +8956,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> joinRoomById(
+  _i12.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
-    _i3.ThirdPartySigned? thirdPartySigned,
+    _i4.ThirdPartySigned? thirdPartySigned,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8940,7 +8975,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8952,7 +8987,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8963,23 +8998,23 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<Map<String, _i3.RoomMember>?> getJoinedMembersByRoom(
+  _i12.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i11.Future<Map<String, _i3.RoomMember>?>.value(),
+        returnValue: _i12.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i11.Future<Map<String, _i3.RoomMember>?>.value(),
-      ) as _i11.Future<Map<String, _i3.RoomMember>?>);
+            _i12.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i12.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i11.Future<void> kick(
+  _i12.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8993,12 +9028,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> leaveRoom(
+  _i12.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9008,16 +9043,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.MatrixEvent>?> getMembersByRoom(
+  _i12.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
-    _i3.Membership? membership,
-    _i3.Membership? notMembership,
+    _i4.Membership? membership,
+    _i4.Membership? notMembership,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9029,14 +9064,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i11.Future<List<_i3.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.MatrixEvent>?>.value(),
-      ) as _i11.Future<List<_i3.MatrixEvent>?>);
+        returnValue: _i12.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i12.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i11.Future<_i3.GetRoomEventsResponse> getRoomEvents(
+  _i12.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
-    _i3.Direction? dir, {
+    _i4.Direction? dir, {
     String? from,
     String? to,
     int? limit,
@@ -9056,8 +9091,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<_i3.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_70(
+        returnValue: _i12.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_71(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9073,8 +9108,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_70(
+        returnValueForMissingStub: _i12.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_71(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9090,10 +9125,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomEventsResponse>);
+      ) as _i12.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i11.Future<void> setReadMarker(
+  _i12.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9109,14 +9144,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> postReceipt(
+  _i12.Future<void> postReceipt(
     String? roomId,
-    _i3.ReceiptType? receiptType,
+    _i4.ReceiptType? receiptType,
     String? eventId, {
     String? threadId,
   }) =>
@@ -9130,12 +9165,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEvent(
+  _i12.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9151,12 +9186,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> reportRoom(
+  _i12.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9168,12 +9203,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             reason,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> reportEvent(
+  _i12.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9191,12 +9226,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #score: score,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> sendMessage(
+  _i12.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9212,7 +9247,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9225,7 +9260,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9237,27 +9272,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<List<_i3.MatrixEvent>> getRoomState(String? roomId) =>
+  _i12.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i11.Future<List<_i3.MatrixEvent>>.value(<_i3.MatrixEvent>[]),
+            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.MatrixEvent>>.value(<_i3.MatrixEvent>[]),
-      ) as _i11.Future<List<_i3.MatrixEvent>>);
+            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i12.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i12.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
-    _i3.Format? format,
+    _i4.Format? format,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9270,13 +9305,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#format: format},
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<String> setRoomStateWithKey(
+  _i12.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9292,7 +9327,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9305,7 +9340,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9317,10 +9352,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> unban(
+  _i12.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9334,12 +9369,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> upgradeRoom(
+  _i12.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9353,7 +9388,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9365,7 +9400,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9376,11 +9411,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.SearchResults> search(
-    _i3.Categories? searchCategories, {
+  _i12.Future<_i4.SearchResults> search(
+    _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
       (super.noSuchMethod(
@@ -9389,7 +9424,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i11.Future<_i3.SearchResults>.value(_FakeSearchResults_71(
+        returnValue: _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
           this,
           Invocation.method(
             #search,
@@ -9398,7 +9433,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SearchResults>.value(_FakeSearchResults_71(
+            _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
           this,
           Invocation.method(
             #search,
@@ -9406,14 +9441,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i11.Future<_i3.SearchResults>);
+      ) as _i12.Future<_i4.SearchResults>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> sync({
+  _i12.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
-    _i3.PresenceType? setPresence,
+    _i4.PresenceType? setPresence,
     int? timeout,
     bool? useStateAfter,
   }) =>
@@ -9430,7 +9465,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #sync,
@@ -9446,7 +9481,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #sync,
@@ -9461,22 +9496,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<List<_i3.Location>> queryLocationByAlias(String? alias) =>
+  _i12.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
+        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
-      ) as _i11.Future<List<_i3.Location>>);
+            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i12.Future<List<_i4.Location>>);
 
   @override
-  _i11.Future<List<_i3.Location>> queryLocationByProtocol(
+  _i12.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9486,21 +9521,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
+        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
-      ) as _i11.Future<List<_i3.Location>>);
+            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i12.Future<List<_i4.Location>>);
 
   @override
-  _i11.Future<_i3.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i12.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i11.Future<_i3.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_72(
+        returnValue: _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_73(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9508,45 +9543,45 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_72(
+            _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_73(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i11.Future<_i3.GetProtocolMetadataResponse$2>);
+      ) as _i12.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i11.Future<Map<String, _i3.GetProtocolsResponse$2>> getProtocols() =>
+  _i12.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>.value(
-            <String, _i3.GetProtocolsResponse$2>{}),
+        returnValue: _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>.value(
-                <String, _i3.GetProtocolsResponse$2>{}),
-      ) as _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>);
+            _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+                <String, _i4.GetProtocolsResponse$2>{}),
+      ) as _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
-      ) as _i11.Future<List<_i3.ThirdPartyUser>>);
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyUser>> queryUserByProtocol(
+  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9557,13 +9592,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
-      ) as _i11.Future<List<_i3.ThirdPartyUser>>);
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getAccountData(
+  _i12.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9576,13 +9611,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> setAccountData(
+  _i12.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9596,14 +9631,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> defineFilter(
+  _i12.Future<String> defineFilter(
     String? userId,
-    _i3.Filter? body,
+    _i4.Filter? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9613,7 +9648,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9624,7 +9659,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9634,10 +9669,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.Filter> getFilter(
+  _i12.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9649,7 +9684,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             filterId,
           ],
         ),
-        returnValue: _i11.Future<_i3.Filter>.value(_FakeFilter_16(
+        returnValue: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
           this,
           Invocation.method(
             #getFilter,
@@ -9659,7 +9694,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.Filter>.value(_FakeFilter_16(
+        returnValueForMissingStub: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
           this,
           Invocation.method(
             #getFilter,
@@ -9669,10 +9704,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.Filter>);
+      ) as _i12.Future<_i4.Filter>);
 
   @override
-  _i11.Future<_i3.OpenIdCredentials> requestOpenIdToken(
+  _i12.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9685,7 +9720,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<_i3.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
+            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9696,7 +9731,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
+            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9706,10 +9741,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.OpenIdCredentials>);
+      ) as _i12.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i11.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i12.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9724,13 +9759,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> setAccountDataPerRoom(
+  _i12.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9746,12 +9781,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, _i3.Tag>?> getRoomTags(
+  _i12.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9763,12 +9798,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             roomId,
           ],
         ),
-        returnValue: _i11.Future<Map<String, _i3.Tag>?>.value(),
-        returnValueForMissingStub: _i11.Future<Map<String, _i3.Tag>?>.value(),
-      ) as _i11.Future<Map<String, _i3.Tag>?>);
+        returnValue: _i12.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i12.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i12.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i11.Future<void> deleteRoomTag(
+  _i12.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9782,16 +9817,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             tag,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setRoomTag(
+  _i12.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
-    _i3.Tag? body,
+    _i4.Tag? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9803,12 +9838,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.SearchUserDirectoryResponse> searchUserDirectory(
+  _i12.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9818,8 +9853,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i11.Future<_i3.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_74(
+        returnValue: _i12.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_75(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9828,8 +9863,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_74(
+            _i12.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_75(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9837,10 +9872,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i11.Future<_i3.SearchUserDirectoryResponse>);
+      ) as _i12.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> reportUser(
+  _i12.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9853,40 +9888,40 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i12.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i11.Future<_i3.CreateContentResponse>.value(
-            _FakeCreateContentResponse_75(
+        returnValue: _i12.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_76(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.CreateContentResponse>.value(
-            _FakeCreateContentResponse_75(
+        returnValueForMissingStub: _i12.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_76(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.CreateContentResponse>);
+      ) as _i12.Future<_i4.CreateContentResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> uploadContentToMXC(
+  _i12.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i21.Uint8List? body, {
+    _i22.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -9904,8 +9939,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 }

--- a/test/widgets/bootstrap_controller_test.mocks.dart
+++ b/test/widgets/bootstrap_controller_test.mocks.dart
@@ -4,31 +4,33 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i13;
-import 'package:matrix/encryption/cross_signing.dart' as _i16;
-import 'package:matrix/encryption/key_verification_manager.dart' as _i15;
-import 'package:matrix/encryption/olm_manager.dart' as _i14;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i14;
+import 'package:matrix/encryption/cross_signing.dart' as _i17;
+import 'package:matrix/encryption/key_verification_manager.dart' as _i16;
+import 'package:matrix/encryption/olm_manager.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -747,8 +749,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -757,8 +760,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -767,9 +770,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -778,9 +780,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -789,8 +791,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -799,8 +802,8 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -809,8 +812,8 @@ class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
         );
 }
 
-class _FakeKeyManager_72 extends _i1.SmartFake implements _i13.KeyManager {
-  _FakeKeyManager_72(
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -819,8 +822,8 @@ class _FakeKeyManager_72 extends _i1.SmartFake implements _i13.KeyManager {
         );
 }
 
-class _FakeOlmManager_73 extends _i1.SmartFake implements _i14.OlmManager {
-  _FakeOlmManager_73(
+class _FakeKeyManager_73 extends _i1.SmartFake implements _i14.KeyManager {
+  _FakeKeyManager_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,9 +832,8 @@ class _FakeOlmManager_73 extends _i1.SmartFake implements _i14.OlmManager {
         );
 }
 
-class _FakeKeyVerificationManager_74 extends _i1.SmartFake
-    implements _i15.KeyVerificationManager {
-  _FakeKeyVerificationManager_74(
+class _FakeOlmManager_74 extends _i1.SmartFake implements _i15.OlmManager {
+  _FakeOlmManager_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -840,8 +842,9 @@ class _FakeKeyVerificationManager_74 extends _i1.SmartFake
         );
 }
 
-class _FakeCrossSigning_75 extends _i1.SmartFake implements _i16.CrossSigning {
-  _FakeCrossSigning_75(
+class _FakeKeyVerificationManager_75 extends _i1.SmartFake
+    implements _i16.KeyVerificationManager {
+  _FakeKeyVerificationManager_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -850,8 +853,8 @@ class _FakeCrossSigning_75 extends _i1.SmartFake implements _i16.CrossSigning {
         );
 }
 
-class _FakeSSSS_76 extends _i1.SmartFake implements _i13.SSSS {
-  _FakeSSSS_76(
+class _FakeCrossSigning_76 extends _i1.SmartFake implements _i17.CrossSigning {
+  _FakeCrossSigning_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -860,8 +863,8 @@ class _FakeSSSS_76 extends _i1.SmartFake implements _i13.SSSS {
         );
 }
 
-class _FakeBootstrap_77 extends _i1.SmartFake implements _i13.Bootstrap {
-  _FakeBootstrap_77(
+class _FakeSSSS_77 extends _i1.SmartFake implements _i14.SSSS {
+  _FakeSSSS_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -870,8 +873,8 @@ class _FakeBootstrap_77 extends _i1.SmartFake implements _i13.Bootstrap {
         );
 }
 
-class _FakeToDeviceEvent_78 extends _i1.SmartFake implements _i2.ToDeviceEvent {
-  _FakeToDeviceEvent_78(
+class _FakeBootstrap_78 extends _i1.SmartFake implements _i14.Bootstrap {
+  _FakeBootstrap_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -880,8 +883,8 @@ class _FakeToDeviceEvent_78 extends _i1.SmartFake implements _i2.ToDeviceEvent {
         );
 }
 
-class _FakeEvent_79 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_79(
+class _FakeToDeviceEvent_79 extends _i1.SmartFake implements _i2.ToDeviceEvent {
+  _FakeToDeviceEvent_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -890,8 +893,8 @@ class _FakeEvent_79 extends _i1.SmartFake implements _i2.Event {
         );
 }
 
-class _FakeEncryption_80 extends _i1.SmartFake implements _i13.Encryption {
-  _FakeEncryption_80(
+class _FakeEvent_80 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -900,9 +903,19 @@ class _FakeEncryption_80 extends _i1.SmartFake implements _i13.Encryption {
         );
 }
 
-class _FakeSecretStorageKeyContent_81 extends _i1.SmartFake
+class _FakeEncryption_81 extends _i1.SmartFake implements _i14.Encryption {
+  _FakeEncryption_81(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeSecretStorageKeyContent_82 extends _i1.SmartFake
     implements _i2.SecretStorageKeyContent {
-  _FakeSecretStorageKeyContent_81(
+  _FakeSecretStorageKeyContent_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -929,12 +942,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i13.KeyVerificationMethod> get verificationMethods =>
+  Set<_i14.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i13.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i13.KeyVerificationMethod>{},
-      ) as Set<_i13.KeyVerificationMethod>);
+        returnValue: <_i14.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
+      ) as Set<_i14.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1054,11 +1067,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1095,11 +1108,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1129,11 +1142,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1142,11 +1155,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1432,34 +1445,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i13.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i13.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i13.KeyVerification>
+  _i3.CachedStreamController<_i14.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i13.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i13.KeyVerification>(
+                _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i13.KeyVerification>);
+          ) as _i3.CachedStreamController<_i14.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1615,7 +1628,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i13.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1904,14 +1917,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2299,8 +2312,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2316,8 +2329,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2358,7 +2371,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2374,7 +2387,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2423,7 +2436,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2444,7 +2457,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2547,7 +2560,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2565,7 +2578,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3084,7 +3097,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3436,7 +3449,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3450,7 +3463,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3601,7 +3614,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4979,7 +4992,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5001,7 +5014,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5495,7 +5508,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5507,7 +5520,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6515,7 +6528,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6526,7 +6539,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6774,7 +6787,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6786,7 +6799,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7046,7 +7059,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7059,7 +7072,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7126,7 +7139,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7139,7 +7152,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7187,7 +7200,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7199,7 +7212,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7447,7 +7460,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7458,7 +7471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7720,7 +7733,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7747,7 +7760,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7762,13 +7775,26 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7777,11 +7803,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7802,69 +7828,69 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7883,6 +7909,15 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7892,7 +7927,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7901,7 +7936,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7910,7 +7945,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7919,7 +7954,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7928,7 +7963,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7981,7 +8016,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8075,7 +8110,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8084,7 +8119,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8103,7 +8138,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8114,7 +8149,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8162,7 +8197,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8200,7 +8235,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8209,7 +8244,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8218,16 +8253,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8251,7 +8286,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 /// A class which mocks [ChatBackupService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockChatBackupService extends _i1.Mock implements _i9.ChatBackupService {
+class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
   @override
   bool get chatBackupEnabled => (super.noSuchMethod(
         Invocation.getter(#chatBackupEnabled),
@@ -8313,7 +8348,7 @@ class MockChatBackupService extends _i1.Mock implements _i9.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> runKeyRecovery({_i13.OpenSSSS? ssssKey}) =>
+  _i5.Future<void> runKeyRecovery({_i14.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
@@ -8367,7 +8402,7 @@ class MockChatBackupService extends _i1.Mock implements _i9.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8376,7 +8411,7 @@ class MockChatBackupService extends _i1.Mock implements _i9.ChatBackupService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8406,15 +8441,15 @@ class MockChatBackupService extends _i1.Mock implements _i9.ChatBackupService {
 /// A class which mocks [Encryption].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEncryption extends _i1.Mock implements _i13.Encryption {
+class MockEncryption extends _i1.Mock implements _i14.Encryption {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -8435,85 +8470,85 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
       ) as bool);
 
   @override
-  _i13.KeyManager get keyManager => (super.noSuchMethod(
+  _i14.KeyManager get keyManager => (super.noSuchMethod(
         Invocation.getter(#keyManager),
-        returnValue: _FakeKeyManager_72(
+        returnValue: _FakeKeyManager_73(
           this,
           Invocation.getter(#keyManager),
         ),
-        returnValueForMissingStub: _FakeKeyManager_72(
+        returnValueForMissingStub: _FakeKeyManager_73(
           this,
           Invocation.getter(#keyManager),
         ),
-      ) as _i13.KeyManager);
+      ) as _i14.KeyManager);
 
   @override
-  _i14.OlmManager get olmManager => (super.noSuchMethod(
+  _i15.OlmManager get olmManager => (super.noSuchMethod(
         Invocation.getter(#olmManager),
-        returnValue: _FakeOlmManager_73(
+        returnValue: _FakeOlmManager_74(
           this,
           Invocation.getter(#olmManager),
         ),
-        returnValueForMissingStub: _FakeOlmManager_73(
+        returnValueForMissingStub: _FakeOlmManager_74(
           this,
           Invocation.getter(#olmManager),
         ),
-      ) as _i14.OlmManager);
+      ) as _i15.OlmManager);
 
   @override
-  _i15.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
+  _i16.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
         Invocation.getter(#keyVerificationManager),
-        returnValue: _FakeKeyVerificationManager_74(
+        returnValue: _FakeKeyVerificationManager_75(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-        returnValueForMissingStub: _FakeKeyVerificationManager_74(
+        returnValueForMissingStub: _FakeKeyVerificationManager_75(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-      ) as _i15.KeyVerificationManager);
+      ) as _i16.KeyVerificationManager);
 
   @override
-  _i16.CrossSigning get crossSigning => (super.noSuchMethod(
+  _i17.CrossSigning get crossSigning => (super.noSuchMethod(
         Invocation.getter(#crossSigning),
-        returnValue: _FakeCrossSigning_75(
+        returnValue: _FakeCrossSigning_76(
           this,
           Invocation.getter(#crossSigning),
         ),
-        returnValueForMissingStub: _FakeCrossSigning_75(
+        returnValueForMissingStub: _FakeCrossSigning_76(
           this,
           Invocation.getter(#crossSigning),
         ),
-      ) as _i16.CrossSigning);
+      ) as _i17.CrossSigning);
 
   @override
-  _i13.SSSS get ssss => (super.noSuchMethod(
+  _i14.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_76(
+        returnValue: _FakeSSSS_77(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_76(
+        returnValueForMissingStub: _FakeSSSS_77(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i13.SSSS);
+      ) as _i14.SSSS);
 
   @override
   String get ourDeviceId => (super.noSuchMethod(
         Invocation.getter(#ourDeviceId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
       ) as String);
 
   @override
-  set keyManager(_i13.KeyManager? value) => super.noSuchMethod(
+  set keyManager(_i14.KeyManager? value) => super.noSuchMethod(
         Invocation.setter(
           #keyManager,
           value,
@@ -8522,7 +8557,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
       );
 
   @override
-  set olmManager(_i14.OlmManager? value) => super.noSuchMethod(
+  set olmManager(_i15.OlmManager? value) => super.noSuchMethod(
         Invocation.setter(
           #olmManager,
           value,
@@ -8531,7 +8566,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
       );
 
   @override
-  set keyVerificationManager(_i15.KeyVerificationManager? value) =>
+  set keyVerificationManager(_i16.KeyVerificationManager? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #keyVerificationManager,
@@ -8541,7 +8576,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
       );
 
   @override
-  set crossSigning(_i16.CrossSigning? value) => super.noSuchMethod(
+  set crossSigning(_i17.CrossSigning? value) => super.noSuchMethod(
         Invocation.setter(
           #crossSigning,
           value,
@@ -8550,7 +8585,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
       );
 
   @override
-  set ssss(_i13.SSSS? value) => super.noSuchMethod(
+  set ssss(_i14.SSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #ssss,
           value,
@@ -8589,14 +8624,14 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
       ) as _i5.Future<void>);
 
   @override
-  _i13.Bootstrap bootstrap({void Function(_i13.Bootstrap)? onUpdate}) =>
+  _i14.Bootstrap bootstrap({void Function(_i14.Bootstrap)? onUpdate}) =>
       (super.noSuchMethod(
         Invocation.method(
           #bootstrap,
           [],
           {#onUpdate: onUpdate},
         ),
-        returnValue: _FakeBootstrap_77(
+        returnValue: _FakeBootstrap_78(
           this,
           Invocation.method(
             #bootstrap,
@@ -8604,7 +8639,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-        returnValueForMissingStub: _FakeBootstrap_77(
+        returnValueForMissingStub: _FakeBootstrap_78(
           this,
           Invocation.method(
             #bootstrap,
@@ -8612,7 +8647,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-      ) as _i13.Bootstrap);
+      ) as _i14.Bootstrap);
 
   @override
   void handleDeviceOneTimeKeysCount(
@@ -8675,7 +8710,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
           #decryptToDeviceEvent,
           [event],
         ),
-        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_78(
+        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_79(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8683,7 +8718,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_78(
+            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_79(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8698,14 +8733,14 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
           #decryptRoomEventSync,
           [event],
         ),
-        returnValue: _FakeEvent_79(
+        returnValue: _FakeEvent_80(
           this,
           Invocation.method(
             #decryptRoomEventSync,
             [event],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_79(
+        returnValueForMissingStub: _FakeEvent_80(
           this,
           Invocation.method(
             #decryptRoomEventSync,
@@ -8729,7 +8764,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
             #updateType: updateType,
           },
         ),
-        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_79(
+        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_80(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -8740,7 +8775,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
             },
           ),
         )),
-        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_79(
+        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_80(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -8822,42 +8857,42 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
 /// A class which mocks [Bootstrap].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBootstrap extends _i1.Mock implements _i13.Bootstrap {
+class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
   @override
-  _i13.Encryption get encryption => (super.noSuchMethod(
+  _i14.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_80(
+        returnValue: _FakeEncryption_81(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_80(
+        returnValueForMissingStub: _FakeEncryption_81(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i13.Encryption);
+      ) as _i14.Encryption);
 
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
       ) as _i2.Client);
 
   @override
-  _i13.BootstrapState get state => (super.noSuchMethod(
+  _i14.BootstrapState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i13.BootstrapState.loading,
-        returnValueForMissingStub: _i13.BootstrapState.loading,
-      ) as _i13.BootstrapState);
+        returnValue: _i14.BootstrapState.loading,
+        returnValueForMissingStub: _i14.BootstrapState.loading,
+      ) as _i14.BootstrapState);
 
   @override
-  set onUpdate(void Function(_i13.Bootstrap)? value) => super.noSuchMethod(
+  set onUpdate(void Function(_i14.Bootstrap)? value) => super.noSuchMethod(
         Invocation.setter(
           #onUpdate,
           value,
@@ -8866,7 +8901,7 @@ class MockBootstrap extends _i1.Mock implements _i13.Bootstrap {
       );
 
   @override
-  set oldSsssKeys(Map<String, _i13.OpenSSSS>? value) => super.noSuchMethod(
+  set oldSsssKeys(Map<String, _i14.OpenSSSS>? value) => super.noSuchMethod(
         Invocation.setter(
           #oldSsssKeys,
           value,
@@ -8875,7 +8910,7 @@ class MockBootstrap extends _i1.Mock implements _i13.Bootstrap {
       );
 
   @override
-  set newSsssKey(_i13.OpenSSSS? value) => super.noSuchMethod(
+  set newSsssKey(_i14.OpenSSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #newSsssKey,
           value,
@@ -8893,7 +8928,7 @@ class MockBootstrap extends _i1.Mock implements _i13.Bootstrap {
       );
 
   @override
-  set state(_i13.BootstrapState? newState) => super.noSuchMethod(
+  set state(_i14.BootstrapState? newState) => super.noSuchMethod(
         Invocation.setter(
           #state,
           newState,
@@ -8927,14 +8962,14 @@ class MockBootstrap extends _i1.Mock implements _i13.Bootstrap {
           #mostUsedKey,
           [secrets],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
             [secrets],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
@@ -9101,28 +9136,28 @@ class MockBootstrap extends _i1.Mock implements _i13.Bootstrap {
 /// A class which mocks [OpenSSSS].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockOpenSSSS extends _i1.Mock implements _i13.OpenSSSS {
+class MockOpenSSSS extends _i1.Mock implements _i14.OpenSSSS {
   @override
-  _i13.SSSS get ssss => (super.noSuchMethod(
+  _i14.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_76(
+        returnValue: _FakeSSSS_77(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_76(
+        returnValueForMissingStub: _FakeSSSS_77(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i13.SSSS);
+      ) as _i14.SSSS);
 
   @override
   String get keyId => (super.noSuchMethod(
         Invocation.getter(#keyId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
@@ -9131,11 +9166,11 @@ class MockOpenSSSS extends _i1.Mock implements _i13.OpenSSSS {
   @override
   _i2.SecretStorageKeyContent get keyData => (super.noSuchMethod(
         Invocation.getter(#keyData),
-        returnValue: _FakeSecretStorageKeyContent_81(
+        returnValue: _FakeSecretStorageKeyContent_82(
           this,
           Invocation.getter(#keyData),
         ),
-        returnValueForMissingStub: _FakeSecretStorageKeyContent_81(
+        returnValueForMissingStub: _FakeSecretStorageKeyContent_82(
           this,
           Invocation.getter(#keyData),
         ),
@@ -9156,7 +9191,7 @@ class MockOpenSSSS extends _i1.Mock implements _i13.OpenSSSS {
       ) as bool);
 
   @override
-  set privateKey(_i18.Uint8List? value) => super.noSuchMethod(
+  set privateKey(_i19.Uint8List? value) => super.noSuchMethod(
         Invocation.setter(
           #privateKey,
           value,
@@ -9187,7 +9222,7 @@ class MockOpenSSSS extends _i1.Mock implements _i13.OpenSSSS {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setPrivateKey(_i18.Uint8List? key) => (super.noSuchMethod(
+  _i5.Future<void> setPrivateKey(_i19.Uint8List? key) => (super.noSuchMethod(
         Invocation.method(
           #setPrivateKey,
           [key],
@@ -9202,7 +9237,7 @@ class MockOpenSSSS extends _i1.Mock implements _i13.OpenSSSS {
           #getStored,
           [type],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,
@@ -9210,7 +9245,7 @@ class MockOpenSSSS extends _i1.Mock implements _i13.OpenSSSS {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,
@@ -9269,7 +9304,7 @@ class MockOpenSSSS extends _i1.Mock implements _i13.OpenSSSS {
 /// A class which mocks [UiaService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockUiaService extends _i1.Mock implements _i8.UiaService {
+class MockUiaService extends _i1.Mock implements _i9.UiaService {
   @override
   _i5.Stream<_i2.UiaRequest<dynamic>> get onUiaRequest => (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),

--- a/test/widgets/bootstrap_driver_test.mocks.dart
+++ b/test/widgets/bootstrap_driver_test.mocks.dart
@@ -4,31 +4,33 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i13;
-import 'package:matrix/encryption/cross_signing.dart' as _i16;
-import 'package:matrix/encryption/key_verification_manager.dart' as _i15;
-import 'package:matrix/encryption/olm_manager.dart' as _i14;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i14;
+import 'package:matrix/encryption/cross_signing.dart' as _i17;
+import 'package:matrix/encryption/key_verification_manager.dart' as _i16;
+import 'package:matrix/encryption/olm_manager.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -747,8 +749,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -757,8 +760,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -767,9 +770,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -778,9 +780,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -789,8 +791,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -799,8 +802,8 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -809,8 +812,8 @@ class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
         );
 }
 
-class _FakeKeyManager_72 extends _i1.SmartFake implements _i13.KeyManager {
-  _FakeKeyManager_72(
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -819,8 +822,8 @@ class _FakeKeyManager_72 extends _i1.SmartFake implements _i13.KeyManager {
         );
 }
 
-class _FakeOlmManager_73 extends _i1.SmartFake implements _i14.OlmManager {
-  _FakeOlmManager_73(
+class _FakeKeyManager_73 extends _i1.SmartFake implements _i14.KeyManager {
+  _FakeKeyManager_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,9 +832,8 @@ class _FakeOlmManager_73 extends _i1.SmartFake implements _i14.OlmManager {
         );
 }
 
-class _FakeKeyVerificationManager_74 extends _i1.SmartFake
-    implements _i15.KeyVerificationManager {
-  _FakeKeyVerificationManager_74(
+class _FakeOlmManager_74 extends _i1.SmartFake implements _i15.OlmManager {
+  _FakeOlmManager_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -840,8 +842,9 @@ class _FakeKeyVerificationManager_74 extends _i1.SmartFake
         );
 }
 
-class _FakeCrossSigning_75 extends _i1.SmartFake implements _i16.CrossSigning {
-  _FakeCrossSigning_75(
+class _FakeKeyVerificationManager_75 extends _i1.SmartFake
+    implements _i16.KeyVerificationManager {
+  _FakeKeyVerificationManager_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -850,8 +853,8 @@ class _FakeCrossSigning_75 extends _i1.SmartFake implements _i16.CrossSigning {
         );
 }
 
-class _FakeSSSS_76 extends _i1.SmartFake implements _i13.SSSS {
-  _FakeSSSS_76(
+class _FakeCrossSigning_76 extends _i1.SmartFake implements _i17.CrossSigning {
+  _FakeCrossSigning_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -860,8 +863,8 @@ class _FakeSSSS_76 extends _i1.SmartFake implements _i13.SSSS {
         );
 }
 
-class _FakeBootstrap_77 extends _i1.SmartFake implements _i13.Bootstrap {
-  _FakeBootstrap_77(
+class _FakeSSSS_77 extends _i1.SmartFake implements _i14.SSSS {
+  _FakeSSSS_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -870,8 +873,8 @@ class _FakeBootstrap_77 extends _i1.SmartFake implements _i13.Bootstrap {
         );
 }
 
-class _FakeToDeviceEvent_78 extends _i1.SmartFake implements _i2.ToDeviceEvent {
-  _FakeToDeviceEvent_78(
+class _FakeBootstrap_78 extends _i1.SmartFake implements _i14.Bootstrap {
+  _FakeBootstrap_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -880,8 +883,8 @@ class _FakeToDeviceEvent_78 extends _i1.SmartFake implements _i2.ToDeviceEvent {
         );
 }
 
-class _FakeEvent_79 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_79(
+class _FakeToDeviceEvent_79 extends _i1.SmartFake implements _i2.ToDeviceEvent {
+  _FakeToDeviceEvent_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -890,8 +893,18 @@ class _FakeEvent_79 extends _i1.SmartFake implements _i2.Event {
         );
 }
 
-class _FakeEncryption_80 extends _i1.SmartFake implements _i13.Encryption {
-  _FakeEncryption_80(
+class _FakeEvent_80 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_80(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeEncryption_81 extends _i1.SmartFake implements _i14.Encryption {
+  _FakeEncryption_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -918,12 +931,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i13.KeyVerificationMethod> get verificationMethods =>
+  Set<_i14.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i13.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i13.KeyVerificationMethod>{},
-      ) as Set<_i13.KeyVerificationMethod>);
+        returnValue: <_i14.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
+      ) as Set<_i14.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1043,11 +1056,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1084,11 +1097,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1118,11 +1131,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1131,11 +1144,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1421,34 +1434,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i13.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i13.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i13.KeyVerification>
+  _i3.CachedStreamController<_i14.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i13.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i13.KeyVerification>(
+                _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i13.KeyVerification>);
+          ) as _i3.CachedStreamController<_i14.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1604,7 +1617,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i13.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1893,14 +1906,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2288,8 +2301,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2305,8 +2318,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2347,7 +2360,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2363,7 +2376,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2412,7 +2425,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2433,7 +2446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2536,7 +2549,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2554,7 +2567,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3073,7 +3086,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3425,7 +3438,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3439,7 +3452,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3590,7 +3603,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4968,7 +4981,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4990,7 +5003,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5484,7 +5497,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5496,7 +5509,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6504,7 +6517,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6515,7 +6528,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6763,7 +6776,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6775,7 +6788,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7035,7 +7048,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7048,7 +7061,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7115,7 +7128,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7128,7 +7141,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7176,7 +7189,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7188,7 +7201,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7436,7 +7449,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7447,7 +7460,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7709,7 +7722,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7736,7 +7749,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7751,13 +7764,26 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7766,11 +7792,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7791,69 +7817,69 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7872,6 +7898,15 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7881,7 +7916,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7890,7 +7925,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7899,7 +7934,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7908,7 +7943,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7917,7 +7952,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7970,7 +8005,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8064,7 +8099,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8073,7 +8108,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8092,7 +8127,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8103,7 +8138,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8151,7 +8186,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8189,7 +8224,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8198,7 +8233,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8207,16 +8242,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8240,15 +8275,15 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 /// A class which mocks [Encryption].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEncryption extends _i1.Mock implements _i13.Encryption {
+class MockEncryption extends _i1.Mock implements _i14.Encryption {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -8269,85 +8304,85 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
       ) as bool);
 
   @override
-  _i13.KeyManager get keyManager => (super.noSuchMethod(
+  _i14.KeyManager get keyManager => (super.noSuchMethod(
         Invocation.getter(#keyManager),
-        returnValue: _FakeKeyManager_72(
+        returnValue: _FakeKeyManager_73(
           this,
           Invocation.getter(#keyManager),
         ),
-        returnValueForMissingStub: _FakeKeyManager_72(
+        returnValueForMissingStub: _FakeKeyManager_73(
           this,
           Invocation.getter(#keyManager),
         ),
-      ) as _i13.KeyManager);
+      ) as _i14.KeyManager);
 
   @override
-  _i14.OlmManager get olmManager => (super.noSuchMethod(
+  _i15.OlmManager get olmManager => (super.noSuchMethod(
         Invocation.getter(#olmManager),
-        returnValue: _FakeOlmManager_73(
+        returnValue: _FakeOlmManager_74(
           this,
           Invocation.getter(#olmManager),
         ),
-        returnValueForMissingStub: _FakeOlmManager_73(
+        returnValueForMissingStub: _FakeOlmManager_74(
           this,
           Invocation.getter(#olmManager),
         ),
-      ) as _i14.OlmManager);
+      ) as _i15.OlmManager);
 
   @override
-  _i15.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
+  _i16.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
         Invocation.getter(#keyVerificationManager),
-        returnValue: _FakeKeyVerificationManager_74(
+        returnValue: _FakeKeyVerificationManager_75(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-        returnValueForMissingStub: _FakeKeyVerificationManager_74(
+        returnValueForMissingStub: _FakeKeyVerificationManager_75(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-      ) as _i15.KeyVerificationManager);
+      ) as _i16.KeyVerificationManager);
 
   @override
-  _i16.CrossSigning get crossSigning => (super.noSuchMethod(
+  _i17.CrossSigning get crossSigning => (super.noSuchMethod(
         Invocation.getter(#crossSigning),
-        returnValue: _FakeCrossSigning_75(
+        returnValue: _FakeCrossSigning_76(
           this,
           Invocation.getter(#crossSigning),
         ),
-        returnValueForMissingStub: _FakeCrossSigning_75(
+        returnValueForMissingStub: _FakeCrossSigning_76(
           this,
           Invocation.getter(#crossSigning),
         ),
-      ) as _i16.CrossSigning);
+      ) as _i17.CrossSigning);
 
   @override
-  _i13.SSSS get ssss => (super.noSuchMethod(
+  _i14.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_76(
+        returnValue: _FakeSSSS_77(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_76(
+        returnValueForMissingStub: _FakeSSSS_77(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i13.SSSS);
+      ) as _i14.SSSS);
 
   @override
   String get ourDeviceId => (super.noSuchMethod(
         Invocation.getter(#ourDeviceId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
       ) as String);
 
   @override
-  set keyManager(_i13.KeyManager? value) => super.noSuchMethod(
+  set keyManager(_i14.KeyManager? value) => super.noSuchMethod(
         Invocation.setter(
           #keyManager,
           value,
@@ -8356,7 +8391,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
       );
 
   @override
-  set olmManager(_i14.OlmManager? value) => super.noSuchMethod(
+  set olmManager(_i15.OlmManager? value) => super.noSuchMethod(
         Invocation.setter(
           #olmManager,
           value,
@@ -8365,7 +8400,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
       );
 
   @override
-  set keyVerificationManager(_i15.KeyVerificationManager? value) =>
+  set keyVerificationManager(_i16.KeyVerificationManager? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #keyVerificationManager,
@@ -8375,7 +8410,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
       );
 
   @override
-  set crossSigning(_i16.CrossSigning? value) => super.noSuchMethod(
+  set crossSigning(_i17.CrossSigning? value) => super.noSuchMethod(
         Invocation.setter(
           #crossSigning,
           value,
@@ -8384,7 +8419,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
       );
 
   @override
-  set ssss(_i13.SSSS? value) => super.noSuchMethod(
+  set ssss(_i14.SSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #ssss,
           value,
@@ -8423,14 +8458,14 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
       ) as _i5.Future<void>);
 
   @override
-  _i13.Bootstrap bootstrap({void Function(_i13.Bootstrap)? onUpdate}) =>
+  _i14.Bootstrap bootstrap({void Function(_i14.Bootstrap)? onUpdate}) =>
       (super.noSuchMethod(
         Invocation.method(
           #bootstrap,
           [],
           {#onUpdate: onUpdate},
         ),
-        returnValue: _FakeBootstrap_77(
+        returnValue: _FakeBootstrap_78(
           this,
           Invocation.method(
             #bootstrap,
@@ -8438,7 +8473,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-        returnValueForMissingStub: _FakeBootstrap_77(
+        returnValueForMissingStub: _FakeBootstrap_78(
           this,
           Invocation.method(
             #bootstrap,
@@ -8446,7 +8481,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-      ) as _i13.Bootstrap);
+      ) as _i14.Bootstrap);
 
   @override
   void handleDeviceOneTimeKeysCount(
@@ -8509,7 +8544,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
           #decryptToDeviceEvent,
           [event],
         ),
-        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_78(
+        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_79(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8517,7 +8552,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_78(
+            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_79(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8532,14 +8567,14 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
           #decryptRoomEventSync,
           [event],
         ),
-        returnValue: _FakeEvent_79(
+        returnValue: _FakeEvent_80(
           this,
           Invocation.method(
             #decryptRoomEventSync,
             [event],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_79(
+        returnValueForMissingStub: _FakeEvent_80(
           this,
           Invocation.method(
             #decryptRoomEventSync,
@@ -8563,7 +8598,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
             #updateType: updateType,
           },
         ),
-        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_79(
+        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_80(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -8574,7 +8609,7 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
             },
           ),
         )),
-        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_79(
+        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_80(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -8656,42 +8691,42 @@ class MockEncryption extends _i1.Mock implements _i13.Encryption {
 /// A class which mocks [Bootstrap].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBootstrap extends _i1.Mock implements _i13.Bootstrap {
+class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
   @override
-  _i13.Encryption get encryption => (super.noSuchMethod(
+  _i14.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_80(
+        returnValue: _FakeEncryption_81(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_80(
+        returnValueForMissingStub: _FakeEncryption_81(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i13.Encryption);
+      ) as _i14.Encryption);
 
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
       ) as _i2.Client);
 
   @override
-  _i13.BootstrapState get state => (super.noSuchMethod(
+  _i14.BootstrapState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i13.BootstrapState.loading,
-        returnValueForMissingStub: _i13.BootstrapState.loading,
-      ) as _i13.BootstrapState);
+        returnValue: _i14.BootstrapState.loading,
+        returnValueForMissingStub: _i14.BootstrapState.loading,
+      ) as _i14.BootstrapState);
 
   @override
-  set onUpdate(void Function(_i13.Bootstrap)? value) => super.noSuchMethod(
+  set onUpdate(void Function(_i14.Bootstrap)? value) => super.noSuchMethod(
         Invocation.setter(
           #onUpdate,
           value,
@@ -8700,7 +8735,7 @@ class MockBootstrap extends _i1.Mock implements _i13.Bootstrap {
       );
 
   @override
-  set oldSsssKeys(Map<String, _i13.OpenSSSS>? value) => super.noSuchMethod(
+  set oldSsssKeys(Map<String, _i14.OpenSSSS>? value) => super.noSuchMethod(
         Invocation.setter(
           #oldSsssKeys,
           value,
@@ -8709,7 +8744,7 @@ class MockBootstrap extends _i1.Mock implements _i13.Bootstrap {
       );
 
   @override
-  set newSsssKey(_i13.OpenSSSS? value) => super.noSuchMethod(
+  set newSsssKey(_i14.OpenSSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #newSsssKey,
           value,
@@ -8727,7 +8762,7 @@ class MockBootstrap extends _i1.Mock implements _i13.Bootstrap {
       );
 
   @override
-  set state(_i13.BootstrapState? newState) => super.noSuchMethod(
+  set state(_i14.BootstrapState? newState) => super.noSuchMethod(
         Invocation.setter(
           #state,
           newState,
@@ -8761,14 +8796,14 @@ class MockBootstrap extends _i1.Mock implements _i13.Bootstrap {
           #mostUsedKey,
           [secrets],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
             [secrets],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,

--- a/test/widgets/chat/message_actions_test.mocks.dart
+++ b/test/widgets/chat/message_actions_test.mocks.dart
@@ -4,30 +4,32 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i13;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i14;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/src/utils/space_child.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -746,8 +748,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,8 +759,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,9 +769,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -777,9 +779,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -788,8 +790,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,8 +801,8 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,8 +811,8 @@ class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
         );
 }
 
-class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_72(
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -818,9 +821,19 @@ class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_73 extends _i1.SmartFake
+class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_74 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_73(
+  _FakeLatestReceiptState_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,8 +842,8 @@ class _FakeLatestReceiptState_73 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_74(
+class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -839,8 +852,8 @@ class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_75 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_75(
+class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -849,8 +862,8 @@ class _FakeUser_75 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_76 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_76(
+class _FakeRoom_77 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -859,9 +872,9 @@ class _FakeRoom_76 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_77 extends _i1.SmartFake
-    implements _i13.TimelineChunk {
-  _FakeTimelineChunk_77(
+class _FakeTimelineChunk_78 extends _i1.SmartFake
+    implements _i14.TimelineChunk {
+  _FakeTimelineChunk_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -870,8 +883,8 @@ class _FakeTimelineChunk_77 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixFile_78 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_78(
+class _FakeMatrixFile_79 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -880,8 +893,8 @@ class _FakeMatrixFile_78 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_79 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_79(
+class _FakeEvent_80 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -908,12 +921,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1033,11 +1046,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1074,11 +1087,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1108,11 +1121,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1121,11 +1134,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1411,34 +1424,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1594,7 +1607,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1883,14 +1896,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2278,8 +2291,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2295,8 +2308,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2337,7 +2350,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2353,7 +2366,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2402,7 +2415,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2423,7 +2436,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2526,7 +2539,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2544,7 +2557,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3063,7 +3076,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3415,7 +3428,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3429,7 +3442,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3580,7 +3593,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4958,7 +4971,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4980,7 +4993,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5474,7 +5487,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5486,7 +5499,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6494,7 +6507,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6505,7 +6518,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6753,7 +6766,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6765,7 +6778,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7025,7 +7038,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7038,7 +7051,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7105,7 +7118,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7118,7 +7131,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7166,7 +7179,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7178,7 +7191,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7426,7 +7439,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7437,7 +7450,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7699,7 +7712,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7726,7 +7739,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7741,13 +7754,26 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7756,11 +7782,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7781,69 +7807,69 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7862,6 +7888,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7871,7 +7906,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7880,7 +7915,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7889,7 +7924,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7898,7 +7933,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7907,7 +7942,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7960,7 +7995,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8054,7 +8089,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8063,7 +8098,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8082,7 +8117,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8093,7 +8128,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8141,7 +8176,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8179,7 +8214,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8188,7 +8223,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8197,16 +8232,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8234,11 +8269,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8268,11 +8303,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_72(
+        returnValue: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_72(
+        returnValueForMissingStub: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
@@ -8325,11 +8360,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8365,11 +8400,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8385,11 +8420,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8398,11 +8433,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8425,11 +8460,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -8445,11 +8480,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8492,11 +8527,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_73(
+        returnValue: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_73(
+        returnValueForMissingStub: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8708,18 +8743,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i22.SpaceParent>[],
+        returnValueForMissingStub: <_i22.SpaceParent>[],
+      ) as List<_i22.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i22.SpaceChild>[],
+        returnValueForMissingStub: <_i22.SpaceChild>[],
+      ) as List<_i22.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8886,14 +8921,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8941,7 +8976,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8949,7 +8984,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8964,7 +8999,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8972,7 +9007,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9056,7 +9091,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9064,7 +9099,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9306,7 +9341,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9317,7 +9352,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9406,15 +9441,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i13.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i14.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i13.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i13.TimelineChunk?>.value(),
-      ) as _i5.Future<_i13.TimelineChunk?>);
+        returnValue: _i5.Future<_i14.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i14.TimelineChunk?>.value(),
+      ) as _i5.Future<_i14.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9455,7 +9490,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9472,7 +9507,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9536,14 +9571,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9559,14 +9594,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9622,7 +9657,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9630,7 +9665,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9942,11 +9977,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_76(
+        returnValue: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_76(
+        returnValueForMissingStub: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
@@ -9996,17 +10031,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i13.TimelineChunk get chunk => (super.noSuchMethod(
+  _i14.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_77(
+        returnValue: _FakeTimelineChunk_78(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_77(
+        returnValueForMissingStub: _FakeTimelineChunk_78(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i13.TimelineChunk);
+      ) as _i14.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10109,7 +10144,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i13.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i14.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -10308,11 +10343,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.getter(#sender),
         ),
@@ -10321,11 +10356,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10334,11 +10369,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_76(
+        returnValue: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_76(
+        returnValueForMissingStub: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
@@ -10361,11 +10396,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10374,11 +10409,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10387,11 +10422,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10400,11 +10435,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10413,11 +10448,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10426,11 +10461,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10495,11 +10530,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10508,11 +10543,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10565,11 +10600,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10654,11 +10689,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10676,11 +10711,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10891,7 +10926,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i16.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i17.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10906,7 +10941,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_78(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_79(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10920,7 +10955,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_78(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_79(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10956,7 +10991,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10971,7 +11006,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11008,7 +11043,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11022,7 +11057,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11059,7 +11094,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11073,7 +11108,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11107,7 +11142,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11120,7 +11155,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11196,14 +11231,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_79(
+        returnValue: _FakeEvent_80(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_79(
+        returnValueForMissingStub: _FakeEvent_80(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -11220,11 +11255,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_76(
+        returnValue: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_76(
+        returnValueForMissingStub: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
@@ -11233,11 +11268,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -11303,11 +11338,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11332,11 +11367,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11354,11 +11389,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11405,7 +11440,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11417,7 +11452,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11487,7 +11522,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11500,7 +11535,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/chat/pinned_messages_test.mocks.dart
+++ b/test/widgets/chat/pinned_messages_test.mocks.dart
@@ -4,30 +4,32 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i13;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i14;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/src/utils/space_child.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -746,8 +748,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,8 +759,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,9 +769,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -777,9 +779,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -788,8 +790,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,8 +801,8 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,8 +811,8 @@ class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
         );
 }
 
-class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_72(
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -818,9 +821,19 @@ class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_73 extends _i1.SmartFake
+class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_74 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_73(
+  _FakeLatestReceiptState_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,8 +842,8 @@ class _FakeLatestReceiptState_73 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_74(
+class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -839,8 +852,8 @@ class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_75 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_75(
+class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -849,8 +862,8 @@ class _FakeUser_75 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_76 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_76(
+class _FakeRoom_77 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -859,9 +872,9 @@ class _FakeRoom_76 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_77 extends _i1.SmartFake
-    implements _i13.TimelineChunk {
-  _FakeTimelineChunk_77(
+class _FakeTimelineChunk_78 extends _i1.SmartFake
+    implements _i14.TimelineChunk {
+  _FakeTimelineChunk_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -870,8 +883,8 @@ class _FakeTimelineChunk_77 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixFile_78 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_78(
+class _FakeMatrixFile_79 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -880,8 +893,8 @@ class _FakeMatrixFile_78 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_79 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_79(
+class _FakeEvent_80 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -908,12 +921,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1033,11 +1046,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1074,11 +1087,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1108,11 +1121,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1121,11 +1134,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1411,34 +1424,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1594,7 +1607,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1883,14 +1896,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2278,8 +2291,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2295,8 +2308,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2337,7 +2350,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2353,7 +2366,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2402,7 +2415,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2423,7 +2436,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2526,7 +2539,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2544,7 +2557,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3063,7 +3076,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3415,7 +3428,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3429,7 +3442,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3580,7 +3593,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4958,7 +4971,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4980,7 +4993,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5474,7 +5487,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5486,7 +5499,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6494,7 +6507,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6505,7 +6518,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6753,7 +6766,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6765,7 +6778,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7025,7 +7038,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7038,7 +7051,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7105,7 +7118,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7118,7 +7131,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7166,7 +7179,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7178,7 +7191,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7426,7 +7439,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7437,7 +7450,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7699,7 +7712,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7726,7 +7739,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7741,13 +7754,26 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7756,11 +7782,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7781,69 +7807,69 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7862,6 +7888,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7871,7 +7906,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7880,7 +7915,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7889,7 +7924,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7898,7 +7933,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7907,7 +7942,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7960,7 +7995,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8054,7 +8089,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8063,7 +8098,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8082,7 +8117,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8093,7 +8128,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8141,7 +8176,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8179,7 +8214,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8188,7 +8223,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8197,16 +8232,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8234,11 +8269,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8268,11 +8303,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_72(
+        returnValue: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_72(
+        returnValueForMissingStub: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
@@ -8325,11 +8360,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8365,11 +8400,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8385,11 +8420,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8398,11 +8433,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8425,11 +8460,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -8445,11 +8480,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8492,11 +8527,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_73(
+        returnValue: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_73(
+        returnValueForMissingStub: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8708,18 +8743,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i22.SpaceParent>[],
+        returnValueForMissingStub: <_i22.SpaceParent>[],
+      ) as List<_i22.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i22.SpaceChild>[],
+        returnValueForMissingStub: <_i22.SpaceChild>[],
+      ) as List<_i22.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8886,14 +8921,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8941,7 +8976,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8949,7 +8984,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8964,7 +8999,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8972,7 +9007,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9056,7 +9091,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9064,7 +9099,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9306,7 +9341,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9317,7 +9352,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9406,15 +9441,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i13.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i14.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i13.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i13.TimelineChunk?>.value(),
-      ) as _i5.Future<_i13.TimelineChunk?>);
+        returnValue: _i5.Future<_i14.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i14.TimelineChunk?>.value(),
+      ) as _i5.Future<_i14.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9455,7 +9490,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9472,7 +9507,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9536,14 +9571,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9559,14 +9594,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9622,7 +9657,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9630,7 +9665,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9942,11 +9977,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_76(
+        returnValue: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_76(
+        returnValueForMissingStub: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
@@ -9996,17 +10031,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i13.TimelineChunk get chunk => (super.noSuchMethod(
+  _i14.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_77(
+        returnValue: _FakeTimelineChunk_78(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_77(
+        returnValueForMissingStub: _FakeTimelineChunk_78(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i13.TimelineChunk);
+      ) as _i14.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10109,7 +10144,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i13.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i14.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -10308,11 +10343,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.getter(#sender),
         ),
@@ -10321,11 +10356,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10334,11 +10369,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_76(
+        returnValue: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_76(
+        returnValueForMissingStub: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
@@ -10361,11 +10396,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10374,11 +10409,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10387,11 +10422,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10400,11 +10435,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10413,11 +10448,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10426,11 +10461,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10495,11 +10530,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10508,11 +10543,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10565,11 +10600,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10654,11 +10689,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10676,11 +10711,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10891,7 +10926,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i16.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i17.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10906,7 +10941,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_78(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_79(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10920,7 +10955,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_78(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_79(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10956,7 +10991,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10971,7 +11006,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11008,7 +11043,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11022,7 +11057,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11059,7 +11094,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11073,7 +11108,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11107,7 +11142,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11120,7 +11155,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11196,14 +11231,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_79(
+        returnValue: _FakeEvent_80(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_79(
+        returnValueForMissingStub: _FakeEvent_80(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -11220,11 +11255,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_76(
+        returnValue: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_76(
+        returnValueForMissingStub: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
@@ -11233,11 +11268,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -11303,11 +11338,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11332,11 +11367,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11354,11 +11389,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11405,7 +11440,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11417,7 +11452,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11487,7 +11522,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11500,7 +11535,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/create_subspace_dialog_test.mocks.dart
+++ b/test/widgets/create_subspace_dialog_test.mocks.dart
@@ -4,30 +4,32 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i15;
-import 'dart:ui' as _i17;
+import 'dart:typed_data' as _i16;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i13;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i14;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i20;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -746,8 +748,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,8 +759,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,9 +769,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -777,9 +779,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -788,8 +790,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,8 +801,8 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,8 +811,8 @@ class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
         );
 }
 
-class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_72(
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -818,9 +821,19 @@ class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_73 extends _i1.SmartFake
+class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_74 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_73(
+  _FakeLatestReceiptState_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,8 +842,8 @@ class _FakeLatestReceiptState_73 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_74(
+class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -839,8 +852,8 @@ class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_75 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_75(
+class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,12 +880,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i13.KeyVerificationMethod> get verificationMethods =>
+  Set<_i14.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i13.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i13.KeyVerificationMethod>{},
-      ) as Set<_i13.KeyVerificationMethod>);
+        returnValue: <_i14.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
+      ) as Set<_i14.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -992,11 +1005,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1033,11 +1046,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1067,11 +1080,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1080,11 +1093,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1370,34 +1383,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i13.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i13.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i13.KeyVerification>
+  _i3.CachedStreamController<_i14.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i13.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i13.KeyVerification>(
+                _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i13.KeyVerification>);
+          ) as _i3.CachedStreamController<_i14.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1553,7 +1566,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i13.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1842,14 +1855,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2237,8 +2250,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2254,8 +2267,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2296,7 +2309,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2312,7 +2325,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2361,7 +2374,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2382,7 +2395,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2485,7 +2498,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2503,7 +2516,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3022,7 +3035,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i15.Uint8List? file, {
+    _i16.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3374,7 +3387,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3388,7 +3401,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3539,7 +3552,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i15.Uint8List? body,
+    _i16.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4917,7 +4930,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4939,7 +4952,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5433,7 +5446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5445,7 +5458,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6453,7 +6466,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6464,7 +6477,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6712,7 +6725,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6724,7 +6737,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6984,7 +6997,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6997,7 +7010,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7064,7 +7077,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7077,7 +7090,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7125,7 +7138,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7137,7 +7150,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7385,7 +7398,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7396,7 +7409,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7658,7 +7671,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i15.Uint8List? body, {
+    _i16.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7685,7 +7698,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7700,13 +7713,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7715,11 +7741,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7740,69 +7766,69 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7821,6 +7847,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7830,7 +7865,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7839,7 +7874,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7848,7 +7883,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7857,7 +7892,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7866,7 +7901,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7919,7 +7954,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8013,7 +8048,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8022,7 +8057,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8041,7 +8076,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8052,7 +8087,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8100,7 +8135,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8138,7 +8173,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8147,7 +8182,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8156,16 +8191,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i5.Future<_i17.AppExitResponse>);
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8193,11 +8228,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8227,11 +8262,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_72(
+        returnValue: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_72(
+        returnValueForMissingStub: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
@@ -8284,11 +8319,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8324,11 +8359,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8344,11 +8379,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8357,11 +8392,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8384,11 +8419,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -8404,11 +8439,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8451,11 +8486,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_73(
+        returnValue: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_73(
+        returnValueForMissingStub: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8667,18 +8702,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i20.SpaceParent>[],
-        returnValueForMissingStub: <_i20.SpaceParent>[],
-      ) as List<_i20.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i20.SpaceChild>[],
-        returnValueForMissingStub: <_i20.SpaceChild>[],
-      ) as List<_i20.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8845,14 +8880,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8900,7 +8935,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8908,7 +8943,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8923,7 +8958,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8931,7 +8966,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9015,7 +9050,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9023,7 +9058,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9265,7 +9300,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9276,7 +9311,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9365,15 +9400,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i21.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i21.TimelineChunk?>.value(),
-      ) as _i5.Future<_i21.TimelineChunk?>);
+        returnValue: _i5.Future<_i22.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i22.TimelineChunk?>.value(),
+      ) as _i5.Future<_i22.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9414,7 +9449,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9431,7 +9466,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9495,14 +9530,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9518,14 +9553,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9581,7 +9616,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9589,7 +9624,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/homeserver_controller_test.mocks.dart
+++ b/test/widgets/homeserver_controller_test.mocks.dart
@@ -3,25 +3,27 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i12;
-import 'dart:ui' as _i13;
+import 'dart:async' as _i13;
+import 'dart:ui' as _i14;
 
-import 'package:flutter/services.dart' as _i14;
-import 'package:flutter/widgets.dart' as _i15;
-import 'package:kohera/core/models/server_auth_capabilities.dart' as _i9;
-import 'package:kohera/core/services/matrix_service.dart' as _i10;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
+import 'package:flutter/services.dart' as _i15;
+import 'package:flutter/widgets.dart' as _i16;
+import 'package:kohera/core/models/server_auth_capabilities.dart' as _i10;
+import 'package:kohera/core/services/matrix_service.dart' as _i11;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i5;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i7;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i4;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i7;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
-import 'package:matrix/matrix.dart' as _i3;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i3;
+import 'package:matrix/matrix.dart' as _i4;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i11;
+import 'package:mockito/src/dummies.dart' as _i12;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -49,8 +51,9 @@ class _FakeCallPushRuleManager_0 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
-  _FakeClient_1(
+class _FakeMegolmKeyMirror_1 extends _i1.SmartFake
+    implements _i3.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_1(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -59,8 +62,8 @@ class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
         );
 }
 
-class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
-  _FakeUiaService_2(
+class _FakeClient_2 extends _i1.SmartFake implements _i4.Client {
+  _FakeClient_2(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -69,9 +72,8 @@ class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
         );
 }
 
-class _FakeChatBackupService_3 extends _i1.SmartFake
-    implements _i5.ChatBackupService {
-  _FakeChatBackupService_3(
+class _FakeUiaService_3 extends _i1.SmartFake implements _i5.UiaService {
+  _FakeUiaService_3(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -80,9 +82,9 @@ class _FakeChatBackupService_3 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_4 extends _i1.SmartFake
-    implements _i6.SelectionService {
-  _FakeSelectionService_4(
+class _FakeChatBackupService_4 extends _i1.SmartFake
+    implements _i6.ChatBackupService {
+  _FakeChatBackupService_4(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -91,8 +93,9 @@ class _FakeSelectionService_4 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
-  _FakeSyncService_5(
+class _FakeSelectionService_5 extends _i1.SmartFake
+    implements _i7.SelectionService {
+  _FakeSelectionService_5(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -101,8 +104,8 @@ class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
         );
 }
 
-class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
-  _FakeAuthService_6(
+class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
+  _FakeSyncService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -111,9 +114,19 @@ class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
         );
 }
 
-class _FakeServerAuthCapabilities_7 extends _i1.SmartFake
-    implements _i9.ServerAuthCapabilities {
-  _FakeServerAuthCapabilities_7(
+class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
+  _FakeAuthService_7(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeServerAuthCapabilities_8 extends _i1.SmartFake
+    implements _i10.ServerAuthCapabilities {
+  _FakeServerAuthCapabilities_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -125,7 +138,7 @@ class _FakeServerAuthCapabilities_7 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -140,30 +153,43 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       ) as _i2.CallPushRuleManager);
 
   @override
+  _i3.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i3.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i11.dummyValue<String>(
+        returnValue: _i12.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i11.dummyValue<String>(
+        returnValueForMissingStub: _i12.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
       ) as String);
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get isLoggedIn => (super.noSuchMethod(
@@ -180,69 +206,69 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       ) as bool);
 
   @override
-  _i4.UiaService get uia => (super.noSuchMethod(
+  _i5.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_2(
+        returnValue: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_2(
+        returnValueForMissingStub: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i4.UiaService);
+      ) as _i5.UiaService);
 
   @override
-  _i5.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i6.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_3(
+        returnValue: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_3(
+        returnValueForMissingStub: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i5.ChatBackupService);
+      ) as _i6.ChatBackupService);
 
   @override
-  _i6.SelectionService get selection => (super.noSuchMethod(
+  _i7.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_4(
+        returnValue: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_4(
+        returnValueForMissingStub: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i6.SelectionService);
+      ) as _i7.SelectionService);
 
   @override
-  _i7.SyncService get sync => (super.noSuchMethod(
+  _i8.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_5(
+        returnValue: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_5(
+        returnValueForMissingStub: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i7.SyncService);
+      ) as _i8.SyncService);
 
   @override
-  _i8.AuthService get auth => (super.noSuchMethod(
+  _i9.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_6(
+        returnValue: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_6(
+        returnValueForMissingStub: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i8.AuthService);
+      ) as _i9.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -261,6 +287,15 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
+  set keyMirror(_i3.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -270,7 +305,7 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  set uia(_i4.UiaService? value) => super.noSuchMethod(
+  set uia(_i5.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -279,7 +314,7 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  set chatBackup(_i5.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i6.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -288,7 +323,7 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  set selection(_i6.SelectionService? value) => super.noSuchMethod(
+  set selection(_i7.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -297,7 +332,7 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  set sync(_i7.SyncService? value) => super.noSuchMethod(
+  set sync(_i8.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -306,7 +341,7 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  set auth(_i8.AuthService? value) => super.noSuchMethod(
+  set auth(_i9.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -322,14 +357,14 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       ) as bool);
 
   @override
-  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -359,7 +394,7 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i13.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i14.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -369,18 +404,18 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  _i12.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<bool> login({
+  _i13.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -395,12 +430,12 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> completeSsoLogin({
+  _i13.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -413,13 +448,13 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> completeRegistration(
-    _i3.RegisterResponse? response, {
+  _i13.Future<void> completeRegistration(
+    _i4.RegisterResponse? response, {
     String? password,
   }) =>
       (super.noSuchMethod(
@@ -428,32 +463,32 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  void addListener(_i13.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i14.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -462,7 +497,7 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  void removeListener(_i13.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i14.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -471,17 +506,17 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i14.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i15.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -492,7 +527,7 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i14.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i15.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -529,26 +564,26 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> didPushRouteInformation(
-          _i15.RouteInformation? routeInformation) =>
+  _i13.Future<bool> didPushRouteInformation(
+          _i16.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -578,7 +613,7 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i13.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i14.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -587,7 +622,7 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i13.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i14.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -596,16 +631,16 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  _i12.Future<_i13.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i13.Future<_i14.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i12.Future<_i13.AppExitResponse>.value(_i13.AppExitResponse.exit),
+            _i13.Future<_i14.AppExitResponse>.value(_i14.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i12.Future<_i13.AppExitResponse>.value(_i13.AppExitResponse.exit),
-      ) as _i12.Future<_i13.AppExitResponse>);
+            _i13.Future<_i14.AppExitResponse>.value(_i14.AppExitResponse.exit),
+      ) as _i13.Future<_i14.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -629,7 +664,7 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
 /// A class which mocks [AuthService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAuthService extends _i1.Mock implements _i8.AuthService {
+class MockAuthService extends _i1.Mock implements _i9.AuthService {
   @override
   bool get isLoggedIn => (super.noSuchMethod(
         Invocation.getter(#isLoggedIn),
@@ -663,7 +698,7 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
       ) as bool);
 
   @override
-  _i12.Future<bool> login({
+  _i13.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -678,12 +713,12 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
             #password: password,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> completeSsoLogin({
+  _i13.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -696,13 +731,13 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> completeRegistration(
-    _i3.RegisterResponse? response, {
+  _i13.Future<void> completeRegistration(
+    _i4.RegisterResponse? response, {
     String? password,
   }) =>
       (super.noSuchMethod(
@@ -711,9 +746,9 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
           [response],
           {#password: password},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void activateRestoredSession() => super.noSuchMethod(
@@ -725,37 +760,37 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
       );
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleServerLogout() => (super.noSuchMethod(
+  _i13.Future<void> handleServerLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleServerLogout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> saveSessionBackup() => (super.noSuchMethod(
+  _i13.Future<void> saveSessionBackup() => (super.noSuchMethod(
         Invocation.method(
           #saveSessionBackup,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i9.ServerAuthCapabilities> getServerAuthCapabilities(
+  _i13.Future<_i10.ServerAuthCapabilities> getServerAuthCapabilities(
     String? homeserver, {
     required bool? isLoggedIn,
   }) =>
@@ -765,8 +800,8 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
           [homeserver],
           {#isLoggedIn: isLoggedIn},
         ),
-        returnValue: _i12.Future<_i9.ServerAuthCapabilities>.value(
-            _FakeServerAuthCapabilities_7(
+        returnValue: _i13.Future<_i10.ServerAuthCapabilities>.value(
+            _FakeServerAuthCapabilities_8(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -775,8 +810,8 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i9.ServerAuthCapabilities>.value(
-                _FakeServerAuthCapabilities_7(
+            _i13.Future<_i10.ServerAuthCapabilities>.value(
+                _FakeServerAuthCapabilities_8(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -784,7 +819,7 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
             {#isLoggedIn: isLoggedIn},
           ),
         )),
-      ) as _i12.Future<_i9.ServerAuthCapabilities>);
+      ) as _i13.Future<_i10.ServerAuthCapabilities>);
 
   @override
   bool isPermanentAuthFailure(Object? error) => (super.noSuchMethod(
@@ -797,37 +832,37 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
       ) as bool);
 
   @override
-  _i12.Future<void> clearSessionKeys() => (super.noSuchMethod(
+  _i13.Future<void> clearSessionKeys() => (super.noSuchMethod(
         Invocation.method(
           #clearSessionKeys,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> migrateStorageKeys() => (super.noSuchMethod(
+  _i13.Future<void> migrateStorageKeys() => (super.noSuchMethod(
         Invocation.method(
           #migrateStorageKeys,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> persistCredentials() => (super.noSuchMethod(
+  _i13.Future<void> persistCredentials() => (super.noSuchMethod(
         Invocation.method(
           #persistCredentials,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  void addListener(_i13.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i14.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -836,7 +871,7 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
       );
 
   @override
-  void removeListener(_i13.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i14.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/test/widgets/invite_dialog_test.mocks.dart
+++ b/test/widgets/invite_dialog_test.mocks.dart
@@ -3,31 +3,33 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i11;
-import 'dart:typed_data' as _i21;
-import 'dart:ui' as _i15;
+import 'dart:async' as _i12;
+import 'dart:typed_data' as _i22;
+import 'dart:ui' as _i16;
 
-import 'package:flutter/services.dart' as _i16;
-import 'package:flutter/widgets.dart' as _i17;
-import 'package:http/http.dart' as _i10;
-import 'package:kohera/core/services/matrix_service.dart' as _i13;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
+import 'package:flutter/services.dart' as _i17;
+import 'package:flutter/widgets.dart' as _i18;
+import 'package:http/http.dart' as _i11;
+import 'package:kohera/core/services/matrix_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i5;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i7;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i4;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i7;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
-import 'package:matrix/encryption.dart' as _i20;
-import 'package:matrix/matrix.dart' as _i3;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i12;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i9;
-import 'package:matrix/src/utils/space_child.dart' as _i18;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i3;
+import 'package:matrix/encryption.dart' as _i21;
+import 'package:matrix/matrix.dart' as _i4;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i13;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i20;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i10;
+import 'package:matrix/src/utils/space_child.dart' as _i19;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -55,8 +57,9 @@ class _FakeCallPushRuleManager_0 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
-  _FakeClient_1(
+class _FakeMegolmKeyMirror_1 extends _i1.SmartFake
+    implements _i3.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_1(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -65,8 +68,8 @@ class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
         );
 }
 
-class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
-  _FakeUiaService_2(
+class _FakeClient_2 extends _i1.SmartFake implements _i4.Client {
+  _FakeClient_2(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -75,9 +78,8 @@ class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
         );
 }
 
-class _FakeChatBackupService_3 extends _i1.SmartFake
-    implements _i5.ChatBackupService {
-  _FakeChatBackupService_3(
+class _FakeUiaService_3 extends _i1.SmartFake implements _i5.UiaService {
+  _FakeUiaService_3(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -86,9 +88,9 @@ class _FakeChatBackupService_3 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_4 extends _i1.SmartFake
-    implements _i6.SelectionService {
-  _FakeSelectionService_4(
+class _FakeChatBackupService_4 extends _i1.SmartFake
+    implements _i6.ChatBackupService {
+  _FakeChatBackupService_4(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -97,8 +99,9 @@ class _FakeSelectionService_4 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
-  _FakeSyncService_5(
+class _FakeSelectionService_5 extends _i1.SmartFake
+    implements _i7.SelectionService {
+  _FakeSelectionService_5(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -107,8 +110,8 @@ class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
         );
 }
 
-class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
-  _FakeAuthService_6(
+class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
+  _FakeSyncService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -117,8 +120,8 @@ class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
         );
 }
 
-class _FakeRoomSummary_7 extends _i1.SmartFake implements _i3.RoomSummary {
-  _FakeRoomSummary_7(
+class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
+  _FakeAuthService_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -127,9 +130,8 @@ class _FakeRoomSummary_7 extends _i1.SmartFake implements _i3.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_8<T> extends _i1.SmartFake
-    implements _i9.CachedStreamController<T> {
-  _FakeCachedStreamController_8(
+class _FakeRoomSummary_8 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -138,8 +140,9 @@ class _FakeCachedStreamController_8<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_9 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_9(
+class _FakeCachedStreamController_9<T> extends _i1.SmartFake
+    implements _i10.CachedStreamController<T> {
+  _FakeCachedStreamController_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -148,9 +151,8 @@ class _FakeDateTime_9 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_10 extends _i1.SmartFake
-    implements _i3.LatestReceiptState {
-  _FakeLatestReceiptState_10(
+class _FakeDateTime_10 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -159,8 +161,9 @@ class _FakeLatestReceiptState_10 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_11 extends _i1.SmartFake implements _i3.SyncUpdate {
-  _FakeSyncUpdate_11(
+class _FakeLatestReceiptState_11 extends _i1.SmartFake
+    implements _i4.LatestReceiptState {
+  _FakeLatestReceiptState_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -169,8 +172,8 @@ class _FakeSyncUpdate_11 extends _i1.SmartFake implements _i3.SyncUpdate {
         );
 }
 
-class _FakeTimeline_12 extends _i1.SmartFake implements _i3.Timeline {
-  _FakeTimeline_12(
+class _FakeSyncUpdate_12 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -179,8 +182,8 @@ class _FakeTimeline_12 extends _i1.SmartFake implements _i3.Timeline {
         );
 }
 
-class _FakeUser_13 extends _i1.SmartFake implements _i3.User {
-  _FakeUser_13(
+class _FakeTimeline_13 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -189,8 +192,8 @@ class _FakeUser_13 extends _i1.SmartFake implements _i3.User {
         );
 }
 
-class _FakeUri_14 extends _i1.SmartFake implements Uri {
-  _FakeUri_14(
+class _FakeUser_14 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -199,8 +202,8 @@ class _FakeUri_14 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_15 extends _i1.SmartFake implements _i3.DatabaseApi {
-  _FakeDatabaseApi_15(
+class _FakeUri_15 extends _i1.SmartFake implements Uri {
+  _FakeUri_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -209,8 +212,8 @@ class _FakeDatabaseApi_15 extends _i1.SmartFake implements _i3.DatabaseApi {
         );
 }
 
-class _FakeFilter_16 extends _i1.SmartFake implements _i3.Filter {
-  _FakeFilter_16(
+class _FakeDatabaseApi_16 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -219,9 +222,8 @@ class _FakeFilter_16 extends _i1.SmartFake implements _i3.Filter {
         );
 }
 
-class _FakeNativeImplementations_17 extends _i1.SmartFake
-    implements _i3.NativeImplementations {
-  _FakeNativeImplementations_17(
+class _FakeFilter_17 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -230,8 +232,9 @@ class _FakeNativeImplementations_17 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_18 extends _i1.SmartFake implements Duration {
-  _FakeDuration_18(
+class _FakeNativeImplementations_18 extends _i1.SmartFake
+    implements _i4.NativeImplementations {
+  _FakeNativeImplementations_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -240,9 +243,8 @@ class _FakeDuration_18 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_19 extends _i1.SmartFake
-    implements _i3.PushruleEvaluator {
-  _FakePushruleEvaluator_19(
+class _FakeDuration_19 extends _i1.SmartFake implements Duration {
+  _FakeDuration_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -251,8 +253,9 @@ class _FakePushruleEvaluator_19 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_20 extends _i1.SmartFake implements _i3.Profile {
-  _FakeProfile_20(
+class _FakePushruleEvaluator_20 extends _i1.SmartFake
+    implements _i4.PushruleEvaluator {
+  _FakePushruleEvaluator_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -261,8 +264,8 @@ class _FakeProfile_20 extends _i1.SmartFake implements _i3.Profile {
         );
 }
 
-class _FakeClient_21 extends _i1.SmartFake implements _i10.Client {
-  _FakeClient_21(
+class _FakeProfile_21 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -271,9 +274,8 @@ class _FakeClient_21 extends _i1.SmartFake implements _i10.Client {
         );
 }
 
-class _FakeDiscoveryInformation_22 extends _i1.SmartFake
-    implements _i3.DiscoveryInformation {
-  _FakeDiscoveryInformation_22(
+class _FakeClient_22 extends _i1.SmartFake implements _i11.Client {
+  _FakeClient_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -282,9 +284,9 @@ class _FakeDiscoveryInformation_22 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_23 extends _i1.SmartFake
-    implements _i3.GetVersionsResponse {
-  _FakeGetVersionsResponse_23(
+class _FakeDiscoveryInformation_23 extends _i1.SmartFake
+    implements _i4.DiscoveryInformation {
+  _FakeDiscoveryInformation_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -293,9 +295,9 @@ class _FakeGetVersionsResponse_23 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_24 extends _i1.SmartFake
-    implements _i3.RegisterResponse {
-  _FakeRegisterResponse_24(
+class _FakeGetVersionsResponse_24 extends _i1.SmartFake
+    implements _i4.GetVersionsResponse {
+  _FakeGetVersionsResponse_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -304,8 +306,9 @@ class _FakeRegisterResponse_24 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_25 extends _i1.SmartFake implements _i3.LoginResponse {
-  _FakeLoginResponse_25(
+class _FakeRegisterResponse_25 extends _i1.SmartFake
+    implements _i4.RegisterResponse {
+  _FakeRegisterResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -314,9 +317,8 @@ class _FakeLoginResponse_25 extends _i1.SmartFake implements _i3.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_26 extends _i1.SmartFake
-    implements _i3.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_26(
+class _FakeLoginResponse_26 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -325,8 +327,9 @@ class _FakeGetAuthMetadataResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_27<T1> extends _i1.SmartFake implements _i11.Future<T1> {
-  _FakeFuture_27(
+class _FakeGetAuthMetadataResponse_27 extends _i1.SmartFake
+    implements _i4.GetAuthMetadataResponse {
+  _FakeGetAuthMetadataResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -335,9 +338,8 @@ class _FakeFuture_27<T1> extends _i1.SmartFake implements _i11.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_28 extends _i1.SmartFake
-    implements _i3.CachedProfileInformation {
-  _FakeCachedProfileInformation_28(
+class _FakeFuture_28<T1> extends _i1.SmartFake implements _i12.Future<T1> {
+  _FakeFuture_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -346,8 +348,9 @@ class _FakeCachedProfileInformation_28 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_29 extends _i1.SmartFake implements _i3.MediaConfig {
-  _FakeMediaConfig_29(
+class _FakeCachedProfileInformation_29 extends _i1.SmartFake
+    implements _i4.CachedProfileInformation {
+  _FakeCachedProfileInformation_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -356,8 +359,8 @@ class _FakeMediaConfig_29 extends _i1.SmartFake implements _i3.MediaConfig {
         );
 }
 
-class _FakeFileResponse_30 extends _i1.SmartFake implements _i12.FileResponse {
-  _FakeFileResponse_30(
+class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -366,8 +369,8 @@ class _FakeFileResponse_30 extends _i1.SmartFake implements _i12.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_31 extends _i1.SmartFake implements _i3.PreviewForUrl {
-  _FakePreviewForUrl_31(
+class _FakeFileResponse_31 extends _i1.SmartFake implements _i13.FileResponse {
+  _FakeFileResponse_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -376,9 +379,8 @@ class _FakePreviewForUrl_31 extends _i1.SmartFake implements _i3.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_32 extends _i1.SmartFake
-    implements _i3.CachedPresence {
-  _FakeCachedPresence_32(
+class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -387,9 +389,9 @@ class _FakeCachedPresence_32 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_33 extends _i1.SmartFake
-    implements _i3.TurnServerCredentials {
-  _FakeTurnServerCredentials_33(
+class _FakeCachedPresence_33 extends _i1.SmartFake
+    implements _i4.CachedPresence {
+  _FakeCachedPresence_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -398,9 +400,9 @@ class _FakeTurnServerCredentials_33 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
-    implements _i3.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_34(
+class _FakeTurnServerCredentials_34 extends _i1.SmartFake
+    implements _i4.TurnServerCredentials {
+  _FakeTurnServerCredentials_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -409,8 +411,9 @@ class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i3.KeyBackupData {
-  _FakeKeyBackupData_35(
+class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
+    implements _i4.RoomKeysUpdateResponse {
+  _FakeRoomKeysUpdateResponse_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -419,9 +422,8 @@ class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i3.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
-    implements _i3.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_36(
+class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -430,9 +432,9 @@ class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
-    implements _i3.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_37(
+class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
+    implements _i4.GetWellknownSupportResponse {
+  _FakeGetWellknownSupportResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -441,9 +443,9 @@ class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
-    implements _i3.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_38(
+class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
+    implements _i4.GenerateLoginTokenResponse {
+  _FakeGenerateLoginTokenResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -452,9 +454,9 @@ class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
-    implements _i3.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_39(
+class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
+    implements _i4.GetRoomSummaryResponse$3 {
+  _FakeGetRoomSummaryResponse$3_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -463,9 +465,9 @@ class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
-    implements _i3.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_40(
+class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
+    implements _i4.GetSpaceHierarchyResponse {
+  _FakeGetSpaceHierarchyResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -474,9 +476,9 @@ class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
-    implements _i3.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_41(
+class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
+    implements _i4.GetRelatingEventsResponse {
+  _FakeGetRelatingEventsResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -485,9 +487,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
-    .SmartFake implements _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
+    implements _i4.GetRelatingEventsWithRelTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -496,9 +498,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
-    implements _i3.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_43(
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
+    .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -507,9 +509,9 @@ class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
-    implements _i3.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_44(
+class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
+    implements _i4.GetThreadRootsResponse {
+  _FakeGetThreadRootsResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -518,9 +520,9 @@ class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_45 extends _i1.SmartFake
-    implements _i3.RequestTokenResponse {
-  _FakeRequestTokenResponse_45(
+class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
+    implements _i4.GetEventByTimestampResponse {
+  _FakeGetEventByTimestampResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -529,9 +531,9 @@ class _FakeRequestTokenResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
-    implements _i3.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_46(
+class _FakeRequestTokenResponse_46 extends _i1.SmartFake
+    implements _i4.RequestTokenResponse {
+  _FakeRequestTokenResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -540,8 +542,9 @@ class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i3.WhoIsInfo {
-  _FakeWhoIsInfo_47(
+class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
+    implements _i4.TokenOwnerInfo {
+  _FakeTokenOwnerInfo_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -550,8 +553,8 @@ class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i3.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_48 extends _i1.SmartFake implements _i3.Capabilities {
-  _FakeCapabilities_48(
+class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -560,8 +563,8 @@ class _FakeCapabilities_48 extends _i1.SmartFake implements _i3.Capabilities {
         );
 }
 
-class _FakeDevice_49 extends _i1.SmartFake implements _i3.Device {
-  _FakeDevice_49(
+class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -570,9 +573,8 @@ class _FakeDevice_49 extends _i1.SmartFake implements _i3.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
-    implements _i3.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_50(
+class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -581,9 +583,9 @@ class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_51 extends _i1.SmartFake
-    implements _i3.GetEventsResponse {
-  _FakeGetEventsResponse_51(
+class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
+    implements _i4.GetRoomIdByAliasResponse {
+  _FakeGetRoomIdByAliasResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -592,9 +594,9 @@ class _FakeGetEventsResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_52 extends _i1.SmartFake
-    implements _i3.PeekEventsResponse {
-  _FakePeekEventsResponse_52(
+class _FakeGetEventsResponse_52 extends _i1.SmartFake
+    implements _i4.GetEventsResponse {
+  _FakeGetEventsResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -603,8 +605,9 @@ class _FakePeekEventsResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i3.MatrixEvent {
-  _FakeMatrixEvent_53(
+class _FakePeekEventsResponse_53 extends _i1.SmartFake
+    implements _i4.PeekEventsResponse {
+  _FakePeekEventsResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -613,9 +616,8 @@ class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i3.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
-    implements _i3.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_54(
+class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -624,9 +626,9 @@ class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_55 extends _i1.SmartFake
-    implements _i3.ClaimKeysResponse {
-  _FakeClaimKeysResponse_55(
+class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
+    implements _i4.GetKeysChangesResponse {
+  _FakeGetKeysChangesResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -635,9 +637,9 @@ class _FakeClaimKeysResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_56 extends _i1.SmartFake
-    implements _i3.QueryKeysResponse {
-  _FakeQueryKeysResponse_56(
+class _FakeClaimKeysResponse_56 extends _i1.SmartFake
+    implements _i4.ClaimKeysResponse {
+  _FakeClaimKeysResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -646,9 +648,9 @@ class _FakeQueryKeysResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
-    implements _i3.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_57(
+class _FakeQueryKeysResponse_57 extends _i1.SmartFake
+    implements _i4.QueryKeysResponse {
+  _FakeQueryKeysResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -657,9 +659,9 @@ class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_58 extends _i1.SmartFake
-    implements _i3.GetPresenceResponse {
-  _FakeGetPresenceResponse_58(
+class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
+    implements _i4.GetNotificationsResponse {
+  _FakeGetNotificationsResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -668,9 +670,9 @@ class _FakeGetPresenceResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
-    implements _i3.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_59(
+class _FakeGetPresenceResponse_59 extends _i1.SmartFake
+    implements _i4.GetPresenceResponse {
+  _FakeGetPresenceResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -679,9 +681,9 @@ class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
-    implements _i3.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_60(
+class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
+    implements _i4.GetPublicRoomsResponse {
+  _FakeGetPublicRoomsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -690,8 +692,9 @@ class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_61 extends _i1.SmartFake implements _i3.PushRuleSet {
-  _FakePushRuleSet_61(
+class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
+    implements _i4.QueryPublicRoomsResponse {
+  _FakeQueryPublicRoomsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -700,9 +703,8 @@ class _FakePushRuleSet_61 extends _i1.SmartFake implements _i3.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
-    implements _i3.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_62(
+class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -711,8 +713,9 @@ class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_63 extends _i1.SmartFake implements _i3.PushRule {
-  _FakePushRule_63(
+class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
+    implements _i4.GetPushRulesGlobalResponse {
+  _FakeGetPushRulesGlobalResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -721,9 +724,8 @@ class _FakePushRule_63 extends _i1.SmartFake implements _i3.PushRule {
         );
 }
 
-class _FakeRefreshResponse_64 extends _i1.SmartFake
-    implements _i3.RefreshResponse {
-  _FakeRefreshResponse_64(
+class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -732,8 +734,9 @@ class _FakeRefreshResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_65 extends _i1.SmartFake implements _i3.RoomKeys {
-  _FakeRoomKeys_65(
+class _FakeRefreshResponse_65 extends _i1.SmartFake
+    implements _i4.RefreshResponse {
+  _FakeRefreshResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -742,8 +745,8 @@ class _FakeRoomKeys_65 extends _i1.SmartFake implements _i3.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i3.RoomKeyBackup {
-  _FakeRoomKeyBackup_66(
+class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -752,9 +755,8 @@ class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i3.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
-    implements _i3.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_67(
+class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -763,9 +765,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
-    implements _i3.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_68(
+class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
+    implements _i4.GetRoomKeysVersionCurrentResponse {
+  _FakeGetRoomKeysVersionCurrentResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -774,8 +776,9 @@ class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_69 extends _i1.SmartFake implements _i3.EventContext {
-  _FakeEventContext_69(
+class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
+    implements _i4.GetRoomKeysVersionResponse {
+  _FakeGetRoomKeysVersionResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -784,9 +787,8 @@ class _FakeEventContext_69 extends _i1.SmartFake implements _i3.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
-    implements _i3.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_70(
+class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -795,8 +797,9 @@ class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_71 extends _i1.SmartFake implements _i3.SearchResults {
-  _FakeSearchResults_71(
+class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
+    implements _i4.GetRoomEventsResponse {
+  _FakeGetRoomEventsResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -805,9 +808,8 @@ class _FakeSearchResults_71 extends _i1.SmartFake implements _i3.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
-    implements _i3.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_72(
+class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -816,9 +818,9 @@ class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_73 extends _i1.SmartFake
-    implements _i3.OpenIdCredentials {
-  _FakeOpenIdCredentials_73(
+class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
+    implements _i4.GetProtocolMetadataResponse$2 {
+  _FakeGetProtocolMetadataResponse$2_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -827,9 +829,9 @@ class _FakeOpenIdCredentials_73 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
-    implements _i3.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_74(
+class _FakeOpenIdCredentials_74 extends _i1.SmartFake
+    implements _i4.OpenIdCredentials {
+  _FakeOpenIdCredentials_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -838,9 +840,20 @@ class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_75 extends _i1.SmartFake
-    implements _i3.CreateContentResponse {
-  _FakeCreateContentResponse_75(
+class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
+    implements _i4.SearchUserDirectoryResponse {
+  _FakeSearchUserDirectoryResponse_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeCreateContentResponse_76 extends _i1.SmartFake
+    implements _i4.CreateContentResponse {
+  _FakeCreateContentResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,7 +865,7 @@ class _FakeCreateContentResponse_75 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -867,30 +880,43 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as _i2.CallPushRuleManager);
 
   @override
+  _i3.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i3.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
       ) as String);
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get isLoggedIn => (super.noSuchMethod(
@@ -907,69 +933,69 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  _i4.UiaService get uia => (super.noSuchMethod(
+  _i5.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_2(
+        returnValue: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_2(
+        returnValueForMissingStub: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i4.UiaService);
+      ) as _i5.UiaService);
 
   @override
-  _i5.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i6.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_3(
+        returnValue: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_3(
+        returnValueForMissingStub: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i5.ChatBackupService);
+      ) as _i6.ChatBackupService);
 
   @override
-  _i6.SelectionService get selection => (super.noSuchMethod(
+  _i7.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_4(
+        returnValue: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_4(
+        returnValueForMissingStub: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i6.SelectionService);
+      ) as _i7.SelectionService);
 
   @override
-  _i7.SyncService get sync => (super.noSuchMethod(
+  _i8.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_5(
+        returnValue: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_5(
+        returnValueForMissingStub: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i7.SyncService);
+      ) as _i8.SyncService);
 
   @override
-  _i8.AuthService get auth => (super.noSuchMethod(
+  _i9.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_6(
+        returnValue: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_6(
+        returnValueForMissingStub: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i8.AuthService);
+      ) as _i9.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -988,6 +1014,15 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
+  set keyMirror(_i3.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -997,7 +1032,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set uia(_i4.UiaService? value) => super.noSuchMethod(
+  set uia(_i5.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -1006,7 +1041,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set chatBackup(_i5.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i6.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -1015,7 +1050,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set selection(_i6.SelectionService? value) => super.noSuchMethod(
+  set selection(_i7.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -1024,7 +1059,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set sync(_i7.SyncService? value) => super.noSuchMethod(
+  set sync(_i8.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -1033,7 +1068,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set auth(_i8.AuthService? value) => super.noSuchMethod(
+  set auth(_i9.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -1049,14 +1084,14 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  _i11.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1086,7 +1121,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i15.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i16.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1096,18 +1131,18 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i12.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<bool> login({
+  _i12.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1122,12 +1157,12 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<bool> completeSsoLogin({
+  _i12.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1140,13 +1175,13 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> completeRegistration(
-    _i3.RegisterResponse? response, {
+  _i12.Future<void> completeRegistration(
+    _i4.RegisterResponse? response, {
     String? password,
   }) =>
       (super.noSuchMethod(
@@ -1155,32 +1190,32 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> logout() => (super.noSuchMethod(
+  _i12.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i12.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  void addListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1189,7 +1224,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void removeListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1198,17 +1233,17 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i16.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i17.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1219,7 +1254,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i16.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i17.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1256,26 +1291,26 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<bool> didPushRouteInformation(
-          _i17.RouteInformation? routeInformation) =>
+  _i12.Future<bool> didPushRouteInformation(
+          _i18.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1305,7 +1340,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i15.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i16.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1314,7 +1349,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i15.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i16.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1323,16 +1358,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<_i15.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i12.Future<_i16.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
-      ) as _i11.Future<_i15.AppExitResponse>);
+            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
+      ) as _i12.Future<_i16.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1356,26 +1391,26 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
 /// A class which mocks [Room].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockRoom extends _i1.Mock implements _i3.Room {
+class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
       ) as String);
 
   @override
-  _i3.Membership get membership => (super.noSuchMethod(
+  _i4.Membership get membership => (super.noSuchMethod(
         Invocation.getter(#membership),
-        returnValue: _i3.Membership.ban,
-        returnValueForMissingStub: _i3.Membership.ban,
-      ) as _i3.Membership);
+        returnValue: _i4.Membership.ban,
+        returnValueForMissingStub: _i4.Membership.ban,
+      ) as _i4.Membership);
 
   @override
   int get notificationCount => (super.noSuchMethod(
@@ -1392,47 +1427,47 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i3.RoomSummary get summary => (super.noSuchMethod(
+  _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_7(
+        returnValue: _FakeRoomSummary_8(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_7(
+        returnValueForMissingStub: _FakeRoomSummary_8(
           this,
           Invocation.getter(#summary),
         ),
-      ) as _i3.RoomSummary);
+      ) as _i4.RoomSummary);
 
   @override
-  Map<String, Map<String, _i3.StrippedStateEvent>> get states =>
+  Map<String, Map<String, _i4.StrippedStateEvent>> get states =>
       (super.noSuchMethod(
         Invocation.getter(#states),
-        returnValue: <String, Map<String, _i3.StrippedStateEvent>>{},
+        returnValue: <String, Map<String, _i4.StrippedStateEvent>>{},
         returnValueForMissingStub: <String,
-            Map<String, _i3.StrippedStateEvent>>{},
-      ) as Map<String, Map<String, _i3.StrippedStateEvent>>);
+            Map<String, _i4.StrippedStateEvent>>{},
+      ) as Map<String, Map<String, _i4.StrippedStateEvent>>);
 
   @override
-  Map<String, _i3.BasicEvent> get ephemerals => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get ephemerals => (super.noSuchMethod(
         Invocation.getter(#ephemerals),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  Map<String, _i3.BasicEvent> get roomAccountData => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get roomAccountData => (super.noSuchMethod(
         Invocation.getter(#roomAccountData),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i11.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i12.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i11.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i11.Completer<dynamic>>[],
-      ) as List<_i11.Completer<dynamic>>);
+        returnValue: <_i12.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i12.Completer<dynamic>>[],
+      ) as List<_i12.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1451,51 +1486,51 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i9.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i10.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i9.CachedStreamController<String> get onSessionKeyReceived =>
+  _i10.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1511,11 +1546,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1524,11 +1559,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1542,24 +1577,24 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i3.User> get typingUsers => (super.noSuchMethod(
+  List<_i4.User> get typingUsers => (super.noSuchMethod(
         Invocation.getter(#typingUsers),
-        returnValue: <_i3.User>[],
-        returnValueForMissingStub: <_i3.User>[],
-      ) as List<_i3.User>);
+        returnValue: <_i4.User>[],
+        returnValueForMissingStub: <_i4.User>[],
+      ) as List<_i4.User>);
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get isAbandonedDMRoom => (super.noSuchMethod(
@@ -1571,11 +1606,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1584,22 +1619,22 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_9(
+        returnValue: _FakeDateTime_10(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_9(
+        returnValueForMissingStub: _FakeDateTime_10(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
       ) as DateTime);
 
   @override
-  Map<String, _i3.Tag> get tags => (super.noSuchMethod(
+  Map<String, _i4.Tag> get tags => (super.noSuchMethod(
         Invocation.getter(#tags),
-        returnValue: <String, _i3.Tag>{},
-        returnValueForMissingStub: <String, _i3.Tag>{},
-      ) as Map<String, _i3.Tag>);
+        returnValue: <String, _i4.Tag>{},
+        returnValueForMissingStub: <String, _i4.Tag>{},
+      ) as Map<String, _i4.Tag>);
 
   @override
   bool get markedUnread => (super.noSuchMethod(
@@ -1616,17 +1651,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.LatestReceiptState get receiptState => (super.noSuchMethod(
+  _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_10(
+        returnValue: _FakeLatestReceiptState_11(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_10(
+        returnValueForMissingStub: _FakeLatestReceiptState_11(
           this,
           Invocation.getter(#receiptState),
         ),
-      ) as _i3.LatestReceiptState);
+      ) as _i4.LatestReceiptState);
 
   @override
   bool get isUnread => (super.noSuchMethod(
@@ -1643,18 +1678,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i11.Future<_i3.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i12.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -1664,20 +1699,20 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  Map<String, _i3.MatrixFile> get sendingFilePlaceholders =>
+  Map<String, _i4.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
-        returnValue: <String, _i3.MatrixFile>{},
-        returnValueForMissingStub: <String, _i3.MatrixFile>{},
-      ) as Map<String, _i3.MatrixFile>);
+        returnValue: <String, _i4.MatrixFile>{},
+        returnValueForMissingStub: <String, _i4.MatrixFile>{},
+      ) as Map<String, _i4.MatrixFile>);
 
   @override
-  Map<String, _i3.MatrixImageFile> get sendingFileThumbnails =>
+  Map<String, _i4.MatrixImageFile> get sendingFileThumbnails =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFileThumbnails),
-        returnValue: <String, _i3.MatrixImageFile>{},
-        returnValueForMissingStub: <String, _i3.MatrixImageFile>{},
-      ) as Map<String, _i3.MatrixImageFile>);
+        returnValue: <String, _i4.MatrixImageFile>{},
+        returnValueForMissingStub: <String, _i4.MatrixImageFile>{},
+      ) as Map<String, _i4.MatrixImageFile>);
 
   @override
   bool get isFederated => (super.noSuchMethod(
@@ -1778,11 +1813,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.PushRuleState get pushRuleState => (super.noSuchMethod(
+  _i4.PushRuleState get pushRuleState => (super.noSuchMethod(
         Invocation.getter(#pushRuleState),
-        returnValue: _i3.PushRuleState.notify,
-        returnValueForMissingStub: _i3.PushRuleState.notify,
-      ) as _i3.PushRuleState);
+        returnValue: _i4.PushRuleState.notify,
+        returnValueForMissingStub: _i4.PushRuleState.notify,
+      ) as _i4.PushRuleState);
 
   @override
   bool get canChangeJoinRules => (super.noSuchMethod(
@@ -1792,11 +1827,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.GuestAccess get guestAccess => (super.noSuchMethod(
+  _i4.GuestAccess get guestAccess => (super.noSuchMethod(
         Invocation.getter(#guestAccess),
-        returnValue: _i3.GuestAccess.canJoin,
-        returnValueForMissingStub: _i3.GuestAccess.canJoin,
-      ) as _i3.GuestAccess);
+        returnValue: _i4.GuestAccess.canJoin,
+        returnValueForMissingStub: _i4.GuestAccess.canJoin,
+      ) as _i4.GuestAccess);
 
   @override
   bool get canChangeGuestAccess => (super.noSuchMethod(
@@ -1834,21 +1869,21 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i19.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i18.SpaceParent>[],
-        returnValueForMissingStub: <_i18.SpaceParent>[],
-      ) as List<_i18.SpaceParent>);
+        returnValue: <_i19.SpaceParent>[],
+        returnValueForMissingStub: <_i19.SpaceParent>[],
+      ) as List<_i19.SpaceParent>);
 
   @override
-  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i19.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i18.SpaceChild>[],
-        returnValueForMissingStub: <_i18.SpaceChild>[],
-      ) as List<_i18.SpaceChild>);
+        returnValue: <_i19.SpaceChild>[],
+        returnValueForMissingStub: <_i19.SpaceChild>[],
+      ) as List<_i19.SpaceChild>);
 
   @override
-  set membership(_i3.Membership? value) => super.noSuchMethod(
+  set membership(_i4.Membership? value) => super.noSuchMethod(
         Invocation.setter(
           #membership,
           value,
@@ -1884,7 +1919,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set summary(_i3.RoomSummary? value) => super.noSuchMethod(
+  set summary(_i4.RoomSummary? value) => super.noSuchMethod(
         Invocation.setter(
           #summary,
           value,
@@ -1893,7 +1928,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set states(Map<String, Map<String, _i3.StrippedStateEvent>>? value) =>
+  set states(Map<String, Map<String, _i4.StrippedStateEvent>>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #states,
@@ -1903,7 +1938,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set ephemerals(Map<String, _i3.BasicEvent>? value) => super.noSuchMethod(
+  set ephemerals(Map<String, _i4.BasicEvent>? value) => super.noSuchMethod(
         Invocation.setter(
           #ephemerals,
           value,
@@ -1912,7 +1947,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set roomAccountData(Map<String, _i3.BasicEvent>? value) => super.noSuchMethod(
+  set roomAccountData(Map<String, _i4.BasicEvent>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomAccountData,
           value,
@@ -1930,7 +1965,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set lastEvent(_i3.Event? value) => super.noSuchMethod(
+  set lastEvent(_i4.Event? value) => super.noSuchMethod(
         Invocation.setter(
           #lastEvent,
           value,
@@ -1939,7 +1974,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set receiptState(_i3.LatestReceiptState? value) => super.noSuchMethod(
+  set receiptState(_i4.LatestReceiptState? value) => super.noSuchMethod(
         Invocation.setter(
           #receiptState,
           value,
@@ -1958,17 +1993,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i11.Future<void> postLoad() => (super.noSuchMethod(
+  _i12.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i3.StrippedStateEvent? getState(
+  _i4.StrippedStateEvent? getState(
     String? typeKey, [
     String? stateKey = '',
   ]) =>
@@ -1981,10 +2016,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.StrippedStateEvent?);
+      ) as _i4.StrippedStateEvent?);
 
   @override
-  void setState(_i3.StrippedStateEvent? state) => super.noSuchMethod(
+  void setState(_i4.StrippedStateEvent? state) => super.noSuchMethod(
         Invocation.method(
           #setState,
           [state],
@@ -1993,33 +2028,33 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  _i11.Future<List<_i3.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i12.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
+        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
-      ) as _i11.Future<List<_i3.User>>);
+            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i12.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
-          [_i3.MatrixLocalizations? i18n =
-              const _i3.MatrixDefaultLocalizations()]) =>
+          [_i4.MatrixLocalizations? i18n =
+              const _i4.MatrixDefaultLocalizations()]) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2029,18 +2064,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as String);
 
   @override
-  _i11.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i12.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Event?> refreshLastEvent(
+  _i12.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2048,12 +2083,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
-  void setEphemeral(_i3.BasicEvent? ephemeral) => super.noSuchMethod(
+  void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
         Invocation.method(
           #setEphemeral,
           [ephemeral],
@@ -2062,12 +2097,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  _i11.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i12.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2075,22 +2110,22 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i12.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2098,17 +2133,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> addTag(
+  _i12.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2118,27 +2153,27 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i12.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i12.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2146,43 +2181,43 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i12.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i12.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i12.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2190,14 +2225,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2209,10 +2244,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as String?);
 
   @override
-  _i11.Future<String?> sendTextEvent(
+  _i12.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     bool? parseMarkdown = true,
     bool? parseCommands = true,
@@ -2241,12 +2276,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendReaction(
+  _i12.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2260,12 +2295,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendLocation(
+  _i12.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2279,18 +2314,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendFileEvent(
-    _i3.MatrixFile? file, {
+  _i12.Future<String?> sendFileEvent(
+    _i4.MatrixFile? file, {
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     int? shrinkImageMaxDimension,
-    _i3.MatrixImageFile? thumbnail,
+    _i4.MatrixImageFile? thumbnail,
     Map<String, dynamic>? extraContent,
     String? threadRootEventId,
     String? threadLastEventId,
@@ -2312,29 +2347,29 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<_i3.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i12.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i11.Future<_i3.EncryptionHealthState>.value(
-            _i3.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i11.Future<_i3.EncryptionHealthState>.value(
-            _i3.EncryptionHealthState.allVerified),
-      ) as _i11.Future<_i3.EncryptionHealthState>);
+        returnValue: _i12.Future<_i4.EncryptionHealthState>.value(
+            _i4.EncryptionHealthState.allVerified),
+        returnValueForMissingStub: _i12.Future<_i4.EncryptionHealthState>.value(
+            _i4.EncryptionHealthState.allVerified),
+      ) as _i12.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i11.Future<String?> sendEvent(
+  _i12.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     String? threadRootEventId,
     String? threadLastEventId,
@@ -2354,73 +2389,73 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i12.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> leave() => (super.noSuchMethod(
+  _i12.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> forget() => (super.noSuchMethod(
+  _i12.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> setPower(
+  _i12.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2432,7 +2467,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             power,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2443,7 +2478,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2453,10 +2488,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> invite(
+  _i12.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2466,16 +2501,16 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<int> requestHistory({
+  _i12.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
-    dynamic direction = _i3.Direction.b,
-    _i3.StateFilter? filter,
+    dynamic direction = _i4.Direction.b,
+    _i4.StateFilter? filter,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2488,32 +2523,32 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<int>.value(0),
-        returnValueForMissingStub: _i11.Future<int>.value(0),
-      ) as _i11.Future<int>);
+        returnValue: _i12.Future<int>.value(0),
+        returnValueForMissingStub: _i12.Future<int>.value(0),
+      ) as _i12.Future<int>);
 
   @override
-  _i11.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i12.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setReadMarker(
+  _i12.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2527,25 +2562,25 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #public: public,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
+  _i12.Future<_i20.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i11.Future<_i19.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i11.Future<_i19.TimelineChunk?>.value(),
-      ) as _i11.Future<_i19.TimelineChunk?>);
+        returnValue: _i12.Future<_i20.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i12.Future<_i20.TimelineChunk?>.value(),
+      ) as _i12.Future<_i20.TimelineChunk?>);
 
   @override
-  _i11.Future<void> postReceipt(
+  _i12.Future<void> postReceipt(
     String? eventId, {
-    _i3.ReceiptType? type = _i3.ReceiptType.mRead,
+    _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2553,12 +2588,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Timeline> getTimeline({
+  _i12.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2581,7 +2616,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i11.Future<_i3.Timeline>.value(_FakeTimeline_12(
+        returnValue: _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
           this,
           Invocation.method(
             #getTimeline,
@@ -2598,7 +2633,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Timeline>.value(_FakeTimeline_12(
+            _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
           this,
           Invocation.method(
             #getTimeline,
@@ -2614,30 +2649,30 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Timeline>);
+      ) as _i12.Future<_i4.Timeline>);
 
   @override
-  List<_i3.User> getParticipants(
-          [List<_i3.Membership>? membershipFilter = const [
-            _i3.Membership.join,
-            _i3.Membership.invite,
-            _i3.Membership.knock,
+  List<_i4.User> getParticipants(
+          [List<_i4.Membership>? membershipFilter = const [
+            _i4.Membership.join,
+            _i4.Membership.invite,
+            _i4.Membership.knock,
           ]]) =>
       (super.noSuchMethod(
         Invocation.method(
           #getParticipants,
           [membershipFilter],
         ),
-        returnValue: <_i3.User>[],
-        returnValueForMissingStub: <_i3.User>[],
-      ) as List<_i3.User>);
+        returnValue: <_i4.User>[],
+        returnValueForMissingStub: <_i4.User>[],
+      ) as List<_i4.User>);
 
   @override
-  _i11.Future<List<_i3.User>> requestParticipants([
-    List<_i3.Membership>? membershipFilter = const [
-      _i3.Membership.join,
-      _i3.Membership.invite,
-      _i3.Membership.knock,
+  _i12.Future<List<_i4.User>> requestParticipants([
+    List<_i4.Membership>? membershipFilter = const [
+      _i4.Membership.join,
+      _i4.Membership.invite,
+      _i4.Membership.knock,
     ],
     bool? suppressWarning = false,
     bool? cache,
@@ -2651,58 +2686,58 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             cache,
           ],
         ),
-        returnValue: _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
+        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
-      ) as _i11.Future<List<_i3.User>>);
+            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i12.Future<List<_i4.User>>);
 
   @override
-  _i3.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
+  _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
         Invocation.method(
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_13(
+        returnValue: _FakeUser_14(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_13(
+        returnValueForMissingStub: _FakeUser_14(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-      ) as _i3.User);
+      ) as _i4.User);
 
   @override
-  _i3.User unsafeGetUserFromMemoryOrFallback(String? mxID) =>
+  _i4.User unsafeGetUserFromMemoryOrFallback(String? mxID) =>
       (super.noSuchMethod(
         Invocation.method(
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_13(
+        returnValue: _FakeUser_14(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_13(
+        returnValueForMissingStub: _FakeUser_14(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-      ) as _i3.User);
+      ) as _i4.User);
 
   @override
-  _i11.Future<_i3.User?> requestUser(
+  _i12.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2718,19 +2753,19 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i11.Future<_i3.User?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.User?>.value(),
-      ) as _i11.Future<_i3.User?>);
+        returnValue: _i12.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.User?>.value(),
+      ) as _i12.Future<_i4.User?>);
 
   @override
-  _i11.Future<_i3.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i12.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2743,12 +2778,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i11.Future<String> setAvatar(_i3.MatrixFile? file) => (super.noSuchMethod(
+  _i12.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2756,14 +2791,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2786,14 +2821,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i11.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i12.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -2832,18 +2867,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i11.Future<void> setPushRuleState(_i3.PushRuleState? newState) =>
+  _i12.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEvent(
+  _i12.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -2857,12 +2892,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> setTyping(
+  _i12.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -2872,13 +2907,13 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setJoinRules(
-    _i3.JoinRules? joinRules, {
+  _i12.Future<void> setJoinRules(
+    _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
   }) =>
@@ -2891,59 +2926,59 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setGuestAccess(_i3.GuestAccess? guestAccess) =>
+  _i12.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setHistoryVisibility(
-          _i3.HistoryVisibility? historyVisibility) =>
+  _i12.Future<void> setHistoryVisibility(
+          _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i12.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i12.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i11.Future<List<_i3.DeviceKeys>>.value(<_i3.DeviceKeys>[]),
+            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.DeviceKeys>>.value(<_i3.DeviceKeys>[]),
-      ) as _i11.Future<List<_i3.DeviceKeys>>);
+            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i12.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i11.Future<void> requestSessionKey(
+  _i12.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -2955,12 +2990,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             senderKey,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setSpaceChild(
+  _i12.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -2976,51 +3011,51 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i12.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i11.Future<Uri>);
+      ) as _i12.Future<Uri>);
 
   @override
-  _i11.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i12.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<
+  _i12.Future<
       ({
-        List<_i3.Event> events,
+        List<_i4.Event> events,
         String? nextBatch,
         DateTime? searchedUntil
       })> searchEvents({
     String? searchTerm,
-    bool Function(_i3.Event)? searchFunc,
+    bool Function(_i4.Event)? searchFunc,
     String? nextBatch,
     int? limit = 1000,
     Set<String>? includeEventTypes = const {
@@ -3040,23 +3075,23 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i11.Future<
+        returnValue: _i12.Future<
                 ({
-                  List<_i3.Event> events,
+                  List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
-            (events: <_i3.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i11.Future<
+            (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
+        returnValueForMissingStub: _i12.Future<
                 ({
-                  List<_i3.Event> events,
+                  List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
-            (events: <_i3.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i11.Future<
+            (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
+      ) as _i12.Future<
           ({
-            List<_i3.Event> events,
+            List<_i4.Event> events,
             String? nextBatch,
             DateTime? searchedUntil
           })>);
@@ -3065,27 +3100,27 @@ class MockRoom extends _i1.Mock implements _i3.Room {
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockClient extends _i1.Mock implements _i3.Client {
+class MockClient extends _i1.Mock implements _i4.Client {
   @override
-  _i3.DatabaseApi get database => (super.noSuchMethod(
+  _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_15(
+        returnValue: _FakeDatabaseApi_16(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_15(
+        returnValueForMissingStub: _FakeDatabaseApi_16(
           this,
           Invocation.getter(#database),
         ),
-      ) as _i3.DatabaseApi);
+      ) as _i4.DatabaseApi);
 
   @override
-  Set<_i20.KeyVerificationMethod> get verificationMethods =>
+  Set<_i21.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i20.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
-      ) as Set<_i20.KeyVerificationMethod>);
+        returnValue: <_i21.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i21.KeyVerificationMethod>{},
+      ) as Set<_i21.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3130,44 +3165,44 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  _i3.ShareKeysWith get shareKeysWith => (super.noSuchMethod(
+  _i4.ShareKeysWith get shareKeysWith => (super.noSuchMethod(
         Invocation.getter(#shareKeysWith),
-        returnValue: _i3.ShareKeysWith.all,
-        returnValueForMissingStub: _i3.ShareKeysWith.all,
-      ) as _i3.ShareKeysWith);
+        returnValue: _i4.ShareKeysWith.all,
+        returnValueForMissingStub: _i4.ShareKeysWith.all,
+      ) as _i4.ShareKeysWith);
 
   @override
-  Map<String, _i3.CommandExecutionCallback> get commands => (super.noSuchMethod(
+  Map<String, _i4.CommandExecutionCallback> get commands => (super.noSuchMethod(
         Invocation.getter(#commands),
-        returnValue: <String, _i3.CommandExecutionCallback>{},
-        returnValueForMissingStub: <String, _i3.CommandExecutionCallback>{},
-      ) as Map<String, _i3.CommandExecutionCallback>);
+        returnValue: <String, _i4.CommandExecutionCallback>{},
+        returnValueForMissingStub: <String, _i4.CommandExecutionCallback>{},
+      ) as Map<String, _i4.CommandExecutionCallback>);
 
   @override
-  _i3.Filter get syncFilter => (super.noSuchMethod(
+  _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_16(
+        returnValue: _FakeFilter_17(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_16(
+        returnValueForMissingStub: _FakeFilter_17(
           this,
           Invocation.getter(#syncFilter),
         ),
-      ) as _i3.Filter);
+      ) as _i4.Filter);
 
   @override
-  _i3.NativeImplementations get nativeImplementations => (super.noSuchMethod(
+  _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_17(
+        returnValue: _FakeNativeImplementations_18(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_17(
+        returnValueForMissingStub: _FakeNativeImplementations_18(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-      ) as _i3.NativeImplementations);
+      ) as _i4.NativeImplementations);
 
   @override
   bool get convertLinebreaksInFormatting => (super.noSuchMethod(
@@ -3179,11 +3214,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_18(
+        returnValue: _FakeDuration_19(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_18(
+        returnValueForMissingStub: _FakeDuration_19(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3192,11 +3227,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_18(
+        returnValue: _FakeDuration_19(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_18(
+        returnValueForMissingStub: _FakeDuration_19(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3205,36 +3240,36 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
       ) as String);
 
   @override
-  _i3.LoginState get loginState => (super.noSuchMethod(
+  _i4.LoginState get loginState => (super.noSuchMethod(
         Invocation.getter(#loginState),
-        returnValue: _i3.LoginState.loggedIn,
-        returnValueForMissingStub: _i3.LoginState.loggedIn,
-      ) as _i3.LoginState);
+        returnValue: _i4.LoginState.loggedIn,
+        returnValueForMissingStub: _i4.LoginState.loggedIn,
+      ) as _i4.LoginState);
 
   @override
-  List<_i3.Room> get rooms => (super.noSuchMethod(
+  List<_i4.Room> get rooms => (super.noSuchMethod(
         Invocation.getter(#rooms),
-        returnValue: <_i3.Room>[],
-        returnValueForMissingStub: <_i3.Room>[],
-      ) as List<_i3.Room>);
+        returnValue: <_i4.Room>[],
+        returnValueForMissingStub: <_i4.Room>[],
+      ) as List<_i4.Room>);
 
   @override
-  List<_i3.ArchivedRoom> get archivedRooms => (super.noSuchMethod(
+  List<_i4.ArchivedRoom> get archivedRooms => (super.noSuchMethod(
         Invocation.getter(#archivedRooms),
-        returnValue: <_i3.ArchivedRoom>[],
-        returnValueForMissingStub: <_i3.ArchivedRoom>[],
-      ) as List<_i3.ArchivedRoom>);
+        returnValue: <_i4.ArchivedRoom>[],
+        returnValueForMissingStub: <_i4.ArchivedRoom>[],
+      ) as List<_i4.ArchivedRoom>);
 
   @override
   bool get enableDehydratedDevices => (super.noSuchMethod(
@@ -3246,11 +3281,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3280,11 +3315,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3293,11 +3328,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3311,31 +3346,31 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  Map<String, _i3.BasicEvent> get accountData => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get accountData => (super.noSuchMethod(
         Invocation.getter(#accountData),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  _i3.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
+  _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_19(
+        returnValue: _FakePushruleEvaluator_20(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_19(
+        returnValueForMissingStub: _FakePushruleEvaluator_20(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-      ) as _i3.PushruleEvaluator);
+      ) as _i4.PushruleEvaluator);
 
   @override
-  Map<String, _i3.CachedPresence> get presences => (super.noSuchMethod(
+  Map<String, _i4.CachedPresence> get presences => (super.noSuchMethod(
         Invocation.getter(#presences),
-        returnValue: <String, _i3.CachedPresence>{},
-        returnValueForMissingStub: <String, _i3.CachedPresence>{},
-      ) as Map<String, _i3.CachedPresence>);
+        returnValue: <String, _i4.CachedPresence>{},
+        returnValueForMissingStub: <String, _i4.CachedPresence>{},
+      ) as Map<String, _i4.CachedPresence>);
 
   @override
   Map<String, List<String>> get directChats => (super.noSuchMethod(
@@ -3345,333 +3380,333 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i11.Future<_i3.Profile> get ownProfile => (super.noSuchMethod(
+  _i12.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i9.CachedStreamController<String> get onUserProfileUpdate =>
+  _i10.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i11.Future<List<_i3.Room>> get archive => (super.noSuchMethod(
+  _i12.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
+        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
-      ) as _i11.Future<List<_i3.Room>>);
+            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i12.Future<List<_i4.Room>>);
 
   @override
-  _i9.CachedStreamController<_i3.EventUpdate> get onEvent =>
+  _i10.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.EventUpdate>(
+        returnValue: _FakeCachedStreamController_9<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.EventUpdate>(
+            _FakeCachedStreamController_9<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.EventUpdate>);
+      ) as _i10.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onTimelineEvent =>
+  _i10.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onHistoryEvent =>
+  _i10.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onNotification =>
+  _i10.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.ToDeviceEvent> get onToDeviceEvent =>
+  _i10.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.ToDeviceEvent>(
+            _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.ToDeviceEvent>);
+      ) as _i10.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i9.CachedStreamController<List<_i3.BasicEventWithSender>> get onCallEvents =>
-      (super.noSuchMethod(
-        Invocation.getter(#onCallEvents),
-        returnValue:
-            _FakeCachedStreamController_8<List<_i3.BasicEventWithSender>>(
-          this,
-          Invocation.getter(#onCallEvents),
-        ),
-        returnValueForMissingStub:
-            _FakeCachedStreamController_8<List<_i3.BasicEventWithSender>>(
-          this,
-          Invocation.getter(#onCallEvents),
-        ),
-      ) as _i9.CachedStreamController<List<_i3.BasicEventWithSender>>);
+  _i10.CachedStreamController<List<_i4.BasicEventWithSender>>
+      get onCallEvents => (super.noSuchMethod(
+            Invocation.getter(#onCallEvents),
+            returnValue:
+                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+              this,
+              Invocation.getter(#onCallEvents),
+            ),
+            returnValueForMissingStub:
+                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+              this,
+              Invocation.getter(#onCallEvents),
+            ),
+          ) as _i10.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i9.CachedStreamController<_i3.LoginState> get onLoginStateChanged =>
+  _i10.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_8<_i3.LoginState>(
+        returnValue: _FakeCachedStreamController_9<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.LoginState>(
+            _FakeCachedStreamController_9<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i9.CachedStreamController<_i3.LoginState>);
+      ) as _i10.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i9.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i10.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_8<bool>(
+        returnValue: _FakeCachedStreamController_9<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i9.CachedStreamController<bool>);
+      ) as _i10.CachedStreamController<bool>);
 
   @override
-  _i9.CachedStreamController<_i3.SdkError> get onEncryptionError =>
+  _i10.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_8<_i3.SdkError>(
+        returnValue: _FakeCachedStreamController_9<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i9.CachedStreamController<_i3.SdkError>);
+      ) as _i10.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i9.CachedStreamController<_i3.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i10.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_8<_i3.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_9<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.SyncUpdate>(
+            _FakeCachedStreamController_9<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i9.CachedStreamController<_i3.SyncUpdate>);
+      ) as _i10.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.SyncStatusUpdate> get onSyncStatus =>
+  _i10.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_8<_i3.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.SyncStatusUpdate>(
+            _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i9.CachedStreamController<_i3.SyncStatusUpdate>);
+      ) as _i10.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.Presence> get onPresence =>
+  _i10.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_8<_i3.Presence>(
+        returnValue: _FakeCachedStreamController_9<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i9.CachedStreamController<_i3.Presence>);
+      ) as _i10.CachedStreamController<_i4.Presence>);
 
   @override
-  _i9.CachedStreamController<_i3.CachedPresence> get onPresenceChanged =>
+  _i10.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_8<_i3.CachedPresence>(
+        returnValue: _FakeCachedStreamController_9<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.CachedPresence>(
+            _FakeCachedStreamController_9<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i9.CachedStreamController<_i3.CachedPresence>);
+      ) as _i10.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i9.CachedStreamController<_i3.BasicEvent> get onAccountData =>
+  _i10.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_8<_i3.BasicEvent>(
+        returnValue: _FakeCachedStreamController_9<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.BasicEvent>(
+            _FakeCachedStreamController_9<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i9.CachedStreamController<_i3.BasicEvent>);
+      ) as _i10.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i9.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
+  _i10.CachedStreamController<_i21.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
+            _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i9.CachedStreamController<_i20.RoomKeyRequest>);
+      ) as _i10.CachedStreamController<_i21.RoomKeyRequest>);
 
   @override
-  _i9.CachedStreamController<_i20.KeyVerification>
+  _i10.CachedStreamController<_i21.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_8<_i20.KeyVerification>(
+            returnValue: _FakeCachedStreamController_9<_i21.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_8<_i20.KeyVerification>(
+                _FakeCachedStreamController_9<_i21.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i9.CachedStreamController<_i20.KeyVerification>);
+          ) as _i10.CachedStreamController<_i21.KeyVerification>);
 
   @override
-  _i9.CachedStreamController<_i3.UiaRequest<dynamic>> get onUiaRequest =>
+  _i10.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_8<_i3.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i9.CachedStreamController<_i3.UiaRequest<dynamic>>);
+      ) as _i10.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onGroupMember =>
+  _i10.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<String> get onCancelSendEvent =>
+  _i10.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i9.CachedStreamController<({String roomId, _i3.StrippedStateEvent state})>
+  _i10.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_8<
-                ({String roomId, _i3.StrippedStateEvent state})>(
+            returnValue: _FakeCachedStreamController_9<
+                ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_8<
-                ({String roomId, _i3.StrippedStateEvent state})>(
+            returnValueForMissingStub: _FakeCachedStreamController_9<
+                ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i9.CachedStreamController<
-              ({String roomId, _i3.StrippedStateEvent state})>);
+          ) as _i10.CachedStreamController<
+              ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
   int get syncErrorTimeoutSec => (super.noSuchMethod(
@@ -3690,11 +3725,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_9(
+        returnValue: _FakeDateTime_10(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_9(
+        returnValueForMissingStub: _FakeDateTime_10(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3715,33 +3750,33 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  _i3.RoomSorter get sortRoomsBy => (super.noSuchMethod(
+  _i4.RoomSorter get sortRoomsBy => (super.noSuchMethod(
         Invocation.getter(#sortRoomsBy),
         returnValue: (
-          _i3.Room a,
-          _i3.Room b,
+          _i4.Room a,
+          _i4.Room b,
         ) =>
             0,
         returnValueForMissingStub: (
-          _i3.Room a,
-          _i3.Room b,
+          _i4.Room a,
+          _i4.Room b,
         ) =>
             0,
-      ) as _i3.RoomSorter);
+      ) as _i4.RoomSorter);
 
   @override
-  Map<String, _i3.DeviceKeysList> get userDeviceKeys => (super.noSuchMethod(
+  Map<String, _i4.DeviceKeysList> get userDeviceKeys => (super.noSuchMethod(
         Invocation.getter(#userDeviceKeys),
-        returnValue: <String, _i3.DeviceKeysList>{},
-        returnValueForMissingStub: <String, _i3.DeviceKeysList>{},
-      ) as Map<String, _i3.DeviceKeysList>);
+        returnValue: <String, _i4.DeviceKeysList>{},
+        returnValueForMissingStub: <String, _i4.DeviceKeysList>{},
+      ) as Map<String, _i4.DeviceKeysList>);
 
   @override
-  List<_i3.DeviceKeys> get unverifiedDevices => (super.noSuchMethod(
+  List<_i4.DeviceKeys> get unverifiedDevices => (super.noSuchMethod(
         Invocation.getter(#unverifiedDevices),
-        returnValue: <_i3.DeviceKeys>[],
-        returnValueForMissingStub: <_i3.DeviceKeys>[],
-      ) as List<_i3.DeviceKeys>);
+        returnValue: <_i4.DeviceKeys>[],
+        returnValueForMissingStub: <_i4.DeviceKeys>[],
+      ) as List<_i4.DeviceKeys>);
 
   @override
   bool get allPushNotificationsMuted => (super.noSuchMethod(
@@ -3758,7 +3793,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as List<String>);
 
   @override
-  set database(_i3.DatabaseApi? db) => super.noSuchMethod(
+  set database(_i4.DatabaseApi? db) => super.noSuchMethod(
         Invocation.setter(
           #database,
           db,
@@ -3767,7 +3802,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i21.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3813,7 +3848,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set shareKeysWith(_i3.ShareKeysWith? value) => super.noSuchMethod(
+  set shareKeysWith(_i4.ShareKeysWith? value) => super.noSuchMethod(
         Invocation.setter(
           #shareKeysWith,
           value,
@@ -3822,7 +3857,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set onSoftLogout(_i11.Future<void> Function(_i3.Client)? value) =>
+  set onSoftLogout(_i12.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3833,8 +3868,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
 
   @override
   set customImageResizer(
-          _i11.Future<_i3.MatrixImageFileResizedResponse?> Function(
-                  _i3.MatrixImageFileResizeArguments)?
+          _i12.Future<_i4.MatrixImageFileResizedResponse?> Function(
+                  _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
         Invocation.setter(
@@ -3872,7 +3907,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set rooms(List<_i3.Room>? newList) => super.noSuchMethod(
+  set rooms(List<_i4.Room>? newList) => super.noSuchMethod(
         Invocation.setter(
           #rooms,
           newList,
@@ -3881,7 +3916,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set presences(Map<String, _i3.CachedPresence>? value) => super.noSuchMethod(
+  set presences(Map<String, _i4.CachedPresence>? value) => super.noSuchMethod(
         Invocation.setter(
           #presences,
           value,
@@ -3908,7 +3943,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set syncPresence(_i3.PresenceType? value) => super.noSuchMethod(
+  set syncPresence(_i4.PresenceType? value) => super.noSuchMethod(
         Invocation.setter(
           #syncPresence,
           value,
@@ -3944,7 +3979,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -3953,7 +3988,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set roomsLoading(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -3962,7 +3997,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set firstSyncReceived(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -3989,20 +4024,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i10.Client get httpClient => (super.noSuchMethod(
+  _i11.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_21(
+        returnValue: _FakeClient_22(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_21(
+        returnValueForMissingStub: _FakeClient_22(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i10.Client);
+      ) as _i11.Client);
 
   @override
-  set httpClient(_i10.Client? value) => super.noSuchMethod(
+  set httpClient(_i11.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4029,7 +4064,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<void> refreshAccessToken(
+  _i12.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4037,9 +4072,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4057,14 +4092,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4074,22 +4109,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as String);
 
   @override
-  _i3.Room? getRoomByAlias(String? alias) => (super.noSuchMethod(
+  _i4.Room? getRoomByAlias(String? alias) => (super.noSuchMethod(
         Invocation.method(
           #getRoomByAlias,
           [alias],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.Room?);
+      ) as _i4.Room?);
 
   @override
-  _i3.Room? getRoomById(String? id) => (super.noSuchMethod(
+  _i4.Room? getRoomById(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getRoomById,
           [id],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.Room?);
+      ) as _i4.Room?);
 
   @override
   String? getDirectChatFromUserId(String? userId) => (super.noSuchMethod(
@@ -4101,38 +4136,38 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as String?);
 
   @override
-  _i11.Future<_i3.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i12.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i11.Future<_i3.DiscoveryInformation>);
+      ) as _i12.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i11.Future<
+  _i12.Future<
       (
-        _i3.DiscoveryInformation?,
-        _i3.GetVersionsResponse,
-        List<_i3.LoginFlow>,
-        _i3.GetAuthMetadataResponse?
+        _i4.DiscoveryInformation?,
+        _i4.GetVersionsResponse,
+        List<_i4.LoginFlow>,
+        _i4.GetAuthMetadataResponse?
       )> checkHomeserver(
     Uri? homeserverUrl, {
     bool? checkWellKnown = true,
@@ -4149,15 +4184,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i11.Future<
+        returnValue: _i12.Future<
             (
-              _i3.DiscoveryInformation?,
-              _i3.GetVersionsResponse,
-              List<_i3.LoginFlow>,
-              _i3.GetAuthMetadataResponse?
+              _i4.DiscoveryInformation?,
+              _i4.GetVersionsResponse,
+              List<_i4.LoginFlow>,
+              _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_23(
+          _FakeGetVersionsResponse_24(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4169,18 +4204,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
           ),
-          <_i3.LoginFlow>[],
+          <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i11.Future<
+        returnValueForMissingStub: _i12.Future<
             (
-              _i3.DiscoveryInformation?,
-              _i3.GetVersionsResponse,
-              List<_i3.LoginFlow>,
-              _i3.GetAuthMetadataResponse?
+              _i4.DiscoveryInformation?,
+              _i4.GetVersionsResponse,
+              List<_i4.LoginFlow>,
+              _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_23(
+          _FakeGetVersionsResponse_24(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4192,19 +4227,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
           ),
-          <_i3.LoginFlow>[],
+          <_i4.LoginFlow>[],
           null
         )),
-      ) as _i11.Future<
+      ) as _i12.Future<
           (
-            _i3.DiscoveryInformation?,
-            _i3.GetVersionsResponse,
-            List<_i3.LoginFlow>,
-            _i3.GetAuthMetadataResponse?
+            _i4.DiscoveryInformation?,
+            _i4.GetVersionsResponse,
+            List<_i4.LoginFlow>,
+            _i4.GetAuthMetadataResponse?
           )>);
 
   @override
-  _i11.Future<_i3.DiscoveryInformation> getWellknown({
+  _i12.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4217,8 +4252,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getWellknown,
@@ -4229,8 +4264,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getWellknown,
@@ -4241,19 +4276,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.DiscoveryInformation>);
+      ) as _i12.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i11.Future<_i3.RegisterResponse> register({
+  _i12.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
     String? initialDeviceDisplayName,
     bool? inhibitLogin,
     bool? refreshToken,
-    _i3.AuthenticationData? auth,
-    _i3.AccountKind? kind,
-    void Function(_i3.InitState)? onInitStateChanged,
+    _i4.AuthenticationData? auth,
+    _i4.AccountKind? kind,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4272,7 +4307,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<_i3.RegisterResponse>.value(_FakeRegisterResponse_24(
+            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
           this,
           Invocation.method(
             #register,
@@ -4291,7 +4326,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RegisterResponse>.value(_FakeRegisterResponse_24(
+            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
           this,
           Invocation.method(
             #register,
@@ -4309,12 +4344,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RegisterResponse>);
+      ) as _i12.Future<_i4.RegisterResponse>);
 
   @override
-  _i11.Future<_i3.LoginResponse> login(
+  _i12.Future<_i4.LoginResponse> login(
     String? type, {
-    _i3.AuthenticationIdentifier? identifier,
+    _i4.AuthenticationIdentifier? identifier,
     String? password,
     String? token,
     String? deviceId,
@@ -4323,7 +4358,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? user,
     String? medium,
     String? address,
-    void Function(_i3.InitState)? onInitStateChanged,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4342,7 +4377,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i11.Future<_i3.LoginResponse>.value(_FakeLoginResponse_25(
+        returnValue: _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
           this,
           Invocation.method(
             #login,
@@ -4362,7 +4397,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.LoginResponse>.value(_FakeLoginResponse_25(
+            _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
           this,
           Invocation.method(
             #login,
@@ -4381,10 +4416,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.LoginResponse>);
+      ) as _i12.Future<_i4.LoginResponse>);
 
   @override
-  _i11.Future<_i3.GetAuthMetadataResponse> getAuthMetadata({
+  _i12.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4397,8 +4432,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_26(
+        returnValue: _i12.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_27(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4410,8 +4445,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_26(
+            _i12.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_27(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4422,80 +4457,80 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetAuthMetadataResponse>);
+      ) as _i12.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i11.Future<void> logout() => (super.noSuchMethod(
+  _i12.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> logoutAll() => (super.noSuchMethod(
+  _i12.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<T> uiaRequestBackground<T>(
-          _i11.Future<T> Function(_i3.AuthenticationData?)? request) =>
+  _i12.Future<T> uiaRequestBackground<T>(
+          _i12.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i11.Future<T>.value(v),
+              (T v) => _i12.Future<T>.value(v),
             ) ??
-            _FakeFuture_27<T>(
+            _FakeFuture_28<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i11.Future<T>.value(v),
+              (T v) => _i12.Future<T>.value(v),
             ) ??
-            _FakeFuture_27<T>(
+            _FakeFuture_28<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i11.Future<T>);
+      ) as _i12.Future<T>);
 
   @override
-  _i11.Future<String> startDirectChat(
+  _i12.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
-    List<_i3.StateEvent>? initialState,
+    List<_i4.StateEvent>? initialState,
     bool? waitForSync = true,
     Map<String, dynamic>? powerLevelContentOverride,
-    _i3.CreateRoomPreset? preset = _i3.CreateRoomPreset.trustedPrivateChat,
+    _i4.CreateRoomPreset? preset = _i4.CreateRoomPreset.trustedPrivateChat,
     bool? skipExistingChat = false,
   }) =>
       (super.noSuchMethod(
@@ -4511,7 +4546,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4527,7 +4562,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4542,17 +4577,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<String> createGroupChat({
+  _i12.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
-    _i3.CreateRoomPreset? preset = _i3.CreateRoomPreset.privateChat,
-    List<_i3.StateEvent>? initialState,
-    _i3.Visibility? visibility,
-    _i3.HistoryVisibility? historyVisibility,
+    _i4.CreateRoomPreset? preset = _i4.CreateRoomPreset.privateChat,
+    List<_i4.StateEvent>? initialState,
+    _i4.Visibility? visibility,
+    _i4.HistoryVisibility? historyVisibility,
     bool? waitForSync = true,
     bool? groupCall = false,
     bool? federated = true,
@@ -4576,7 +4611,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4597,7 +4632,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4617,10 +4652,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> waitForRoomInSync(
+  _i12.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4636,7 +4671,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4649,7 +4684,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4661,27 +4696,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i12.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<String> createSpace({
+  _i12.Future<String> createSpace({
     String? name,
     String? topic,
-    _i3.Visibility? visibility = _i3.Visibility.public,
+    _i4.Visibility? visibility = _i4.Visibility.public,
     String? spaceAliasName,
     List<String>? invite,
-    List<_i3.Invite3pid>? invite3pid,
+    List<_i4.Invite3pid>? invite3pid,
     String? roomVersion,
     bool? waitForSync = false,
   }) =>
@@ -4700,7 +4735,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4718,7 +4753,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4735,10 +4770,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.Profile> fetchOwnProfileFromServer(
+  _i12.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4746,7 +4781,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4755,7 +4790,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4763,10 +4798,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i11.Future<_i3.Profile> fetchOwnProfile({
+  _i12.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4779,7 +4814,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4791,7 +4826,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4802,10 +4837,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i11.Future<_i3.CachedProfileInformation> getUserProfile(
+  _i12.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4819,8 +4854,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i11.Future<_i3.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_28(
+        returnValue: _i12.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_29(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4832,8 +4867,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_28(
+            _i12.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_29(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4844,10 +4879,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.CachedProfileInformation>);
+      ) as _i12.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i11.Future<_i3.Profile> getProfileFromUserId(
+  _i12.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4865,7 +4900,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4879,7 +4914,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4892,17 +4927,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i3.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
+  _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getArchiveRoomFromCache,
           [roomId],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.ArchivedRoom?);
+      ) as _i4.ArchivedRoom?);
 
   @override
   void clearArchivesFromCache() => super.noSuchMethod(
@@ -4914,31 +4949,31 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<List<_i3.Room>> loadArchive() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
+        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
-      ) as _i11.Future<List<_i3.Room>>);
+            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i12.Future<List<_i4.Room>>);
 
   @override
-  _i11.Future<List<_i3.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i12.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i11.Future<List<_i3.ArchivedRoom>>.value(<_i3.ArchivedRoom>[]),
+            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ArchivedRoom>>.value(<_i3.ArchivedRoom>[]),
-      ) as _i11.Future<List<_i3.ArchivedRoom>>);
+            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i12.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i11.Future<_i3.GetVersionsResponse> getVersions({
+  _i12.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4951,8 +4986,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_23(
+        returnValue: _i12.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_24(
           this,
           Invocation.method(
             #getVersions,
@@ -4963,8 +4998,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_23(
+        returnValueForMissingStub: _i12.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_24(
           this,
           Invocation.method(
             #getVersions,
@@ -4975,20 +5010,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetVersionsResponse>);
+      ) as _i12.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i11.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i12.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<_i3.MediaConfig> getConfig({
+  _i12.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5001,7 +5036,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfig,
@@ -5013,7 +5048,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfig,
@@ -5024,10 +5059,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.MediaConfig>);
+      ) as _i12.Future<_i4.MediaConfig>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContent(
+  _i12.Future<_i13.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5047,7 +5082,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContent,
@@ -5063,7 +5098,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContent,
@@ -5078,10 +5113,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentOverrideName(
+  _i12.Future<_i13.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5103,7 +5138,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5120,7 +5155,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5136,15 +5171,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentThumbnail(
+  _i12.Future<_i13.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
     int? height, {
-    _i3.Method? method,
+    _i4.Method? method,
     bool? allowRemote,
     int? timeoutMs,
     bool? allowRedirect,
@@ -5167,7 +5202,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5187,7 +5222,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5206,10 +5241,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i3.PreviewForUrl> getUrlPreview(
+  _i12.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5219,7 +5254,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5228,7 +5263,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5236,11 +5271,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i11.Future<_i3.PreviewForUrl>);
+      ) as _i12.Future<_i4.PreviewForUrl>);
 
   @override
-  _i11.Future<Uri> uploadContent(
-    _i21.Uint8List? file, {
+  _i12.Future<Uri> uploadContent(
+    _i22.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5253,7 +5288,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #uploadContent,
@@ -5264,7 +5299,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #uploadContent,
@@ -5275,10 +5310,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<Uri>);
+      ) as _i12.Future<Uri>);
 
   @override
-  _i11.Future<void> setTyping(
+  _i12.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5294,43 +5329,43 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> exportDump() => (super.noSuchMethod(
+  _i12.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i12.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> setAvatar(_i3.MatrixFile? file) => (super.noSuchMethod(
+  _i12.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Event?> getEventByPushNotification(
-    _i3.PushNotification? notification, {
+  _i12.Future<_i4.Event?> getEventByPushNotification(
+    _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
     bool? returnNullIfSeen = true,
@@ -5345,12 +5380,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
-  _i11.Future<void> init({
+  _i12.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5363,7 +5398,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     bool? waitForFirstSync = true,
     bool? waitUntilLoadCompletedLoaded = true,
     void Function()? onMigration,
-    void Function(_i3.InitState)? onInitStateChanged,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5385,9 +5420,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5399,42 +5434,42 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<void> clear() => (super.noSuchMethod(
+  _i12.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i12.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ensureNotSoftLoggedOut(
+  _i12.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> handleSync(
-    _i3.SyncUpdate? sync, {
-    _i3.Direction? direction,
+  _i12.Future<void> handleSync(
+    _i4.SyncUpdate? sync, {
+    _i4.Direction? direction,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5442,44 +5477,44 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i3.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
+  _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeysByCurve25519Key,
           [senderKey],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.DeviceKeys?);
+      ) as _i4.DeviceKeys?);
 
   @override
-  _i11.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i12.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i12.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDevice(
+  _i12.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5493,12 +5528,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             messages,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDevicesOfUserIds(
+  _i12.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5514,13 +5549,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDeviceEncrypted(
-    List<_i3.DeviceKeys>? deviceKeys,
+  _i12.Future<void> sendToDeviceEncrypted(
+    List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
     String? messageId,
@@ -5539,13 +5574,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDeviceEncryptedChunked(
-    List<_i3.DeviceKeys>? deviceKeys,
+  _i12.Future<void> sendToDeviceEncryptedChunked(
+    List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
   ) =>
@@ -5558,28 +5593,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
             message,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i12.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> joinRoom(
+  _i12.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
     String? reason,
-    _i3.ThirdPartySigned? thirdPartySigned,
+    _i4.ThirdPartySigned? thirdPartySigned,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5592,7 +5627,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5606,7 +5641,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5619,13 +5654,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> changePassword(
+  _i12.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
     bool? logoutDevices,
   }) =>
       (super.noSuchMethod(
@@ -5638,22 +5673,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> clearCache() => (super.noSuchMethod(
+  _i12.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ignoreUser(
+  _i12.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5663,22 +5698,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i12.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.CachedPresence> fetchCurrentPresence(
+  _i12.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5689,7 +5724,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i11.Future<_i3.CachedPresence>.value(_FakeCachedPresence_32(
+            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5698,7 +5733,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.CachedPresence>.value(_FakeCachedPresence_32(
+            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5706,32 +5741,32 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i11.Future<_i3.CachedPresence>);
+      ) as _i12.Future<_i4.CachedPresence>);
 
   @override
-  _i11.Future<void> abortSync() => (super.noSuchMethod(
+  _i12.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i12.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEventWithMetadata(
+  _i12.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5751,14 +5786,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i10.BaseResponse? response,
-    _i21.Uint8List? body,
+    _i11.BaseResponse? response,
+    _i22.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5790,8 +5825,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as Never);
 
   @override
-  _i11.Future<Map<String, Object?>> request(
-    _i3.RequestType? type,
+  _i12.Future<Map<String, Object?>> request(
+    _i4.RequestType? type,
     String? action, {
     dynamic data = '',
     String? contentType = 'application/json',
@@ -5811,14 +5846,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> postPusher(
-    _i3.Pusher? pusher, {
+  _i12.Future<void> postPusher(
+    _i4.Pusher? pusher, {
     bool? append,
   }) =>
       (super.noSuchMethod(
@@ -5827,57 +5862,57 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deletePusher(_i3.PusherId? pusher) => (super.noSuchMethod(
+  _i12.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i12.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i12.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i11.Future<_i3.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_33(
+        returnValue: _i12.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_34(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_33(
+        returnValueForMissingStub: _i12.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_34(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.TurnServerCredentials>);
+      ) as _i12.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5891,8 +5926,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5904,8 +5939,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5916,14 +5951,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
-    _i3.KeyBackupData? data,
+    _i4.KeyBackupData? data,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5935,8 +5970,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             data,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5949,8 +5984,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5962,10 +5997,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.KeyBackupData> getRoomKeysBySessionId(
+  _i12.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5979,7 +6014,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -5991,7 +6026,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6002,17 +6037,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.KeyBackupData>);
+      ) as _i12.Future<_i4.KeyBackupData>);
 
   @override
-  _i11.Future<_i3.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i12.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i11.Future<_i3.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_36(
+        returnValue: _i12.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_37(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6020,18 +6055,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_36(
+            _i12.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_37(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.GetWellknownSupportResponse>);
+      ) as _i12.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i11.Future<int> pingAppservice(
+  _i12.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6041,21 +6076,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i11.Future<int>.value(0),
-        returnValueForMissingStub: _i11.Future<int>.value(0),
-      ) as _i11.Future<int>);
+        returnValue: _i12.Future<int>.value(0),
+        returnValueForMissingStub: _i12.Future<int>.value(0),
+      ) as _i12.Future<int>);
 
   @override
-  _i11.Future<_i3.GenerateLoginTokenResponse> generateLoginToken(
-          {_i3.AuthenticationData? auth}) =>
+  _i12.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+          {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
           #generateLoginToken,
           [],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<_i3.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_37(
+        returnValue: _i12.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_38(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6064,8 +6099,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_37(
+            _i12.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_38(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6073,15 +6108,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i11.Future<_i3.GenerateLoginTokenResponse>);
+      ) as _i12.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i11.Future<_i3.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i12.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6089,17 +6124,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.MediaConfig>);
+      ) as _i12.Future<_i4.MediaConfig>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentAuthed(
+  _i12.Future<_i13.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6113,7 +6148,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6125,7 +6160,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6136,10 +6171,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentOverrideNameAuthed(
+  _i12.Future<_i13.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6155,7 +6190,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6168,7 +6203,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6180,10 +6215,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i3.PreviewForUrl> getUrlPreviewAuthed(
+  _i12.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6193,7 +6228,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6202,7 +6237,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6210,15 +6245,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i11.Future<_i3.PreviewForUrl>);
+      ) as _i12.Future<_i4.PreviewForUrl>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentThumbnailAuthed(
+  _i12.Future<_i13.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
     int? height, {
-    _i3.Method? method,
+    _i4.Method? method,
     int? timeoutMs,
     bool? animated,
   }) =>
@@ -6237,7 +6272,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6255,7 +6290,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6272,21 +6307,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<bool> registrationTokenValidity(String? token) =>
+  _i12.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<_i3.GetRoomSummaryResponse$3> getRoomSummary(
+  _i12.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6296,8 +6331,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i11.Future<_i3.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_38(
+        returnValue: _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_39(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6306,8 +6341,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_38(
+            _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_39(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6315,10 +6350,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#via: via},
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomSummaryResponse$3>);
+      ) as _i12.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i11.Future<_i3.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i12.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6336,8 +6371,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #from: from,
           },
         ),
-        returnValue: _i11.Future<_i3.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_39(
+        returnValue: _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_40(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6351,8 +6386,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_39(
+            _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_40(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6365,16 +6400,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetSpaceHierarchyResponse>);
+      ) as _i12.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsResponse> getRelatingEvents(
+  _i12.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
       (super.noSuchMethod(
@@ -6392,8 +6427,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i11.Future<_i3.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_40(
+        returnValue: _i12.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_41(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6411,8 +6446,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_40(
+            _i12.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_41(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6429,10 +6464,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetRelatingEventsResponse>);
+      ) as _i12.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>
+  _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6440,7 +6475,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
           (super.noSuchMethod(
@@ -6460,8 +6495,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
             returnValue:
-                _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_41(
+                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6480,8 +6515,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_41(
+                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6499,10 +6534,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-          ) as _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i12.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6511,7 +6546,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
           (super.noSuchMethod(
@@ -6531,9 +6566,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i11.Future<
-                    _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+            returnValue: _i12.Future<
+                    _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6552,9 +6587,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i11.Future<
-                    _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+            returnValueForMissingStub: _i12.Future<
+                    _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6573,13 +6608,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-          ) as _i11
-              .Future<_i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
+          ) as _i12
+              .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i11.Future<_i3.GetThreadRootsResponse> getThreadRoots(
+  _i12.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
-    _i3.Include? include,
+    _i4.Include? include,
     int? limit,
     String? from,
   }) =>
@@ -6593,8 +6628,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #from: from,
           },
         ),
-        returnValue: _i11.Future<_i3.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_43(
+        returnValue: _i12.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_44(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6607,8 +6642,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_43(
+            _i12.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_44(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6620,13 +6655,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetThreadRootsResponse>);
+      ) as _i12.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i11.Future<_i3.GetEventByTimestampResponse> getEventByTimestamp(
+  _i12.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6637,8 +6672,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             dir,
           ],
         ),
-        returnValue: _i11.Future<_i3.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_44(
+        returnValue: _i12.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_45(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6650,8 +6685,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_44(
+            _i12.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_45(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6662,36 +6697,36 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.GetEventByTimestampResponse>);
+      ) as _i12.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i12.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyIdentifier>?>.value(),
-      ) as _i11.Future<List<_i3.ThirdPartyIdentifier>?>);
+            _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i12.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i11.Future<Uri?> post3PIDs(_i3.ThreePidCredentials? threePidCreds) =>
+  _i12.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i11.Future<Uri?>.value(),
-        returnValueForMissingStub: _i11.Future<Uri?>.value(),
-      ) as _i11.Future<Uri?>);
+        returnValue: _i12.Future<Uri?>.value(),
+        returnValueForMissingStub: _i12.Future<Uri?>.value(),
+      ) as _i12.Future<Uri?>);
 
   @override
-  _i11.Future<void> add3PID(
+  _i12.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6702,12 +6737,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> bind3PID(
+  _i12.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6723,14 +6758,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             sid,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> delete3pidFromAccount(
+  _i12.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
-    _i3.ThirdPartyIdentifierMedium? medium, {
+    _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
   }) =>
       (super.noSuchMethod(
@@ -6742,14 +6777,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6771,8 +6806,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6788,8 +6823,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6805,10 +6840,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6832,8 +6867,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6850,8 +6885,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6868,12 +6903,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> unbind3pidFromAccount(
+  _i12.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
-    _i3.ThirdPartyIdentifierMedium? medium, {
+    _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
   }) =>
       (super.noSuchMethod(
@@ -6885,15 +6920,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> deactivateAccount({
-    _i3.AuthenticationData? auth,
+  _i12.Future<_i4.IdServerUnbindResult> deactivateAccount({
+    _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
   }) =>
@@ -6907,14 +6942,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6936,8 +6971,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -6953,8 +6988,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -6970,10 +7005,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6997,8 +7032,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7015,8 +7050,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7033,16 +7068,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i12.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i11.Future<_i3.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
+            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7050,22 +7085,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
+            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.TokenOwnerInfo>);
+      ) as _i12.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i11.Future<_i3.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i12.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i11.Future<_i3.WhoIsInfo>.value(_FakeWhoIsInfo_47(
+        returnValue: _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7073,22 +7108,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.WhoIsInfo>.value(_FakeWhoIsInfo_47(
+            _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i11.Future<_i3.WhoIsInfo>);
+      ) as _i12.Future<_i4.WhoIsInfo>);
 
   @override
-  _i11.Future<_i3.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i12.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i11.Future<_i3.Capabilities>.value(_FakeCapabilities_48(
+        returnValue: _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7096,29 +7131,29 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Capabilities>.value(_FakeCapabilities_48(
+            _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.Capabilities>);
+      ) as _i12.Future<_i4.Capabilities>);
 
   @override
-  _i11.Future<String> createRoom({
+  _i12.Future<String> createRoom({
     Map<String, Object?>? creationContent,
-    List<_i3.StateEvent>? initialState,
+    List<_i4.StateEvent>? initialState,
     List<String>? invite,
-    List<_i3.Invite3pid>? invite3pid,
+    List<_i4.Invite3pid>? invite3pid,
     bool? isDirect,
     String? name,
     Map<String, Object?>? powerLevelContentOverride,
-    _i3.CreateRoomPreset? preset,
+    _i4.CreateRoomPreset? preset,
     String? roomAliasName,
     String? roomVersion,
     String? topic,
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7139,7 +7174,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7161,7 +7196,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7182,12 +7217,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> deleteDevices(
+  _i12.Future<void> deleteDevices(
     List<String>? devices, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7195,24 +7230,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.Device>?> getDevices() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Device>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.Device>?>.value(),
-      ) as _i11.Future<List<_i3.Device>?>);
+        returnValue: _i12.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.Device>?>.value(),
+      ) as _i12.Future<List<_i4.Device>?>);
 
   @override
-  _i11.Future<void> deleteDevice(
+  _i12.Future<void> deleteDevice(
     String? deviceId, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7220,34 +7255,34 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i12.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i11.Future<_i3.Device>.value(_FakeDevice_49(
+        returnValue: _i12.Future<_i4.Device>.value(_FakeDevice_50(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.Device>.value(_FakeDevice_49(
+        returnValueForMissingStub: _i12.Future<_i4.Device>.value(_FakeDevice_50(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i11.Future<_i3.Device>);
+      ) as _i12.Future<_i4.Device>);
 
   @override
-  _i11.Future<void> updateDevice(
+  _i12.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7257,15 +7292,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i12.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7277,26 +7312,26 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i12.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i11.Future<_i3.Visibility?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Visibility?>.value(),
-      ) as _i11.Future<_i3.Visibility?>);
+        returnValue: _i12.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Visibility?>.value(),
+      ) as _i12.Future<_i4.Visibility?>);
 
   @override
-  _i11.Future<void> setRoomVisibilityOnDirectory(
+  _i12.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7304,30 +7339,30 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i12.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i12.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i11.Future<_i3.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_50(
+        returnValue: _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_51(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7335,18 +7370,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_50(
+            _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_51(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomIdByAliasResponse>);
+      ) as _i12.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i11.Future<void> setRoomAlias(
+  _i12.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7358,12 +7393,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             roomId,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetEventsResponse> getEvents({
+  _i12.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7377,7 +7412,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<_i3.GetEventsResponse>.value(_FakeGetEventsResponse_51(
+            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
           this,
           Invocation.method(
             #getEvents,
@@ -7389,7 +7424,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetEventsResponse>.value(_FakeGetEventsResponse_51(
+            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
           this,
           Invocation.method(
             #getEvents,
@@ -7400,10 +7435,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetEventsResponse>);
+      ) as _i12.Future<_i4.GetEventsResponse>);
 
   @override
-  _i11.Future<_i3.PeekEventsResponse> peekEvents({
+  _i12.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7418,8 +7453,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i11.Future<_i3.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_52(
+        returnValue: _i12.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_53(
           this,
           Invocation.method(
             #peekEvents,
@@ -7431,8 +7466,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_52(
+        returnValueForMissingStub: _i12.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_53(
           this,
           Invocation.method(
             #peekEvents,
@@ -7444,16 +7479,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.PeekEventsResponse>);
+      ) as _i12.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i11.Future<_i3.MatrixEvent> getOneEvent(String? eventId) =>
+  _i12.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7461,27 +7496,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i11.Future<_i3.MatrixEvent>);
+      ) as _i12.Future<_i4.MatrixEvent>);
 
   @override
-  _i11.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i12.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i11.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i11.Future<List<String>>.value(<String>[]),
-      ) as _i11.Future<List<String>>);
+        returnValue: _i12.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
+      ) as _i12.Future<List<String>>);
 
   @override
-  _i11.Future<_i3.GetKeysChangesResponse> getKeysChanges(
+  _i12.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7493,8 +7528,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             to,
           ],
         ),
-        returnValue: _i11.Future<_i3.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_54(
+        returnValue: _i12.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_55(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7505,8 +7540,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_54(
+            _i12.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_55(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7516,10 +7551,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.GetKeysChangesResponse>);
+      ) as _i12.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i11.Future<_i3.ClaimKeysResponse> claimKeys(
+  _i12.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7530,7 +7565,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i11.Future<_i3.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
+            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
           this,
           Invocation.method(
             #claimKeys,
@@ -7539,7 +7574,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
+            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
           this,
           Invocation.method(
             #claimKeys,
@@ -7547,14 +7582,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i11.Future<_i3.ClaimKeysResponse>);
+      ) as _i12.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i11.Future<void> uploadCrossSigningKeys({
-    _i3.AuthenticationData? auth,
-    _i3.MatrixCrossSigningKey? masterKey,
-    _i3.MatrixCrossSigningKey? selfSigningKey,
-    _i3.MatrixCrossSigningKey? userSigningKey,
+  _i12.Future<void> uploadCrossSigningKeys({
+    _i4.AuthenticationData? auth,
+    _i4.MatrixCrossSigningKey? masterKey,
+    _i4.MatrixCrossSigningKey? selfSigningKey,
+    _i4.MatrixCrossSigningKey? userSigningKey,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7567,12 +7602,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.QueryKeysResponse> queryKeys(
+  _i12.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7583,7 +7618,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i11.Future<_i3.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
+            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
           this,
           Invocation.method(
             #queryKeys,
@@ -7592,7 +7627,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
+            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
           this,
           Invocation.method(
             #queryKeys,
@@ -7600,10 +7635,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i11.Future<_i3.QueryKeysResponse>);
+      ) as _i12.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i11.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7611,15 +7646,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i11.Future<
+            returnValue: _i12.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i11.Future<
+            returnValueForMissingStub: _i12.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i11.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i11.Future<Map<String, int>> uploadKeys({
-    _i3.MatrixDeviceKeys? deviceKeys,
+  _i12.Future<Map<String, int>> uploadKeys({
+    _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
   }) =>
@@ -7633,13 +7668,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i11.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i12.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i11.Future<Map<String, int>>);
+            _i12.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i12.Future<Map<String, int>>);
 
   @override
-  _i11.Future<String> knockRoom(
+  _i12.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7653,7 +7688,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7665,7 +7700,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7676,20 +7711,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<List<_i3.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i12.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.LoginFlow>?>.value(),
-      ) as _i11.Future<List<_i3.LoginFlow>?>);
+        returnValue: _i12.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i12.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i11.Future<_i3.GetNotificationsResponse> getNotifications({
+  _i12.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7704,8 +7739,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #only: only,
           },
         ),
-        returnValue: _i11.Future<_i3.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_57(
+        returnValue: _i12.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_58(
           this,
           Invocation.method(
             #getNotifications,
@@ -7718,8 +7753,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_57(
+            _i12.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_58(
           this,
           Invocation.method(
             #getNotifications,
@@ -7731,37 +7766,37 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetNotificationsResponse>);
+      ) as _i12.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i11.Future<_i3.GetPresenceResponse> getPresence(String? userId) =>
+  _i12.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i11.Future<_i3.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_58(
+        returnValue: _i12.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_59(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_58(
+        returnValueForMissingStub: _i12.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_59(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i11.Future<_i3.GetPresenceResponse>);
+      ) as _i12.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i11.Future<void> setPresence(
+  _i12.Future<void> setPresence(
     String? userId,
-    _i3.PresenceType? presence, {
+    _i4.PresenceType? presence, {
     String? statusMsg,
   }) =>
       (super.noSuchMethod(
@@ -7773,12 +7808,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, Object?>> deleteProfileField(
+  _i12.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7791,13 +7826,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getProfileField(
+  _i12.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7810,13 +7845,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<Map<String, Object?>> setProfileField(
+  _i12.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7831,13 +7866,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.GetPublicRoomsResponse> getPublicRooms({
+  _i12.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7852,8 +7887,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #server: server,
           },
         ),
-        returnValue: _i11.Future<_i3.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_59(
+        returnValue: _i12.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_60(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7866,8 +7901,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_59(
+            _i12.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_60(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7879,12 +7914,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetPublicRoomsResponse>);
+      ) as _i12.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i11.Future<_i3.QueryPublicRoomsResponse> queryPublicRooms({
+  _i12.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
-    _i3.PublicRoomQueryFilter? filter,
+    _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
     int? limit,
     String? since,
@@ -7903,8 +7938,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i11.Future<_i3.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_60(
+        returnValue: _i12.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_61(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7920,8 +7955,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_60(
+            _i12.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_61(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7936,25 +7971,25 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.QueryPublicRoomsResponse>);
+      ) as _i12.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i11.Future<List<_i3.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Pusher>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.Pusher>?>.value(),
-      ) as _i11.Future<List<_i3.Pusher>?>);
+        returnValue: _i12.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.Pusher>?>.value(),
+      ) as _i12.Future<List<_i4.Pusher>?>);
 
   @override
-  _i11.Future<_i3.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i12.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i11.Future<_i3.PushRuleSet>.value(_FakePushRuleSet_61(
+        returnValue: _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
           this,
           Invocation.method(
             #getPushRules,
@@ -7962,24 +7997,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PushRuleSet>.value(_FakePushRuleSet_61(
+            _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.PushRuleSet>);
+      ) as _i12.Future<_i4.PushRuleSet>);
 
   @override
-  _i11.Future<_i3.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i12.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i11.Future<_i3.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_62(
+        returnValue: _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_63(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -7987,19 +8022,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_62(
+            _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_63(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.GetPushRulesGlobalResponse>);
+      ) as _i12.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i11.Future<void> deletePushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> deletePushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8010,13 +8045,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.PushRule> getPushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<_i4.PushRule> getPushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8027,7 +8062,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<_i3.PushRule>.value(_FakePushRule_63(
+        returnValue: _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
           this,
           Invocation.method(
             #getPushRule,
@@ -8038,7 +8073,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PushRule>.value(_FakePushRule_63(
+            _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
           this,
           Invocation.method(
             #getPushRule,
@@ -8048,16 +8083,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.PushRule>);
+      ) as _i12.Future<_i4.PushRule>);
 
   @override
-  _i11.Future<void> setPushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
     String? before,
     String? after,
-    List<_i3.PushCondition>? conditions,
+    List<_i4.PushCondition>? conditions,
     String? pattern,
   }) =>
       (super.noSuchMethod(
@@ -8075,13 +8110,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<Object?>> getPushRuleActions(
-    _i3.PushRuleKind? kind,
+  _i12.Future<List<Object?>> getPushRuleActions(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8092,14 +8127,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i12.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i11.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i11.Future<List<Object?>>);
+            _i12.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i12.Future<List<Object?>>);
 
   @override
-  _i11.Future<void> setPushRuleActions(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRuleActions(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
   ) =>
@@ -8112,13 +8147,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             actions,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<bool> isPushRuleEnabled(
-    _i3.PushRuleKind? kind,
+  _i12.Future<bool> isPushRuleEnabled(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8129,13 +8164,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> setPushRuleEnabled(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRuleEnabled(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
   ) =>
@@ -8148,19 +8183,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
             enabled,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.RefreshResponse> refresh(String? refreshToken) =>
+  _i12.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i11.Future<_i3.RefreshResponse>.value(_FakeRefreshResponse_64(
+            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
           this,
           Invocation.method(
             #refresh,
@@ -8168,28 +8203,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RefreshResponse>.value(_FakeRefreshResponse_64(
+            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i11.Future<_i3.RefreshResponse>);
+      ) as _i12.Future<_i4.RefreshResponse>);
 
   @override
-  _i11.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i12.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i11.Future<bool?>.value(),
-        returnValueForMissingStub: _i11.Future<bool?>.value(),
-      ) as _i11.Future<bool?>);
+        returnValue: _i12.Future<bool?>.value(),
+        returnValueForMissingStub: _i12.Future<bool?>.value(),
+      ) as _i12.Future<bool?>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8211,8 +8246,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8228,8 +8263,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8245,10 +8280,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8272,8 +8307,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8290,8 +8325,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8308,17 +8343,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8326,23 +8361,23 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i12.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i11.Future<_i3.RoomKeys>.value(_FakeRoomKeys_65(
+        returnValue: _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8350,19 +8385,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeys>.value(_FakeRoomKeys_65(
+            _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeys>);
+      ) as _i12.Future<_i4.RoomKeys>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeys(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
-    _i3.RoomKeys? body,
+    _i4.RoomKeys? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8372,8 +8407,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8384,8 +8419,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8395,10 +8430,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8410,8 +8445,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8422,8 +8457,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8433,10 +8468,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeyBackup> getRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8448,7 +8483,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
+        returnValue: _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8459,7 +8494,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
+            _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8469,13 +8504,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeyBackup>);
+      ) as _i12.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
-    _i3.RoomKeyBackup? body,
+    _i4.RoomKeyBackup? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8486,8 +8521,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8499,8 +8534,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8511,10 +8546,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8528,8 +8563,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8541,8 +8576,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8553,10 +8588,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.KeyBackupData> getRoomKeyBySessionId(
+  _i12.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8570,7 +8605,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8582,7 +8617,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8593,14 +8628,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.KeyBackupData>);
+      ) as _i12.Future<_i4.KeyBackupData>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
-    _i3.KeyBackupData? body,
+    _i4.KeyBackupData? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8612,8 +8647,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8626,8 +8661,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8639,18 +8674,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>
+  _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_67(
+                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_68(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8658,19 +8693,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_67(
+                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_68(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>);
+          ) as _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i11.Future<String> postRoomKeysVersion(
-    _i3.BackupAlgorithm? algorithm,
+  _i12.Future<String> postRoomKeysVersion(
+    _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
       (super.noSuchMethod(
@@ -8681,7 +8716,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             authData,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8692,7 +8727,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8702,29 +8737,29 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i12.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i12.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i11.Future<_i3.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_68(
+        returnValue: _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_69(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8732,20 +8767,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_68(
+            _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_69(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomKeysVersionResponse>);
+      ) as _i12.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i12.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
-    _i3.BackupAlgorithm? algorithm,
+    _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
       (super.noSuchMethod(
@@ -8758,24 +8793,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i12.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i11.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i11.Future<List<String>>.value(<String>[]),
-      ) as _i11.Future<List<String>>);
+        returnValue: _i12.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
+      ) as _i12.Future<List<String>>);
 
   @override
-  _i11.Future<void> ban(
+  _i12.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8789,12 +8824,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.EventContext> getEventContext(
+  _i12.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8812,7 +8847,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<_i3.EventContext>.value(_FakeEventContext_69(
+        returnValue: _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
           this,
           Invocation.method(
             #getEventContext,
@@ -8827,7 +8862,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.EventContext>.value(_FakeEventContext_69(
+            _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
           this,
           Invocation.method(
             #getEventContext,
@@ -8841,10 +8876,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.EventContext>);
+      ) as _i12.Future<_i4.EventContext>);
 
   @override
-  _i11.Future<_i3.MatrixEvent> getOneRoomEvent(
+  _i12.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8856,7 +8891,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             eventId,
           ],
         ),
-        returnValue: _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8867,7 +8902,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8877,22 +8912,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.MatrixEvent>);
+      ) as _i12.Future<_i4.MatrixEvent>);
 
   @override
-  _i11.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i12.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> inviteBy3PID(
+  _i12.Future<void> inviteBy3PID(
     String? roomId,
-    _i3.Invite3pid? body,
+    _i4.Invite3pid? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8902,12 +8937,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> inviteUser(
+  _i12.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8921,15 +8956,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> joinRoomById(
+  _i12.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
-    _i3.ThirdPartySigned? thirdPartySigned,
+    _i4.ThirdPartySigned? thirdPartySigned,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8940,7 +8975,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8952,7 +8987,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8963,23 +8998,23 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<Map<String, _i3.RoomMember>?> getJoinedMembersByRoom(
+  _i12.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i11.Future<Map<String, _i3.RoomMember>?>.value(),
+        returnValue: _i12.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i11.Future<Map<String, _i3.RoomMember>?>.value(),
-      ) as _i11.Future<Map<String, _i3.RoomMember>?>);
+            _i12.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i12.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i11.Future<void> kick(
+  _i12.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8993,12 +9028,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> leaveRoom(
+  _i12.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9008,16 +9043,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.MatrixEvent>?> getMembersByRoom(
+  _i12.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
-    _i3.Membership? membership,
-    _i3.Membership? notMembership,
+    _i4.Membership? membership,
+    _i4.Membership? notMembership,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9029,14 +9064,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i11.Future<List<_i3.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.MatrixEvent>?>.value(),
-      ) as _i11.Future<List<_i3.MatrixEvent>?>);
+        returnValue: _i12.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i12.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i11.Future<_i3.GetRoomEventsResponse> getRoomEvents(
+  _i12.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
-    _i3.Direction? dir, {
+    _i4.Direction? dir, {
     String? from,
     String? to,
     int? limit,
@@ -9056,8 +9091,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<_i3.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_70(
+        returnValue: _i12.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_71(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9073,8 +9108,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_70(
+        returnValueForMissingStub: _i12.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_71(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9090,10 +9125,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomEventsResponse>);
+      ) as _i12.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i11.Future<void> setReadMarker(
+  _i12.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9109,14 +9144,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> postReceipt(
+  _i12.Future<void> postReceipt(
     String? roomId,
-    _i3.ReceiptType? receiptType,
+    _i4.ReceiptType? receiptType,
     String? eventId, {
     String? threadId,
   }) =>
@@ -9130,12 +9165,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEvent(
+  _i12.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9151,12 +9186,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> reportRoom(
+  _i12.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9168,12 +9203,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             reason,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> reportEvent(
+  _i12.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9191,12 +9226,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #score: score,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> sendMessage(
+  _i12.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9212,7 +9247,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9225,7 +9260,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9237,27 +9272,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<List<_i3.MatrixEvent>> getRoomState(String? roomId) =>
+  _i12.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i11.Future<List<_i3.MatrixEvent>>.value(<_i3.MatrixEvent>[]),
+            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.MatrixEvent>>.value(<_i3.MatrixEvent>[]),
-      ) as _i11.Future<List<_i3.MatrixEvent>>);
+            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i12.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i12.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
-    _i3.Format? format,
+    _i4.Format? format,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9270,13 +9305,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#format: format},
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<String> setRoomStateWithKey(
+  _i12.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9292,7 +9327,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9305,7 +9340,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9317,10 +9352,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> unban(
+  _i12.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9334,12 +9369,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> upgradeRoom(
+  _i12.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9353,7 +9388,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9365,7 +9400,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9376,11 +9411,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.SearchResults> search(
-    _i3.Categories? searchCategories, {
+  _i12.Future<_i4.SearchResults> search(
+    _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
       (super.noSuchMethod(
@@ -9389,7 +9424,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i11.Future<_i3.SearchResults>.value(_FakeSearchResults_71(
+        returnValue: _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
           this,
           Invocation.method(
             #search,
@@ -9398,7 +9433,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SearchResults>.value(_FakeSearchResults_71(
+            _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
           this,
           Invocation.method(
             #search,
@@ -9406,14 +9441,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i11.Future<_i3.SearchResults>);
+      ) as _i12.Future<_i4.SearchResults>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> sync({
+  _i12.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
-    _i3.PresenceType? setPresence,
+    _i4.PresenceType? setPresence,
     int? timeout,
     bool? useStateAfter,
   }) =>
@@ -9430,7 +9465,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #sync,
@@ -9446,7 +9481,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #sync,
@@ -9461,22 +9496,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<List<_i3.Location>> queryLocationByAlias(String? alias) =>
+  _i12.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
+        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
-      ) as _i11.Future<List<_i3.Location>>);
+            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i12.Future<List<_i4.Location>>);
 
   @override
-  _i11.Future<List<_i3.Location>> queryLocationByProtocol(
+  _i12.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9486,21 +9521,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
+        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
-      ) as _i11.Future<List<_i3.Location>>);
+            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i12.Future<List<_i4.Location>>);
 
   @override
-  _i11.Future<_i3.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i12.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i11.Future<_i3.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_72(
+        returnValue: _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_73(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9508,45 +9543,45 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_72(
+            _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_73(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i11.Future<_i3.GetProtocolMetadataResponse$2>);
+      ) as _i12.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i11.Future<Map<String, _i3.GetProtocolsResponse$2>> getProtocols() =>
+  _i12.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>.value(
-            <String, _i3.GetProtocolsResponse$2>{}),
+        returnValue: _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>.value(
-                <String, _i3.GetProtocolsResponse$2>{}),
-      ) as _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>);
+            _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+                <String, _i4.GetProtocolsResponse$2>{}),
+      ) as _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
-      ) as _i11.Future<List<_i3.ThirdPartyUser>>);
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyUser>> queryUserByProtocol(
+  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9557,13 +9592,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
-      ) as _i11.Future<List<_i3.ThirdPartyUser>>);
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getAccountData(
+  _i12.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9576,13 +9611,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> setAccountData(
+  _i12.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9596,14 +9631,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> defineFilter(
+  _i12.Future<String> defineFilter(
     String? userId,
-    _i3.Filter? body,
+    _i4.Filter? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9613,7 +9648,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9624,7 +9659,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9634,10 +9669,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.Filter> getFilter(
+  _i12.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9649,7 +9684,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             filterId,
           ],
         ),
-        returnValue: _i11.Future<_i3.Filter>.value(_FakeFilter_16(
+        returnValue: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
           this,
           Invocation.method(
             #getFilter,
@@ -9659,7 +9694,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.Filter>.value(_FakeFilter_16(
+        returnValueForMissingStub: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
           this,
           Invocation.method(
             #getFilter,
@@ -9669,10 +9704,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.Filter>);
+      ) as _i12.Future<_i4.Filter>);
 
   @override
-  _i11.Future<_i3.OpenIdCredentials> requestOpenIdToken(
+  _i12.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9685,7 +9720,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<_i3.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
+            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9696,7 +9731,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
+            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9706,10 +9741,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.OpenIdCredentials>);
+      ) as _i12.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i11.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i12.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9724,13 +9759,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> setAccountDataPerRoom(
+  _i12.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9746,12 +9781,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, _i3.Tag>?> getRoomTags(
+  _i12.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9763,12 +9798,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             roomId,
           ],
         ),
-        returnValue: _i11.Future<Map<String, _i3.Tag>?>.value(),
-        returnValueForMissingStub: _i11.Future<Map<String, _i3.Tag>?>.value(),
-      ) as _i11.Future<Map<String, _i3.Tag>?>);
+        returnValue: _i12.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i12.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i12.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i11.Future<void> deleteRoomTag(
+  _i12.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9782,16 +9817,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             tag,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setRoomTag(
+  _i12.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
-    _i3.Tag? body,
+    _i4.Tag? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9803,12 +9838,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.SearchUserDirectoryResponse> searchUserDirectory(
+  _i12.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9818,8 +9853,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i11.Future<_i3.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_74(
+        returnValue: _i12.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_75(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9828,8 +9863,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_74(
+            _i12.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_75(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9837,10 +9872,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i11.Future<_i3.SearchUserDirectoryResponse>);
+      ) as _i12.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> reportUser(
+  _i12.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9853,40 +9888,40 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i12.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i11.Future<_i3.CreateContentResponse>.value(
-            _FakeCreateContentResponse_75(
+        returnValue: _i12.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_76(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.CreateContentResponse>.value(
-            _FakeCreateContentResponse_75(
+        returnValueForMissingStub: _i12.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_76(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.CreateContentResponse>);
+      ) as _i12.Future<_i4.CreateContentResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> uploadContentToMXC(
+  _i12.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i21.Uint8List? body, {
+    _i22.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -9904,8 +9939,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 }

--- a/test/widgets/invite_tile_test.mocks.dart
+++ b/test/widgets/invite_tile_test.mocks.dart
@@ -3,31 +3,33 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i11;
-import 'dart:typed_data' as _i21;
-import 'dart:ui' as _i15;
+import 'dart:async' as _i12;
+import 'dart:typed_data' as _i22;
+import 'dart:ui' as _i16;
 
-import 'package:flutter/services.dart' as _i16;
-import 'package:flutter/widgets.dart' as _i17;
-import 'package:http/http.dart' as _i10;
-import 'package:kohera/core/services/matrix_service.dart' as _i13;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
+import 'package:flutter/services.dart' as _i17;
+import 'package:flutter/widgets.dart' as _i18;
+import 'package:http/http.dart' as _i11;
+import 'package:kohera/core/services/matrix_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i5;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i7;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i4;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i7;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
-import 'package:matrix/encryption.dart' as _i20;
-import 'package:matrix/matrix.dart' as _i3;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i12;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i9;
-import 'package:matrix/src/utils/space_child.dart' as _i18;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i3;
+import 'package:matrix/encryption.dart' as _i21;
+import 'package:matrix/matrix.dart' as _i4;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i13;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i20;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i10;
+import 'package:matrix/src/utils/space_child.dart' as _i19;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -55,8 +57,9 @@ class _FakeCallPushRuleManager_0 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
-  _FakeClient_1(
+class _FakeMegolmKeyMirror_1 extends _i1.SmartFake
+    implements _i3.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_1(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -65,8 +68,8 @@ class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
         );
 }
 
-class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
-  _FakeUiaService_2(
+class _FakeClient_2 extends _i1.SmartFake implements _i4.Client {
+  _FakeClient_2(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -75,9 +78,8 @@ class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
         );
 }
 
-class _FakeChatBackupService_3 extends _i1.SmartFake
-    implements _i5.ChatBackupService {
-  _FakeChatBackupService_3(
+class _FakeUiaService_3 extends _i1.SmartFake implements _i5.UiaService {
+  _FakeUiaService_3(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -86,9 +88,9 @@ class _FakeChatBackupService_3 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_4 extends _i1.SmartFake
-    implements _i6.SelectionService {
-  _FakeSelectionService_4(
+class _FakeChatBackupService_4 extends _i1.SmartFake
+    implements _i6.ChatBackupService {
+  _FakeChatBackupService_4(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -97,8 +99,9 @@ class _FakeSelectionService_4 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
-  _FakeSyncService_5(
+class _FakeSelectionService_5 extends _i1.SmartFake
+    implements _i7.SelectionService {
+  _FakeSelectionService_5(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -107,8 +110,8 @@ class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
         );
 }
 
-class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
-  _FakeAuthService_6(
+class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
+  _FakeSyncService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -117,8 +120,8 @@ class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
         );
 }
 
-class _FakeRoomSummary_7 extends _i1.SmartFake implements _i3.RoomSummary {
-  _FakeRoomSummary_7(
+class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
+  _FakeAuthService_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -127,9 +130,8 @@ class _FakeRoomSummary_7 extends _i1.SmartFake implements _i3.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_8<T> extends _i1.SmartFake
-    implements _i9.CachedStreamController<T> {
-  _FakeCachedStreamController_8(
+class _FakeRoomSummary_8 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -138,8 +140,9 @@ class _FakeCachedStreamController_8<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_9 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_9(
+class _FakeCachedStreamController_9<T> extends _i1.SmartFake
+    implements _i10.CachedStreamController<T> {
+  _FakeCachedStreamController_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -148,9 +151,8 @@ class _FakeDateTime_9 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_10 extends _i1.SmartFake
-    implements _i3.LatestReceiptState {
-  _FakeLatestReceiptState_10(
+class _FakeDateTime_10 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -159,8 +161,9 @@ class _FakeLatestReceiptState_10 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_11 extends _i1.SmartFake implements _i3.SyncUpdate {
-  _FakeSyncUpdate_11(
+class _FakeLatestReceiptState_11 extends _i1.SmartFake
+    implements _i4.LatestReceiptState {
+  _FakeLatestReceiptState_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -169,8 +172,8 @@ class _FakeSyncUpdate_11 extends _i1.SmartFake implements _i3.SyncUpdate {
         );
 }
 
-class _FakeTimeline_12 extends _i1.SmartFake implements _i3.Timeline {
-  _FakeTimeline_12(
+class _FakeSyncUpdate_12 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -179,8 +182,8 @@ class _FakeTimeline_12 extends _i1.SmartFake implements _i3.Timeline {
         );
 }
 
-class _FakeUser_13 extends _i1.SmartFake implements _i3.User {
-  _FakeUser_13(
+class _FakeTimeline_13 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -189,8 +192,8 @@ class _FakeUser_13 extends _i1.SmartFake implements _i3.User {
         );
 }
 
-class _FakeUri_14 extends _i1.SmartFake implements Uri {
-  _FakeUri_14(
+class _FakeUser_14 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -199,8 +202,8 @@ class _FakeUri_14 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_15 extends _i1.SmartFake implements _i3.DatabaseApi {
-  _FakeDatabaseApi_15(
+class _FakeUri_15 extends _i1.SmartFake implements Uri {
+  _FakeUri_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -209,8 +212,8 @@ class _FakeDatabaseApi_15 extends _i1.SmartFake implements _i3.DatabaseApi {
         );
 }
 
-class _FakeFilter_16 extends _i1.SmartFake implements _i3.Filter {
-  _FakeFilter_16(
+class _FakeDatabaseApi_16 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -219,9 +222,8 @@ class _FakeFilter_16 extends _i1.SmartFake implements _i3.Filter {
         );
 }
 
-class _FakeNativeImplementations_17 extends _i1.SmartFake
-    implements _i3.NativeImplementations {
-  _FakeNativeImplementations_17(
+class _FakeFilter_17 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -230,8 +232,9 @@ class _FakeNativeImplementations_17 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_18 extends _i1.SmartFake implements Duration {
-  _FakeDuration_18(
+class _FakeNativeImplementations_18 extends _i1.SmartFake
+    implements _i4.NativeImplementations {
+  _FakeNativeImplementations_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -240,9 +243,8 @@ class _FakeDuration_18 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_19 extends _i1.SmartFake
-    implements _i3.PushruleEvaluator {
-  _FakePushruleEvaluator_19(
+class _FakeDuration_19 extends _i1.SmartFake implements Duration {
+  _FakeDuration_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -251,8 +253,9 @@ class _FakePushruleEvaluator_19 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_20 extends _i1.SmartFake implements _i3.Profile {
-  _FakeProfile_20(
+class _FakePushruleEvaluator_20 extends _i1.SmartFake
+    implements _i4.PushruleEvaluator {
+  _FakePushruleEvaluator_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -261,8 +264,8 @@ class _FakeProfile_20 extends _i1.SmartFake implements _i3.Profile {
         );
 }
 
-class _FakeClient_21 extends _i1.SmartFake implements _i10.Client {
-  _FakeClient_21(
+class _FakeProfile_21 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -271,9 +274,8 @@ class _FakeClient_21 extends _i1.SmartFake implements _i10.Client {
         );
 }
 
-class _FakeDiscoveryInformation_22 extends _i1.SmartFake
-    implements _i3.DiscoveryInformation {
-  _FakeDiscoveryInformation_22(
+class _FakeClient_22 extends _i1.SmartFake implements _i11.Client {
+  _FakeClient_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -282,9 +284,9 @@ class _FakeDiscoveryInformation_22 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_23 extends _i1.SmartFake
-    implements _i3.GetVersionsResponse {
-  _FakeGetVersionsResponse_23(
+class _FakeDiscoveryInformation_23 extends _i1.SmartFake
+    implements _i4.DiscoveryInformation {
+  _FakeDiscoveryInformation_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -293,9 +295,9 @@ class _FakeGetVersionsResponse_23 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_24 extends _i1.SmartFake
-    implements _i3.RegisterResponse {
-  _FakeRegisterResponse_24(
+class _FakeGetVersionsResponse_24 extends _i1.SmartFake
+    implements _i4.GetVersionsResponse {
+  _FakeGetVersionsResponse_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -304,8 +306,9 @@ class _FakeRegisterResponse_24 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_25 extends _i1.SmartFake implements _i3.LoginResponse {
-  _FakeLoginResponse_25(
+class _FakeRegisterResponse_25 extends _i1.SmartFake
+    implements _i4.RegisterResponse {
+  _FakeRegisterResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -314,9 +317,8 @@ class _FakeLoginResponse_25 extends _i1.SmartFake implements _i3.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_26 extends _i1.SmartFake
-    implements _i3.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_26(
+class _FakeLoginResponse_26 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -325,8 +327,9 @@ class _FakeGetAuthMetadataResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_27<T1> extends _i1.SmartFake implements _i11.Future<T1> {
-  _FakeFuture_27(
+class _FakeGetAuthMetadataResponse_27 extends _i1.SmartFake
+    implements _i4.GetAuthMetadataResponse {
+  _FakeGetAuthMetadataResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -335,9 +338,8 @@ class _FakeFuture_27<T1> extends _i1.SmartFake implements _i11.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_28 extends _i1.SmartFake
-    implements _i3.CachedProfileInformation {
-  _FakeCachedProfileInformation_28(
+class _FakeFuture_28<T1> extends _i1.SmartFake implements _i12.Future<T1> {
+  _FakeFuture_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -346,8 +348,9 @@ class _FakeCachedProfileInformation_28 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_29 extends _i1.SmartFake implements _i3.MediaConfig {
-  _FakeMediaConfig_29(
+class _FakeCachedProfileInformation_29 extends _i1.SmartFake
+    implements _i4.CachedProfileInformation {
+  _FakeCachedProfileInformation_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -356,8 +359,8 @@ class _FakeMediaConfig_29 extends _i1.SmartFake implements _i3.MediaConfig {
         );
 }
 
-class _FakeFileResponse_30 extends _i1.SmartFake implements _i12.FileResponse {
-  _FakeFileResponse_30(
+class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -366,8 +369,8 @@ class _FakeFileResponse_30 extends _i1.SmartFake implements _i12.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_31 extends _i1.SmartFake implements _i3.PreviewForUrl {
-  _FakePreviewForUrl_31(
+class _FakeFileResponse_31 extends _i1.SmartFake implements _i13.FileResponse {
+  _FakeFileResponse_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -376,9 +379,8 @@ class _FakePreviewForUrl_31 extends _i1.SmartFake implements _i3.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_32 extends _i1.SmartFake
-    implements _i3.CachedPresence {
-  _FakeCachedPresence_32(
+class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -387,9 +389,9 @@ class _FakeCachedPresence_32 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_33 extends _i1.SmartFake
-    implements _i3.TurnServerCredentials {
-  _FakeTurnServerCredentials_33(
+class _FakeCachedPresence_33 extends _i1.SmartFake
+    implements _i4.CachedPresence {
+  _FakeCachedPresence_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -398,9 +400,9 @@ class _FakeTurnServerCredentials_33 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
-    implements _i3.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_34(
+class _FakeTurnServerCredentials_34 extends _i1.SmartFake
+    implements _i4.TurnServerCredentials {
+  _FakeTurnServerCredentials_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -409,8 +411,9 @@ class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i3.KeyBackupData {
-  _FakeKeyBackupData_35(
+class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
+    implements _i4.RoomKeysUpdateResponse {
+  _FakeRoomKeysUpdateResponse_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -419,9 +422,8 @@ class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i3.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
-    implements _i3.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_36(
+class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -430,9 +432,9 @@ class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
-    implements _i3.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_37(
+class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
+    implements _i4.GetWellknownSupportResponse {
+  _FakeGetWellknownSupportResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -441,9 +443,9 @@ class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
-    implements _i3.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_38(
+class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
+    implements _i4.GenerateLoginTokenResponse {
+  _FakeGenerateLoginTokenResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -452,9 +454,9 @@ class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
-    implements _i3.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_39(
+class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
+    implements _i4.GetRoomSummaryResponse$3 {
+  _FakeGetRoomSummaryResponse$3_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -463,9 +465,9 @@ class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
-    implements _i3.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_40(
+class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
+    implements _i4.GetSpaceHierarchyResponse {
+  _FakeGetSpaceHierarchyResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -474,9 +476,9 @@ class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
-    implements _i3.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_41(
+class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
+    implements _i4.GetRelatingEventsResponse {
+  _FakeGetRelatingEventsResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -485,9 +487,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
-    .SmartFake implements _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
+    implements _i4.GetRelatingEventsWithRelTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -496,9 +498,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
-    implements _i3.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_43(
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
+    .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -507,9 +509,9 @@ class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
-    implements _i3.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_44(
+class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
+    implements _i4.GetThreadRootsResponse {
+  _FakeGetThreadRootsResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -518,9 +520,9 @@ class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_45 extends _i1.SmartFake
-    implements _i3.RequestTokenResponse {
-  _FakeRequestTokenResponse_45(
+class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
+    implements _i4.GetEventByTimestampResponse {
+  _FakeGetEventByTimestampResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -529,9 +531,9 @@ class _FakeRequestTokenResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
-    implements _i3.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_46(
+class _FakeRequestTokenResponse_46 extends _i1.SmartFake
+    implements _i4.RequestTokenResponse {
+  _FakeRequestTokenResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -540,8 +542,9 @@ class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i3.WhoIsInfo {
-  _FakeWhoIsInfo_47(
+class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
+    implements _i4.TokenOwnerInfo {
+  _FakeTokenOwnerInfo_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -550,8 +553,8 @@ class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i3.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_48 extends _i1.SmartFake implements _i3.Capabilities {
-  _FakeCapabilities_48(
+class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -560,8 +563,8 @@ class _FakeCapabilities_48 extends _i1.SmartFake implements _i3.Capabilities {
         );
 }
 
-class _FakeDevice_49 extends _i1.SmartFake implements _i3.Device {
-  _FakeDevice_49(
+class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -570,9 +573,8 @@ class _FakeDevice_49 extends _i1.SmartFake implements _i3.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
-    implements _i3.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_50(
+class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -581,9 +583,9 @@ class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_51 extends _i1.SmartFake
-    implements _i3.GetEventsResponse {
-  _FakeGetEventsResponse_51(
+class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
+    implements _i4.GetRoomIdByAliasResponse {
+  _FakeGetRoomIdByAliasResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -592,9 +594,9 @@ class _FakeGetEventsResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_52 extends _i1.SmartFake
-    implements _i3.PeekEventsResponse {
-  _FakePeekEventsResponse_52(
+class _FakeGetEventsResponse_52 extends _i1.SmartFake
+    implements _i4.GetEventsResponse {
+  _FakeGetEventsResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -603,8 +605,9 @@ class _FakePeekEventsResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i3.MatrixEvent {
-  _FakeMatrixEvent_53(
+class _FakePeekEventsResponse_53 extends _i1.SmartFake
+    implements _i4.PeekEventsResponse {
+  _FakePeekEventsResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -613,9 +616,8 @@ class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i3.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
-    implements _i3.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_54(
+class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -624,9 +626,9 @@ class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_55 extends _i1.SmartFake
-    implements _i3.ClaimKeysResponse {
-  _FakeClaimKeysResponse_55(
+class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
+    implements _i4.GetKeysChangesResponse {
+  _FakeGetKeysChangesResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -635,9 +637,9 @@ class _FakeClaimKeysResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_56 extends _i1.SmartFake
-    implements _i3.QueryKeysResponse {
-  _FakeQueryKeysResponse_56(
+class _FakeClaimKeysResponse_56 extends _i1.SmartFake
+    implements _i4.ClaimKeysResponse {
+  _FakeClaimKeysResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -646,9 +648,9 @@ class _FakeQueryKeysResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
-    implements _i3.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_57(
+class _FakeQueryKeysResponse_57 extends _i1.SmartFake
+    implements _i4.QueryKeysResponse {
+  _FakeQueryKeysResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -657,9 +659,9 @@ class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_58 extends _i1.SmartFake
-    implements _i3.GetPresenceResponse {
-  _FakeGetPresenceResponse_58(
+class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
+    implements _i4.GetNotificationsResponse {
+  _FakeGetNotificationsResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -668,9 +670,9 @@ class _FakeGetPresenceResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
-    implements _i3.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_59(
+class _FakeGetPresenceResponse_59 extends _i1.SmartFake
+    implements _i4.GetPresenceResponse {
+  _FakeGetPresenceResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -679,9 +681,9 @@ class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
-    implements _i3.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_60(
+class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
+    implements _i4.GetPublicRoomsResponse {
+  _FakeGetPublicRoomsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -690,8 +692,9 @@ class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_61 extends _i1.SmartFake implements _i3.PushRuleSet {
-  _FakePushRuleSet_61(
+class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
+    implements _i4.QueryPublicRoomsResponse {
+  _FakeQueryPublicRoomsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -700,9 +703,8 @@ class _FakePushRuleSet_61 extends _i1.SmartFake implements _i3.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
-    implements _i3.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_62(
+class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -711,8 +713,9 @@ class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_63 extends _i1.SmartFake implements _i3.PushRule {
-  _FakePushRule_63(
+class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
+    implements _i4.GetPushRulesGlobalResponse {
+  _FakeGetPushRulesGlobalResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -721,9 +724,8 @@ class _FakePushRule_63 extends _i1.SmartFake implements _i3.PushRule {
         );
 }
 
-class _FakeRefreshResponse_64 extends _i1.SmartFake
-    implements _i3.RefreshResponse {
-  _FakeRefreshResponse_64(
+class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -732,8 +734,9 @@ class _FakeRefreshResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_65 extends _i1.SmartFake implements _i3.RoomKeys {
-  _FakeRoomKeys_65(
+class _FakeRefreshResponse_65 extends _i1.SmartFake
+    implements _i4.RefreshResponse {
+  _FakeRefreshResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -742,8 +745,8 @@ class _FakeRoomKeys_65 extends _i1.SmartFake implements _i3.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i3.RoomKeyBackup {
-  _FakeRoomKeyBackup_66(
+class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -752,9 +755,8 @@ class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i3.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
-    implements _i3.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_67(
+class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -763,9 +765,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
-    implements _i3.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_68(
+class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
+    implements _i4.GetRoomKeysVersionCurrentResponse {
+  _FakeGetRoomKeysVersionCurrentResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -774,8 +776,9 @@ class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_69 extends _i1.SmartFake implements _i3.EventContext {
-  _FakeEventContext_69(
+class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
+    implements _i4.GetRoomKeysVersionResponse {
+  _FakeGetRoomKeysVersionResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -784,9 +787,8 @@ class _FakeEventContext_69 extends _i1.SmartFake implements _i3.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
-    implements _i3.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_70(
+class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -795,8 +797,9 @@ class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_71 extends _i1.SmartFake implements _i3.SearchResults {
-  _FakeSearchResults_71(
+class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
+    implements _i4.GetRoomEventsResponse {
+  _FakeGetRoomEventsResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -805,9 +808,8 @@ class _FakeSearchResults_71 extends _i1.SmartFake implements _i3.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
-    implements _i3.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_72(
+class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -816,9 +818,9 @@ class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_73 extends _i1.SmartFake
-    implements _i3.OpenIdCredentials {
-  _FakeOpenIdCredentials_73(
+class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
+    implements _i4.GetProtocolMetadataResponse$2 {
+  _FakeGetProtocolMetadataResponse$2_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -827,9 +829,9 @@ class _FakeOpenIdCredentials_73 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
-    implements _i3.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_74(
+class _FakeOpenIdCredentials_74 extends _i1.SmartFake
+    implements _i4.OpenIdCredentials {
+  _FakeOpenIdCredentials_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -838,9 +840,20 @@ class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_75 extends _i1.SmartFake
-    implements _i3.CreateContentResponse {
-  _FakeCreateContentResponse_75(
+class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
+    implements _i4.SearchUserDirectoryResponse {
+  _FakeSearchUserDirectoryResponse_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeCreateContentResponse_76 extends _i1.SmartFake
+    implements _i4.CreateContentResponse {
+  _FakeCreateContentResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,7 +865,7 @@ class _FakeCreateContentResponse_75 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -867,30 +880,43 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as _i2.CallPushRuleManager);
 
   @override
+  _i3.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i3.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
       ) as String);
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get isLoggedIn => (super.noSuchMethod(
@@ -907,69 +933,69 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  _i4.UiaService get uia => (super.noSuchMethod(
+  _i5.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_2(
+        returnValue: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_2(
+        returnValueForMissingStub: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i4.UiaService);
+      ) as _i5.UiaService);
 
   @override
-  _i5.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i6.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_3(
+        returnValue: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_3(
+        returnValueForMissingStub: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i5.ChatBackupService);
+      ) as _i6.ChatBackupService);
 
   @override
-  _i6.SelectionService get selection => (super.noSuchMethod(
+  _i7.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_4(
+        returnValue: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_4(
+        returnValueForMissingStub: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i6.SelectionService);
+      ) as _i7.SelectionService);
 
   @override
-  _i7.SyncService get sync => (super.noSuchMethod(
+  _i8.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_5(
+        returnValue: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_5(
+        returnValueForMissingStub: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i7.SyncService);
+      ) as _i8.SyncService);
 
   @override
-  _i8.AuthService get auth => (super.noSuchMethod(
+  _i9.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_6(
+        returnValue: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_6(
+        returnValueForMissingStub: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i8.AuthService);
+      ) as _i9.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -988,6 +1014,15 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
+  set keyMirror(_i3.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -997,7 +1032,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set uia(_i4.UiaService? value) => super.noSuchMethod(
+  set uia(_i5.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -1006,7 +1041,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set chatBackup(_i5.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i6.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -1015,7 +1050,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set selection(_i6.SelectionService? value) => super.noSuchMethod(
+  set selection(_i7.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -1024,7 +1059,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set sync(_i7.SyncService? value) => super.noSuchMethod(
+  set sync(_i8.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -1033,7 +1068,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set auth(_i8.AuthService? value) => super.noSuchMethod(
+  set auth(_i9.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -1049,14 +1084,14 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  _i11.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1086,7 +1121,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i15.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i16.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1096,18 +1131,18 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i12.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<bool> login({
+  _i12.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1122,12 +1157,12 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<bool> completeSsoLogin({
+  _i12.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1140,13 +1175,13 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> completeRegistration(
-    _i3.RegisterResponse? response, {
+  _i12.Future<void> completeRegistration(
+    _i4.RegisterResponse? response, {
     String? password,
   }) =>
       (super.noSuchMethod(
@@ -1155,32 +1190,32 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> logout() => (super.noSuchMethod(
+  _i12.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i12.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  void addListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1189,7 +1224,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void removeListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1198,17 +1233,17 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i16.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i17.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1219,7 +1254,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i16.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i17.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1256,26 +1291,26 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<bool> didPushRouteInformation(
-          _i17.RouteInformation? routeInformation) =>
+  _i12.Future<bool> didPushRouteInformation(
+          _i18.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1305,7 +1340,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i15.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i16.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1314,7 +1349,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i15.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i16.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1323,16 +1358,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<_i15.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i12.Future<_i16.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
-      ) as _i11.Future<_i15.AppExitResponse>);
+            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
+      ) as _i12.Future<_i16.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1356,26 +1391,26 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
 /// A class which mocks [Room].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockRoom extends _i1.Mock implements _i3.Room {
+class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
       ) as String);
 
   @override
-  _i3.Membership get membership => (super.noSuchMethod(
+  _i4.Membership get membership => (super.noSuchMethod(
         Invocation.getter(#membership),
-        returnValue: _i3.Membership.ban,
-        returnValueForMissingStub: _i3.Membership.ban,
-      ) as _i3.Membership);
+        returnValue: _i4.Membership.ban,
+        returnValueForMissingStub: _i4.Membership.ban,
+      ) as _i4.Membership);
 
   @override
   int get notificationCount => (super.noSuchMethod(
@@ -1392,47 +1427,47 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i3.RoomSummary get summary => (super.noSuchMethod(
+  _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_7(
+        returnValue: _FakeRoomSummary_8(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_7(
+        returnValueForMissingStub: _FakeRoomSummary_8(
           this,
           Invocation.getter(#summary),
         ),
-      ) as _i3.RoomSummary);
+      ) as _i4.RoomSummary);
 
   @override
-  Map<String, Map<String, _i3.StrippedStateEvent>> get states =>
+  Map<String, Map<String, _i4.StrippedStateEvent>> get states =>
       (super.noSuchMethod(
         Invocation.getter(#states),
-        returnValue: <String, Map<String, _i3.StrippedStateEvent>>{},
+        returnValue: <String, Map<String, _i4.StrippedStateEvent>>{},
         returnValueForMissingStub: <String,
-            Map<String, _i3.StrippedStateEvent>>{},
-      ) as Map<String, Map<String, _i3.StrippedStateEvent>>);
+            Map<String, _i4.StrippedStateEvent>>{},
+      ) as Map<String, Map<String, _i4.StrippedStateEvent>>);
 
   @override
-  Map<String, _i3.BasicEvent> get ephemerals => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get ephemerals => (super.noSuchMethod(
         Invocation.getter(#ephemerals),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  Map<String, _i3.BasicEvent> get roomAccountData => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get roomAccountData => (super.noSuchMethod(
         Invocation.getter(#roomAccountData),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i11.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i12.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i11.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i11.Completer<dynamic>>[],
-      ) as List<_i11.Completer<dynamic>>);
+        returnValue: <_i12.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i12.Completer<dynamic>>[],
+      ) as List<_i12.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1451,51 +1486,51 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i9.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i10.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i9.CachedStreamController<String> get onSessionKeyReceived =>
+  _i10.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1511,11 +1546,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1524,11 +1559,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1542,24 +1577,24 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i3.User> get typingUsers => (super.noSuchMethod(
+  List<_i4.User> get typingUsers => (super.noSuchMethod(
         Invocation.getter(#typingUsers),
-        returnValue: <_i3.User>[],
-        returnValueForMissingStub: <_i3.User>[],
-      ) as List<_i3.User>);
+        returnValue: <_i4.User>[],
+        returnValueForMissingStub: <_i4.User>[],
+      ) as List<_i4.User>);
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get isAbandonedDMRoom => (super.noSuchMethod(
@@ -1571,11 +1606,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1584,22 +1619,22 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_9(
+        returnValue: _FakeDateTime_10(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_9(
+        returnValueForMissingStub: _FakeDateTime_10(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
       ) as DateTime);
 
   @override
-  Map<String, _i3.Tag> get tags => (super.noSuchMethod(
+  Map<String, _i4.Tag> get tags => (super.noSuchMethod(
         Invocation.getter(#tags),
-        returnValue: <String, _i3.Tag>{},
-        returnValueForMissingStub: <String, _i3.Tag>{},
-      ) as Map<String, _i3.Tag>);
+        returnValue: <String, _i4.Tag>{},
+        returnValueForMissingStub: <String, _i4.Tag>{},
+      ) as Map<String, _i4.Tag>);
 
   @override
   bool get markedUnread => (super.noSuchMethod(
@@ -1616,17 +1651,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.LatestReceiptState get receiptState => (super.noSuchMethod(
+  _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_10(
+        returnValue: _FakeLatestReceiptState_11(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_10(
+        returnValueForMissingStub: _FakeLatestReceiptState_11(
           this,
           Invocation.getter(#receiptState),
         ),
-      ) as _i3.LatestReceiptState);
+      ) as _i4.LatestReceiptState);
 
   @override
   bool get isUnread => (super.noSuchMethod(
@@ -1643,18 +1678,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i11.Future<_i3.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i12.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -1664,20 +1699,20 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  Map<String, _i3.MatrixFile> get sendingFilePlaceholders =>
+  Map<String, _i4.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
-        returnValue: <String, _i3.MatrixFile>{},
-        returnValueForMissingStub: <String, _i3.MatrixFile>{},
-      ) as Map<String, _i3.MatrixFile>);
+        returnValue: <String, _i4.MatrixFile>{},
+        returnValueForMissingStub: <String, _i4.MatrixFile>{},
+      ) as Map<String, _i4.MatrixFile>);
 
   @override
-  Map<String, _i3.MatrixImageFile> get sendingFileThumbnails =>
+  Map<String, _i4.MatrixImageFile> get sendingFileThumbnails =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFileThumbnails),
-        returnValue: <String, _i3.MatrixImageFile>{},
-        returnValueForMissingStub: <String, _i3.MatrixImageFile>{},
-      ) as Map<String, _i3.MatrixImageFile>);
+        returnValue: <String, _i4.MatrixImageFile>{},
+        returnValueForMissingStub: <String, _i4.MatrixImageFile>{},
+      ) as Map<String, _i4.MatrixImageFile>);
 
   @override
   bool get isFederated => (super.noSuchMethod(
@@ -1778,11 +1813,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.PushRuleState get pushRuleState => (super.noSuchMethod(
+  _i4.PushRuleState get pushRuleState => (super.noSuchMethod(
         Invocation.getter(#pushRuleState),
-        returnValue: _i3.PushRuleState.notify,
-        returnValueForMissingStub: _i3.PushRuleState.notify,
-      ) as _i3.PushRuleState);
+        returnValue: _i4.PushRuleState.notify,
+        returnValueForMissingStub: _i4.PushRuleState.notify,
+      ) as _i4.PushRuleState);
 
   @override
   bool get canChangeJoinRules => (super.noSuchMethod(
@@ -1792,11 +1827,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.GuestAccess get guestAccess => (super.noSuchMethod(
+  _i4.GuestAccess get guestAccess => (super.noSuchMethod(
         Invocation.getter(#guestAccess),
-        returnValue: _i3.GuestAccess.canJoin,
-        returnValueForMissingStub: _i3.GuestAccess.canJoin,
-      ) as _i3.GuestAccess);
+        returnValue: _i4.GuestAccess.canJoin,
+        returnValueForMissingStub: _i4.GuestAccess.canJoin,
+      ) as _i4.GuestAccess);
 
   @override
   bool get canChangeGuestAccess => (super.noSuchMethod(
@@ -1834,21 +1869,21 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i19.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i18.SpaceParent>[],
-        returnValueForMissingStub: <_i18.SpaceParent>[],
-      ) as List<_i18.SpaceParent>);
+        returnValue: <_i19.SpaceParent>[],
+        returnValueForMissingStub: <_i19.SpaceParent>[],
+      ) as List<_i19.SpaceParent>);
 
   @override
-  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i19.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i18.SpaceChild>[],
-        returnValueForMissingStub: <_i18.SpaceChild>[],
-      ) as List<_i18.SpaceChild>);
+        returnValue: <_i19.SpaceChild>[],
+        returnValueForMissingStub: <_i19.SpaceChild>[],
+      ) as List<_i19.SpaceChild>);
 
   @override
-  set membership(_i3.Membership? value) => super.noSuchMethod(
+  set membership(_i4.Membership? value) => super.noSuchMethod(
         Invocation.setter(
           #membership,
           value,
@@ -1884,7 +1919,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set summary(_i3.RoomSummary? value) => super.noSuchMethod(
+  set summary(_i4.RoomSummary? value) => super.noSuchMethod(
         Invocation.setter(
           #summary,
           value,
@@ -1893,7 +1928,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set states(Map<String, Map<String, _i3.StrippedStateEvent>>? value) =>
+  set states(Map<String, Map<String, _i4.StrippedStateEvent>>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #states,
@@ -1903,7 +1938,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set ephemerals(Map<String, _i3.BasicEvent>? value) => super.noSuchMethod(
+  set ephemerals(Map<String, _i4.BasicEvent>? value) => super.noSuchMethod(
         Invocation.setter(
           #ephemerals,
           value,
@@ -1912,7 +1947,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set roomAccountData(Map<String, _i3.BasicEvent>? value) => super.noSuchMethod(
+  set roomAccountData(Map<String, _i4.BasicEvent>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomAccountData,
           value,
@@ -1930,7 +1965,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set lastEvent(_i3.Event? value) => super.noSuchMethod(
+  set lastEvent(_i4.Event? value) => super.noSuchMethod(
         Invocation.setter(
           #lastEvent,
           value,
@@ -1939,7 +1974,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set receiptState(_i3.LatestReceiptState? value) => super.noSuchMethod(
+  set receiptState(_i4.LatestReceiptState? value) => super.noSuchMethod(
         Invocation.setter(
           #receiptState,
           value,
@@ -1958,17 +1993,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i11.Future<void> postLoad() => (super.noSuchMethod(
+  _i12.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i3.StrippedStateEvent? getState(
+  _i4.StrippedStateEvent? getState(
     String? typeKey, [
     String? stateKey = '',
   ]) =>
@@ -1981,10 +2016,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.StrippedStateEvent?);
+      ) as _i4.StrippedStateEvent?);
 
   @override
-  void setState(_i3.StrippedStateEvent? state) => super.noSuchMethod(
+  void setState(_i4.StrippedStateEvent? state) => super.noSuchMethod(
         Invocation.method(
           #setState,
           [state],
@@ -1993,33 +2028,33 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  _i11.Future<List<_i3.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i12.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
+        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
-      ) as _i11.Future<List<_i3.User>>);
+            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i12.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
-          [_i3.MatrixLocalizations? i18n =
-              const _i3.MatrixDefaultLocalizations()]) =>
+          [_i4.MatrixLocalizations? i18n =
+              const _i4.MatrixDefaultLocalizations()]) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2029,18 +2064,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as String);
 
   @override
-  _i11.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i12.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Event?> refreshLastEvent(
+  _i12.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2048,12 +2083,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
-  void setEphemeral(_i3.BasicEvent? ephemeral) => super.noSuchMethod(
+  void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
         Invocation.method(
           #setEphemeral,
           [ephemeral],
@@ -2062,12 +2097,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  _i11.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i12.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2075,22 +2110,22 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i12.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2098,17 +2133,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> addTag(
+  _i12.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2118,27 +2153,27 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i12.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i12.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2146,43 +2181,43 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i12.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i12.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i12.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2190,14 +2225,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2209,10 +2244,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as String?);
 
   @override
-  _i11.Future<String?> sendTextEvent(
+  _i12.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     bool? parseMarkdown = true,
     bool? parseCommands = true,
@@ -2241,12 +2276,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendReaction(
+  _i12.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2260,12 +2295,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendLocation(
+  _i12.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2279,18 +2314,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendFileEvent(
-    _i3.MatrixFile? file, {
+  _i12.Future<String?> sendFileEvent(
+    _i4.MatrixFile? file, {
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     int? shrinkImageMaxDimension,
-    _i3.MatrixImageFile? thumbnail,
+    _i4.MatrixImageFile? thumbnail,
     Map<String, dynamic>? extraContent,
     String? threadRootEventId,
     String? threadLastEventId,
@@ -2312,29 +2347,29 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<_i3.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i12.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i11.Future<_i3.EncryptionHealthState>.value(
-            _i3.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i11.Future<_i3.EncryptionHealthState>.value(
-            _i3.EncryptionHealthState.allVerified),
-      ) as _i11.Future<_i3.EncryptionHealthState>);
+        returnValue: _i12.Future<_i4.EncryptionHealthState>.value(
+            _i4.EncryptionHealthState.allVerified),
+        returnValueForMissingStub: _i12.Future<_i4.EncryptionHealthState>.value(
+            _i4.EncryptionHealthState.allVerified),
+      ) as _i12.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i11.Future<String?> sendEvent(
+  _i12.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     String? threadRootEventId,
     String? threadLastEventId,
@@ -2354,73 +2389,73 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i12.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> leave() => (super.noSuchMethod(
+  _i12.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> forget() => (super.noSuchMethod(
+  _i12.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> setPower(
+  _i12.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2432,7 +2467,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             power,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2443,7 +2478,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2453,10 +2488,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> invite(
+  _i12.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2466,16 +2501,16 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<int> requestHistory({
+  _i12.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
-    dynamic direction = _i3.Direction.b,
-    _i3.StateFilter? filter,
+    dynamic direction = _i4.Direction.b,
+    _i4.StateFilter? filter,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2488,32 +2523,32 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<int>.value(0),
-        returnValueForMissingStub: _i11.Future<int>.value(0),
-      ) as _i11.Future<int>);
+        returnValue: _i12.Future<int>.value(0),
+        returnValueForMissingStub: _i12.Future<int>.value(0),
+      ) as _i12.Future<int>);
 
   @override
-  _i11.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i12.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setReadMarker(
+  _i12.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2527,25 +2562,25 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #public: public,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
+  _i12.Future<_i20.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i11.Future<_i19.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i11.Future<_i19.TimelineChunk?>.value(),
-      ) as _i11.Future<_i19.TimelineChunk?>);
+        returnValue: _i12.Future<_i20.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i12.Future<_i20.TimelineChunk?>.value(),
+      ) as _i12.Future<_i20.TimelineChunk?>);
 
   @override
-  _i11.Future<void> postReceipt(
+  _i12.Future<void> postReceipt(
     String? eventId, {
-    _i3.ReceiptType? type = _i3.ReceiptType.mRead,
+    _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2553,12 +2588,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Timeline> getTimeline({
+  _i12.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2581,7 +2616,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i11.Future<_i3.Timeline>.value(_FakeTimeline_12(
+        returnValue: _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
           this,
           Invocation.method(
             #getTimeline,
@@ -2598,7 +2633,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Timeline>.value(_FakeTimeline_12(
+            _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
           this,
           Invocation.method(
             #getTimeline,
@@ -2614,30 +2649,30 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Timeline>);
+      ) as _i12.Future<_i4.Timeline>);
 
   @override
-  List<_i3.User> getParticipants(
-          [List<_i3.Membership>? membershipFilter = const [
-            _i3.Membership.join,
-            _i3.Membership.invite,
-            _i3.Membership.knock,
+  List<_i4.User> getParticipants(
+          [List<_i4.Membership>? membershipFilter = const [
+            _i4.Membership.join,
+            _i4.Membership.invite,
+            _i4.Membership.knock,
           ]]) =>
       (super.noSuchMethod(
         Invocation.method(
           #getParticipants,
           [membershipFilter],
         ),
-        returnValue: <_i3.User>[],
-        returnValueForMissingStub: <_i3.User>[],
-      ) as List<_i3.User>);
+        returnValue: <_i4.User>[],
+        returnValueForMissingStub: <_i4.User>[],
+      ) as List<_i4.User>);
 
   @override
-  _i11.Future<List<_i3.User>> requestParticipants([
-    List<_i3.Membership>? membershipFilter = const [
-      _i3.Membership.join,
-      _i3.Membership.invite,
-      _i3.Membership.knock,
+  _i12.Future<List<_i4.User>> requestParticipants([
+    List<_i4.Membership>? membershipFilter = const [
+      _i4.Membership.join,
+      _i4.Membership.invite,
+      _i4.Membership.knock,
     ],
     bool? suppressWarning = false,
     bool? cache,
@@ -2651,58 +2686,58 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             cache,
           ],
         ),
-        returnValue: _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
+        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
-      ) as _i11.Future<List<_i3.User>>);
+            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i12.Future<List<_i4.User>>);
 
   @override
-  _i3.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
+  _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
         Invocation.method(
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_13(
+        returnValue: _FakeUser_14(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_13(
+        returnValueForMissingStub: _FakeUser_14(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-      ) as _i3.User);
+      ) as _i4.User);
 
   @override
-  _i3.User unsafeGetUserFromMemoryOrFallback(String? mxID) =>
+  _i4.User unsafeGetUserFromMemoryOrFallback(String? mxID) =>
       (super.noSuchMethod(
         Invocation.method(
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_13(
+        returnValue: _FakeUser_14(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_13(
+        returnValueForMissingStub: _FakeUser_14(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-      ) as _i3.User);
+      ) as _i4.User);
 
   @override
-  _i11.Future<_i3.User?> requestUser(
+  _i12.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2718,19 +2753,19 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i11.Future<_i3.User?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.User?>.value(),
-      ) as _i11.Future<_i3.User?>);
+        returnValue: _i12.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.User?>.value(),
+      ) as _i12.Future<_i4.User?>);
 
   @override
-  _i11.Future<_i3.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i12.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2743,12 +2778,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i11.Future<String> setAvatar(_i3.MatrixFile? file) => (super.noSuchMethod(
+  _i12.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2756,14 +2791,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2786,14 +2821,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i11.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i12.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -2832,18 +2867,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i11.Future<void> setPushRuleState(_i3.PushRuleState? newState) =>
+  _i12.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEvent(
+  _i12.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -2857,12 +2892,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> setTyping(
+  _i12.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -2872,13 +2907,13 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setJoinRules(
-    _i3.JoinRules? joinRules, {
+  _i12.Future<void> setJoinRules(
+    _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
   }) =>
@@ -2891,59 +2926,59 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setGuestAccess(_i3.GuestAccess? guestAccess) =>
+  _i12.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setHistoryVisibility(
-          _i3.HistoryVisibility? historyVisibility) =>
+  _i12.Future<void> setHistoryVisibility(
+          _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i12.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i12.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i11.Future<List<_i3.DeviceKeys>>.value(<_i3.DeviceKeys>[]),
+            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.DeviceKeys>>.value(<_i3.DeviceKeys>[]),
-      ) as _i11.Future<List<_i3.DeviceKeys>>);
+            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i12.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i11.Future<void> requestSessionKey(
+  _i12.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -2955,12 +2990,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             senderKey,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setSpaceChild(
+  _i12.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -2976,51 +3011,51 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i12.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i11.Future<Uri>);
+      ) as _i12.Future<Uri>);
 
   @override
-  _i11.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i12.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<
+  _i12.Future<
       ({
-        List<_i3.Event> events,
+        List<_i4.Event> events,
         String? nextBatch,
         DateTime? searchedUntil
       })> searchEvents({
     String? searchTerm,
-    bool Function(_i3.Event)? searchFunc,
+    bool Function(_i4.Event)? searchFunc,
     String? nextBatch,
     int? limit = 1000,
     Set<String>? includeEventTypes = const {
@@ -3040,23 +3075,23 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i11.Future<
+        returnValue: _i12.Future<
                 ({
-                  List<_i3.Event> events,
+                  List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
-            (events: <_i3.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i11.Future<
+            (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
+        returnValueForMissingStub: _i12.Future<
                 ({
-                  List<_i3.Event> events,
+                  List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
-            (events: <_i3.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i11.Future<
+            (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
+      ) as _i12.Future<
           ({
-            List<_i3.Event> events,
+            List<_i4.Event> events,
             String? nextBatch,
             DateTime? searchedUntil
           })>);
@@ -3065,27 +3100,27 @@ class MockRoom extends _i1.Mock implements _i3.Room {
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockClient extends _i1.Mock implements _i3.Client {
+class MockClient extends _i1.Mock implements _i4.Client {
   @override
-  _i3.DatabaseApi get database => (super.noSuchMethod(
+  _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_15(
+        returnValue: _FakeDatabaseApi_16(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_15(
+        returnValueForMissingStub: _FakeDatabaseApi_16(
           this,
           Invocation.getter(#database),
         ),
-      ) as _i3.DatabaseApi);
+      ) as _i4.DatabaseApi);
 
   @override
-  Set<_i20.KeyVerificationMethod> get verificationMethods =>
+  Set<_i21.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i20.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
-      ) as Set<_i20.KeyVerificationMethod>);
+        returnValue: <_i21.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i21.KeyVerificationMethod>{},
+      ) as Set<_i21.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3130,44 +3165,44 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  _i3.ShareKeysWith get shareKeysWith => (super.noSuchMethod(
+  _i4.ShareKeysWith get shareKeysWith => (super.noSuchMethod(
         Invocation.getter(#shareKeysWith),
-        returnValue: _i3.ShareKeysWith.all,
-        returnValueForMissingStub: _i3.ShareKeysWith.all,
-      ) as _i3.ShareKeysWith);
+        returnValue: _i4.ShareKeysWith.all,
+        returnValueForMissingStub: _i4.ShareKeysWith.all,
+      ) as _i4.ShareKeysWith);
 
   @override
-  Map<String, _i3.CommandExecutionCallback> get commands => (super.noSuchMethod(
+  Map<String, _i4.CommandExecutionCallback> get commands => (super.noSuchMethod(
         Invocation.getter(#commands),
-        returnValue: <String, _i3.CommandExecutionCallback>{},
-        returnValueForMissingStub: <String, _i3.CommandExecutionCallback>{},
-      ) as Map<String, _i3.CommandExecutionCallback>);
+        returnValue: <String, _i4.CommandExecutionCallback>{},
+        returnValueForMissingStub: <String, _i4.CommandExecutionCallback>{},
+      ) as Map<String, _i4.CommandExecutionCallback>);
 
   @override
-  _i3.Filter get syncFilter => (super.noSuchMethod(
+  _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_16(
+        returnValue: _FakeFilter_17(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_16(
+        returnValueForMissingStub: _FakeFilter_17(
           this,
           Invocation.getter(#syncFilter),
         ),
-      ) as _i3.Filter);
+      ) as _i4.Filter);
 
   @override
-  _i3.NativeImplementations get nativeImplementations => (super.noSuchMethod(
+  _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_17(
+        returnValue: _FakeNativeImplementations_18(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_17(
+        returnValueForMissingStub: _FakeNativeImplementations_18(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-      ) as _i3.NativeImplementations);
+      ) as _i4.NativeImplementations);
 
   @override
   bool get convertLinebreaksInFormatting => (super.noSuchMethod(
@@ -3179,11 +3214,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_18(
+        returnValue: _FakeDuration_19(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_18(
+        returnValueForMissingStub: _FakeDuration_19(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3192,11 +3227,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_18(
+        returnValue: _FakeDuration_19(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_18(
+        returnValueForMissingStub: _FakeDuration_19(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3205,36 +3240,36 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
       ) as String);
 
   @override
-  _i3.LoginState get loginState => (super.noSuchMethod(
+  _i4.LoginState get loginState => (super.noSuchMethod(
         Invocation.getter(#loginState),
-        returnValue: _i3.LoginState.loggedIn,
-        returnValueForMissingStub: _i3.LoginState.loggedIn,
-      ) as _i3.LoginState);
+        returnValue: _i4.LoginState.loggedIn,
+        returnValueForMissingStub: _i4.LoginState.loggedIn,
+      ) as _i4.LoginState);
 
   @override
-  List<_i3.Room> get rooms => (super.noSuchMethod(
+  List<_i4.Room> get rooms => (super.noSuchMethod(
         Invocation.getter(#rooms),
-        returnValue: <_i3.Room>[],
-        returnValueForMissingStub: <_i3.Room>[],
-      ) as List<_i3.Room>);
+        returnValue: <_i4.Room>[],
+        returnValueForMissingStub: <_i4.Room>[],
+      ) as List<_i4.Room>);
 
   @override
-  List<_i3.ArchivedRoom> get archivedRooms => (super.noSuchMethod(
+  List<_i4.ArchivedRoom> get archivedRooms => (super.noSuchMethod(
         Invocation.getter(#archivedRooms),
-        returnValue: <_i3.ArchivedRoom>[],
-        returnValueForMissingStub: <_i3.ArchivedRoom>[],
-      ) as List<_i3.ArchivedRoom>);
+        returnValue: <_i4.ArchivedRoom>[],
+        returnValueForMissingStub: <_i4.ArchivedRoom>[],
+      ) as List<_i4.ArchivedRoom>);
 
   @override
   bool get enableDehydratedDevices => (super.noSuchMethod(
@@ -3246,11 +3281,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3280,11 +3315,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3293,11 +3328,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3311,31 +3346,31 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  Map<String, _i3.BasicEvent> get accountData => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get accountData => (super.noSuchMethod(
         Invocation.getter(#accountData),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  _i3.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
+  _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_19(
+        returnValue: _FakePushruleEvaluator_20(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_19(
+        returnValueForMissingStub: _FakePushruleEvaluator_20(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-      ) as _i3.PushruleEvaluator);
+      ) as _i4.PushruleEvaluator);
 
   @override
-  Map<String, _i3.CachedPresence> get presences => (super.noSuchMethod(
+  Map<String, _i4.CachedPresence> get presences => (super.noSuchMethod(
         Invocation.getter(#presences),
-        returnValue: <String, _i3.CachedPresence>{},
-        returnValueForMissingStub: <String, _i3.CachedPresence>{},
-      ) as Map<String, _i3.CachedPresence>);
+        returnValue: <String, _i4.CachedPresence>{},
+        returnValueForMissingStub: <String, _i4.CachedPresence>{},
+      ) as Map<String, _i4.CachedPresence>);
 
   @override
   Map<String, List<String>> get directChats => (super.noSuchMethod(
@@ -3345,333 +3380,333 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i11.Future<_i3.Profile> get ownProfile => (super.noSuchMethod(
+  _i12.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i9.CachedStreamController<String> get onUserProfileUpdate =>
+  _i10.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i11.Future<List<_i3.Room>> get archive => (super.noSuchMethod(
+  _i12.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
+        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
-      ) as _i11.Future<List<_i3.Room>>);
+            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i12.Future<List<_i4.Room>>);
 
   @override
-  _i9.CachedStreamController<_i3.EventUpdate> get onEvent =>
+  _i10.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.EventUpdate>(
+        returnValue: _FakeCachedStreamController_9<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.EventUpdate>(
+            _FakeCachedStreamController_9<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.EventUpdate>);
+      ) as _i10.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onTimelineEvent =>
+  _i10.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onHistoryEvent =>
+  _i10.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onNotification =>
+  _i10.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.ToDeviceEvent> get onToDeviceEvent =>
+  _i10.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.ToDeviceEvent>(
+            _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.ToDeviceEvent>);
+      ) as _i10.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i9.CachedStreamController<List<_i3.BasicEventWithSender>> get onCallEvents =>
-      (super.noSuchMethod(
-        Invocation.getter(#onCallEvents),
-        returnValue:
-            _FakeCachedStreamController_8<List<_i3.BasicEventWithSender>>(
-          this,
-          Invocation.getter(#onCallEvents),
-        ),
-        returnValueForMissingStub:
-            _FakeCachedStreamController_8<List<_i3.BasicEventWithSender>>(
-          this,
-          Invocation.getter(#onCallEvents),
-        ),
-      ) as _i9.CachedStreamController<List<_i3.BasicEventWithSender>>);
+  _i10.CachedStreamController<List<_i4.BasicEventWithSender>>
+      get onCallEvents => (super.noSuchMethod(
+            Invocation.getter(#onCallEvents),
+            returnValue:
+                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+              this,
+              Invocation.getter(#onCallEvents),
+            ),
+            returnValueForMissingStub:
+                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+              this,
+              Invocation.getter(#onCallEvents),
+            ),
+          ) as _i10.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i9.CachedStreamController<_i3.LoginState> get onLoginStateChanged =>
+  _i10.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_8<_i3.LoginState>(
+        returnValue: _FakeCachedStreamController_9<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.LoginState>(
+            _FakeCachedStreamController_9<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i9.CachedStreamController<_i3.LoginState>);
+      ) as _i10.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i9.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i10.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_8<bool>(
+        returnValue: _FakeCachedStreamController_9<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i9.CachedStreamController<bool>);
+      ) as _i10.CachedStreamController<bool>);
 
   @override
-  _i9.CachedStreamController<_i3.SdkError> get onEncryptionError =>
+  _i10.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_8<_i3.SdkError>(
+        returnValue: _FakeCachedStreamController_9<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i9.CachedStreamController<_i3.SdkError>);
+      ) as _i10.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i9.CachedStreamController<_i3.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i10.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_8<_i3.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_9<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.SyncUpdate>(
+            _FakeCachedStreamController_9<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i9.CachedStreamController<_i3.SyncUpdate>);
+      ) as _i10.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.SyncStatusUpdate> get onSyncStatus =>
+  _i10.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_8<_i3.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.SyncStatusUpdate>(
+            _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i9.CachedStreamController<_i3.SyncStatusUpdate>);
+      ) as _i10.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.Presence> get onPresence =>
+  _i10.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_8<_i3.Presence>(
+        returnValue: _FakeCachedStreamController_9<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i9.CachedStreamController<_i3.Presence>);
+      ) as _i10.CachedStreamController<_i4.Presence>);
 
   @override
-  _i9.CachedStreamController<_i3.CachedPresence> get onPresenceChanged =>
+  _i10.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_8<_i3.CachedPresence>(
+        returnValue: _FakeCachedStreamController_9<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.CachedPresence>(
+            _FakeCachedStreamController_9<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i9.CachedStreamController<_i3.CachedPresence>);
+      ) as _i10.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i9.CachedStreamController<_i3.BasicEvent> get onAccountData =>
+  _i10.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_8<_i3.BasicEvent>(
+        returnValue: _FakeCachedStreamController_9<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.BasicEvent>(
+            _FakeCachedStreamController_9<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i9.CachedStreamController<_i3.BasicEvent>);
+      ) as _i10.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i9.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
+  _i10.CachedStreamController<_i21.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
+            _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i9.CachedStreamController<_i20.RoomKeyRequest>);
+      ) as _i10.CachedStreamController<_i21.RoomKeyRequest>);
 
   @override
-  _i9.CachedStreamController<_i20.KeyVerification>
+  _i10.CachedStreamController<_i21.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_8<_i20.KeyVerification>(
+            returnValue: _FakeCachedStreamController_9<_i21.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_8<_i20.KeyVerification>(
+                _FakeCachedStreamController_9<_i21.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i9.CachedStreamController<_i20.KeyVerification>);
+          ) as _i10.CachedStreamController<_i21.KeyVerification>);
 
   @override
-  _i9.CachedStreamController<_i3.UiaRequest<dynamic>> get onUiaRequest =>
+  _i10.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_8<_i3.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i9.CachedStreamController<_i3.UiaRequest<dynamic>>);
+      ) as _i10.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onGroupMember =>
+  _i10.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<String> get onCancelSendEvent =>
+  _i10.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i9.CachedStreamController<({String roomId, _i3.StrippedStateEvent state})>
+  _i10.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_8<
-                ({String roomId, _i3.StrippedStateEvent state})>(
+            returnValue: _FakeCachedStreamController_9<
+                ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_8<
-                ({String roomId, _i3.StrippedStateEvent state})>(
+            returnValueForMissingStub: _FakeCachedStreamController_9<
+                ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i9.CachedStreamController<
-              ({String roomId, _i3.StrippedStateEvent state})>);
+          ) as _i10.CachedStreamController<
+              ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
   int get syncErrorTimeoutSec => (super.noSuchMethod(
@@ -3690,11 +3725,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_9(
+        returnValue: _FakeDateTime_10(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_9(
+        returnValueForMissingStub: _FakeDateTime_10(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3715,33 +3750,33 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  _i3.RoomSorter get sortRoomsBy => (super.noSuchMethod(
+  _i4.RoomSorter get sortRoomsBy => (super.noSuchMethod(
         Invocation.getter(#sortRoomsBy),
         returnValue: (
-          _i3.Room a,
-          _i3.Room b,
+          _i4.Room a,
+          _i4.Room b,
         ) =>
             0,
         returnValueForMissingStub: (
-          _i3.Room a,
-          _i3.Room b,
+          _i4.Room a,
+          _i4.Room b,
         ) =>
             0,
-      ) as _i3.RoomSorter);
+      ) as _i4.RoomSorter);
 
   @override
-  Map<String, _i3.DeviceKeysList> get userDeviceKeys => (super.noSuchMethod(
+  Map<String, _i4.DeviceKeysList> get userDeviceKeys => (super.noSuchMethod(
         Invocation.getter(#userDeviceKeys),
-        returnValue: <String, _i3.DeviceKeysList>{},
-        returnValueForMissingStub: <String, _i3.DeviceKeysList>{},
-      ) as Map<String, _i3.DeviceKeysList>);
+        returnValue: <String, _i4.DeviceKeysList>{},
+        returnValueForMissingStub: <String, _i4.DeviceKeysList>{},
+      ) as Map<String, _i4.DeviceKeysList>);
 
   @override
-  List<_i3.DeviceKeys> get unverifiedDevices => (super.noSuchMethod(
+  List<_i4.DeviceKeys> get unverifiedDevices => (super.noSuchMethod(
         Invocation.getter(#unverifiedDevices),
-        returnValue: <_i3.DeviceKeys>[],
-        returnValueForMissingStub: <_i3.DeviceKeys>[],
-      ) as List<_i3.DeviceKeys>);
+        returnValue: <_i4.DeviceKeys>[],
+        returnValueForMissingStub: <_i4.DeviceKeys>[],
+      ) as List<_i4.DeviceKeys>);
 
   @override
   bool get allPushNotificationsMuted => (super.noSuchMethod(
@@ -3758,7 +3793,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as List<String>);
 
   @override
-  set database(_i3.DatabaseApi? db) => super.noSuchMethod(
+  set database(_i4.DatabaseApi? db) => super.noSuchMethod(
         Invocation.setter(
           #database,
           db,
@@ -3767,7 +3802,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i21.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3813,7 +3848,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set shareKeysWith(_i3.ShareKeysWith? value) => super.noSuchMethod(
+  set shareKeysWith(_i4.ShareKeysWith? value) => super.noSuchMethod(
         Invocation.setter(
           #shareKeysWith,
           value,
@@ -3822,7 +3857,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set onSoftLogout(_i11.Future<void> Function(_i3.Client)? value) =>
+  set onSoftLogout(_i12.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3833,8 +3868,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
 
   @override
   set customImageResizer(
-          _i11.Future<_i3.MatrixImageFileResizedResponse?> Function(
-                  _i3.MatrixImageFileResizeArguments)?
+          _i12.Future<_i4.MatrixImageFileResizedResponse?> Function(
+                  _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
         Invocation.setter(
@@ -3872,7 +3907,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set rooms(List<_i3.Room>? newList) => super.noSuchMethod(
+  set rooms(List<_i4.Room>? newList) => super.noSuchMethod(
         Invocation.setter(
           #rooms,
           newList,
@@ -3881,7 +3916,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set presences(Map<String, _i3.CachedPresence>? value) => super.noSuchMethod(
+  set presences(Map<String, _i4.CachedPresence>? value) => super.noSuchMethod(
         Invocation.setter(
           #presences,
           value,
@@ -3908,7 +3943,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set syncPresence(_i3.PresenceType? value) => super.noSuchMethod(
+  set syncPresence(_i4.PresenceType? value) => super.noSuchMethod(
         Invocation.setter(
           #syncPresence,
           value,
@@ -3944,7 +3979,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -3953,7 +3988,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set roomsLoading(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -3962,7 +3997,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set firstSyncReceived(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -3989,20 +4024,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i10.Client get httpClient => (super.noSuchMethod(
+  _i11.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_21(
+        returnValue: _FakeClient_22(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_21(
+        returnValueForMissingStub: _FakeClient_22(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i10.Client);
+      ) as _i11.Client);
 
   @override
-  set httpClient(_i10.Client? value) => super.noSuchMethod(
+  set httpClient(_i11.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4029,7 +4064,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<void> refreshAccessToken(
+  _i12.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4037,9 +4072,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4057,14 +4092,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4074,22 +4109,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as String);
 
   @override
-  _i3.Room? getRoomByAlias(String? alias) => (super.noSuchMethod(
+  _i4.Room? getRoomByAlias(String? alias) => (super.noSuchMethod(
         Invocation.method(
           #getRoomByAlias,
           [alias],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.Room?);
+      ) as _i4.Room?);
 
   @override
-  _i3.Room? getRoomById(String? id) => (super.noSuchMethod(
+  _i4.Room? getRoomById(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getRoomById,
           [id],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.Room?);
+      ) as _i4.Room?);
 
   @override
   String? getDirectChatFromUserId(String? userId) => (super.noSuchMethod(
@@ -4101,38 +4136,38 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as String?);
 
   @override
-  _i11.Future<_i3.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i12.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i11.Future<_i3.DiscoveryInformation>);
+      ) as _i12.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i11.Future<
+  _i12.Future<
       (
-        _i3.DiscoveryInformation?,
-        _i3.GetVersionsResponse,
-        List<_i3.LoginFlow>,
-        _i3.GetAuthMetadataResponse?
+        _i4.DiscoveryInformation?,
+        _i4.GetVersionsResponse,
+        List<_i4.LoginFlow>,
+        _i4.GetAuthMetadataResponse?
       )> checkHomeserver(
     Uri? homeserverUrl, {
     bool? checkWellKnown = true,
@@ -4149,15 +4184,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i11.Future<
+        returnValue: _i12.Future<
             (
-              _i3.DiscoveryInformation?,
-              _i3.GetVersionsResponse,
-              List<_i3.LoginFlow>,
-              _i3.GetAuthMetadataResponse?
+              _i4.DiscoveryInformation?,
+              _i4.GetVersionsResponse,
+              List<_i4.LoginFlow>,
+              _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_23(
+          _FakeGetVersionsResponse_24(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4169,18 +4204,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
           ),
-          <_i3.LoginFlow>[],
+          <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i11.Future<
+        returnValueForMissingStub: _i12.Future<
             (
-              _i3.DiscoveryInformation?,
-              _i3.GetVersionsResponse,
-              List<_i3.LoginFlow>,
-              _i3.GetAuthMetadataResponse?
+              _i4.DiscoveryInformation?,
+              _i4.GetVersionsResponse,
+              List<_i4.LoginFlow>,
+              _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_23(
+          _FakeGetVersionsResponse_24(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4192,19 +4227,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
           ),
-          <_i3.LoginFlow>[],
+          <_i4.LoginFlow>[],
           null
         )),
-      ) as _i11.Future<
+      ) as _i12.Future<
           (
-            _i3.DiscoveryInformation?,
-            _i3.GetVersionsResponse,
-            List<_i3.LoginFlow>,
-            _i3.GetAuthMetadataResponse?
+            _i4.DiscoveryInformation?,
+            _i4.GetVersionsResponse,
+            List<_i4.LoginFlow>,
+            _i4.GetAuthMetadataResponse?
           )>);
 
   @override
-  _i11.Future<_i3.DiscoveryInformation> getWellknown({
+  _i12.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4217,8 +4252,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getWellknown,
@@ -4229,8 +4264,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getWellknown,
@@ -4241,19 +4276,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.DiscoveryInformation>);
+      ) as _i12.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i11.Future<_i3.RegisterResponse> register({
+  _i12.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
     String? initialDeviceDisplayName,
     bool? inhibitLogin,
     bool? refreshToken,
-    _i3.AuthenticationData? auth,
-    _i3.AccountKind? kind,
-    void Function(_i3.InitState)? onInitStateChanged,
+    _i4.AuthenticationData? auth,
+    _i4.AccountKind? kind,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4272,7 +4307,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<_i3.RegisterResponse>.value(_FakeRegisterResponse_24(
+            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
           this,
           Invocation.method(
             #register,
@@ -4291,7 +4326,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RegisterResponse>.value(_FakeRegisterResponse_24(
+            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
           this,
           Invocation.method(
             #register,
@@ -4309,12 +4344,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RegisterResponse>);
+      ) as _i12.Future<_i4.RegisterResponse>);
 
   @override
-  _i11.Future<_i3.LoginResponse> login(
+  _i12.Future<_i4.LoginResponse> login(
     String? type, {
-    _i3.AuthenticationIdentifier? identifier,
+    _i4.AuthenticationIdentifier? identifier,
     String? password,
     String? token,
     String? deviceId,
@@ -4323,7 +4358,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? user,
     String? medium,
     String? address,
-    void Function(_i3.InitState)? onInitStateChanged,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4342,7 +4377,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i11.Future<_i3.LoginResponse>.value(_FakeLoginResponse_25(
+        returnValue: _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
           this,
           Invocation.method(
             #login,
@@ -4362,7 +4397,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.LoginResponse>.value(_FakeLoginResponse_25(
+            _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
           this,
           Invocation.method(
             #login,
@@ -4381,10 +4416,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.LoginResponse>);
+      ) as _i12.Future<_i4.LoginResponse>);
 
   @override
-  _i11.Future<_i3.GetAuthMetadataResponse> getAuthMetadata({
+  _i12.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4397,8 +4432,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_26(
+        returnValue: _i12.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_27(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4410,8 +4445,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_26(
+            _i12.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_27(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4422,80 +4457,80 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetAuthMetadataResponse>);
+      ) as _i12.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i11.Future<void> logout() => (super.noSuchMethod(
+  _i12.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> logoutAll() => (super.noSuchMethod(
+  _i12.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<T> uiaRequestBackground<T>(
-          _i11.Future<T> Function(_i3.AuthenticationData?)? request) =>
+  _i12.Future<T> uiaRequestBackground<T>(
+          _i12.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i11.Future<T>.value(v),
+              (T v) => _i12.Future<T>.value(v),
             ) ??
-            _FakeFuture_27<T>(
+            _FakeFuture_28<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i11.Future<T>.value(v),
+              (T v) => _i12.Future<T>.value(v),
             ) ??
-            _FakeFuture_27<T>(
+            _FakeFuture_28<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i11.Future<T>);
+      ) as _i12.Future<T>);
 
   @override
-  _i11.Future<String> startDirectChat(
+  _i12.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
-    List<_i3.StateEvent>? initialState,
+    List<_i4.StateEvent>? initialState,
     bool? waitForSync = true,
     Map<String, dynamic>? powerLevelContentOverride,
-    _i3.CreateRoomPreset? preset = _i3.CreateRoomPreset.trustedPrivateChat,
+    _i4.CreateRoomPreset? preset = _i4.CreateRoomPreset.trustedPrivateChat,
     bool? skipExistingChat = false,
   }) =>
       (super.noSuchMethod(
@@ -4511,7 +4546,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4527,7 +4562,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4542,17 +4577,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<String> createGroupChat({
+  _i12.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
-    _i3.CreateRoomPreset? preset = _i3.CreateRoomPreset.privateChat,
-    List<_i3.StateEvent>? initialState,
-    _i3.Visibility? visibility,
-    _i3.HistoryVisibility? historyVisibility,
+    _i4.CreateRoomPreset? preset = _i4.CreateRoomPreset.privateChat,
+    List<_i4.StateEvent>? initialState,
+    _i4.Visibility? visibility,
+    _i4.HistoryVisibility? historyVisibility,
     bool? waitForSync = true,
     bool? groupCall = false,
     bool? federated = true,
@@ -4576,7 +4611,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4597,7 +4632,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4617,10 +4652,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> waitForRoomInSync(
+  _i12.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4636,7 +4671,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4649,7 +4684,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4661,27 +4696,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i12.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<String> createSpace({
+  _i12.Future<String> createSpace({
     String? name,
     String? topic,
-    _i3.Visibility? visibility = _i3.Visibility.public,
+    _i4.Visibility? visibility = _i4.Visibility.public,
     String? spaceAliasName,
     List<String>? invite,
-    List<_i3.Invite3pid>? invite3pid,
+    List<_i4.Invite3pid>? invite3pid,
     String? roomVersion,
     bool? waitForSync = false,
   }) =>
@@ -4700,7 +4735,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4718,7 +4753,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4735,10 +4770,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.Profile> fetchOwnProfileFromServer(
+  _i12.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4746,7 +4781,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4755,7 +4790,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4763,10 +4798,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i11.Future<_i3.Profile> fetchOwnProfile({
+  _i12.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4779,7 +4814,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4791,7 +4826,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4802,10 +4837,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i11.Future<_i3.CachedProfileInformation> getUserProfile(
+  _i12.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4819,8 +4854,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i11.Future<_i3.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_28(
+        returnValue: _i12.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_29(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4832,8 +4867,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_28(
+            _i12.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_29(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4844,10 +4879,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.CachedProfileInformation>);
+      ) as _i12.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i11.Future<_i3.Profile> getProfileFromUserId(
+  _i12.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4865,7 +4900,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4879,7 +4914,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4892,17 +4927,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i3.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
+  _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getArchiveRoomFromCache,
           [roomId],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.ArchivedRoom?);
+      ) as _i4.ArchivedRoom?);
 
   @override
   void clearArchivesFromCache() => super.noSuchMethod(
@@ -4914,31 +4949,31 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<List<_i3.Room>> loadArchive() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
+        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
-      ) as _i11.Future<List<_i3.Room>>);
+            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i12.Future<List<_i4.Room>>);
 
   @override
-  _i11.Future<List<_i3.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i12.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i11.Future<List<_i3.ArchivedRoom>>.value(<_i3.ArchivedRoom>[]),
+            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ArchivedRoom>>.value(<_i3.ArchivedRoom>[]),
-      ) as _i11.Future<List<_i3.ArchivedRoom>>);
+            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i12.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i11.Future<_i3.GetVersionsResponse> getVersions({
+  _i12.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4951,8 +4986,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_23(
+        returnValue: _i12.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_24(
           this,
           Invocation.method(
             #getVersions,
@@ -4963,8 +4998,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_23(
+        returnValueForMissingStub: _i12.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_24(
           this,
           Invocation.method(
             #getVersions,
@@ -4975,20 +5010,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetVersionsResponse>);
+      ) as _i12.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i11.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i12.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<_i3.MediaConfig> getConfig({
+  _i12.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5001,7 +5036,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfig,
@@ -5013,7 +5048,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfig,
@@ -5024,10 +5059,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.MediaConfig>);
+      ) as _i12.Future<_i4.MediaConfig>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContent(
+  _i12.Future<_i13.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5047,7 +5082,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContent,
@@ -5063,7 +5098,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContent,
@@ -5078,10 +5113,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentOverrideName(
+  _i12.Future<_i13.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5103,7 +5138,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5120,7 +5155,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5136,15 +5171,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentThumbnail(
+  _i12.Future<_i13.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
     int? height, {
-    _i3.Method? method,
+    _i4.Method? method,
     bool? allowRemote,
     int? timeoutMs,
     bool? allowRedirect,
@@ -5167,7 +5202,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5187,7 +5222,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5206,10 +5241,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i3.PreviewForUrl> getUrlPreview(
+  _i12.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5219,7 +5254,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5228,7 +5263,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5236,11 +5271,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i11.Future<_i3.PreviewForUrl>);
+      ) as _i12.Future<_i4.PreviewForUrl>);
 
   @override
-  _i11.Future<Uri> uploadContent(
-    _i21.Uint8List? file, {
+  _i12.Future<Uri> uploadContent(
+    _i22.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5253,7 +5288,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #uploadContent,
@@ -5264,7 +5299,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #uploadContent,
@@ -5275,10 +5310,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<Uri>);
+      ) as _i12.Future<Uri>);
 
   @override
-  _i11.Future<void> setTyping(
+  _i12.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5294,43 +5329,43 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> exportDump() => (super.noSuchMethod(
+  _i12.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i12.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> setAvatar(_i3.MatrixFile? file) => (super.noSuchMethod(
+  _i12.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Event?> getEventByPushNotification(
-    _i3.PushNotification? notification, {
+  _i12.Future<_i4.Event?> getEventByPushNotification(
+    _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
     bool? returnNullIfSeen = true,
@@ -5345,12 +5380,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
-  _i11.Future<void> init({
+  _i12.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5363,7 +5398,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     bool? waitForFirstSync = true,
     bool? waitUntilLoadCompletedLoaded = true,
     void Function()? onMigration,
-    void Function(_i3.InitState)? onInitStateChanged,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5385,9 +5420,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5399,42 +5434,42 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<void> clear() => (super.noSuchMethod(
+  _i12.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i12.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ensureNotSoftLoggedOut(
+  _i12.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> handleSync(
-    _i3.SyncUpdate? sync, {
-    _i3.Direction? direction,
+  _i12.Future<void> handleSync(
+    _i4.SyncUpdate? sync, {
+    _i4.Direction? direction,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5442,44 +5477,44 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i3.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
+  _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeysByCurve25519Key,
           [senderKey],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.DeviceKeys?);
+      ) as _i4.DeviceKeys?);
 
   @override
-  _i11.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i12.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i12.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDevice(
+  _i12.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5493,12 +5528,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             messages,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDevicesOfUserIds(
+  _i12.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5514,13 +5549,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDeviceEncrypted(
-    List<_i3.DeviceKeys>? deviceKeys,
+  _i12.Future<void> sendToDeviceEncrypted(
+    List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
     String? messageId,
@@ -5539,13 +5574,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDeviceEncryptedChunked(
-    List<_i3.DeviceKeys>? deviceKeys,
+  _i12.Future<void> sendToDeviceEncryptedChunked(
+    List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
   ) =>
@@ -5558,28 +5593,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
             message,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i12.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> joinRoom(
+  _i12.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
     String? reason,
-    _i3.ThirdPartySigned? thirdPartySigned,
+    _i4.ThirdPartySigned? thirdPartySigned,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5592,7 +5627,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5606,7 +5641,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5619,13 +5654,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> changePassword(
+  _i12.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
     bool? logoutDevices,
   }) =>
       (super.noSuchMethod(
@@ -5638,22 +5673,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> clearCache() => (super.noSuchMethod(
+  _i12.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ignoreUser(
+  _i12.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5663,22 +5698,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i12.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.CachedPresence> fetchCurrentPresence(
+  _i12.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5689,7 +5724,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i11.Future<_i3.CachedPresence>.value(_FakeCachedPresence_32(
+            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5698,7 +5733,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.CachedPresence>.value(_FakeCachedPresence_32(
+            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5706,32 +5741,32 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i11.Future<_i3.CachedPresence>);
+      ) as _i12.Future<_i4.CachedPresence>);
 
   @override
-  _i11.Future<void> abortSync() => (super.noSuchMethod(
+  _i12.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i12.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEventWithMetadata(
+  _i12.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5751,14 +5786,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i10.BaseResponse? response,
-    _i21.Uint8List? body,
+    _i11.BaseResponse? response,
+    _i22.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5790,8 +5825,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as Never);
 
   @override
-  _i11.Future<Map<String, Object?>> request(
-    _i3.RequestType? type,
+  _i12.Future<Map<String, Object?>> request(
+    _i4.RequestType? type,
     String? action, {
     dynamic data = '',
     String? contentType = 'application/json',
@@ -5811,14 +5846,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> postPusher(
-    _i3.Pusher? pusher, {
+  _i12.Future<void> postPusher(
+    _i4.Pusher? pusher, {
     bool? append,
   }) =>
       (super.noSuchMethod(
@@ -5827,57 +5862,57 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deletePusher(_i3.PusherId? pusher) => (super.noSuchMethod(
+  _i12.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i12.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i12.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i11.Future<_i3.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_33(
+        returnValue: _i12.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_34(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_33(
+        returnValueForMissingStub: _i12.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_34(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.TurnServerCredentials>);
+      ) as _i12.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5891,8 +5926,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5904,8 +5939,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5916,14 +5951,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
-    _i3.KeyBackupData? data,
+    _i4.KeyBackupData? data,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5935,8 +5970,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             data,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5949,8 +5984,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5962,10 +5997,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.KeyBackupData> getRoomKeysBySessionId(
+  _i12.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5979,7 +6014,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -5991,7 +6026,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6002,17 +6037,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.KeyBackupData>);
+      ) as _i12.Future<_i4.KeyBackupData>);
 
   @override
-  _i11.Future<_i3.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i12.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i11.Future<_i3.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_36(
+        returnValue: _i12.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_37(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6020,18 +6055,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_36(
+            _i12.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_37(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.GetWellknownSupportResponse>);
+      ) as _i12.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i11.Future<int> pingAppservice(
+  _i12.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6041,21 +6076,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i11.Future<int>.value(0),
-        returnValueForMissingStub: _i11.Future<int>.value(0),
-      ) as _i11.Future<int>);
+        returnValue: _i12.Future<int>.value(0),
+        returnValueForMissingStub: _i12.Future<int>.value(0),
+      ) as _i12.Future<int>);
 
   @override
-  _i11.Future<_i3.GenerateLoginTokenResponse> generateLoginToken(
-          {_i3.AuthenticationData? auth}) =>
+  _i12.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+          {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
           #generateLoginToken,
           [],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<_i3.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_37(
+        returnValue: _i12.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_38(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6064,8 +6099,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_37(
+            _i12.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_38(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6073,15 +6108,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i11.Future<_i3.GenerateLoginTokenResponse>);
+      ) as _i12.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i11.Future<_i3.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i12.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6089,17 +6124,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.MediaConfig>);
+      ) as _i12.Future<_i4.MediaConfig>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentAuthed(
+  _i12.Future<_i13.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6113,7 +6148,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6125,7 +6160,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6136,10 +6171,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentOverrideNameAuthed(
+  _i12.Future<_i13.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6155,7 +6190,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6168,7 +6203,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6180,10 +6215,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i3.PreviewForUrl> getUrlPreviewAuthed(
+  _i12.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6193,7 +6228,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6202,7 +6237,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6210,15 +6245,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i11.Future<_i3.PreviewForUrl>);
+      ) as _i12.Future<_i4.PreviewForUrl>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentThumbnailAuthed(
+  _i12.Future<_i13.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
     int? height, {
-    _i3.Method? method,
+    _i4.Method? method,
     int? timeoutMs,
     bool? animated,
   }) =>
@@ -6237,7 +6272,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6255,7 +6290,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6272,21 +6307,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<bool> registrationTokenValidity(String? token) =>
+  _i12.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<_i3.GetRoomSummaryResponse$3> getRoomSummary(
+  _i12.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6296,8 +6331,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i11.Future<_i3.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_38(
+        returnValue: _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_39(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6306,8 +6341,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_38(
+            _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_39(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6315,10 +6350,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#via: via},
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomSummaryResponse$3>);
+      ) as _i12.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i11.Future<_i3.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i12.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6336,8 +6371,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #from: from,
           },
         ),
-        returnValue: _i11.Future<_i3.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_39(
+        returnValue: _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_40(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6351,8 +6386,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_39(
+            _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_40(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6365,16 +6400,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetSpaceHierarchyResponse>);
+      ) as _i12.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsResponse> getRelatingEvents(
+  _i12.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
       (super.noSuchMethod(
@@ -6392,8 +6427,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i11.Future<_i3.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_40(
+        returnValue: _i12.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_41(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6411,8 +6446,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_40(
+            _i12.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_41(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6429,10 +6464,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetRelatingEventsResponse>);
+      ) as _i12.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>
+  _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6440,7 +6475,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
           (super.noSuchMethod(
@@ -6460,8 +6495,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
             returnValue:
-                _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_41(
+                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6480,8 +6515,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_41(
+                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6499,10 +6534,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-          ) as _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i12.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6511,7 +6546,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
           (super.noSuchMethod(
@@ -6531,9 +6566,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i11.Future<
-                    _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+            returnValue: _i12.Future<
+                    _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6552,9 +6587,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i11.Future<
-                    _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+            returnValueForMissingStub: _i12.Future<
+                    _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6573,13 +6608,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-          ) as _i11
-              .Future<_i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
+          ) as _i12
+              .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i11.Future<_i3.GetThreadRootsResponse> getThreadRoots(
+  _i12.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
-    _i3.Include? include,
+    _i4.Include? include,
     int? limit,
     String? from,
   }) =>
@@ -6593,8 +6628,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #from: from,
           },
         ),
-        returnValue: _i11.Future<_i3.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_43(
+        returnValue: _i12.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_44(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6607,8 +6642,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_43(
+            _i12.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_44(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6620,13 +6655,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetThreadRootsResponse>);
+      ) as _i12.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i11.Future<_i3.GetEventByTimestampResponse> getEventByTimestamp(
+  _i12.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6637,8 +6672,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             dir,
           ],
         ),
-        returnValue: _i11.Future<_i3.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_44(
+        returnValue: _i12.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_45(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6650,8 +6685,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_44(
+            _i12.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_45(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6662,36 +6697,36 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.GetEventByTimestampResponse>);
+      ) as _i12.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i12.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyIdentifier>?>.value(),
-      ) as _i11.Future<List<_i3.ThirdPartyIdentifier>?>);
+            _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i12.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i11.Future<Uri?> post3PIDs(_i3.ThreePidCredentials? threePidCreds) =>
+  _i12.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i11.Future<Uri?>.value(),
-        returnValueForMissingStub: _i11.Future<Uri?>.value(),
-      ) as _i11.Future<Uri?>);
+        returnValue: _i12.Future<Uri?>.value(),
+        returnValueForMissingStub: _i12.Future<Uri?>.value(),
+      ) as _i12.Future<Uri?>);
 
   @override
-  _i11.Future<void> add3PID(
+  _i12.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6702,12 +6737,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> bind3PID(
+  _i12.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6723,14 +6758,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             sid,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> delete3pidFromAccount(
+  _i12.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
-    _i3.ThirdPartyIdentifierMedium? medium, {
+    _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
   }) =>
       (super.noSuchMethod(
@@ -6742,14 +6777,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6771,8 +6806,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6788,8 +6823,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6805,10 +6840,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6832,8 +6867,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6850,8 +6885,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6868,12 +6903,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> unbind3pidFromAccount(
+  _i12.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
-    _i3.ThirdPartyIdentifierMedium? medium, {
+    _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
   }) =>
       (super.noSuchMethod(
@@ -6885,15 +6920,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> deactivateAccount({
-    _i3.AuthenticationData? auth,
+  _i12.Future<_i4.IdServerUnbindResult> deactivateAccount({
+    _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
   }) =>
@@ -6907,14 +6942,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6936,8 +6971,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -6953,8 +6988,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -6970,10 +7005,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6997,8 +7032,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7015,8 +7050,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7033,16 +7068,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i12.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i11.Future<_i3.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
+            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7050,22 +7085,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
+            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.TokenOwnerInfo>);
+      ) as _i12.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i11.Future<_i3.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i12.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i11.Future<_i3.WhoIsInfo>.value(_FakeWhoIsInfo_47(
+        returnValue: _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7073,22 +7108,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.WhoIsInfo>.value(_FakeWhoIsInfo_47(
+            _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i11.Future<_i3.WhoIsInfo>);
+      ) as _i12.Future<_i4.WhoIsInfo>);
 
   @override
-  _i11.Future<_i3.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i12.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i11.Future<_i3.Capabilities>.value(_FakeCapabilities_48(
+        returnValue: _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7096,29 +7131,29 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Capabilities>.value(_FakeCapabilities_48(
+            _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.Capabilities>);
+      ) as _i12.Future<_i4.Capabilities>);
 
   @override
-  _i11.Future<String> createRoom({
+  _i12.Future<String> createRoom({
     Map<String, Object?>? creationContent,
-    List<_i3.StateEvent>? initialState,
+    List<_i4.StateEvent>? initialState,
     List<String>? invite,
-    List<_i3.Invite3pid>? invite3pid,
+    List<_i4.Invite3pid>? invite3pid,
     bool? isDirect,
     String? name,
     Map<String, Object?>? powerLevelContentOverride,
-    _i3.CreateRoomPreset? preset,
+    _i4.CreateRoomPreset? preset,
     String? roomAliasName,
     String? roomVersion,
     String? topic,
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7139,7 +7174,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7161,7 +7196,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7182,12 +7217,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> deleteDevices(
+  _i12.Future<void> deleteDevices(
     List<String>? devices, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7195,24 +7230,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.Device>?> getDevices() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Device>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.Device>?>.value(),
-      ) as _i11.Future<List<_i3.Device>?>);
+        returnValue: _i12.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.Device>?>.value(),
+      ) as _i12.Future<List<_i4.Device>?>);
 
   @override
-  _i11.Future<void> deleteDevice(
+  _i12.Future<void> deleteDevice(
     String? deviceId, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7220,34 +7255,34 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i12.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i11.Future<_i3.Device>.value(_FakeDevice_49(
+        returnValue: _i12.Future<_i4.Device>.value(_FakeDevice_50(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.Device>.value(_FakeDevice_49(
+        returnValueForMissingStub: _i12.Future<_i4.Device>.value(_FakeDevice_50(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i11.Future<_i3.Device>);
+      ) as _i12.Future<_i4.Device>);
 
   @override
-  _i11.Future<void> updateDevice(
+  _i12.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7257,15 +7292,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i12.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7277,26 +7312,26 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i12.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i11.Future<_i3.Visibility?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Visibility?>.value(),
-      ) as _i11.Future<_i3.Visibility?>);
+        returnValue: _i12.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Visibility?>.value(),
+      ) as _i12.Future<_i4.Visibility?>);
 
   @override
-  _i11.Future<void> setRoomVisibilityOnDirectory(
+  _i12.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7304,30 +7339,30 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i12.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i12.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i11.Future<_i3.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_50(
+        returnValue: _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_51(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7335,18 +7370,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_50(
+            _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_51(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomIdByAliasResponse>);
+      ) as _i12.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i11.Future<void> setRoomAlias(
+  _i12.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7358,12 +7393,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             roomId,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetEventsResponse> getEvents({
+  _i12.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7377,7 +7412,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<_i3.GetEventsResponse>.value(_FakeGetEventsResponse_51(
+            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
           this,
           Invocation.method(
             #getEvents,
@@ -7389,7 +7424,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetEventsResponse>.value(_FakeGetEventsResponse_51(
+            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
           this,
           Invocation.method(
             #getEvents,
@@ -7400,10 +7435,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetEventsResponse>);
+      ) as _i12.Future<_i4.GetEventsResponse>);
 
   @override
-  _i11.Future<_i3.PeekEventsResponse> peekEvents({
+  _i12.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7418,8 +7453,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i11.Future<_i3.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_52(
+        returnValue: _i12.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_53(
           this,
           Invocation.method(
             #peekEvents,
@@ -7431,8 +7466,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_52(
+        returnValueForMissingStub: _i12.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_53(
           this,
           Invocation.method(
             #peekEvents,
@@ -7444,16 +7479,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.PeekEventsResponse>);
+      ) as _i12.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i11.Future<_i3.MatrixEvent> getOneEvent(String? eventId) =>
+  _i12.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7461,27 +7496,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i11.Future<_i3.MatrixEvent>);
+      ) as _i12.Future<_i4.MatrixEvent>);
 
   @override
-  _i11.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i12.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i11.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i11.Future<List<String>>.value(<String>[]),
-      ) as _i11.Future<List<String>>);
+        returnValue: _i12.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
+      ) as _i12.Future<List<String>>);
 
   @override
-  _i11.Future<_i3.GetKeysChangesResponse> getKeysChanges(
+  _i12.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7493,8 +7528,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             to,
           ],
         ),
-        returnValue: _i11.Future<_i3.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_54(
+        returnValue: _i12.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_55(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7505,8 +7540,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_54(
+            _i12.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_55(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7516,10 +7551,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.GetKeysChangesResponse>);
+      ) as _i12.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i11.Future<_i3.ClaimKeysResponse> claimKeys(
+  _i12.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7530,7 +7565,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i11.Future<_i3.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
+            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
           this,
           Invocation.method(
             #claimKeys,
@@ -7539,7 +7574,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
+            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
           this,
           Invocation.method(
             #claimKeys,
@@ -7547,14 +7582,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i11.Future<_i3.ClaimKeysResponse>);
+      ) as _i12.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i11.Future<void> uploadCrossSigningKeys({
-    _i3.AuthenticationData? auth,
-    _i3.MatrixCrossSigningKey? masterKey,
-    _i3.MatrixCrossSigningKey? selfSigningKey,
-    _i3.MatrixCrossSigningKey? userSigningKey,
+  _i12.Future<void> uploadCrossSigningKeys({
+    _i4.AuthenticationData? auth,
+    _i4.MatrixCrossSigningKey? masterKey,
+    _i4.MatrixCrossSigningKey? selfSigningKey,
+    _i4.MatrixCrossSigningKey? userSigningKey,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7567,12 +7602,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.QueryKeysResponse> queryKeys(
+  _i12.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7583,7 +7618,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i11.Future<_i3.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
+            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
           this,
           Invocation.method(
             #queryKeys,
@@ -7592,7 +7627,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
+            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
           this,
           Invocation.method(
             #queryKeys,
@@ -7600,10 +7635,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i11.Future<_i3.QueryKeysResponse>);
+      ) as _i12.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i11.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7611,15 +7646,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i11.Future<
+            returnValue: _i12.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i11.Future<
+            returnValueForMissingStub: _i12.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i11.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i11.Future<Map<String, int>> uploadKeys({
-    _i3.MatrixDeviceKeys? deviceKeys,
+  _i12.Future<Map<String, int>> uploadKeys({
+    _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
   }) =>
@@ -7633,13 +7668,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i11.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i12.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i11.Future<Map<String, int>>);
+            _i12.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i12.Future<Map<String, int>>);
 
   @override
-  _i11.Future<String> knockRoom(
+  _i12.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7653,7 +7688,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7665,7 +7700,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7676,20 +7711,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<List<_i3.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i12.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.LoginFlow>?>.value(),
-      ) as _i11.Future<List<_i3.LoginFlow>?>);
+        returnValue: _i12.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i12.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i11.Future<_i3.GetNotificationsResponse> getNotifications({
+  _i12.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7704,8 +7739,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #only: only,
           },
         ),
-        returnValue: _i11.Future<_i3.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_57(
+        returnValue: _i12.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_58(
           this,
           Invocation.method(
             #getNotifications,
@@ -7718,8 +7753,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_57(
+            _i12.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_58(
           this,
           Invocation.method(
             #getNotifications,
@@ -7731,37 +7766,37 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetNotificationsResponse>);
+      ) as _i12.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i11.Future<_i3.GetPresenceResponse> getPresence(String? userId) =>
+  _i12.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i11.Future<_i3.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_58(
+        returnValue: _i12.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_59(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_58(
+        returnValueForMissingStub: _i12.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_59(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i11.Future<_i3.GetPresenceResponse>);
+      ) as _i12.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i11.Future<void> setPresence(
+  _i12.Future<void> setPresence(
     String? userId,
-    _i3.PresenceType? presence, {
+    _i4.PresenceType? presence, {
     String? statusMsg,
   }) =>
       (super.noSuchMethod(
@@ -7773,12 +7808,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, Object?>> deleteProfileField(
+  _i12.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7791,13 +7826,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getProfileField(
+  _i12.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7810,13 +7845,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<Map<String, Object?>> setProfileField(
+  _i12.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7831,13 +7866,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.GetPublicRoomsResponse> getPublicRooms({
+  _i12.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7852,8 +7887,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #server: server,
           },
         ),
-        returnValue: _i11.Future<_i3.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_59(
+        returnValue: _i12.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_60(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7866,8 +7901,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_59(
+            _i12.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_60(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7879,12 +7914,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetPublicRoomsResponse>);
+      ) as _i12.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i11.Future<_i3.QueryPublicRoomsResponse> queryPublicRooms({
+  _i12.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
-    _i3.PublicRoomQueryFilter? filter,
+    _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
     int? limit,
     String? since,
@@ -7903,8 +7938,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i11.Future<_i3.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_60(
+        returnValue: _i12.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_61(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7920,8 +7955,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_60(
+            _i12.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_61(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7936,25 +7971,25 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.QueryPublicRoomsResponse>);
+      ) as _i12.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i11.Future<List<_i3.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Pusher>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.Pusher>?>.value(),
-      ) as _i11.Future<List<_i3.Pusher>?>);
+        returnValue: _i12.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.Pusher>?>.value(),
+      ) as _i12.Future<List<_i4.Pusher>?>);
 
   @override
-  _i11.Future<_i3.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i12.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i11.Future<_i3.PushRuleSet>.value(_FakePushRuleSet_61(
+        returnValue: _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
           this,
           Invocation.method(
             #getPushRules,
@@ -7962,24 +7997,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PushRuleSet>.value(_FakePushRuleSet_61(
+            _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.PushRuleSet>);
+      ) as _i12.Future<_i4.PushRuleSet>);
 
   @override
-  _i11.Future<_i3.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i12.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i11.Future<_i3.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_62(
+        returnValue: _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_63(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -7987,19 +8022,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_62(
+            _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_63(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.GetPushRulesGlobalResponse>);
+      ) as _i12.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i11.Future<void> deletePushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> deletePushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8010,13 +8045,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.PushRule> getPushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<_i4.PushRule> getPushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8027,7 +8062,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<_i3.PushRule>.value(_FakePushRule_63(
+        returnValue: _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
           this,
           Invocation.method(
             #getPushRule,
@@ -8038,7 +8073,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PushRule>.value(_FakePushRule_63(
+            _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
           this,
           Invocation.method(
             #getPushRule,
@@ -8048,16 +8083,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.PushRule>);
+      ) as _i12.Future<_i4.PushRule>);
 
   @override
-  _i11.Future<void> setPushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
     String? before,
     String? after,
-    List<_i3.PushCondition>? conditions,
+    List<_i4.PushCondition>? conditions,
     String? pattern,
   }) =>
       (super.noSuchMethod(
@@ -8075,13 +8110,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<Object?>> getPushRuleActions(
-    _i3.PushRuleKind? kind,
+  _i12.Future<List<Object?>> getPushRuleActions(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8092,14 +8127,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i12.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i11.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i11.Future<List<Object?>>);
+            _i12.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i12.Future<List<Object?>>);
 
   @override
-  _i11.Future<void> setPushRuleActions(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRuleActions(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
   ) =>
@@ -8112,13 +8147,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             actions,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<bool> isPushRuleEnabled(
-    _i3.PushRuleKind? kind,
+  _i12.Future<bool> isPushRuleEnabled(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8129,13 +8164,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> setPushRuleEnabled(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRuleEnabled(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
   ) =>
@@ -8148,19 +8183,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
             enabled,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.RefreshResponse> refresh(String? refreshToken) =>
+  _i12.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i11.Future<_i3.RefreshResponse>.value(_FakeRefreshResponse_64(
+            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
           this,
           Invocation.method(
             #refresh,
@@ -8168,28 +8203,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RefreshResponse>.value(_FakeRefreshResponse_64(
+            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i11.Future<_i3.RefreshResponse>);
+      ) as _i12.Future<_i4.RefreshResponse>);
 
   @override
-  _i11.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i12.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i11.Future<bool?>.value(),
-        returnValueForMissingStub: _i11.Future<bool?>.value(),
-      ) as _i11.Future<bool?>);
+        returnValue: _i12.Future<bool?>.value(),
+        returnValueForMissingStub: _i12.Future<bool?>.value(),
+      ) as _i12.Future<bool?>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8211,8 +8246,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8228,8 +8263,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8245,10 +8280,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8272,8 +8307,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8290,8 +8325,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8308,17 +8343,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8326,23 +8361,23 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i12.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i11.Future<_i3.RoomKeys>.value(_FakeRoomKeys_65(
+        returnValue: _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8350,19 +8385,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeys>.value(_FakeRoomKeys_65(
+            _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeys>);
+      ) as _i12.Future<_i4.RoomKeys>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeys(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
-    _i3.RoomKeys? body,
+    _i4.RoomKeys? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8372,8 +8407,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8384,8 +8419,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8395,10 +8430,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8410,8 +8445,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8422,8 +8457,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8433,10 +8468,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeyBackup> getRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8448,7 +8483,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
+        returnValue: _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8459,7 +8494,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
+            _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8469,13 +8504,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeyBackup>);
+      ) as _i12.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
-    _i3.RoomKeyBackup? body,
+    _i4.RoomKeyBackup? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8486,8 +8521,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8499,8 +8534,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8511,10 +8546,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8528,8 +8563,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8541,8 +8576,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8553,10 +8588,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.KeyBackupData> getRoomKeyBySessionId(
+  _i12.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8570,7 +8605,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8582,7 +8617,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8593,14 +8628,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.KeyBackupData>);
+      ) as _i12.Future<_i4.KeyBackupData>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
-    _i3.KeyBackupData? body,
+    _i4.KeyBackupData? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8612,8 +8647,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8626,8 +8661,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8639,18 +8674,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>
+  _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_67(
+                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_68(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8658,19 +8693,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_67(
+                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_68(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>);
+          ) as _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i11.Future<String> postRoomKeysVersion(
-    _i3.BackupAlgorithm? algorithm,
+  _i12.Future<String> postRoomKeysVersion(
+    _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
       (super.noSuchMethod(
@@ -8681,7 +8716,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             authData,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8692,7 +8727,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8702,29 +8737,29 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i12.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i12.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i11.Future<_i3.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_68(
+        returnValue: _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_69(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8732,20 +8767,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_68(
+            _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_69(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomKeysVersionResponse>);
+      ) as _i12.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i12.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
-    _i3.BackupAlgorithm? algorithm,
+    _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
       (super.noSuchMethod(
@@ -8758,24 +8793,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i12.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i11.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i11.Future<List<String>>.value(<String>[]),
-      ) as _i11.Future<List<String>>);
+        returnValue: _i12.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
+      ) as _i12.Future<List<String>>);
 
   @override
-  _i11.Future<void> ban(
+  _i12.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8789,12 +8824,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.EventContext> getEventContext(
+  _i12.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8812,7 +8847,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<_i3.EventContext>.value(_FakeEventContext_69(
+        returnValue: _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
           this,
           Invocation.method(
             #getEventContext,
@@ -8827,7 +8862,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.EventContext>.value(_FakeEventContext_69(
+            _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
           this,
           Invocation.method(
             #getEventContext,
@@ -8841,10 +8876,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.EventContext>);
+      ) as _i12.Future<_i4.EventContext>);
 
   @override
-  _i11.Future<_i3.MatrixEvent> getOneRoomEvent(
+  _i12.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8856,7 +8891,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             eventId,
           ],
         ),
-        returnValue: _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8867,7 +8902,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8877,22 +8912,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.MatrixEvent>);
+      ) as _i12.Future<_i4.MatrixEvent>);
 
   @override
-  _i11.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i12.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> inviteBy3PID(
+  _i12.Future<void> inviteBy3PID(
     String? roomId,
-    _i3.Invite3pid? body,
+    _i4.Invite3pid? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8902,12 +8937,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> inviteUser(
+  _i12.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8921,15 +8956,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> joinRoomById(
+  _i12.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
-    _i3.ThirdPartySigned? thirdPartySigned,
+    _i4.ThirdPartySigned? thirdPartySigned,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8940,7 +8975,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8952,7 +8987,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8963,23 +8998,23 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<Map<String, _i3.RoomMember>?> getJoinedMembersByRoom(
+  _i12.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i11.Future<Map<String, _i3.RoomMember>?>.value(),
+        returnValue: _i12.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i11.Future<Map<String, _i3.RoomMember>?>.value(),
-      ) as _i11.Future<Map<String, _i3.RoomMember>?>);
+            _i12.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i12.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i11.Future<void> kick(
+  _i12.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8993,12 +9028,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> leaveRoom(
+  _i12.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9008,16 +9043,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.MatrixEvent>?> getMembersByRoom(
+  _i12.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
-    _i3.Membership? membership,
-    _i3.Membership? notMembership,
+    _i4.Membership? membership,
+    _i4.Membership? notMembership,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9029,14 +9064,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i11.Future<List<_i3.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.MatrixEvent>?>.value(),
-      ) as _i11.Future<List<_i3.MatrixEvent>?>);
+        returnValue: _i12.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i12.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i11.Future<_i3.GetRoomEventsResponse> getRoomEvents(
+  _i12.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
-    _i3.Direction? dir, {
+    _i4.Direction? dir, {
     String? from,
     String? to,
     int? limit,
@@ -9056,8 +9091,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<_i3.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_70(
+        returnValue: _i12.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_71(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9073,8 +9108,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_70(
+        returnValueForMissingStub: _i12.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_71(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9090,10 +9125,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomEventsResponse>);
+      ) as _i12.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i11.Future<void> setReadMarker(
+  _i12.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9109,14 +9144,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> postReceipt(
+  _i12.Future<void> postReceipt(
     String? roomId,
-    _i3.ReceiptType? receiptType,
+    _i4.ReceiptType? receiptType,
     String? eventId, {
     String? threadId,
   }) =>
@@ -9130,12 +9165,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEvent(
+  _i12.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9151,12 +9186,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> reportRoom(
+  _i12.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9168,12 +9203,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             reason,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> reportEvent(
+  _i12.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9191,12 +9226,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #score: score,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> sendMessage(
+  _i12.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9212,7 +9247,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9225,7 +9260,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9237,27 +9272,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<List<_i3.MatrixEvent>> getRoomState(String? roomId) =>
+  _i12.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i11.Future<List<_i3.MatrixEvent>>.value(<_i3.MatrixEvent>[]),
+            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.MatrixEvent>>.value(<_i3.MatrixEvent>[]),
-      ) as _i11.Future<List<_i3.MatrixEvent>>);
+            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i12.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i12.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
-    _i3.Format? format,
+    _i4.Format? format,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9270,13 +9305,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#format: format},
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<String> setRoomStateWithKey(
+  _i12.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9292,7 +9327,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9305,7 +9340,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9317,10 +9352,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> unban(
+  _i12.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9334,12 +9369,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> upgradeRoom(
+  _i12.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9353,7 +9388,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9365,7 +9400,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9376,11 +9411,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.SearchResults> search(
-    _i3.Categories? searchCategories, {
+  _i12.Future<_i4.SearchResults> search(
+    _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
       (super.noSuchMethod(
@@ -9389,7 +9424,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i11.Future<_i3.SearchResults>.value(_FakeSearchResults_71(
+        returnValue: _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
           this,
           Invocation.method(
             #search,
@@ -9398,7 +9433,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SearchResults>.value(_FakeSearchResults_71(
+            _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
           this,
           Invocation.method(
             #search,
@@ -9406,14 +9441,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i11.Future<_i3.SearchResults>);
+      ) as _i12.Future<_i4.SearchResults>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> sync({
+  _i12.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
-    _i3.PresenceType? setPresence,
+    _i4.PresenceType? setPresence,
     int? timeout,
     bool? useStateAfter,
   }) =>
@@ -9430,7 +9465,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #sync,
@@ -9446,7 +9481,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #sync,
@@ -9461,22 +9496,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<List<_i3.Location>> queryLocationByAlias(String? alias) =>
+  _i12.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
+        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
-      ) as _i11.Future<List<_i3.Location>>);
+            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i12.Future<List<_i4.Location>>);
 
   @override
-  _i11.Future<List<_i3.Location>> queryLocationByProtocol(
+  _i12.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9486,21 +9521,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
+        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
-      ) as _i11.Future<List<_i3.Location>>);
+            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i12.Future<List<_i4.Location>>);
 
   @override
-  _i11.Future<_i3.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i12.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i11.Future<_i3.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_72(
+        returnValue: _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_73(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9508,45 +9543,45 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_72(
+            _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_73(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i11.Future<_i3.GetProtocolMetadataResponse$2>);
+      ) as _i12.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i11.Future<Map<String, _i3.GetProtocolsResponse$2>> getProtocols() =>
+  _i12.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>.value(
-            <String, _i3.GetProtocolsResponse$2>{}),
+        returnValue: _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>.value(
-                <String, _i3.GetProtocolsResponse$2>{}),
-      ) as _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>);
+            _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+                <String, _i4.GetProtocolsResponse$2>{}),
+      ) as _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
-      ) as _i11.Future<List<_i3.ThirdPartyUser>>);
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyUser>> queryUserByProtocol(
+  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9557,13 +9592,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
-      ) as _i11.Future<List<_i3.ThirdPartyUser>>);
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getAccountData(
+  _i12.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9576,13 +9611,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> setAccountData(
+  _i12.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9596,14 +9631,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> defineFilter(
+  _i12.Future<String> defineFilter(
     String? userId,
-    _i3.Filter? body,
+    _i4.Filter? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9613,7 +9648,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9624,7 +9659,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9634,10 +9669,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.Filter> getFilter(
+  _i12.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9649,7 +9684,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             filterId,
           ],
         ),
-        returnValue: _i11.Future<_i3.Filter>.value(_FakeFilter_16(
+        returnValue: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
           this,
           Invocation.method(
             #getFilter,
@@ -9659,7 +9694,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.Filter>.value(_FakeFilter_16(
+        returnValueForMissingStub: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
           this,
           Invocation.method(
             #getFilter,
@@ -9669,10 +9704,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.Filter>);
+      ) as _i12.Future<_i4.Filter>);
 
   @override
-  _i11.Future<_i3.OpenIdCredentials> requestOpenIdToken(
+  _i12.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9685,7 +9720,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<_i3.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
+            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9696,7 +9731,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
+            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9706,10 +9741,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.OpenIdCredentials>);
+      ) as _i12.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i11.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i12.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9724,13 +9759,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> setAccountDataPerRoom(
+  _i12.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9746,12 +9781,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, _i3.Tag>?> getRoomTags(
+  _i12.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9763,12 +9798,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             roomId,
           ],
         ),
-        returnValue: _i11.Future<Map<String, _i3.Tag>?>.value(),
-        returnValueForMissingStub: _i11.Future<Map<String, _i3.Tag>?>.value(),
-      ) as _i11.Future<Map<String, _i3.Tag>?>);
+        returnValue: _i12.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i12.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i12.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i11.Future<void> deleteRoomTag(
+  _i12.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9782,16 +9817,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             tag,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setRoomTag(
+  _i12.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
-    _i3.Tag? body,
+    _i4.Tag? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9803,12 +9838,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.SearchUserDirectoryResponse> searchUserDirectory(
+  _i12.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9818,8 +9853,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i11.Future<_i3.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_74(
+        returnValue: _i12.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_75(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9828,8 +9863,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_74(
+            _i12.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_75(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9837,10 +9872,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i11.Future<_i3.SearchUserDirectoryResponse>);
+      ) as _i12.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> reportUser(
+  _i12.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9853,40 +9888,40 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i12.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i11.Future<_i3.CreateContentResponse>.value(
-            _FakeCreateContentResponse_75(
+        returnValue: _i12.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_76(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.CreateContentResponse>.value(
-            _FakeCreateContentResponse_75(
+        returnValueForMissingStub: _i12.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_76(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.CreateContentResponse>);
+      ) as _i12.Future<_i4.CreateContentResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> uploadContentToMXC(
+  _i12.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i21.Uint8List? body, {
+    _i22.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -9904,8 +9939,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 }

--- a/test/widgets/login_controller_test.mocks.dart
+++ b/test/widgets/login_controller_test.mocks.dart
@@ -3,31 +3,33 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i12;
-import 'dart:typed_data' as _i21;
-import 'dart:ui' as _i16;
+import 'dart:async' as _i13;
+import 'dart:typed_data' as _i22;
+import 'dart:ui' as _i17;
 
-import 'package:flutter/services.dart' as _i17;
-import 'package:flutter/widgets.dart' as _i18;
-import 'package:http/http.dart' as _i11;
-import 'package:kohera/core/models/server_auth_capabilities.dart' as _i14;
-import 'package:kohera/core/services/client_manager.dart' as _i19;
-import 'package:kohera/core/services/matrix_service.dart' as _i9;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
+import 'package:http/http.dart' as _i12;
+import 'package:kohera/core/models/server_auth_capabilities.dart' as _i15;
+import 'package:kohera/core/services/client_manager.dart' as _i20;
+import 'package:kohera/core/services/matrix_service.dart' as _i10;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i5;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i7;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i4;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i7;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
-import 'package:matrix/encryption.dart' as _i20;
-import 'package:matrix/matrix.dart' as _i3;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i13;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i10;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i3;
+import 'package:matrix/encryption.dart' as _i21;
+import 'package:matrix/matrix.dart' as _i4;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i14;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i11;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -55,8 +57,9 @@ class _FakeCallPushRuleManager_0 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
-  _FakeClient_1(
+class _FakeMegolmKeyMirror_1 extends _i1.SmartFake
+    implements _i3.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_1(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -65,8 +68,8 @@ class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
         );
 }
 
-class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
-  _FakeUiaService_2(
+class _FakeClient_2 extends _i1.SmartFake implements _i4.Client {
+  _FakeClient_2(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -75,9 +78,8 @@ class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
         );
 }
 
-class _FakeChatBackupService_3 extends _i1.SmartFake
-    implements _i5.ChatBackupService {
-  _FakeChatBackupService_3(
+class _FakeUiaService_3 extends _i1.SmartFake implements _i5.UiaService {
+  _FakeUiaService_3(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -86,9 +88,9 @@ class _FakeChatBackupService_3 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_4 extends _i1.SmartFake
-    implements _i6.SelectionService {
-  _FakeSelectionService_4(
+class _FakeChatBackupService_4 extends _i1.SmartFake
+    implements _i6.ChatBackupService {
+  _FakeChatBackupService_4(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -97,8 +99,9 @@ class _FakeSelectionService_4 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
-  _FakeSyncService_5(
+class _FakeSelectionService_5 extends _i1.SmartFake
+    implements _i7.SelectionService {
+  _FakeSelectionService_5(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -107,8 +110,8 @@ class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
         );
 }
 
-class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
-  _FakeAuthService_6(
+class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
+  _FakeSyncService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -117,8 +120,8 @@ class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
         );
 }
 
-class _FakeMatrixService_7 extends _i1.SmartFake implements _i9.MatrixService {
-  _FakeMatrixService_7(
+class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
+  _FakeAuthService_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -127,8 +130,8 @@ class _FakeMatrixService_7 extends _i1.SmartFake implements _i9.MatrixService {
         );
 }
 
-class _FakeDatabaseApi_8 extends _i1.SmartFake implements _i3.DatabaseApi {
-  _FakeDatabaseApi_8(
+class _FakeMatrixService_8 extends _i1.SmartFake implements _i10.MatrixService {
+  _FakeMatrixService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -137,8 +140,8 @@ class _FakeDatabaseApi_8 extends _i1.SmartFake implements _i3.DatabaseApi {
         );
 }
 
-class _FakeFilter_9 extends _i1.SmartFake implements _i3.Filter {
-  _FakeFilter_9(
+class _FakeDatabaseApi_9 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -147,9 +150,8 @@ class _FakeFilter_9 extends _i1.SmartFake implements _i3.Filter {
         );
 }
 
-class _FakeNativeImplementations_10 extends _i1.SmartFake
-    implements _i3.NativeImplementations {
-  _FakeNativeImplementations_10(
+class _FakeFilter_10 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -158,8 +160,9 @@ class _FakeNativeImplementations_10 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_11 extends _i1.SmartFake implements Duration {
-  _FakeDuration_11(
+class _FakeNativeImplementations_11 extends _i1.SmartFake
+    implements _i4.NativeImplementations {
+  _FakeNativeImplementations_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -168,9 +171,8 @@ class _FakeDuration_11 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_12 extends _i1.SmartFake
-    implements _i3.PushruleEvaluator {
-  _FakePushruleEvaluator_12(
+class _FakeDuration_12 extends _i1.SmartFake implements Duration {
+  _FakeDuration_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -179,8 +181,9 @@ class _FakePushruleEvaluator_12 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_13 extends _i1.SmartFake implements _i3.Profile {
-  _FakeProfile_13(
+class _FakePushruleEvaluator_13 extends _i1.SmartFake
+    implements _i4.PushruleEvaluator {
+  _FakePushruleEvaluator_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -189,9 +192,8 @@ class _FakeProfile_13 extends _i1.SmartFake implements _i3.Profile {
         );
 }
 
-class _FakeCachedStreamController_14<T> extends _i1.SmartFake
-    implements _i10.CachedStreamController<T> {
-  _FakeCachedStreamController_14(
+class _FakeProfile_14 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -200,8 +202,9 @@ class _FakeCachedStreamController_14<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_15 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_15(
+class _FakeCachedStreamController_15<T> extends _i1.SmartFake
+    implements _i11.CachedStreamController<T> {
+  _FakeCachedStreamController_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -210,8 +213,8 @@ class _FakeDateTime_15 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_16 extends _i1.SmartFake implements _i11.Client {
-  _FakeClient_16(
+class _FakeDateTime_16 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -220,9 +223,8 @@ class _FakeClient_16 extends _i1.SmartFake implements _i11.Client {
         );
 }
 
-class _FakeDiscoveryInformation_17 extends _i1.SmartFake
-    implements _i3.DiscoveryInformation {
-  _FakeDiscoveryInformation_17(
+class _FakeClient_17 extends _i1.SmartFake implements _i12.Client {
+  _FakeClient_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -231,9 +233,9 @@ class _FakeDiscoveryInformation_17 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_18 extends _i1.SmartFake
-    implements _i3.GetVersionsResponse {
-  _FakeGetVersionsResponse_18(
+class _FakeDiscoveryInformation_18 extends _i1.SmartFake
+    implements _i4.DiscoveryInformation {
+  _FakeDiscoveryInformation_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -242,9 +244,9 @@ class _FakeGetVersionsResponse_18 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_19 extends _i1.SmartFake
-    implements _i3.RegisterResponse {
-  _FakeRegisterResponse_19(
+class _FakeGetVersionsResponse_19 extends _i1.SmartFake
+    implements _i4.GetVersionsResponse {
+  _FakeGetVersionsResponse_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -253,8 +255,9 @@ class _FakeRegisterResponse_19 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_20 extends _i1.SmartFake implements _i3.LoginResponse {
-  _FakeLoginResponse_20(
+class _FakeRegisterResponse_20 extends _i1.SmartFake
+    implements _i4.RegisterResponse {
+  _FakeRegisterResponse_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -263,9 +266,8 @@ class _FakeLoginResponse_20 extends _i1.SmartFake implements _i3.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_21 extends _i1.SmartFake
-    implements _i3.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_21(
+class _FakeLoginResponse_21 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -274,8 +276,9 @@ class _FakeGetAuthMetadataResponse_21 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_22<T1> extends _i1.SmartFake implements _i12.Future<T1> {
-  _FakeFuture_22(
+class _FakeGetAuthMetadataResponse_22 extends _i1.SmartFake
+    implements _i4.GetAuthMetadataResponse {
+  _FakeGetAuthMetadataResponse_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -284,8 +287,8 @@ class _FakeFuture_22<T1> extends _i1.SmartFake implements _i12.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_23 extends _i1.SmartFake implements _i3.SyncUpdate {
-  _FakeSyncUpdate_23(
+class _FakeFuture_23<T1> extends _i1.SmartFake implements _i13.Future<T1> {
+  _FakeFuture_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -294,9 +297,8 @@ class _FakeSyncUpdate_23 extends _i1.SmartFake implements _i3.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_24 extends _i1.SmartFake
-    implements _i3.CachedProfileInformation {
-  _FakeCachedProfileInformation_24(
+class _FakeSyncUpdate_24 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -305,8 +307,9 @@ class _FakeCachedProfileInformation_24 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_25 extends _i1.SmartFake implements _i3.MediaConfig {
-  _FakeMediaConfig_25(
+class _FakeCachedProfileInformation_25 extends _i1.SmartFake
+    implements _i4.CachedProfileInformation {
+  _FakeCachedProfileInformation_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -315,8 +318,8 @@ class _FakeMediaConfig_25 extends _i1.SmartFake implements _i3.MediaConfig {
         );
 }
 
-class _FakeFileResponse_26 extends _i1.SmartFake implements _i13.FileResponse {
-  _FakeFileResponse_26(
+class _FakeMediaConfig_26 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -325,8 +328,8 @@ class _FakeFileResponse_26 extends _i1.SmartFake implements _i13.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_27 extends _i1.SmartFake implements _i3.PreviewForUrl {
-  _FakePreviewForUrl_27(
+class _FakeFileResponse_27 extends _i1.SmartFake implements _i14.FileResponse {
+  _FakeFileResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -335,8 +338,8 @@ class _FakePreviewForUrl_27 extends _i1.SmartFake implements _i3.PreviewForUrl {
         );
 }
 
-class _FakeUri_28 extends _i1.SmartFake implements Uri {
-  _FakeUri_28(
+class _FakePreviewForUrl_28 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -345,9 +348,8 @@ class _FakeUri_28 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_29 extends _i1.SmartFake
-    implements _i3.CachedPresence {
-  _FakeCachedPresence_29(
+class _FakeUri_29 extends _i1.SmartFake implements Uri {
+  _FakeUri_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -356,9 +358,9 @@ class _FakeCachedPresence_29 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_30 extends _i1.SmartFake
-    implements _i3.TurnServerCredentials {
-  _FakeTurnServerCredentials_30(
+class _FakeCachedPresence_30 extends _i1.SmartFake
+    implements _i4.CachedPresence {
+  _FakeCachedPresence_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -367,9 +369,9 @@ class _FakeTurnServerCredentials_30 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_31 extends _i1.SmartFake
-    implements _i3.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_31(
+class _FakeTurnServerCredentials_31 extends _i1.SmartFake
+    implements _i4.TurnServerCredentials {
+  _FakeTurnServerCredentials_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -378,8 +380,9 @@ class _FakeRoomKeysUpdateResponse_31 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_32 extends _i1.SmartFake implements _i3.KeyBackupData {
-  _FakeKeyBackupData_32(
+class _FakeRoomKeysUpdateResponse_32 extends _i1.SmartFake
+    implements _i4.RoomKeysUpdateResponse {
+  _FakeRoomKeysUpdateResponse_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -388,9 +391,8 @@ class _FakeKeyBackupData_32 extends _i1.SmartFake implements _i3.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_33 extends _i1.SmartFake
-    implements _i3.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_33(
+class _FakeKeyBackupData_33 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -399,9 +401,9 @@ class _FakeGetWellknownSupportResponse_33 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_34 extends _i1.SmartFake
-    implements _i3.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_34(
+class _FakeGetWellknownSupportResponse_34 extends _i1.SmartFake
+    implements _i4.GetWellknownSupportResponse {
+  _FakeGetWellknownSupportResponse_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -410,9 +412,9 @@ class _FakeGenerateLoginTokenResponse_34 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_35 extends _i1.SmartFake
-    implements _i3.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_35(
+class _FakeGenerateLoginTokenResponse_35 extends _i1.SmartFake
+    implements _i4.GenerateLoginTokenResponse {
+  _FakeGenerateLoginTokenResponse_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -421,9 +423,9 @@ class _FakeGetRoomSummaryResponse$3_35 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_36 extends _i1.SmartFake
-    implements _i3.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_36(
+class _FakeGetRoomSummaryResponse$3_36 extends _i1.SmartFake
+    implements _i4.GetRoomSummaryResponse$3 {
+  _FakeGetRoomSummaryResponse$3_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -432,9 +434,9 @@ class _FakeGetSpaceHierarchyResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_37 extends _i1.SmartFake
-    implements _i3.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_37(
+class _FakeGetSpaceHierarchyResponse_37 extends _i1.SmartFake
+    implements _i4.GetSpaceHierarchyResponse {
+  _FakeGetSpaceHierarchyResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -443,9 +445,9 @@ class _FakeGetRelatingEventsResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_38 extends _i1.SmartFake
-    implements _i3.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_38(
+class _FakeGetRelatingEventsResponse_38 extends _i1.SmartFake
+    implements _i4.GetRelatingEventsResponse {
+  _FakeGetRelatingEventsResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -454,9 +456,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39 extends _i1
-    .SmartFake implements _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39(
+class _FakeGetRelatingEventsWithRelTypeResponse_39 extends _i1.SmartFake
+    implements _i4.GetRelatingEventsWithRelTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -465,9 +467,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_40 extends _i1.SmartFake
-    implements _i3.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_40(
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40 extends _i1
+    .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -476,9 +478,9 @@ class _FakeGetThreadRootsResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_41 extends _i1.SmartFake
-    implements _i3.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_41(
+class _FakeGetThreadRootsResponse_41 extends _i1.SmartFake
+    implements _i4.GetThreadRootsResponse {
+  _FakeGetThreadRootsResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -487,9 +489,9 @@ class _FakeGetEventByTimestampResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_42 extends _i1.SmartFake
-    implements _i3.RequestTokenResponse {
-  _FakeRequestTokenResponse_42(
+class _FakeGetEventByTimestampResponse_42 extends _i1.SmartFake
+    implements _i4.GetEventByTimestampResponse {
+  _FakeGetEventByTimestampResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -498,9 +500,9 @@ class _FakeRequestTokenResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_43 extends _i1.SmartFake
-    implements _i3.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_43(
+class _FakeRequestTokenResponse_43 extends _i1.SmartFake
+    implements _i4.RequestTokenResponse {
+  _FakeRequestTokenResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -509,8 +511,9 @@ class _FakeTokenOwnerInfo_43 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_44 extends _i1.SmartFake implements _i3.WhoIsInfo {
-  _FakeWhoIsInfo_44(
+class _FakeTokenOwnerInfo_44 extends _i1.SmartFake
+    implements _i4.TokenOwnerInfo {
+  _FakeTokenOwnerInfo_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -519,8 +522,8 @@ class _FakeWhoIsInfo_44 extends _i1.SmartFake implements _i3.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_45 extends _i1.SmartFake implements _i3.Capabilities {
-  _FakeCapabilities_45(
+class _FakeWhoIsInfo_45 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -529,8 +532,8 @@ class _FakeCapabilities_45 extends _i1.SmartFake implements _i3.Capabilities {
         );
 }
 
-class _FakeDevice_46 extends _i1.SmartFake implements _i3.Device {
-  _FakeDevice_46(
+class _FakeCapabilities_46 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -539,9 +542,8 @@ class _FakeDevice_46 extends _i1.SmartFake implements _i3.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_47 extends _i1.SmartFake
-    implements _i3.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_47(
+class _FakeDevice_47 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -550,9 +552,9 @@ class _FakeGetRoomIdByAliasResponse_47 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_48 extends _i1.SmartFake
-    implements _i3.GetEventsResponse {
-  _FakeGetEventsResponse_48(
+class _FakeGetRoomIdByAliasResponse_48 extends _i1.SmartFake
+    implements _i4.GetRoomIdByAliasResponse {
+  _FakeGetRoomIdByAliasResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -561,9 +563,9 @@ class _FakeGetEventsResponse_48 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_49 extends _i1.SmartFake
-    implements _i3.PeekEventsResponse {
-  _FakePeekEventsResponse_49(
+class _FakeGetEventsResponse_49 extends _i1.SmartFake
+    implements _i4.GetEventsResponse {
+  _FakeGetEventsResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -572,8 +574,9 @@ class _FakePeekEventsResponse_49 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_50 extends _i1.SmartFake implements _i3.MatrixEvent {
-  _FakeMatrixEvent_50(
+class _FakePeekEventsResponse_50 extends _i1.SmartFake
+    implements _i4.PeekEventsResponse {
+  _FakePeekEventsResponse_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -582,9 +585,8 @@ class _FakeMatrixEvent_50 extends _i1.SmartFake implements _i3.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_51 extends _i1.SmartFake
-    implements _i3.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_51(
+class _FakeMatrixEvent_51 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -593,9 +595,9 @@ class _FakeGetKeysChangesResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_52 extends _i1.SmartFake
-    implements _i3.ClaimKeysResponse {
-  _FakeClaimKeysResponse_52(
+class _FakeGetKeysChangesResponse_52 extends _i1.SmartFake
+    implements _i4.GetKeysChangesResponse {
+  _FakeGetKeysChangesResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -604,9 +606,9 @@ class _FakeClaimKeysResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_53 extends _i1.SmartFake
-    implements _i3.QueryKeysResponse {
-  _FakeQueryKeysResponse_53(
+class _FakeClaimKeysResponse_53 extends _i1.SmartFake
+    implements _i4.ClaimKeysResponse {
+  _FakeClaimKeysResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -615,9 +617,9 @@ class _FakeQueryKeysResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_54 extends _i1.SmartFake
-    implements _i3.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_54(
+class _FakeQueryKeysResponse_54 extends _i1.SmartFake
+    implements _i4.QueryKeysResponse {
+  _FakeQueryKeysResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -626,9 +628,9 @@ class _FakeGetNotificationsResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_55 extends _i1.SmartFake
-    implements _i3.GetPresenceResponse {
-  _FakeGetPresenceResponse_55(
+class _FakeGetNotificationsResponse_55 extends _i1.SmartFake
+    implements _i4.GetNotificationsResponse {
+  _FakeGetNotificationsResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -637,9 +639,9 @@ class _FakeGetPresenceResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_56 extends _i1.SmartFake
-    implements _i3.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_56(
+class _FakeGetPresenceResponse_56 extends _i1.SmartFake
+    implements _i4.GetPresenceResponse {
+  _FakeGetPresenceResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -648,9 +650,9 @@ class _FakeGetPublicRoomsResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_57 extends _i1.SmartFake
-    implements _i3.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_57(
+class _FakeGetPublicRoomsResponse_57 extends _i1.SmartFake
+    implements _i4.GetPublicRoomsResponse {
+  _FakeGetPublicRoomsResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -659,8 +661,9 @@ class _FakeQueryPublicRoomsResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_58 extends _i1.SmartFake implements _i3.PushRuleSet {
-  _FakePushRuleSet_58(
+class _FakeQueryPublicRoomsResponse_58 extends _i1.SmartFake
+    implements _i4.QueryPublicRoomsResponse {
+  _FakeQueryPublicRoomsResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -669,9 +672,8 @@ class _FakePushRuleSet_58 extends _i1.SmartFake implements _i3.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_59 extends _i1.SmartFake
-    implements _i3.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_59(
+class _FakePushRuleSet_59 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -680,8 +682,9 @@ class _FakeGetPushRulesGlobalResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_60 extends _i1.SmartFake implements _i3.PushRule {
-  _FakePushRule_60(
+class _FakeGetPushRulesGlobalResponse_60 extends _i1.SmartFake
+    implements _i4.GetPushRulesGlobalResponse {
+  _FakeGetPushRulesGlobalResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -690,9 +693,8 @@ class _FakePushRule_60 extends _i1.SmartFake implements _i3.PushRule {
         );
 }
 
-class _FakeRefreshResponse_61 extends _i1.SmartFake
-    implements _i3.RefreshResponse {
-  _FakeRefreshResponse_61(
+class _FakePushRule_61 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -701,8 +703,9 @@ class _FakeRefreshResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_62 extends _i1.SmartFake implements _i3.RoomKeys {
-  _FakeRoomKeys_62(
+class _FakeRefreshResponse_62 extends _i1.SmartFake
+    implements _i4.RefreshResponse {
+  _FakeRefreshResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -711,8 +714,8 @@ class _FakeRoomKeys_62 extends _i1.SmartFake implements _i3.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_63 extends _i1.SmartFake implements _i3.RoomKeyBackup {
-  _FakeRoomKeyBackup_63(
+class _FakeRoomKeys_63 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -721,9 +724,8 @@ class _FakeRoomKeyBackup_63 extends _i1.SmartFake implements _i3.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_64 extends _i1.SmartFake
-    implements _i3.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_64(
+class _FakeRoomKeyBackup_64 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -732,9 +734,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_65 extends _i1.SmartFake
-    implements _i3.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_65(
+class _FakeGetRoomKeysVersionCurrentResponse_65 extends _i1.SmartFake
+    implements _i4.GetRoomKeysVersionCurrentResponse {
+  _FakeGetRoomKeysVersionCurrentResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -743,8 +745,9 @@ class _FakeGetRoomKeysVersionResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_66 extends _i1.SmartFake implements _i3.EventContext {
-  _FakeEventContext_66(
+class _FakeGetRoomKeysVersionResponse_66 extends _i1.SmartFake
+    implements _i4.GetRoomKeysVersionResponse {
+  _FakeGetRoomKeysVersionResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -753,9 +756,8 @@ class _FakeEventContext_66 extends _i1.SmartFake implements _i3.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_67 extends _i1.SmartFake
-    implements _i3.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_67(
+class _FakeEventContext_67 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -764,8 +766,9 @@ class _FakeGetRoomEventsResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_68 extends _i1.SmartFake implements _i3.SearchResults {
-  _FakeSearchResults_68(
+class _FakeGetRoomEventsResponse_68 extends _i1.SmartFake
+    implements _i4.GetRoomEventsResponse {
+  _FakeGetRoomEventsResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -774,9 +777,8 @@ class _FakeSearchResults_68 extends _i1.SmartFake implements _i3.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_69 extends _i1.SmartFake
-    implements _i3.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_69(
+class _FakeSearchResults_69 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -785,9 +787,9 @@ class _FakeGetProtocolMetadataResponse$2_69 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_70 extends _i1.SmartFake
-    implements _i3.OpenIdCredentials {
-  _FakeOpenIdCredentials_70(
+class _FakeGetProtocolMetadataResponse$2_70 extends _i1.SmartFake
+    implements _i4.GetProtocolMetadataResponse$2 {
+  _FakeGetProtocolMetadataResponse$2_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -796,9 +798,9 @@ class _FakeOpenIdCredentials_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_71 extends _i1.SmartFake
-    implements _i3.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_71(
+class _FakeOpenIdCredentials_71 extends _i1.SmartFake
+    implements _i4.OpenIdCredentials {
+  _FakeOpenIdCredentials_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -807,9 +809,9 @@ class _FakeSearchUserDirectoryResponse_71 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_72 extends _i1.SmartFake
-    implements _i3.CreateContentResponse {
-  _FakeCreateContentResponse_72(
+class _FakeSearchUserDirectoryResponse_72 extends _i1.SmartFake
+    implements _i4.SearchUserDirectoryResponse {
+  _FakeSearchUserDirectoryResponse_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -818,9 +820,20 @@ class _FakeCreateContentResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeServerAuthCapabilities_73 extends _i1.SmartFake
-    implements _i14.ServerAuthCapabilities {
-  _FakeServerAuthCapabilities_73(
+class _FakeCreateContentResponse_73 extends _i1.SmartFake
+    implements _i4.CreateContentResponse {
+  _FakeCreateContentResponse_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeServerAuthCapabilities_74 extends _i1.SmartFake
+    implements _i15.ServerAuthCapabilities {
+  _FakeServerAuthCapabilities_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -832,7 +845,7 @@ class _FakeServerAuthCapabilities_73 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -847,30 +860,43 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       ) as _i2.CallPushRuleManager);
 
   @override
+  _i3.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i3.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
       ) as String);
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get isLoggedIn => (super.noSuchMethod(
@@ -887,69 +913,69 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       ) as bool);
 
   @override
-  _i4.UiaService get uia => (super.noSuchMethod(
+  _i5.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_2(
+        returnValue: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_2(
+        returnValueForMissingStub: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i4.UiaService);
+      ) as _i5.UiaService);
 
   @override
-  _i5.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i6.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_3(
+        returnValue: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_3(
+        returnValueForMissingStub: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i5.ChatBackupService);
+      ) as _i6.ChatBackupService);
 
   @override
-  _i6.SelectionService get selection => (super.noSuchMethod(
+  _i7.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_4(
+        returnValue: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_4(
+        returnValueForMissingStub: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i6.SelectionService);
+      ) as _i7.SelectionService);
 
   @override
-  _i7.SyncService get sync => (super.noSuchMethod(
+  _i8.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_5(
+        returnValue: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_5(
+        returnValueForMissingStub: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i7.SyncService);
+      ) as _i8.SyncService);
 
   @override
-  _i8.AuthService get auth => (super.noSuchMethod(
+  _i9.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_6(
+        returnValue: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_6(
+        returnValueForMissingStub: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i8.AuthService);
+      ) as _i9.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -968,6 +994,15 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       );
 
   @override
+  set keyMirror(_i3.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -977,7 +1012,7 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       );
 
   @override
-  set uia(_i4.UiaService? value) => super.noSuchMethod(
+  set uia(_i5.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -986,7 +1021,7 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       );
 
   @override
-  set chatBackup(_i5.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i6.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -995,7 +1030,7 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       );
 
   @override
-  set selection(_i6.SelectionService? value) => super.noSuchMethod(
+  set selection(_i7.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -1004,7 +1039,7 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       );
 
   @override
-  set sync(_i7.SyncService? value) => super.noSuchMethod(
+  set sync(_i8.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -1013,7 +1048,7 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       );
 
   @override
-  set auth(_i8.AuthService? value) => super.noSuchMethod(
+  set auth(_i9.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -1029,14 +1064,14 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       ) as bool);
 
   @override
-  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1066,7 +1101,7 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i16.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1076,18 +1111,18 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       );
 
   @override
-  _i12.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<bool> login({
+  _i13.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1102,12 +1137,12 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> completeSsoLogin({
+  _i13.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1120,13 +1155,13 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> completeRegistration(
-    _i3.RegisterResponse? response, {
+  _i13.Future<void> completeRegistration(
+    _i4.RegisterResponse? response, {
     String? password,
   }) =>
       (super.noSuchMethod(
@@ -1135,32 +1170,32 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1169,7 +1204,7 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       );
 
   @override
-  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1178,17 +1213,17 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i17.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1199,7 +1234,7 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i17.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1236,26 +1271,26 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> didPushRouteInformation(
-          _i18.RouteInformation? routeInformation) =>
+  _i13.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1285,7 +1320,7 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i16.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1294,7 +1329,7 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i16.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1303,16 +1338,16 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
       );
 
   @override
-  _i12.Future<_i16.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i13.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
+            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
-      ) as _i12.Future<_i16.AppExitResponse>);
+            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i13.Future<_i17.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1336,13 +1371,13 @@ class MockMatrixService extends _i1.Mock implements _i9.MatrixService {
 /// A class which mocks [ClientManager].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockClientManager extends _i1.Mock implements _i19.ClientManager {
+class MockClientManager extends _i1.Mock implements _i20.ClientManager {
   @override
-  List<_i9.MatrixService> get services => (super.noSuchMethod(
+  List<_i10.MatrixService> get services => (super.noSuchMethod(
         Invocation.getter(#services),
-        returnValue: <_i9.MatrixService>[],
-        returnValueForMissingStub: <_i9.MatrixService>[],
-      ) as List<_i9.MatrixService>);
+        returnValue: <_i10.MatrixService>[],
+        returnValueForMissingStub: <_i10.MatrixService>[],
+      ) as List<_i10.MatrixService>);
 
   @override
   int get activeIndex => (super.noSuchMethod(
@@ -1352,17 +1387,17 @@ class MockClientManager extends _i1.Mock implements _i19.ClientManager {
       ) as int);
 
   @override
-  _i9.MatrixService get activeService => (super.noSuchMethod(
+  _i10.MatrixService get activeService => (super.noSuchMethod(
         Invocation.getter(#activeService),
-        returnValue: _FakeMatrixService_7(
+        returnValue: _FakeMatrixService_8(
           this,
           Invocation.getter(#activeService),
         ),
-        returnValueForMissingStub: _FakeMatrixService_7(
+        returnValueForMissingStub: _FakeMatrixService_8(
           this,
           Invocation.getter(#activeService),
         ),
-      ) as _i9.MatrixService);
+      ) as _i10.MatrixService);
 
   @override
   bool get hasMultipleAccounts => (super.noSuchMethod(
@@ -1379,14 +1414,14 @@ class MockClientManager extends _i1.Mock implements _i19.ClientManager {
       ) as bool);
 
   @override
-  _i12.Future<void> init() => (super.noSuchMethod(
+  _i13.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void setActiveAccount(int? index) => super.noSuchMethod(
@@ -1398,12 +1433,12 @@ class MockClientManager extends _i1.Mock implements _i19.ClientManager {
       );
 
   @override
-  _i12.Future<_i9.MatrixService> createLoginService() => (super.noSuchMethod(
+  _i13.Future<_i10.MatrixService> createLoginService() => (super.noSuchMethod(
         Invocation.method(
           #createLoginService,
           [],
         ),
-        returnValue: _i12.Future<_i9.MatrixService>.value(_FakeMatrixService_7(
+        returnValue: _i13.Future<_i10.MatrixService>.value(_FakeMatrixService_8(
           this,
           Invocation.method(
             #createLoginService,
@@ -1411,14 +1446,14 @@ class MockClientManager extends _i1.Mock implements _i19.ClientManager {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i9.MatrixService>.value(_FakeMatrixService_7(
+            _i13.Future<_i10.MatrixService>.value(_FakeMatrixService_8(
           this,
           Invocation.method(
             #createLoginService,
             [],
           ),
         )),
-      ) as _i12.Future<_i9.MatrixService>);
+      ) as _i13.Future<_i10.MatrixService>);
 
   @override
   void commitPendingService() => super.noSuchMethod(
@@ -1439,36 +1474,36 @@ class MockClientManager extends _i1.Mock implements _i19.ClientManager {
       );
 
   @override
-  _i12.Future<void> addService(_i9.MatrixService? service) =>
+  _i13.Future<void> addService(_i10.MatrixService? service) =>
       (super.noSuchMethod(
         Invocation.method(
           #addService,
           [service],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> signOut(_i9.MatrixService? service) => (super.noSuchMethod(
+  _i13.Future<void> signOut(_i10.MatrixService? service) => (super.noSuchMethod(
         Invocation.method(
           #signOut,
           [service],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> removeService(_i9.MatrixService? service) =>
+  _i13.Future<void> removeService(_i10.MatrixService? service) =>
       (super.noSuchMethod(
         Invocation.method(
           #removeService,
           [service],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -1480,7 +1515,7 @@ class MockClientManager extends _i1.Mock implements _i19.ClientManager {
       );
 
   @override
-  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1489,7 +1524,7 @@ class MockClientManager extends _i1.Mock implements _i19.ClientManager {
       );
 
   @override
-  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1510,27 +1545,27 @@ class MockClientManager extends _i1.Mock implements _i19.ClientManager {
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockClient extends _i1.Mock implements _i3.Client {
+class MockClient extends _i1.Mock implements _i4.Client {
   @override
-  _i3.DatabaseApi get database => (super.noSuchMethod(
+  _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_8(
+        returnValue: _FakeDatabaseApi_9(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_8(
+        returnValueForMissingStub: _FakeDatabaseApi_9(
           this,
           Invocation.getter(#database),
         ),
-      ) as _i3.DatabaseApi);
+      ) as _i4.DatabaseApi);
 
   @override
-  Set<_i20.KeyVerificationMethod> get verificationMethods =>
+  Set<_i21.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i20.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
-      ) as Set<_i20.KeyVerificationMethod>);
+        returnValue: <_i21.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i21.KeyVerificationMethod>{},
+      ) as Set<_i21.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1575,44 +1610,44 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  _i3.ShareKeysWith get shareKeysWith => (super.noSuchMethod(
+  _i4.ShareKeysWith get shareKeysWith => (super.noSuchMethod(
         Invocation.getter(#shareKeysWith),
-        returnValue: _i3.ShareKeysWith.all,
-        returnValueForMissingStub: _i3.ShareKeysWith.all,
-      ) as _i3.ShareKeysWith);
+        returnValue: _i4.ShareKeysWith.all,
+        returnValueForMissingStub: _i4.ShareKeysWith.all,
+      ) as _i4.ShareKeysWith);
 
   @override
-  Map<String, _i3.CommandExecutionCallback> get commands => (super.noSuchMethod(
+  Map<String, _i4.CommandExecutionCallback> get commands => (super.noSuchMethod(
         Invocation.getter(#commands),
-        returnValue: <String, _i3.CommandExecutionCallback>{},
-        returnValueForMissingStub: <String, _i3.CommandExecutionCallback>{},
-      ) as Map<String, _i3.CommandExecutionCallback>);
+        returnValue: <String, _i4.CommandExecutionCallback>{},
+        returnValueForMissingStub: <String, _i4.CommandExecutionCallback>{},
+      ) as Map<String, _i4.CommandExecutionCallback>);
 
   @override
-  _i3.Filter get syncFilter => (super.noSuchMethod(
+  _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_9(
+        returnValue: _FakeFilter_10(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_9(
+        returnValueForMissingStub: _FakeFilter_10(
           this,
           Invocation.getter(#syncFilter),
         ),
-      ) as _i3.Filter);
+      ) as _i4.Filter);
 
   @override
-  _i3.NativeImplementations get nativeImplementations => (super.noSuchMethod(
+  _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_10(
+        returnValue: _FakeNativeImplementations_11(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_10(
+        returnValueForMissingStub: _FakeNativeImplementations_11(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-      ) as _i3.NativeImplementations);
+      ) as _i4.NativeImplementations);
 
   @override
   bool get convertLinebreaksInFormatting => (super.noSuchMethod(
@@ -1624,11 +1659,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_11(
+        returnValue: _FakeDuration_12(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_11(
+        returnValueForMissingStub: _FakeDuration_12(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -1637,11 +1672,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_11(
+        returnValue: _FakeDuration_12(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_11(
+        returnValueForMissingStub: _FakeDuration_12(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -1650,36 +1685,36 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
       ) as String);
 
   @override
-  _i3.LoginState get loginState => (super.noSuchMethod(
+  _i4.LoginState get loginState => (super.noSuchMethod(
         Invocation.getter(#loginState),
-        returnValue: _i3.LoginState.loggedIn,
-        returnValueForMissingStub: _i3.LoginState.loggedIn,
-      ) as _i3.LoginState);
+        returnValue: _i4.LoginState.loggedIn,
+        returnValueForMissingStub: _i4.LoginState.loggedIn,
+      ) as _i4.LoginState);
 
   @override
-  List<_i3.Room> get rooms => (super.noSuchMethod(
+  List<_i4.Room> get rooms => (super.noSuchMethod(
         Invocation.getter(#rooms),
-        returnValue: <_i3.Room>[],
-        returnValueForMissingStub: <_i3.Room>[],
-      ) as List<_i3.Room>);
+        returnValue: <_i4.Room>[],
+        returnValueForMissingStub: <_i4.Room>[],
+      ) as List<_i4.Room>);
 
   @override
-  List<_i3.ArchivedRoom> get archivedRooms => (super.noSuchMethod(
+  List<_i4.ArchivedRoom> get archivedRooms => (super.noSuchMethod(
         Invocation.getter(#archivedRooms),
-        returnValue: <_i3.ArchivedRoom>[],
-        returnValueForMissingStub: <_i3.ArchivedRoom>[],
-      ) as List<_i3.ArchivedRoom>);
+        returnValue: <_i4.ArchivedRoom>[],
+        returnValueForMissingStub: <_i4.ArchivedRoom>[],
+      ) as List<_i4.ArchivedRoom>);
 
   @override
   bool get enableDehydratedDevices => (super.noSuchMethod(
@@ -1691,11 +1726,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1725,11 +1760,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1738,11 +1773,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1756,31 +1791,31 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  Map<String, _i3.BasicEvent> get accountData => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get accountData => (super.noSuchMethod(
         Invocation.getter(#accountData),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  _i3.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
+  _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_12(
+        returnValue: _FakePushruleEvaluator_13(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_12(
+        returnValueForMissingStub: _FakePushruleEvaluator_13(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-      ) as _i3.PushruleEvaluator);
+      ) as _i4.PushruleEvaluator);
 
   @override
-  Map<String, _i3.CachedPresence> get presences => (super.noSuchMethod(
+  Map<String, _i4.CachedPresence> get presences => (super.noSuchMethod(
         Invocation.getter(#presences),
-        returnValue: <String, _i3.CachedPresence>{},
-        returnValueForMissingStub: <String, _i3.CachedPresence>{},
-      ) as Map<String, _i3.CachedPresence>);
+        returnValue: <String, _i4.CachedPresence>{},
+        returnValueForMissingStub: <String, _i4.CachedPresence>{},
+      ) as Map<String, _i4.CachedPresence>);
 
   @override
   Map<String, List<String>> get directChats => (super.noSuchMethod(
@@ -1790,333 +1825,333 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i12.Future<_i3.Profile> get ownProfile => (super.noSuchMethod(
+  _i13.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i12.Future<_i3.Profile>.value(_FakeProfile_13(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.Profile>.value(_FakeProfile_13(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i12.Future<_i3.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i10.CachedStreamController<String> get onUserProfileUpdate =>
+  _i11.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_14<String>(
+        returnValue: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i12.Future<List<_i3.Room>> get archive => (super.noSuchMethod(
+  _i13.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i12.Future<List<_i3.Room>>.value(<_i3.Room>[]),
+        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i3.Room>>.value(<_i3.Room>[]),
-      ) as _i12.Future<List<_i3.Room>>);
+            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i13.Future<List<_i4.Room>>);
 
   @override
-  _i10.CachedStreamController<_i3.EventUpdate> get onEvent =>
+  _i11.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_14<_i3.EventUpdate>(
+        returnValue: _FakeCachedStreamController_15<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i3.EventUpdate>(
+            _FakeCachedStreamController_15<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i10.CachedStreamController<_i3.EventUpdate>);
+      ) as _i11.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i10.CachedStreamController<_i3.Event> get onTimelineEvent =>
+  _i11.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_14<_i3.Event>(
+        returnValue: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i10.CachedStreamController<_i3.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i3.Event> get onHistoryEvent =>
+  _i11.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_14<_i3.Event>(
+        returnValue: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i10.CachedStreamController<_i3.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i3.Event> get onNotification =>
+  _i11.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_14<_i3.Event>(
+        returnValue: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i10.CachedStreamController<_i3.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i3.ToDeviceEvent> get onToDeviceEvent =>
+  _i11.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_14<_i3.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_15<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i3.ToDeviceEvent>(
+            _FakeCachedStreamController_15<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i10.CachedStreamController<_i3.ToDeviceEvent>);
+      ) as _i11.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i10.CachedStreamController<List<_i3.BasicEventWithSender>>
+  _i11.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_14<List<_i3.BasicEventWithSender>>(
+                _FakeCachedStreamController_15<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_14<List<_i3.BasicEventWithSender>>(
+                _FakeCachedStreamController_15<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i10.CachedStreamController<List<_i3.BasicEventWithSender>>);
+          ) as _i11.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i10.CachedStreamController<_i3.LoginState> get onLoginStateChanged =>
+  _i11.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_14<_i3.LoginState>(
+        returnValue: _FakeCachedStreamController_15<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i3.LoginState>(
+            _FakeCachedStreamController_15<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i10.CachedStreamController<_i3.LoginState>);
+      ) as _i11.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i10.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i11.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_14<bool>(
+        returnValue: _FakeCachedStreamController_15<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i10.CachedStreamController<bool>);
+      ) as _i11.CachedStreamController<bool>);
 
   @override
-  _i10.CachedStreamController<_i3.SdkError> get onEncryptionError =>
+  _i11.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_14<_i3.SdkError>(
+        returnValue: _FakeCachedStreamController_15<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<_i3.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i10.CachedStreamController<_i3.SdkError>);
+      ) as _i11.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i10.CachedStreamController<_i3.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i11.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_14<_i3.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_15<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i3.SyncUpdate>(
+            _FakeCachedStreamController_15<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i10.CachedStreamController<_i3.SyncUpdate>);
+      ) as _i11.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i10.CachedStreamController<_i3.SyncStatusUpdate> get onSyncStatus =>
+  _i11.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_14<_i3.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_15<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i3.SyncStatusUpdate>(
+            _FakeCachedStreamController_15<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i10.CachedStreamController<_i3.SyncStatusUpdate>);
+      ) as _i11.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i10.CachedStreamController<_i3.Presence> get onPresence =>
+  _i11.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_14<_i3.Presence>(
+        returnValue: _FakeCachedStreamController_15<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<_i3.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i10.CachedStreamController<_i3.Presence>);
+      ) as _i11.CachedStreamController<_i4.Presence>);
 
   @override
-  _i10.CachedStreamController<_i3.CachedPresence> get onPresenceChanged =>
+  _i11.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_14<_i3.CachedPresence>(
+        returnValue: _FakeCachedStreamController_15<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i3.CachedPresence>(
+            _FakeCachedStreamController_15<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i10.CachedStreamController<_i3.CachedPresence>);
+      ) as _i11.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i10.CachedStreamController<_i3.BasicEvent> get onAccountData =>
+  _i11.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_14<_i3.BasicEvent>(
+        returnValue: _FakeCachedStreamController_15<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i3.BasicEvent>(
+            _FakeCachedStreamController_15<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i10.CachedStreamController<_i3.BasicEvent>);
+      ) as _i11.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i10.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
+  _i11.CachedStreamController<_i21.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_14<_i20.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_15<_i21.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i20.RoomKeyRequest>(
+            _FakeCachedStreamController_15<_i21.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i10.CachedStreamController<_i20.RoomKeyRequest>);
+      ) as _i11.CachedStreamController<_i21.RoomKeyRequest>);
 
   @override
-  _i10.CachedStreamController<_i20.KeyVerification>
+  _i11.CachedStreamController<_i21.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_14<_i20.KeyVerification>(
+            returnValue: _FakeCachedStreamController_15<_i21.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_14<_i20.KeyVerification>(
+                _FakeCachedStreamController_15<_i21.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i10.CachedStreamController<_i20.KeyVerification>);
+          ) as _i11.CachedStreamController<_i21.KeyVerification>);
 
   @override
-  _i10.CachedStreamController<_i3.UiaRequest<dynamic>> get onUiaRequest =>
+  _i11.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_14<_i3.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_15<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i3.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_15<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i10.CachedStreamController<_i3.UiaRequest<dynamic>>);
+      ) as _i11.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i10.CachedStreamController<_i3.Event> get onGroupMember =>
+  _i11.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_14<_i3.Event>(
+        returnValue: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i10.CachedStreamController<_i3.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<String> get onCancelSendEvent =>
+  _i11.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_14<String>(
+        returnValue: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i10.CachedStreamController<({String roomId, _i3.StrippedStateEvent state})>
+  _i11.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_14<
-                ({String roomId, _i3.StrippedStateEvent state})>(
+            returnValue: _FakeCachedStreamController_15<
+                ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_14<
-                ({String roomId, _i3.StrippedStateEvent state})>(
+            returnValueForMissingStub: _FakeCachedStreamController_15<
+                ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i10.CachedStreamController<
-              ({String roomId, _i3.StrippedStateEvent state})>);
+          ) as _i11.CachedStreamController<
+              ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
   int get syncErrorTimeoutSec => (super.noSuchMethod(
@@ -2135,11 +2170,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_15(
+        returnValue: _FakeDateTime_16(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_15(
+        returnValueForMissingStub: _FakeDateTime_16(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2160,33 +2195,33 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  _i3.RoomSorter get sortRoomsBy => (super.noSuchMethod(
+  _i4.RoomSorter get sortRoomsBy => (super.noSuchMethod(
         Invocation.getter(#sortRoomsBy),
         returnValue: (
-          _i3.Room a,
-          _i3.Room b,
+          _i4.Room a,
+          _i4.Room b,
         ) =>
             0,
         returnValueForMissingStub: (
-          _i3.Room a,
-          _i3.Room b,
+          _i4.Room a,
+          _i4.Room b,
         ) =>
             0,
-      ) as _i3.RoomSorter);
+      ) as _i4.RoomSorter);
 
   @override
-  Map<String, _i3.DeviceKeysList> get userDeviceKeys => (super.noSuchMethod(
+  Map<String, _i4.DeviceKeysList> get userDeviceKeys => (super.noSuchMethod(
         Invocation.getter(#userDeviceKeys),
-        returnValue: <String, _i3.DeviceKeysList>{},
-        returnValueForMissingStub: <String, _i3.DeviceKeysList>{},
-      ) as Map<String, _i3.DeviceKeysList>);
+        returnValue: <String, _i4.DeviceKeysList>{},
+        returnValueForMissingStub: <String, _i4.DeviceKeysList>{},
+      ) as Map<String, _i4.DeviceKeysList>);
 
   @override
-  List<_i3.DeviceKeys> get unverifiedDevices => (super.noSuchMethod(
+  List<_i4.DeviceKeys> get unverifiedDevices => (super.noSuchMethod(
         Invocation.getter(#unverifiedDevices),
-        returnValue: <_i3.DeviceKeys>[],
-        returnValueForMissingStub: <_i3.DeviceKeys>[],
-      ) as List<_i3.DeviceKeys>);
+        returnValue: <_i4.DeviceKeys>[],
+        returnValueForMissingStub: <_i4.DeviceKeys>[],
+      ) as List<_i4.DeviceKeys>);
 
   @override
   bool get allPushNotificationsMuted => (super.noSuchMethod(
@@ -2203,7 +2238,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as List<String>);
 
   @override
-  set database(_i3.DatabaseApi? db) => super.noSuchMethod(
+  set database(_i4.DatabaseApi? db) => super.noSuchMethod(
         Invocation.setter(
           #database,
           db,
@@ -2212,7 +2247,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i21.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2258,7 +2293,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set shareKeysWith(_i3.ShareKeysWith? value) => super.noSuchMethod(
+  set shareKeysWith(_i4.ShareKeysWith? value) => super.noSuchMethod(
         Invocation.setter(
           #shareKeysWith,
           value,
@@ -2267,7 +2302,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set onSoftLogout(_i12.Future<void> Function(_i3.Client)? value) =>
+  set onSoftLogout(_i13.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2278,8 +2313,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
 
   @override
   set customImageResizer(
-          _i12.Future<_i3.MatrixImageFileResizedResponse?> Function(
-                  _i3.MatrixImageFileResizeArguments)?
+          _i13.Future<_i4.MatrixImageFileResizedResponse?> Function(
+                  _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
         Invocation.setter(
@@ -2317,7 +2352,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set rooms(List<_i3.Room>? newList) => super.noSuchMethod(
+  set rooms(List<_i4.Room>? newList) => super.noSuchMethod(
         Invocation.setter(
           #rooms,
           newList,
@@ -2326,7 +2361,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set presences(Map<String, _i3.CachedPresence>? value) => super.noSuchMethod(
+  set presences(Map<String, _i4.CachedPresence>? value) => super.noSuchMethod(
         Invocation.setter(
           #presences,
           value,
@@ -2353,7 +2388,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set syncPresence(_i3.PresenceType? value) => super.noSuchMethod(
+  set syncPresence(_i4.PresenceType? value) => super.noSuchMethod(
         Invocation.setter(
           #syncPresence,
           value,
@@ -2389,7 +2424,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2398,7 +2433,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set roomsLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2407,7 +2442,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set firstSyncReceived(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -2434,20 +2469,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Client get httpClient => (super.noSuchMethod(
+  _i12.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_16(
+        returnValue: _FakeClient_17(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_16(
+        returnValueForMissingStub: _FakeClient_17(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i11.Client);
+      ) as _i12.Client);
 
   @override
-  set httpClient(_i11.Client? value) => super.noSuchMethod(
+  set httpClient(_i12.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -2474,7 +2509,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i12.Future<void> refreshAccessToken(
+  _i13.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2482,9 +2517,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -2502,14 +2537,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2519,22 +2554,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as String);
 
   @override
-  _i3.Room? getRoomByAlias(String? alias) => (super.noSuchMethod(
+  _i4.Room? getRoomByAlias(String? alias) => (super.noSuchMethod(
         Invocation.method(
           #getRoomByAlias,
           [alias],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.Room?);
+      ) as _i4.Room?);
 
   @override
-  _i3.Room? getRoomById(String? id) => (super.noSuchMethod(
+  _i4.Room? getRoomById(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getRoomById,
           [id],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.Room?);
+      ) as _i4.Room?);
 
   @override
   String? getDirectChatFromUserId(String? userId) => (super.noSuchMethod(
@@ -2546,38 +2581,38 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as String?);
 
   @override
-  _i12.Future<_i3.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i13.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i12.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_17(
+        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_18(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_17(
+        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_18(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i12.Future<_i3.DiscoveryInformation>);
+      ) as _i13.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i12.Future<
+  _i13.Future<
       (
-        _i3.DiscoveryInformation?,
-        _i3.GetVersionsResponse,
-        List<_i3.LoginFlow>,
-        _i3.GetAuthMetadataResponse?
+        _i4.DiscoveryInformation?,
+        _i4.GetVersionsResponse,
+        List<_i4.LoginFlow>,
+        _i4.GetAuthMetadataResponse?
       )> checkHomeserver(
     Uri? homeserverUrl, {
     bool? checkWellKnown = true,
@@ -2594,15 +2629,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i12.Future<
+        returnValue: _i13.Future<
             (
-              _i3.DiscoveryInformation?,
-              _i3.GetVersionsResponse,
-              List<_i3.LoginFlow>,
-              _i3.GetAuthMetadataResponse?
+              _i4.DiscoveryInformation?,
+              _i4.GetVersionsResponse,
+              List<_i4.LoginFlow>,
+              _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_18(
+          _FakeGetVersionsResponse_19(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2614,18 +2649,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
           ),
-          <_i3.LoginFlow>[],
+          <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i12.Future<
+        returnValueForMissingStub: _i13.Future<
             (
-              _i3.DiscoveryInformation?,
-              _i3.GetVersionsResponse,
-              List<_i3.LoginFlow>,
-              _i3.GetAuthMetadataResponse?
+              _i4.DiscoveryInformation?,
+              _i4.GetVersionsResponse,
+              List<_i4.LoginFlow>,
+              _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_18(
+          _FakeGetVersionsResponse_19(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2637,19 +2672,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
           ),
-          <_i3.LoginFlow>[],
+          <_i4.LoginFlow>[],
           null
         )),
-      ) as _i12.Future<
+      ) as _i13.Future<
           (
-            _i3.DiscoveryInformation?,
-            _i3.GetVersionsResponse,
-            List<_i3.LoginFlow>,
-            _i3.GetAuthMetadataResponse?
+            _i4.DiscoveryInformation?,
+            _i4.GetVersionsResponse,
+            List<_i4.LoginFlow>,
+            _i4.GetAuthMetadataResponse?
           )>);
 
   @override
-  _i12.Future<_i3.DiscoveryInformation> getWellknown({
+  _i13.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2662,8 +2697,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_17(
+        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_18(
           this,
           Invocation.method(
             #getWellknown,
@@ -2674,8 +2709,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_17(
+        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_18(
           this,
           Invocation.method(
             #getWellknown,
@@ -2686,19 +2721,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.DiscoveryInformation>);
+      ) as _i13.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i12.Future<_i3.RegisterResponse> register({
+  _i13.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
     String? initialDeviceDisplayName,
     bool? inhibitLogin,
     bool? refreshToken,
-    _i3.AuthenticationData? auth,
-    _i3.AccountKind? kind,
-    void Function(_i3.InitState)? onInitStateChanged,
+    _i4.AuthenticationData? auth,
+    _i4.AccountKind? kind,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2717,7 +2752,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i12.Future<_i3.RegisterResponse>.value(_FakeRegisterResponse_19(
+            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_20(
           this,
           Invocation.method(
             #register,
@@ -2736,7 +2771,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RegisterResponse>.value(_FakeRegisterResponse_19(
+            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_20(
           this,
           Invocation.method(
             #register,
@@ -2754,12 +2789,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.RegisterResponse>);
+      ) as _i13.Future<_i4.RegisterResponse>);
 
   @override
-  _i12.Future<_i3.LoginResponse> login(
+  _i13.Future<_i4.LoginResponse> login(
     String? type, {
-    _i3.AuthenticationIdentifier? identifier,
+    _i4.AuthenticationIdentifier? identifier,
     String? password,
     String? token,
     String? deviceId,
@@ -2768,7 +2803,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? user,
     String? medium,
     String? address,
-    void Function(_i3.InitState)? onInitStateChanged,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2787,7 +2822,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i12.Future<_i3.LoginResponse>.value(_FakeLoginResponse_20(
+        returnValue: _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_21(
           this,
           Invocation.method(
             #login,
@@ -2807,7 +2842,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.LoginResponse>.value(_FakeLoginResponse_20(
+            _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_21(
           this,
           Invocation.method(
             #login,
@@ -2826,10 +2861,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.LoginResponse>);
+      ) as _i13.Future<_i4.LoginResponse>);
 
   @override
-  _i12.Future<_i3.GetAuthMetadataResponse> getAuthMetadata({
+  _i13.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2842,8 +2877,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i3.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_21(
+        returnValue: _i13.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_22(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2855,8 +2890,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_21(
+            _i13.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_22(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2867,80 +2902,80 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.GetAuthMetadataResponse>);
+      ) as _i13.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> logoutAll() => (super.noSuchMethod(
+  _i13.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<T> uiaRequestBackground<T>(
-          _i12.Future<T> Function(_i3.AuthenticationData?)? request) =>
+  _i13.Future<T> uiaRequestBackground<T>(
+          _i13.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i12.Future<T>.value(v),
+              (T v) => _i13.Future<T>.value(v),
             ) ??
-            _FakeFuture_22<T>(
+            _FakeFuture_23<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i12.Future<T>.value(v),
+              (T v) => _i13.Future<T>.value(v),
             ) ??
-            _FakeFuture_22<T>(
+            _FakeFuture_23<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i12.Future<T>);
+      ) as _i13.Future<T>);
 
   @override
-  _i12.Future<String> startDirectChat(
+  _i13.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
-    List<_i3.StateEvent>? initialState,
+    List<_i4.StateEvent>? initialState,
     bool? waitForSync = true,
     Map<String, dynamic>? powerLevelContentOverride,
-    _i3.CreateRoomPreset? preset = _i3.CreateRoomPreset.trustedPrivateChat,
+    _i4.CreateRoomPreset? preset = _i4.CreateRoomPreset.trustedPrivateChat,
     bool? skipExistingChat = false,
   }) =>
       (super.noSuchMethod(
@@ -2956,7 +2991,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2972,7 +3007,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2987,17 +3022,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<String> createGroupChat({
+  _i13.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
-    _i3.CreateRoomPreset? preset = _i3.CreateRoomPreset.privateChat,
-    List<_i3.StateEvent>? initialState,
-    _i3.Visibility? visibility,
-    _i3.HistoryVisibility? historyVisibility,
+    _i4.CreateRoomPreset? preset = _i4.CreateRoomPreset.privateChat,
+    List<_i4.StateEvent>? initialState,
+    _i4.Visibility? visibility,
+    _i4.HistoryVisibility? historyVisibility,
     bool? waitForSync = true,
     bool? groupCall = false,
     bool? federated = true,
@@ -3021,7 +3056,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3042,7 +3077,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3062,10 +3097,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i3.SyncUpdate> waitForRoomInSync(
+  _i13.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -3081,7 +3116,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i12.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_23(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3094,7 +3129,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_23(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3106,27 +3141,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i13.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<String> createSpace({
+  _i13.Future<String> createSpace({
     String? name,
     String? topic,
-    _i3.Visibility? visibility = _i3.Visibility.public,
+    _i4.Visibility? visibility = _i4.Visibility.public,
     String? spaceAliasName,
     List<String>? invite,
-    List<_i3.Invite3pid>? invite3pid,
+    List<_i4.Invite3pid>? invite3pid,
     String? roomVersion,
     bool? waitForSync = false,
   }) =>
@@ -3145,7 +3180,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3163,7 +3198,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3180,10 +3215,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i3.Profile> fetchOwnProfileFromServer(
+  _i13.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3191,7 +3226,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i12.Future<_i3.Profile>.value(_FakeProfile_13(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3200,7 +3235,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.Profile>.value(_FakeProfile_13(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3208,10 +3243,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i12.Future<_i3.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i12.Future<_i3.Profile> fetchOwnProfile({
+  _i13.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3224,7 +3259,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i12.Future<_i3.Profile>.value(_FakeProfile_13(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3236,7 +3271,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.Profile>.value(_FakeProfile_13(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3247,10 +3282,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i12.Future<_i3.CachedProfileInformation> getUserProfile(
+  _i13.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3264,8 +3299,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i12.Future<_i3.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_24(
+        returnValue: _i13.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_25(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3277,8 +3312,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_24(
+            _i13.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_25(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3289,10 +3324,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.CachedProfileInformation>);
+      ) as _i13.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i12.Future<_i3.Profile> getProfileFromUserId(
+  _i13.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3310,7 +3345,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i12.Future<_i3.Profile>.value(_FakeProfile_13(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3324,7 +3359,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.Profile>.value(_FakeProfile_13(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3337,17 +3372,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i3.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
+  _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getArchiveRoomFromCache,
           [roomId],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.ArchivedRoom?);
+      ) as _i4.ArchivedRoom?);
 
   @override
   void clearArchivesFromCache() => super.noSuchMethod(
@@ -3359,31 +3394,31 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i12.Future<List<_i3.Room>> loadArchive() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i12.Future<List<_i3.Room>>.value(<_i3.Room>[]),
+        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i3.Room>>.value(<_i3.Room>[]),
-      ) as _i12.Future<List<_i3.Room>>);
+            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i13.Future<List<_i4.Room>>);
 
   @override
-  _i12.Future<List<_i3.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i13.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i12.Future<List<_i3.ArchivedRoom>>.value(<_i3.ArchivedRoom>[]),
+            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i3.ArchivedRoom>>.value(<_i3.ArchivedRoom>[]),
-      ) as _i12.Future<List<_i3.ArchivedRoom>>);
+            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i13.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i12.Future<_i3.GetVersionsResponse> getVersions({
+  _i13.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3396,8 +3431,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i3.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_18(
+        returnValue: _i13.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_19(
           this,
           Invocation.method(
             #getVersions,
@@ -3408,8 +3443,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_18(
+        returnValueForMissingStub: _i13.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_19(
           this,
           Invocation.method(
             #getVersions,
@@ -3420,20 +3455,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.GetVersionsResponse>);
+      ) as _i13.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i12.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i13.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<_i3.MediaConfig> getConfig({
+  _i13.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3446,7 +3481,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i3.MediaConfig>.value(_FakeMediaConfig_25(
+        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
           this,
           Invocation.method(
             #getConfig,
@@ -3458,7 +3493,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.MediaConfig>.value(_FakeMediaConfig_25(
+            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
           this,
           Invocation.method(
             #getConfig,
@@ -3469,10 +3504,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.MediaConfig>);
+      ) as _i13.Future<_i4.MediaConfig>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContent(
+  _i13.Future<_i14.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -3492,7 +3527,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContent,
@@ -3508,7 +3543,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContent,
@@ -3523,10 +3558,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentOverrideName(
+  _i13.Future<_i14.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -3548,7 +3583,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3565,7 +3600,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3581,15 +3616,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentThumbnail(
+  _i13.Future<_i14.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
     int? height, {
-    _i3.Method? method,
+    _i4.Method? method,
     bool? allowRemote,
     int? timeoutMs,
     bool? allowRedirect,
@@ -3612,7 +3647,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3632,7 +3667,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3651,10 +3686,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i3.PreviewForUrl> getUrlPreview(
+  _i13.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -3664,7 +3699,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i12.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_27(
+        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3673,7 +3708,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_27(
+            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3681,11 +3716,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i12.Future<_i3.PreviewForUrl>);
+      ) as _i13.Future<_i4.PreviewForUrl>);
 
   @override
-  _i12.Future<Uri> uploadContent(
-    _i21.Uint8List? file, {
+  _i13.Future<Uri> uploadContent(
+    _i22.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3698,7 +3733,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i12.Future<Uri>.value(_FakeUri_28(
+        returnValue: _i13.Future<Uri>.value(_FakeUri_29(
           this,
           Invocation.method(
             #uploadContent,
@@ -3709,7 +3744,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_28(
+        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_29(
           this,
           Invocation.method(
             #uploadContent,
@@ -3720,10 +3755,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<Uri>);
+      ) as _i13.Future<Uri>);
 
   @override
-  _i12.Future<void> setTyping(
+  _i13.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -3739,43 +3774,43 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> exportDump() => (super.noSuchMethod(
+  _i13.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i13.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> setAvatar(_i3.MatrixFile? file) => (super.noSuchMethod(
+  _i13.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.Event?> getEventByPushNotification(
-    _i3.PushNotification? notification, {
+  _i13.Future<_i4.Event?> getEventByPushNotification(
+    _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
     bool? returnNullIfSeen = true,
@@ -3790,12 +3825,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i12.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i3.Event?>.value(),
-      ) as _i12.Future<_i3.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
-  _i12.Future<void> init({
+  _i13.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -3808,7 +3843,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     bool? waitForFirstSync = true,
     bool? waitUntilLoadCompletedLoaded = true,
     void Function()? onMigration,
-    void Function(_i3.InitState)? onInitStateChanged,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3830,9 +3865,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -3844,42 +3879,42 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i12.Future<void> clear() => (super.noSuchMethod(
+  _i13.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i13.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ensureNotSoftLoggedOut(
+  _i13.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleSync(
-    _i3.SyncUpdate? sync, {
-    _i3.Direction? direction,
+  _i13.Future<void> handleSync(
+    _i4.SyncUpdate? sync, {
+    _i4.Direction? direction,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3887,44 +3922,44 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i3.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
+  _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeysByCurve25519Key,
           [senderKey],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.DeviceKeys?);
+      ) as _i4.DeviceKeys?);
 
   @override
-  _i12.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i13.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i13.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDevice(
+  _i13.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -3938,12 +3973,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             messages,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDevicesOfUserIds(
+  _i13.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -3959,13 +3994,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDeviceEncrypted(
-    List<_i3.DeviceKeys>? deviceKeys,
+  _i13.Future<void> sendToDeviceEncrypted(
+    List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
     String? messageId,
@@ -3984,13 +4019,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDeviceEncryptedChunked(
-    List<_i3.DeviceKeys>? deviceKeys,
+  _i13.Future<void> sendToDeviceEncryptedChunked(
+    List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
   ) =>
@@ -4003,28 +4038,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
             message,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i13.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> joinRoom(
+  _i13.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
     String? reason,
-    _i3.ThirdPartySigned? thirdPartySigned,
+    _i4.ThirdPartySigned? thirdPartySigned,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4037,7 +4072,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4051,7 +4086,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4064,13 +4099,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> changePassword(
+  _i13.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
     bool? logoutDevices,
   }) =>
       (super.noSuchMethod(
@@ -4083,22 +4118,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> clearCache() => (super.noSuchMethod(
+  _i13.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ignoreUser(
+  _i13.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4108,22 +4143,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i13.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.CachedPresence> fetchCurrentPresence(
+  _i13.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4134,7 +4169,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i12.Future<_i3.CachedPresence>.value(_FakeCachedPresence_29(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_30(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4143,7 +4178,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.CachedPresence>.value(_FakeCachedPresence_29(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_30(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4151,32 +4186,32 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i12.Future<_i3.CachedPresence>);
+      ) as _i13.Future<_i4.CachedPresence>);
 
   @override
-  _i12.Future<void> abortSync() => (super.noSuchMethod(
+  _i13.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i13.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEventWithMetadata(
+  _i13.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4196,14 +4231,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i11.BaseResponse? response,
-    _i21.Uint8List? body,
+    _i12.BaseResponse? response,
+    _i22.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4235,8 +4270,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as Never);
 
   @override
-  _i12.Future<Map<String, Object?>> request(
-    _i3.RequestType? type,
+  _i13.Future<Map<String, Object?>> request(
+    _i4.RequestType? type,
     String? action, {
     dynamic data = '',
     String? contentType = 'application/json',
@@ -4256,14 +4291,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> postPusher(
-    _i3.Pusher? pusher, {
+  _i13.Future<void> postPusher(
+    _i4.Pusher? pusher, {
     bool? append,
   }) =>
       (super.noSuchMethod(
@@ -4272,57 +4307,57 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deletePusher(_i3.PusherId? pusher) => (super.noSuchMethod(
+  _i13.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i13.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i13.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i12.Future<_i3.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_30(
+        returnValue: _i13.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_31(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_30(
+        returnValueForMissingStub: _i13.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_31(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i12.Future<_i3.TurnServerCredentials>);
+      ) as _i13.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i12.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4336,8 +4371,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4349,8 +4384,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4361,14 +4396,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i3.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
-    _i3.KeyBackupData? data,
+    _i4.KeyBackupData? data,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4380,8 +4415,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             data,
           ],
         ),
-        returnValue: _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4394,8 +4429,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4407,10 +4442,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i3.KeyBackupData> getRoomKeysBySessionId(
+  _i13.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4424,7 +4459,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_32(
+        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4436,7 +4471,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_32(
+            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4447,17 +4482,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.KeyBackupData>);
+      ) as _i13.Future<_i4.KeyBackupData>);
 
   @override
-  _i12.Future<_i3.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i13.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i12.Future<_i3.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_33(
+        returnValue: _i13.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_34(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -4465,18 +4500,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_33(
+            _i13.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_34(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i12.Future<_i3.GetWellknownSupportResponse>);
+      ) as _i13.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i12.Future<int> pingAppservice(
+  _i13.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -4486,21 +4521,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i12.Future<int>.value(0),
-        returnValueForMissingStub: _i12.Future<int>.value(0),
-      ) as _i12.Future<int>);
+        returnValue: _i13.Future<int>.value(0),
+        returnValueForMissingStub: _i13.Future<int>.value(0),
+      ) as _i13.Future<int>);
 
   @override
-  _i12.Future<_i3.GenerateLoginTokenResponse> generateLoginToken(
-          {_i3.AuthenticationData? auth}) =>
+  _i13.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+          {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
           #generateLoginToken,
           [],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<_i3.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_34(
+        returnValue: _i13.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_35(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4509,8 +4544,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_34(
+            _i13.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_35(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4518,15 +4553,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i12.Future<_i3.GenerateLoginTokenResponse>);
+      ) as _i13.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i12.Future<_i3.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i13.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i12.Future<_i3.MediaConfig>.value(_FakeMediaConfig_25(
+        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -4534,17 +4569,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.MediaConfig>.value(_FakeMediaConfig_25(
+            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i12.Future<_i3.MediaConfig>);
+      ) as _i13.Future<_i4.MediaConfig>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentAuthed(
+  _i13.Future<_i14.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -4558,7 +4593,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4570,7 +4605,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4581,10 +4616,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentOverrideNameAuthed(
+  _i13.Future<_i14.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4600,7 +4635,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4613,7 +4648,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4625,10 +4660,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i3.PreviewForUrl> getUrlPreviewAuthed(
+  _i13.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -4638,7 +4673,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i12.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_27(
+        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4647,7 +4682,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_27(
+            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4655,15 +4690,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i12.Future<_i3.PreviewForUrl>);
+      ) as _i13.Future<_i4.PreviewForUrl>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentThumbnailAuthed(
+  _i13.Future<_i14.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
     int? height, {
-    _i3.Method? method,
+    _i4.Method? method,
     int? timeoutMs,
     bool? animated,
   }) =>
@@ -4682,7 +4717,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4700,7 +4735,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4717,21 +4752,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<bool> registrationTokenValidity(String? token) =>
+  _i13.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<_i3.GetRoomSummaryResponse$3> getRoomSummary(
+  _i13.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -4741,8 +4776,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i12.Future<_i3.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_35(
+        returnValue: _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_36(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4751,8 +4786,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_35(
+            _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_36(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4760,10 +4795,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#via: via},
           ),
         )),
-      ) as _i12.Future<_i3.GetRoomSummaryResponse$3>);
+      ) as _i13.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i12.Future<_i3.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i13.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -4781,8 +4816,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #from: from,
           },
         ),
-        returnValue: _i12.Future<_i3.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_36(
+        returnValue: _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_37(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4796,8 +4831,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_36(
+            _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_37(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4810,16 +4845,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.GetSpaceHierarchyResponse>);
+      ) as _i13.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i12.Future<_i3.GetRelatingEventsResponse> getRelatingEvents(
+  _i13.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
       (super.noSuchMethod(
@@ -4837,8 +4872,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i12.Future<_i3.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_37(
+        returnValue: _i13.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_38(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4856,8 +4891,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_37(
+            _i13.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_38(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4874,10 +4909,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.GetRelatingEventsResponse>);
+      ) as _i13.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i12.Future<_i3.GetRelatingEventsWithRelTypeResponse>
+  _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -4885,7 +4920,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
           (super.noSuchMethod(
@@ -4905,8 +4940,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
             returnValue:
-                _i12.Future<_i3.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_38(
+                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_39(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4925,8 +4960,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i12.Future<_i3.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_38(
+                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_39(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4944,10 +4979,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-          ) as _i12.Future<_i3.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i12.Future<_i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i13.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -4956,7 +4991,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
           (super.noSuchMethod(
@@ -4976,9 +5011,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i12.Future<
-                    _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39(
+            returnValue: _i13.Future<
+                    _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -4997,9 +5032,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i12.Future<
-                    _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39(
+            returnValueForMissingStub: _i13.Future<
+                    _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5018,13 +5053,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-          ) as _i12
-              .Future<_i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
+          ) as _i13
+              .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i12.Future<_i3.GetThreadRootsResponse> getThreadRoots(
+  _i13.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
-    _i3.Include? include,
+    _i4.Include? include,
     int? limit,
     String? from,
   }) =>
@@ -5038,8 +5073,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #from: from,
           },
         ),
-        returnValue: _i12.Future<_i3.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_40(
+        returnValue: _i13.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_41(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5052,8 +5087,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_40(
+            _i13.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_41(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5065,13 +5100,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.GetThreadRootsResponse>);
+      ) as _i13.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i12.Future<_i3.GetEventByTimestampResponse> getEventByTimestamp(
+  _i13.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5082,8 +5117,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             dir,
           ],
         ),
-        returnValue: _i12.Future<_i3.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_41(
+        returnValue: _i13.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_42(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5095,8 +5130,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_41(
+            _i13.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_42(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5107,36 +5142,36 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.GetEventByTimestampResponse>);
+      ) as _i13.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i12.Future<List<_i3.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i13.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i12.Future<List<_i3.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i12.Future<List<_i3.ThirdPartyIdentifier>?>.value(),
-      ) as _i12.Future<List<_i3.ThirdPartyIdentifier>?>);
+            _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i13.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i12.Future<Uri?> post3PIDs(_i3.ThreePidCredentials? threePidCreds) =>
+  _i13.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i12.Future<Uri?>.value(),
-        returnValueForMissingStub: _i12.Future<Uri?>.value(),
-      ) as _i12.Future<Uri?>);
+        returnValue: _i13.Future<Uri?>.value(),
+        returnValueForMissingStub: _i13.Future<Uri?>.value(),
+      ) as _i13.Future<Uri?>);
 
   @override
-  _i12.Future<void> add3PID(
+  _i13.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5147,12 +5182,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> bind3PID(
+  _i13.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5168,14 +5203,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             sid,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.IdServerUnbindResult> delete3pidFromAccount(
+  _i13.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
-    _i3.ThirdPartyIdentifierMedium? medium, {
+    _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
   }) =>
       (super.noSuchMethod(
@@ -5187,14 +5222,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i12.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i3.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5216,8 +5251,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5233,8 +5268,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5250,10 +5285,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i3.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5277,8 +5312,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5295,8 +5330,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5313,12 +5348,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i3.IdServerUnbindResult> unbind3pidFromAccount(
+  _i13.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
-    _i3.ThirdPartyIdentifierMedium? medium, {
+    _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
   }) =>
       (super.noSuchMethod(
@@ -5330,15 +5365,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i12.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i3.IdServerUnbindResult> deactivateAccount({
-    _i3.AuthenticationData? auth,
+  _i13.Future<_i4.IdServerUnbindResult> deactivateAccount({
+    _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
   }) =>
@@ -5352,14 +5387,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i3.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5381,8 +5416,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5398,8 +5433,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5415,10 +5450,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i3.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5442,8 +5477,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5460,8 +5495,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5478,16 +5513,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i3.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i13.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i12.Future<_i3.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_43(
+            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_44(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -5495,22 +5530,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_43(
+            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_44(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i12.Future<_i3.TokenOwnerInfo>);
+      ) as _i13.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i12.Future<_i3.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i13.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i12.Future<_i3.WhoIsInfo>.value(_FakeWhoIsInfo_44(
+        returnValue: _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_45(
           this,
           Invocation.method(
             #getWhoIs,
@@ -5518,22 +5553,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.WhoIsInfo>.value(_FakeWhoIsInfo_44(
+            _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_45(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i3.WhoIsInfo>);
+      ) as _i13.Future<_i4.WhoIsInfo>);
 
   @override
-  _i12.Future<_i3.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i13.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i12.Future<_i3.Capabilities>.value(_FakeCapabilities_45(
+        returnValue: _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_46(
           this,
           Invocation.method(
             #getCapabilities,
@@ -5541,29 +5576,29 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.Capabilities>.value(_FakeCapabilities_45(
+            _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_46(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i12.Future<_i3.Capabilities>);
+      ) as _i13.Future<_i4.Capabilities>);
 
   @override
-  _i12.Future<String> createRoom({
+  _i13.Future<String> createRoom({
     Map<String, Object?>? creationContent,
-    List<_i3.StateEvent>? initialState,
+    List<_i4.StateEvent>? initialState,
     List<String>? invite,
-    List<_i3.Invite3pid>? invite3pid,
+    List<_i4.Invite3pid>? invite3pid,
     bool? isDirect,
     String? name,
     Map<String, Object?>? powerLevelContentOverride,
-    _i3.CreateRoomPreset? preset,
+    _i4.CreateRoomPreset? preset,
     String? roomAliasName,
     String? roomVersion,
     String? topic,
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5584,7 +5619,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5606,7 +5641,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5627,12 +5662,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> deleteDevices(
+  _i13.Future<void> deleteDevices(
     List<String>? devices, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5640,24 +5675,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i3.Device>?> getDevices() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i12.Future<List<_i3.Device>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i3.Device>?>.value(),
-      ) as _i12.Future<List<_i3.Device>?>);
+        returnValue: _i13.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.Device>?>.value(),
+      ) as _i13.Future<List<_i4.Device>?>);
 
   @override
-  _i12.Future<void> deleteDevice(
+  _i13.Future<void> deleteDevice(
     String? deviceId, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5665,34 +5700,34 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i13.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i12.Future<_i3.Device>.value(_FakeDevice_46(
+        returnValue: _i13.Future<_i4.Device>.value(_FakeDevice_47(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.Device>.value(_FakeDevice_46(
+        returnValueForMissingStub: _i13.Future<_i4.Device>.value(_FakeDevice_47(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i12.Future<_i3.Device>);
+      ) as _i13.Future<_i4.Device>);
 
   @override
-  _i12.Future<void> updateDevice(
+  _i13.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -5702,15 +5737,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i13.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5722,26 +5757,26 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i3.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i13.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i12.Future<_i3.Visibility?>.value(),
-        returnValueForMissingStub: _i12.Future<_i3.Visibility?>.value(),
-      ) as _i12.Future<_i3.Visibility?>);
+        returnValue: _i13.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Visibility?>.value(),
+      ) as _i13.Future<_i4.Visibility?>);
 
   @override
-  _i12.Future<void> setRoomVisibilityOnDirectory(
+  _i13.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5749,30 +5784,30 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i13.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i13.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i12.Future<_i3.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_47(
+        returnValue: _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_48(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -5780,18 +5815,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_47(
+            _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_48(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i12.Future<_i3.GetRoomIdByAliasResponse>);
+      ) as _i13.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i12.Future<void> setRoomAlias(
+  _i13.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -5803,12 +5838,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             roomId,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.GetEventsResponse> getEvents({
+  _i13.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -5822,7 +5857,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i12.Future<_i3.GetEventsResponse>.value(_FakeGetEventsResponse_48(
+            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_49(
           this,
           Invocation.method(
             #getEvents,
@@ -5834,7 +5869,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetEventsResponse>.value(_FakeGetEventsResponse_48(
+            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_49(
           this,
           Invocation.method(
             #getEvents,
@@ -5845,10 +5880,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.GetEventsResponse>);
+      ) as _i13.Future<_i4.GetEventsResponse>);
 
   @override
-  _i12.Future<_i3.PeekEventsResponse> peekEvents({
+  _i13.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -5863,8 +5898,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i12.Future<_i3.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_49(
+        returnValue: _i13.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_50(
           this,
           Invocation.method(
             #peekEvents,
@@ -5876,8 +5911,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_49(
+        returnValueForMissingStub: _i13.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_50(
           this,
           Invocation.method(
             #peekEvents,
@@ -5889,16 +5924,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.PeekEventsResponse>);
+      ) as _i13.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i12.Future<_i3.MatrixEvent> getOneEvent(String? eventId) =>
+  _i13.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i12.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_50(
+        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
           this,
           Invocation.method(
             #getOneEvent,
@@ -5906,27 +5941,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_50(
+            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i12.Future<_i3.MatrixEvent>);
+      ) as _i13.Future<_i4.MatrixEvent>);
 
   @override
-  _i12.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i13.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i12.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
-      ) as _i12.Future<List<String>>);
+        returnValue: _i13.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
+      ) as _i13.Future<List<String>>);
 
   @override
-  _i12.Future<_i3.GetKeysChangesResponse> getKeysChanges(
+  _i13.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -5938,8 +5973,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             to,
           ],
         ),
-        returnValue: _i12.Future<_i3.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_51(
+        returnValue: _i13.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_52(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5950,8 +5985,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_51(
+            _i13.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_52(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5961,10 +5996,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.GetKeysChangesResponse>);
+      ) as _i13.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i12.Future<_i3.ClaimKeysResponse> claimKeys(
+  _i13.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -5975,7 +6010,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i12.Future<_i3.ClaimKeysResponse>.value(_FakeClaimKeysResponse_52(
+            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_53(
           this,
           Invocation.method(
             #claimKeys,
@@ -5984,7 +6019,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.ClaimKeysResponse>.value(_FakeClaimKeysResponse_52(
+            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_53(
           this,
           Invocation.method(
             #claimKeys,
@@ -5992,14 +6027,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i12.Future<_i3.ClaimKeysResponse>);
+      ) as _i13.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i12.Future<void> uploadCrossSigningKeys({
-    _i3.AuthenticationData? auth,
-    _i3.MatrixCrossSigningKey? masterKey,
-    _i3.MatrixCrossSigningKey? selfSigningKey,
-    _i3.MatrixCrossSigningKey? userSigningKey,
+  _i13.Future<void> uploadCrossSigningKeys({
+    _i4.AuthenticationData? auth,
+    _i4.MatrixCrossSigningKey? masterKey,
+    _i4.MatrixCrossSigningKey? selfSigningKey,
+    _i4.MatrixCrossSigningKey? userSigningKey,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6012,12 +6047,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.QueryKeysResponse> queryKeys(
+  _i13.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -6028,7 +6063,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i12.Future<_i3.QueryKeysResponse>.value(_FakeQueryKeysResponse_53(
+            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_54(
           this,
           Invocation.method(
             #queryKeys,
@@ -6037,7 +6072,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.QueryKeysResponse>.value(_FakeQueryKeysResponse_53(
+            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_54(
           this,
           Invocation.method(
             #queryKeys,
@@ -6045,10 +6080,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i12.Future<_i3.QueryKeysResponse>);
+      ) as _i13.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -6056,15 +6091,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i12.Future<
+            returnValue: _i13.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i12.Future<
+            returnValueForMissingStub: _i13.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i12.Future<Map<String, int>> uploadKeys({
-    _i3.MatrixDeviceKeys? deviceKeys,
+  _i13.Future<Map<String, int>> uploadKeys({
+    _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
   }) =>
@@ -6078,13 +6113,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i12.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i13.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i12.Future<Map<String, int>>);
+            _i13.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i13.Future<Map<String, int>>);
 
   @override
-  _i12.Future<String> knockRoom(
+  _i13.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6098,7 +6133,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6110,7 +6145,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6121,20 +6156,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<List<_i3.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i13.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i12.Future<List<_i3.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i3.LoginFlow>?>.value(),
-      ) as _i12.Future<List<_i3.LoginFlow>?>);
+        returnValue: _i13.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i13.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i12.Future<_i3.GetNotificationsResponse> getNotifications({
+  _i13.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6149,8 +6184,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #only: only,
           },
         ),
-        returnValue: _i12.Future<_i3.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_54(
+        returnValue: _i13.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_55(
           this,
           Invocation.method(
             #getNotifications,
@@ -6163,8 +6198,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_54(
+            _i13.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_55(
           this,
           Invocation.method(
             #getNotifications,
@@ -6176,37 +6211,37 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.GetNotificationsResponse>);
+      ) as _i13.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i12.Future<_i3.GetPresenceResponse> getPresence(String? userId) =>
+  _i13.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i12.Future<_i3.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_55(
+        returnValue: _i13.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_56(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_55(
+        returnValueForMissingStub: _i13.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_56(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i3.GetPresenceResponse>);
+      ) as _i13.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i12.Future<void> setPresence(
+  _i13.Future<void> setPresence(
     String? userId,
-    _i3.PresenceType? presence, {
+    _i4.PresenceType? presence, {
     String? statusMsg,
   }) =>
       (super.noSuchMethod(
@@ -6218,12 +6253,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, Object?>> deleteProfileField(
+  _i13.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6236,13 +6271,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getProfileField(
+  _i13.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6255,13 +6290,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<Map<String, Object?>> setProfileField(
+  _i13.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6276,13 +6311,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i3.GetPublicRoomsResponse> getPublicRooms({
+  _i13.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6297,8 +6332,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #server: server,
           },
         ),
-        returnValue: _i12.Future<_i3.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_56(
+        returnValue: _i13.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_57(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6311,8 +6346,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_56(
+            _i13.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_57(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6324,12 +6359,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.GetPublicRoomsResponse>);
+      ) as _i13.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i12.Future<_i3.QueryPublicRoomsResponse> queryPublicRooms({
+  _i13.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
-    _i3.PublicRoomQueryFilter? filter,
+    _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
     int? limit,
     String? since,
@@ -6348,8 +6383,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i12.Future<_i3.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_57(
+        returnValue: _i13.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_58(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6365,8 +6400,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_57(
+            _i13.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_58(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6381,25 +6416,25 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.QueryPublicRoomsResponse>);
+      ) as _i13.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i12.Future<List<_i3.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i12.Future<List<_i3.Pusher>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i3.Pusher>?>.value(),
-      ) as _i12.Future<List<_i3.Pusher>?>);
+        returnValue: _i13.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.Pusher>?>.value(),
+      ) as _i13.Future<List<_i4.Pusher>?>);
 
   @override
-  _i12.Future<_i3.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i13.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i12.Future<_i3.PushRuleSet>.value(_FakePushRuleSet_58(
+        returnValue: _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_59(
           this,
           Invocation.method(
             #getPushRules,
@@ -6407,24 +6442,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.PushRuleSet>.value(_FakePushRuleSet_58(
+            _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_59(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i12.Future<_i3.PushRuleSet>);
+      ) as _i13.Future<_i4.PushRuleSet>);
 
   @override
-  _i12.Future<_i3.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i13.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i12.Future<_i3.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_59(
+        returnValue: _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_60(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -6432,19 +6467,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_59(
+            _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_60(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i12.Future<_i3.GetPushRulesGlobalResponse>);
+      ) as _i13.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i12.Future<void> deletePushRule(
-    _i3.PushRuleKind? kind,
+  _i13.Future<void> deletePushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -6455,13 +6490,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.PushRule> getPushRule(
-    _i3.PushRuleKind? kind,
+  _i13.Future<_i4.PushRule> getPushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -6472,7 +6507,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<_i3.PushRule>.value(_FakePushRule_60(
+        returnValue: _i13.Future<_i4.PushRule>.value(_FakePushRule_61(
           this,
           Invocation.method(
             #getPushRule,
@@ -6483,7 +6518,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.PushRule>.value(_FakePushRule_60(
+            _i13.Future<_i4.PushRule>.value(_FakePushRule_61(
           this,
           Invocation.method(
             #getPushRule,
@@ -6493,16 +6528,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.PushRule>);
+      ) as _i13.Future<_i4.PushRule>);
 
   @override
-  _i12.Future<void> setPushRule(
-    _i3.PushRuleKind? kind,
+  _i13.Future<void> setPushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
     String? before,
     String? after,
-    List<_i3.PushCondition>? conditions,
+    List<_i4.PushCondition>? conditions,
     String? pattern,
   }) =>
       (super.noSuchMethod(
@@ -6520,13 +6555,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<Object?>> getPushRuleActions(
-    _i3.PushRuleKind? kind,
+  _i13.Future<List<Object?>> getPushRuleActions(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -6537,14 +6572,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i13.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i12.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i12.Future<List<Object?>>);
+            _i13.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i13.Future<List<Object?>>);
 
   @override
-  _i12.Future<void> setPushRuleActions(
-    _i3.PushRuleKind? kind,
+  _i13.Future<void> setPushRuleActions(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
   ) =>
@@ -6557,13 +6592,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             actions,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<bool> isPushRuleEnabled(
-    _i3.PushRuleKind? kind,
+  _i13.Future<bool> isPushRuleEnabled(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -6574,13 +6609,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> setPushRuleEnabled(
-    _i3.PushRuleKind? kind,
+  _i13.Future<void> setPushRuleEnabled(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
   ) =>
@@ -6593,19 +6628,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
             enabled,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.RefreshResponse> refresh(String? refreshToken) =>
+  _i13.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i12.Future<_i3.RefreshResponse>.value(_FakeRefreshResponse_61(
+            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_62(
           this,
           Invocation.method(
             #refresh,
@@ -6613,28 +6648,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RefreshResponse>.value(_FakeRefreshResponse_61(
+            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_62(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i12.Future<_i3.RefreshResponse>);
+      ) as _i13.Future<_i4.RefreshResponse>);
 
   @override
-  _i12.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i13.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i12.Future<bool?>.value(),
-        returnValueForMissingStub: _i12.Future<bool?>.value(),
-      ) as _i12.Future<bool?>);
+        returnValue: _i13.Future<bool?>.value(),
+        returnValueForMissingStub: _i13.Future<bool?>.value(),
+      ) as _i13.Future<bool?>);
 
   @override
-  _i12.Future<_i3.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6656,8 +6691,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6673,8 +6708,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6690,10 +6725,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i3.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6717,8 +6752,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6735,8 +6770,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6753,17 +6788,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -6771,23 +6806,23 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i3.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i13.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i12.Future<_i3.RoomKeys>.value(_FakeRoomKeys_62(
+        returnValue: _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_63(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -6795,19 +6830,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeys>.value(_FakeRoomKeys_62(
+            _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_63(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeys>);
+      ) as _i13.Future<_i4.RoomKeys>);
 
   @override
-  _i12.Future<_i3.RoomKeysUpdateResponse> putRoomKeys(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
-    _i3.RoomKeys? body,
+    _i4.RoomKeys? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6817,8 +6852,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6829,8 +6864,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6840,10 +6875,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6855,8 +6890,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6867,8 +6902,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6878,10 +6913,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i3.RoomKeyBackup> getRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6893,7 +6928,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i3.RoomKeyBackup>.value(_FakeRoomKeyBackup_63(
+        returnValue: _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_64(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6904,7 +6939,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeyBackup>.value(_FakeRoomKeyBackup_63(
+            _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_64(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6914,13 +6949,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeyBackup>);
+      ) as _i13.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i12.Future<_i3.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
-    _i3.RoomKeyBackup? body,
+    _i4.RoomKeyBackup? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6931,8 +6966,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6944,8 +6979,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6956,10 +6991,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6973,8 +7008,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -6986,8 +7021,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -6998,10 +7033,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i3.KeyBackupData> getRoomKeyBySessionId(
+  _i13.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7015,7 +7050,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_32(
+        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7027,7 +7062,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_32(
+            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7038,14 +7073,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.KeyBackupData>);
+      ) as _i13.Future<_i4.KeyBackupData>);
 
   @override
-  _i12.Future<_i3.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
-    _i3.KeyBackupData? body,
+    _i4.KeyBackupData? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7057,8 +7092,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7071,8 +7106,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7084,18 +7119,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i3.GetRoomKeysVersionCurrentResponse>
+  _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i12.Future<_i3.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_64(
+                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_65(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7103,19 +7138,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i12.Future<_i3.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_64(
+                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_65(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i12.Future<_i3.GetRoomKeysVersionCurrentResponse>);
+          ) as _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i12.Future<String> postRoomKeysVersion(
-    _i3.BackupAlgorithm? algorithm,
+  _i13.Future<String> postRoomKeysVersion(
+    _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
       (super.noSuchMethod(
@@ -7126,7 +7161,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             authData,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7137,7 +7172,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7147,29 +7182,29 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i13.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i13.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i12.Future<_i3.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_65(
+        returnValue: _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_66(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7177,20 +7212,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_65(
+            _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_66(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i12.Future<_i3.GetRoomKeysVersionResponse>);
+      ) as _i13.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i13.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
-    _i3.BackupAlgorithm? algorithm,
+    _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
       (super.noSuchMethod(
@@ -7203,24 +7238,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i13.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i12.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
-      ) as _i12.Future<List<String>>);
+        returnValue: _i13.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
+      ) as _i13.Future<List<String>>);
 
   @override
-  _i12.Future<void> ban(
+  _i13.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7234,12 +7269,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.EventContext> getEventContext(
+  _i13.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7257,7 +7292,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<_i3.EventContext>.value(_FakeEventContext_66(
+        returnValue: _i13.Future<_i4.EventContext>.value(_FakeEventContext_67(
           this,
           Invocation.method(
             #getEventContext,
@@ -7272,7 +7307,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.EventContext>.value(_FakeEventContext_66(
+            _i13.Future<_i4.EventContext>.value(_FakeEventContext_67(
           this,
           Invocation.method(
             #getEventContext,
@@ -7286,10 +7321,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.EventContext>);
+      ) as _i13.Future<_i4.EventContext>);
 
   @override
-  _i12.Future<_i3.MatrixEvent> getOneRoomEvent(
+  _i13.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7301,7 +7336,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             eventId,
           ],
         ),
-        returnValue: _i12.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_50(
+        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7312,7 +7347,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_50(
+            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7322,22 +7357,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.MatrixEvent>);
+      ) as _i13.Future<_i4.MatrixEvent>);
 
   @override
-  _i12.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i13.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> inviteBy3PID(
+  _i13.Future<void> inviteBy3PID(
     String? roomId,
-    _i3.Invite3pid? body,
+    _i4.Invite3pid? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7347,12 +7382,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> inviteUser(
+  _i13.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7366,15 +7401,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> joinRoomById(
+  _i13.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
-    _i3.ThirdPartySigned? thirdPartySigned,
+    _i4.ThirdPartySigned? thirdPartySigned,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7385,7 +7420,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7397,7 +7432,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7408,23 +7443,23 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<Map<String, _i3.RoomMember>?> getJoinedMembersByRoom(
+  _i13.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i12.Future<Map<String, _i3.RoomMember>?>.value(),
+        returnValue: _i13.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i12.Future<Map<String, _i3.RoomMember>?>.value(),
-      ) as _i12.Future<Map<String, _i3.RoomMember>?>);
+            _i13.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i13.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i12.Future<void> kick(
+  _i13.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7438,12 +7473,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> leaveRoom(
+  _i13.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -7453,16 +7488,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i3.MatrixEvent>?> getMembersByRoom(
+  _i13.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
-    _i3.Membership? membership,
-    _i3.Membership? notMembership,
+    _i4.Membership? membership,
+    _i4.Membership? notMembership,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7474,14 +7509,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i12.Future<List<_i3.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i3.MatrixEvent>?>.value(),
-      ) as _i12.Future<List<_i3.MatrixEvent>?>);
+        returnValue: _i13.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i13.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i12.Future<_i3.GetRoomEventsResponse> getRoomEvents(
+  _i13.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
-    _i3.Direction? dir, {
+    _i4.Direction? dir, {
     String? from,
     String? to,
     int? limit,
@@ -7501,8 +7536,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<_i3.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_67(
+        returnValue: _i13.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_68(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7518,8 +7553,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_67(
+        returnValueForMissingStub: _i13.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_68(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7535,10 +7570,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.GetRoomEventsResponse>);
+      ) as _i13.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i12.Future<void> setReadMarker(
+  _i13.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -7554,14 +7589,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> postReceipt(
+  _i13.Future<void> postReceipt(
     String? roomId,
-    _i3.ReceiptType? receiptType,
+    _i4.ReceiptType? receiptType,
     String? eventId, {
     String? threadId,
   }) =>
@@ -7575,12 +7610,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEvent(
+  _i13.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -7596,12 +7631,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> reportRoom(
+  _i13.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -7613,12 +7648,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             reason,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> reportEvent(
+  _i13.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -7636,12 +7671,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #score: score,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> sendMessage(
+  _i13.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -7657,7 +7692,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7670,7 +7705,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7682,27 +7717,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<List<_i3.MatrixEvent>> getRoomState(String? roomId) =>
+  _i13.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i12.Future<List<_i3.MatrixEvent>>.value(<_i3.MatrixEvent>[]),
+            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i3.MatrixEvent>>.value(<_i3.MatrixEvent>[]),
-      ) as _i12.Future<List<_i3.MatrixEvent>>);
+            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i13.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i13.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
-    _i3.Format? format,
+    _i4.Format? format,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7715,13 +7750,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#format: format},
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<String> setRoomStateWithKey(
+  _i13.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -7737,7 +7772,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7750,7 +7785,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7762,10 +7797,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> unban(
+  _i13.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7779,12 +7814,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> upgradeRoom(
+  _i13.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -7798,7 +7833,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7810,7 +7845,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7821,11 +7856,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i3.SearchResults> search(
-    _i3.Categories? searchCategories, {
+  _i13.Future<_i4.SearchResults> search(
+    _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
       (super.noSuchMethod(
@@ -7834,7 +7869,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i12.Future<_i3.SearchResults>.value(_FakeSearchResults_68(
+        returnValue: _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_69(
           this,
           Invocation.method(
             #search,
@@ -7843,7 +7878,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.SearchResults>.value(_FakeSearchResults_68(
+            _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_69(
           this,
           Invocation.method(
             #search,
@@ -7851,14 +7886,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i12.Future<_i3.SearchResults>);
+      ) as _i13.Future<_i4.SearchResults>);
 
   @override
-  _i12.Future<_i3.SyncUpdate> sync({
+  _i13.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
-    _i3.PresenceType? setPresence,
+    _i4.PresenceType? setPresence,
     int? timeout,
     bool? useStateAfter,
   }) =>
@@ -7875,7 +7910,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i12.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_23(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.method(
             #sync,
@@ -7891,7 +7926,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_23(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.method(
             #sync,
@@ -7906,22 +7941,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<List<_i3.Location>> queryLocationByAlias(String? alias) =>
+  _i13.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i12.Future<List<_i3.Location>>.value(<_i3.Location>[]),
+        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i3.Location>>.value(<_i3.Location>[]),
-      ) as _i12.Future<List<_i3.Location>>);
+            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i13.Future<List<_i4.Location>>);
 
   @override
-  _i12.Future<List<_i3.Location>> queryLocationByProtocol(
+  _i13.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -7931,21 +7966,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i12.Future<List<_i3.Location>>.value(<_i3.Location>[]),
+        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i3.Location>>.value(<_i3.Location>[]),
-      ) as _i12.Future<List<_i3.Location>>);
+            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i13.Future<List<_i4.Location>>);
 
   @override
-  _i12.Future<_i3.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i13.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i12.Future<_i3.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_69(
+        returnValue: _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_70(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -7953,45 +7988,45 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_69(
+            _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_70(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i12.Future<_i3.GetProtocolMetadataResponse$2>);
+      ) as _i13.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i12.Future<Map<String, _i3.GetProtocolsResponse$2>> getProtocols() =>
+  _i13.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i12.Future<Map<String, _i3.GetProtocolsResponse$2>>.value(
-            <String, _i3.GetProtocolsResponse$2>{}),
+        returnValue: _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, _i3.GetProtocolsResponse$2>>.value(
-                <String, _i3.GetProtocolsResponse$2>{}),
-      ) as _i12.Future<Map<String, _i3.GetProtocolsResponse$2>>);
+            _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+                <String, _i4.GetProtocolsResponse$2>{}),
+      ) as _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i12.Future<List<_i3.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i12.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
-      ) as _i12.Future<List<_i3.ThirdPartyUser>>);
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i12.Future<List<_i3.ThirdPartyUser>> queryUserByProtocol(
+  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8002,13 +8037,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i12.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
-      ) as _i12.Future<List<_i3.ThirdPartyUser>>);
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getAccountData(
+  _i13.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -8021,13 +8056,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> setAccountData(
+  _i13.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -8041,14 +8076,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> defineFilter(
+  _i13.Future<String> defineFilter(
     String? userId,
-    _i3.Filter? body,
+    _i4.Filter? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8058,7 +8093,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8069,7 +8104,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8079,10 +8114,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i3.Filter> getFilter(
+  _i13.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8094,7 +8129,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             filterId,
           ],
         ),
-        returnValue: _i12.Future<_i3.Filter>.value(_FakeFilter_9(
+        returnValue: _i13.Future<_i4.Filter>.value(_FakeFilter_10(
           this,
           Invocation.method(
             #getFilter,
@@ -8104,7 +8139,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.Filter>.value(_FakeFilter_9(
+        returnValueForMissingStub: _i13.Future<_i4.Filter>.value(_FakeFilter_10(
           this,
           Invocation.method(
             #getFilter,
@@ -8114,10 +8149,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.Filter>);
+      ) as _i13.Future<_i4.Filter>);
 
   @override
-  _i12.Future<_i3.OpenIdCredentials> requestOpenIdToken(
+  _i13.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8130,7 +8165,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i12.Future<_i3.OpenIdCredentials>.value(_FakeOpenIdCredentials_70(
+            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_71(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8141,7 +8176,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.OpenIdCredentials>.value(_FakeOpenIdCredentials_70(
+            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_71(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8151,10 +8186,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.OpenIdCredentials>);
+      ) as _i13.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i12.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i13.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8169,13 +8204,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> setAccountDataPerRoom(
+  _i13.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8191,12 +8226,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, _i3.Tag>?> getRoomTags(
+  _i13.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8208,12 +8243,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             roomId,
           ],
         ),
-        returnValue: _i12.Future<Map<String, _i3.Tag>?>.value(),
-        returnValueForMissingStub: _i12.Future<Map<String, _i3.Tag>?>.value(),
-      ) as _i12.Future<Map<String, _i3.Tag>?>);
+        returnValue: _i13.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i13.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i13.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i12.Future<void> deleteRoomTag(
+  _i13.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8227,16 +8262,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             tag,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setRoomTag(
+  _i13.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
-    _i3.Tag? body,
+    _i4.Tag? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8248,12 +8283,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.SearchUserDirectoryResponse> searchUserDirectory(
+  _i13.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8263,8 +8298,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i12.Future<_i3.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_71(
+        returnValue: _i13.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_72(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8273,8 +8308,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_71(
+            _i13.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_72(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8282,10 +8317,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i12.Future<_i3.SearchUserDirectoryResponse>);
+      ) as _i13.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> reportUser(
+  _i13.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8298,40 +8333,40 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i3.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i13.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i12.Future<_i3.CreateContentResponse>.value(
-            _FakeCreateContentResponse_72(
+        returnValue: _i13.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_73(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.CreateContentResponse>.value(
-            _FakeCreateContentResponse_72(
+        returnValueForMissingStub: _i13.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_73(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i12.Future<_i3.CreateContentResponse>);
+      ) as _i13.Future<_i4.CreateContentResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> uploadContentToMXC(
+  _i13.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i21.Uint8List? body, {
+    _i22.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8349,16 +8384,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [AuthService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAuthService extends _i1.Mock implements _i8.AuthService {
+class MockAuthService extends _i1.Mock implements _i9.AuthService {
   @override
   bool get isLoggedIn => (super.noSuchMethod(
         Invocation.getter(#isLoggedIn),
@@ -8392,7 +8427,7 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
       ) as bool);
 
   @override
-  _i12.Future<bool> login({
+  _i13.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -8407,12 +8442,12 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
             #password: password,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> completeSsoLogin({
+  _i13.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -8425,13 +8460,13 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> completeRegistration(
-    _i3.RegisterResponse? response, {
+  _i13.Future<void> completeRegistration(
+    _i4.RegisterResponse? response, {
     String? password,
   }) =>
       (super.noSuchMethod(
@@ -8440,9 +8475,9 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
           [response],
           {#password: password},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void activateRestoredSession() => super.noSuchMethod(
@@ -8454,37 +8489,37 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
       );
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleServerLogout() => (super.noSuchMethod(
+  _i13.Future<void> handleServerLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleServerLogout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> saveSessionBackup() => (super.noSuchMethod(
+  _i13.Future<void> saveSessionBackup() => (super.noSuchMethod(
         Invocation.method(
           #saveSessionBackup,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i14.ServerAuthCapabilities> getServerAuthCapabilities(
+  _i13.Future<_i15.ServerAuthCapabilities> getServerAuthCapabilities(
     String? homeserver, {
     required bool? isLoggedIn,
   }) =>
@@ -8494,8 +8529,8 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
           [homeserver],
           {#isLoggedIn: isLoggedIn},
         ),
-        returnValue: _i12.Future<_i14.ServerAuthCapabilities>.value(
-            _FakeServerAuthCapabilities_73(
+        returnValue: _i13.Future<_i15.ServerAuthCapabilities>.value(
+            _FakeServerAuthCapabilities_74(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8504,8 +8539,8 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i14.ServerAuthCapabilities>.value(
-                _FakeServerAuthCapabilities_73(
+            _i13.Future<_i15.ServerAuthCapabilities>.value(
+                _FakeServerAuthCapabilities_74(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8513,7 +8548,7 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
             {#isLoggedIn: isLoggedIn},
           ),
         )),
-      ) as _i12.Future<_i14.ServerAuthCapabilities>);
+      ) as _i13.Future<_i15.ServerAuthCapabilities>);
 
   @override
   bool isPermanentAuthFailure(Object? error) => (super.noSuchMethod(
@@ -8526,37 +8561,37 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
       ) as bool);
 
   @override
-  _i12.Future<void> clearSessionKeys() => (super.noSuchMethod(
+  _i13.Future<void> clearSessionKeys() => (super.noSuchMethod(
         Invocation.method(
           #clearSessionKeys,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> migrateStorageKeys() => (super.noSuchMethod(
+  _i13.Future<void> migrateStorageKeys() => (super.noSuchMethod(
         Invocation.method(
           #migrateStorageKeys,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> persistCredentials() => (super.noSuchMethod(
+  _i13.Future<void> persistCredentials() => (super.noSuchMethod(
         Invocation.method(
           #persistCredentials,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8565,7 +8600,7 @@ class MockAuthService extends _i1.Mock implements _i8.AuthService {
       );
 
   @override
-  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/test/widgets/message_reply_test.mocks.dart
+++ b/test/widgets/message_reply_test.mocks.dart
@@ -4,30 +4,32 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i13;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i14;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/src/utils/space_child.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -746,8 +748,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,8 +759,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,9 +769,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -777,9 +779,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -788,8 +790,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,8 +801,8 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,8 +811,8 @@ class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
         );
 }
 
-class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_72(
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -818,9 +821,19 @@ class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_73 extends _i1.SmartFake
+class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_74 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_73(
+  _FakeLatestReceiptState_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,8 +842,8 @@ class _FakeLatestReceiptState_73 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_74(
+class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -839,8 +852,8 @@ class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_75 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_75(
+class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -849,8 +862,8 @@ class _FakeUser_75 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_76 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_76(
+class _FakeRoom_77 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -859,9 +872,9 @@ class _FakeRoom_76 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_77 extends _i1.SmartFake
-    implements _i13.TimelineChunk {
-  _FakeTimelineChunk_77(
+class _FakeTimelineChunk_78 extends _i1.SmartFake
+    implements _i14.TimelineChunk {
+  _FakeTimelineChunk_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -870,8 +883,8 @@ class _FakeTimelineChunk_77 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixFile_78 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_78(
+class _FakeMatrixFile_79 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -880,8 +893,8 @@ class _FakeMatrixFile_78 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_79 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_79(
+class _FakeEvent_80 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -908,12 +921,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1033,11 +1046,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1074,11 +1087,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1108,11 +1121,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1121,11 +1134,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1411,34 +1424,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1594,7 +1607,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1883,14 +1896,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2278,8 +2291,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2295,8 +2308,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2337,7 +2350,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2353,7 +2366,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2402,7 +2415,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2423,7 +2436,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2526,7 +2539,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2544,7 +2557,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3063,7 +3076,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3415,7 +3428,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3429,7 +3442,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3580,7 +3593,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4958,7 +4971,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4980,7 +4993,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5474,7 +5487,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5486,7 +5499,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6494,7 +6507,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6505,7 +6518,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6753,7 +6766,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6765,7 +6778,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7025,7 +7038,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7038,7 +7051,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7105,7 +7118,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7118,7 +7131,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7166,7 +7179,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7178,7 +7191,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7426,7 +7439,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7437,7 +7450,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7699,7 +7712,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7726,7 +7739,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7741,13 +7754,26 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7756,11 +7782,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7781,69 +7807,69 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7862,6 +7888,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7871,7 +7906,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7880,7 +7915,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7889,7 +7924,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7898,7 +7933,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7907,7 +7942,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7960,7 +7995,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8054,7 +8089,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8063,7 +8098,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8082,7 +8117,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8093,7 +8128,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8141,7 +8176,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8179,7 +8214,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8188,7 +8223,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8197,16 +8232,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8234,11 +8269,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8268,11 +8303,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_72(
+        returnValue: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_72(
+        returnValueForMissingStub: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
@@ -8325,11 +8360,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8365,11 +8400,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8385,11 +8420,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8398,11 +8433,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8425,11 +8460,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -8445,11 +8480,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8492,11 +8527,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_73(
+        returnValue: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_73(
+        returnValueForMissingStub: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8708,18 +8743,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i22.SpaceParent>[],
+        returnValueForMissingStub: <_i22.SpaceParent>[],
+      ) as List<_i22.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i22.SpaceChild>[],
+        returnValueForMissingStub: <_i22.SpaceChild>[],
+      ) as List<_i22.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8886,14 +8921,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8941,7 +8976,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8949,7 +8984,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8964,7 +8999,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8972,7 +9007,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9056,7 +9091,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9064,7 +9099,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9306,7 +9341,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9317,7 +9352,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9406,15 +9441,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i13.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i14.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i13.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i13.TimelineChunk?>.value(),
-      ) as _i5.Future<_i13.TimelineChunk?>);
+        returnValue: _i5.Future<_i14.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i14.TimelineChunk?>.value(),
+      ) as _i5.Future<_i14.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9455,7 +9490,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9472,7 +9507,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9536,14 +9571,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9559,14 +9594,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9622,7 +9657,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9630,7 +9665,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9942,11 +9977,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_76(
+        returnValue: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_76(
+        returnValueForMissingStub: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
@@ -9996,17 +10031,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i13.TimelineChunk get chunk => (super.noSuchMethod(
+  _i14.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_77(
+        returnValue: _FakeTimelineChunk_78(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_77(
+        returnValueForMissingStub: _FakeTimelineChunk_78(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i13.TimelineChunk);
+      ) as _i14.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10109,7 +10144,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i13.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i14.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -10308,11 +10343,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.getter(#sender),
         ),
@@ -10321,11 +10356,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10334,11 +10369,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_76(
+        returnValue: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_76(
+        returnValueForMissingStub: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
@@ -10361,11 +10396,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10374,11 +10409,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10387,11 +10422,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10400,11 +10435,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10413,11 +10448,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10426,11 +10461,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10495,11 +10530,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10508,11 +10543,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10565,11 +10600,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10654,11 +10689,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10676,11 +10711,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10891,7 +10926,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i16.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i17.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10906,7 +10941,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_78(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_79(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10920,7 +10955,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_78(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_79(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10956,7 +10991,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10971,7 +11006,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11008,7 +11043,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11022,7 +11057,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11059,7 +11094,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11073,7 +11108,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11107,7 +11142,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11120,7 +11155,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11196,14 +11231,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_79(
+        returnValue: _FakeEvent_80(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_79(
+        returnValueForMissingStub: _FakeEvent_80(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -11220,11 +11255,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_76(
+        returnValue: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_76(
+        returnValueForMissingStub: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
@@ -11233,11 +11268,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -11303,11 +11338,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11332,11 +11367,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11354,11 +11389,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11405,7 +11440,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11417,7 +11452,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11487,7 +11522,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11500,7 +11535,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/new_dm_dialog_test.mocks.dart
+++ b/test/widgets/new_dm_dialog_test.mocks.dart
@@ -4,30 +4,32 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i15;
-import 'dart:ui' as _i17;
+import 'dart:typed_data' as _i16;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i13;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i14;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i20;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -746,8 +748,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,8 +759,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,9 +769,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -777,9 +779,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -788,8 +790,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,8 +801,8 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,8 +811,8 @@ class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
         );
 }
 
-class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_72(
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -818,9 +821,19 @@ class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_73 extends _i1.SmartFake
+class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_74 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_73(
+  _FakeLatestReceiptState_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,8 +842,8 @@ class _FakeLatestReceiptState_73 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_74(
+class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -839,8 +852,8 @@ class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_75 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_75(
+class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,12 +880,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i13.KeyVerificationMethod> get verificationMethods =>
+  Set<_i14.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i13.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i13.KeyVerificationMethod>{},
-      ) as Set<_i13.KeyVerificationMethod>);
+        returnValue: <_i14.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
+      ) as Set<_i14.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -992,11 +1005,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1033,11 +1046,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1067,11 +1080,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1080,11 +1093,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1370,34 +1383,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i13.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i13.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i13.KeyVerification>
+  _i3.CachedStreamController<_i14.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i13.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i13.KeyVerification>(
+                _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i13.KeyVerification>);
+          ) as _i3.CachedStreamController<_i14.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1553,7 +1566,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i13.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1842,14 +1855,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2237,8 +2250,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2254,8 +2267,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2296,7 +2309,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2312,7 +2325,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2361,7 +2374,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2382,7 +2395,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2485,7 +2498,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2503,7 +2516,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3022,7 +3035,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i15.Uint8List? file, {
+    _i16.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3374,7 +3387,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3388,7 +3401,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3539,7 +3552,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i15.Uint8List? body,
+    _i16.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4917,7 +4930,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4939,7 +4952,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5433,7 +5446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5445,7 +5458,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6453,7 +6466,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6464,7 +6477,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6712,7 +6725,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6724,7 +6737,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6984,7 +6997,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6997,7 +7010,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7064,7 +7077,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7077,7 +7090,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7125,7 +7138,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7137,7 +7150,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7385,7 +7398,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7396,7 +7409,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7658,7 +7671,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i15.Uint8List? body, {
+    _i16.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7685,7 +7698,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7700,13 +7713,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7715,11 +7741,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7740,69 +7766,69 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7821,6 +7847,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7830,7 +7865,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7839,7 +7874,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7848,7 +7883,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7857,7 +7892,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7866,7 +7901,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7919,7 +7954,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8013,7 +8048,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8022,7 +8057,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8041,7 +8076,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8052,7 +8087,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8100,7 +8135,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8138,7 +8173,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8147,7 +8182,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8156,16 +8191,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i5.Future<_i17.AppExitResponse>);
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8193,11 +8228,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8227,11 +8262,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_72(
+        returnValue: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_72(
+        returnValueForMissingStub: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
@@ -8284,11 +8319,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8324,11 +8359,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8344,11 +8379,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8357,11 +8392,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8384,11 +8419,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -8404,11 +8439,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8451,11 +8486,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_73(
+        returnValue: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_73(
+        returnValueForMissingStub: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8667,18 +8702,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i20.SpaceParent>[],
-        returnValueForMissingStub: <_i20.SpaceParent>[],
-      ) as List<_i20.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i20.SpaceChild>[],
-        returnValueForMissingStub: <_i20.SpaceChild>[],
-      ) as List<_i20.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8845,14 +8880,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8900,7 +8935,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8908,7 +8943,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8923,7 +8958,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8931,7 +8966,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9015,7 +9050,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9023,7 +9058,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9265,7 +9300,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9276,7 +9311,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9365,15 +9400,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i21.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i21.TimelineChunk?>.value(),
-      ) as _i5.Future<_i21.TimelineChunk?>);
+        returnValue: _i5.Future<_i22.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i22.TimelineChunk?>.value(),
+      ) as _i5.Future<_i22.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9414,7 +9449,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9431,7 +9466,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9495,14 +9530,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9518,14 +9553,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9581,7 +9616,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9589,7 +9624,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/new_room_dialog_test.mocks.dart
+++ b/test/widgets/new_room_dialog_test.mocks.dart
@@ -4,28 +4,30 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i15;
-import 'dart:ui' as _i17;
+import 'dart:typed_data' as _i16;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i13;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i14;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -744,8 +746,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -754,8 +757,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -764,9 +767,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -775,9 +777,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -786,8 +788,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -796,8 +799,18 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -824,12 +837,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i13.KeyVerificationMethod> get verificationMethods =>
+  Set<_i14.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i13.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i13.KeyVerificationMethod>{},
-      ) as Set<_i13.KeyVerificationMethod>);
+        returnValue: <_i14.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
+      ) as Set<_i14.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -949,11 +962,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -990,11 +1003,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1024,11 +1037,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1037,11 +1050,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1327,34 +1340,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i13.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i13.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i13.KeyVerification>
+  _i3.CachedStreamController<_i14.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i13.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i13.KeyVerification>(
+                _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i13.KeyVerification>);
+          ) as _i3.CachedStreamController<_i14.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1510,7 +1523,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i13.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1799,14 +1812,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2194,8 +2207,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2211,8 +2224,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2253,7 +2266,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2269,7 +2282,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2318,7 +2331,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2339,7 +2352,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2442,7 +2455,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2460,7 +2473,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2979,7 +2992,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i15.Uint8List? file, {
+    _i16.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3331,7 +3344,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3345,7 +3358,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3496,7 +3509,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i15.Uint8List? body,
+    _i16.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4874,7 +4887,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4896,7 +4909,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5390,7 +5403,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5402,7 +5415,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6410,7 +6423,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6421,7 +6434,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6669,7 +6682,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6681,7 +6694,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6941,7 +6954,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6954,7 +6967,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7021,7 +7034,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7034,7 +7047,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7082,7 +7095,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7094,7 +7107,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7342,7 +7355,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7353,7 +7366,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7615,7 +7628,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i15.Uint8List? body, {
+    _i16.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7642,7 +7655,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7657,13 +7670,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7672,11 +7698,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7697,69 +7723,69 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7778,6 +7804,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7787,7 +7822,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7796,7 +7831,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7805,7 +7840,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7814,7 +7849,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7823,7 +7858,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7876,7 +7911,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -7970,7 +8005,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -7979,7 +8014,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -7998,7 +8033,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8009,7 +8044,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8057,7 +8092,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8095,7 +8130,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8104,7 +8139,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8113,16 +8148,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i5.Future<_i17.AppExitResponse>);
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/recovery_key_handler_test.mocks.dart
+++ b/test/widgets/recovery_key_handler_test.mocks.dart
@@ -3,32 +3,34 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i12;
-import 'dart:typed_data' as _i22;
-import 'dart:ui' as _i19;
+import 'dart:async' as _i13;
+import 'dart:typed_data' as _i23;
+import 'dart:ui' as _i20;
 
-import 'package:flutter/services.dart' as _i20;
-import 'package:flutter/widgets.dart' as _i21;
-import 'package:http/http.dart' as _i11;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
+import 'package:http/http.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i5;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i7;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i4;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i7;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
-import 'package:matrix/encryption.dart' as _i9;
-import 'package:matrix/encryption/cross_signing.dart' as _i16;
-import 'package:matrix/encryption/key_verification_manager.dart' as _i15;
-import 'package:matrix/encryption/olm_manager.dart' as _i14;
-import 'package:matrix/matrix.dart' as _i3;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i13;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i10;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i3;
+import 'package:matrix/encryption.dart' as _i10;
+import 'package:matrix/encryption/cross_signing.dart' as _i17;
+import 'package:matrix/encryption/key_verification_manager.dart' as _i16;
+import 'package:matrix/encryption/olm_manager.dart' as _i15;
+import 'package:matrix/matrix.dart' as _i4;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i14;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i11;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i18;
+import 'package:mockito/src/dummies.dart' as _i19;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -56,8 +58,9 @@ class _FakeCallPushRuleManager_0 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
-  _FakeClient_1(
+class _FakeMegolmKeyMirror_1 extends _i1.SmartFake
+    implements _i3.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_1(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -66,8 +69,8 @@ class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
         );
 }
 
-class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
-  _FakeUiaService_2(
+class _FakeClient_2 extends _i1.SmartFake implements _i4.Client {
+  _FakeClient_2(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -76,9 +79,8 @@ class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
         );
 }
 
-class _FakeChatBackupService_3 extends _i1.SmartFake
-    implements _i5.ChatBackupService {
-  _FakeChatBackupService_3(
+class _FakeUiaService_3 extends _i1.SmartFake implements _i5.UiaService {
+  _FakeUiaService_3(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -87,9 +89,9 @@ class _FakeChatBackupService_3 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_4 extends _i1.SmartFake
-    implements _i6.SelectionService {
-  _FakeSelectionService_4(
+class _FakeChatBackupService_4 extends _i1.SmartFake
+    implements _i6.ChatBackupService {
+  _FakeChatBackupService_4(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -98,8 +100,9 @@ class _FakeSelectionService_4 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
-  _FakeSyncService_5(
+class _FakeSelectionService_5 extends _i1.SmartFake
+    implements _i7.SelectionService {
+  _FakeSelectionService_5(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -108,8 +111,8 @@ class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
         );
 }
 
-class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
-  _FakeAuthService_6(
+class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
+  _FakeSyncService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -118,8 +121,8 @@ class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
         );
 }
 
-class _FakeEncryption_7 extends _i1.SmartFake implements _i9.Encryption {
-  _FakeEncryption_7(
+class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
+  _FakeAuthService_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -128,8 +131,8 @@ class _FakeEncryption_7 extends _i1.SmartFake implements _i9.Encryption {
         );
 }
 
-class _FakeSSSS_8 extends _i1.SmartFake implements _i9.SSSS {
-  _FakeSSSS_8(
+class _FakeEncryption_8 extends _i1.SmartFake implements _i10.Encryption {
+  _FakeEncryption_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -138,9 +141,8 @@ class _FakeSSSS_8 extends _i1.SmartFake implements _i9.SSSS {
         );
 }
 
-class _FakeSecretStorageKeyContent_9 extends _i1.SmartFake
-    implements _i3.SecretStorageKeyContent {
-  _FakeSecretStorageKeyContent_9(
+class _FakeSSSS_9 extends _i1.SmartFake implements _i10.SSSS {
+  _FakeSSSS_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -149,8 +151,9 @@ class _FakeSecretStorageKeyContent_9 extends _i1.SmartFake
         );
 }
 
-class _FakeDatabaseApi_10 extends _i1.SmartFake implements _i3.DatabaseApi {
-  _FakeDatabaseApi_10(
+class _FakeSecretStorageKeyContent_10 extends _i1.SmartFake
+    implements _i4.SecretStorageKeyContent {
+  _FakeSecretStorageKeyContent_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -159,8 +162,8 @@ class _FakeDatabaseApi_10 extends _i1.SmartFake implements _i3.DatabaseApi {
         );
 }
 
-class _FakeFilter_11 extends _i1.SmartFake implements _i3.Filter {
-  _FakeFilter_11(
+class _FakeDatabaseApi_11 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -169,9 +172,8 @@ class _FakeFilter_11 extends _i1.SmartFake implements _i3.Filter {
         );
 }
 
-class _FakeNativeImplementations_12 extends _i1.SmartFake
-    implements _i3.NativeImplementations {
-  _FakeNativeImplementations_12(
+class _FakeFilter_12 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -180,8 +182,9 @@ class _FakeNativeImplementations_12 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_13 extends _i1.SmartFake implements Duration {
-  _FakeDuration_13(
+class _FakeNativeImplementations_13 extends _i1.SmartFake
+    implements _i4.NativeImplementations {
+  _FakeNativeImplementations_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -190,9 +193,8 @@ class _FakeDuration_13 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_14 extends _i1.SmartFake
-    implements _i3.PushruleEvaluator {
-  _FakePushruleEvaluator_14(
+class _FakeDuration_14 extends _i1.SmartFake implements Duration {
+  _FakeDuration_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -201,8 +203,9 @@ class _FakePushruleEvaluator_14 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_15 extends _i1.SmartFake implements _i3.Profile {
-  _FakeProfile_15(
+class _FakePushruleEvaluator_15 extends _i1.SmartFake
+    implements _i4.PushruleEvaluator {
+  _FakePushruleEvaluator_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -211,9 +214,8 @@ class _FakeProfile_15 extends _i1.SmartFake implements _i3.Profile {
         );
 }
 
-class _FakeCachedStreamController_16<T> extends _i1.SmartFake
-    implements _i10.CachedStreamController<T> {
-  _FakeCachedStreamController_16(
+class _FakeProfile_16 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -222,8 +224,9 @@ class _FakeCachedStreamController_16<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_17 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_17(
+class _FakeCachedStreamController_17<T> extends _i1.SmartFake
+    implements _i11.CachedStreamController<T> {
+  _FakeCachedStreamController_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -232,8 +235,8 @@ class _FakeDateTime_17 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_18 extends _i1.SmartFake implements _i11.Client {
-  _FakeClient_18(
+class _FakeDateTime_18 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -242,9 +245,8 @@ class _FakeClient_18 extends _i1.SmartFake implements _i11.Client {
         );
 }
 
-class _FakeDiscoveryInformation_19 extends _i1.SmartFake
-    implements _i3.DiscoveryInformation {
-  _FakeDiscoveryInformation_19(
+class _FakeClient_19 extends _i1.SmartFake implements _i12.Client {
+  _FakeClient_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -253,9 +255,9 @@ class _FakeDiscoveryInformation_19 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_20 extends _i1.SmartFake
-    implements _i3.GetVersionsResponse {
-  _FakeGetVersionsResponse_20(
+class _FakeDiscoveryInformation_20 extends _i1.SmartFake
+    implements _i4.DiscoveryInformation {
+  _FakeDiscoveryInformation_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -264,9 +266,9 @@ class _FakeGetVersionsResponse_20 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_21 extends _i1.SmartFake
-    implements _i3.RegisterResponse {
-  _FakeRegisterResponse_21(
+class _FakeGetVersionsResponse_21 extends _i1.SmartFake
+    implements _i4.GetVersionsResponse {
+  _FakeGetVersionsResponse_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -275,8 +277,9 @@ class _FakeRegisterResponse_21 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_22 extends _i1.SmartFake implements _i3.LoginResponse {
-  _FakeLoginResponse_22(
+class _FakeRegisterResponse_22 extends _i1.SmartFake
+    implements _i4.RegisterResponse {
+  _FakeRegisterResponse_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -285,9 +288,8 @@ class _FakeLoginResponse_22 extends _i1.SmartFake implements _i3.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_23 extends _i1.SmartFake
-    implements _i3.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_23(
+class _FakeLoginResponse_23 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -296,8 +298,9 @@ class _FakeGetAuthMetadataResponse_23 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_24<T1> extends _i1.SmartFake implements _i12.Future<T1> {
-  _FakeFuture_24(
+class _FakeGetAuthMetadataResponse_24 extends _i1.SmartFake
+    implements _i4.GetAuthMetadataResponse {
+  _FakeGetAuthMetadataResponse_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -306,8 +309,8 @@ class _FakeFuture_24<T1> extends _i1.SmartFake implements _i12.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_25 extends _i1.SmartFake implements _i3.SyncUpdate {
-  _FakeSyncUpdate_25(
+class _FakeFuture_25<T1> extends _i1.SmartFake implements _i13.Future<T1> {
+  _FakeFuture_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -316,9 +319,8 @@ class _FakeSyncUpdate_25 extends _i1.SmartFake implements _i3.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_26 extends _i1.SmartFake
-    implements _i3.CachedProfileInformation {
-  _FakeCachedProfileInformation_26(
+class _FakeSyncUpdate_26 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -327,8 +329,9 @@ class _FakeCachedProfileInformation_26 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_27 extends _i1.SmartFake implements _i3.MediaConfig {
-  _FakeMediaConfig_27(
+class _FakeCachedProfileInformation_27 extends _i1.SmartFake
+    implements _i4.CachedProfileInformation {
+  _FakeCachedProfileInformation_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -337,8 +340,8 @@ class _FakeMediaConfig_27 extends _i1.SmartFake implements _i3.MediaConfig {
         );
 }
 
-class _FakeFileResponse_28 extends _i1.SmartFake implements _i13.FileResponse {
-  _FakeFileResponse_28(
+class _FakeMediaConfig_28 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -347,8 +350,8 @@ class _FakeFileResponse_28 extends _i1.SmartFake implements _i13.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_29 extends _i1.SmartFake implements _i3.PreviewForUrl {
-  _FakePreviewForUrl_29(
+class _FakeFileResponse_29 extends _i1.SmartFake implements _i14.FileResponse {
+  _FakeFileResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -357,8 +360,8 @@ class _FakePreviewForUrl_29 extends _i1.SmartFake implements _i3.PreviewForUrl {
         );
 }
 
-class _FakeUri_30 extends _i1.SmartFake implements Uri {
-  _FakeUri_30(
+class _FakePreviewForUrl_30 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -367,9 +370,8 @@ class _FakeUri_30 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_31 extends _i1.SmartFake
-    implements _i3.CachedPresence {
-  _FakeCachedPresence_31(
+class _FakeUri_31 extends _i1.SmartFake implements Uri {
+  _FakeUri_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -378,9 +380,9 @@ class _FakeCachedPresence_31 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_32 extends _i1.SmartFake
-    implements _i3.TurnServerCredentials {
-  _FakeTurnServerCredentials_32(
+class _FakeCachedPresence_32 extends _i1.SmartFake
+    implements _i4.CachedPresence {
+  _FakeCachedPresence_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -389,9 +391,9 @@ class _FakeTurnServerCredentials_32 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_33 extends _i1.SmartFake
-    implements _i3.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_33(
+class _FakeTurnServerCredentials_33 extends _i1.SmartFake
+    implements _i4.TurnServerCredentials {
+  _FakeTurnServerCredentials_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -400,8 +402,9 @@ class _FakeRoomKeysUpdateResponse_33 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_34 extends _i1.SmartFake implements _i3.KeyBackupData {
-  _FakeKeyBackupData_34(
+class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
+    implements _i4.RoomKeysUpdateResponse {
+  _FakeRoomKeysUpdateResponse_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -410,9 +413,8 @@ class _FakeKeyBackupData_34 extends _i1.SmartFake implements _i3.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_35 extends _i1.SmartFake
-    implements _i3.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_35(
+class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -421,9 +423,9 @@ class _FakeGetWellknownSupportResponse_35 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_36 extends _i1.SmartFake
-    implements _i3.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_36(
+class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
+    implements _i4.GetWellknownSupportResponse {
+  _FakeGetWellknownSupportResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -432,9 +434,9 @@ class _FakeGenerateLoginTokenResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_37 extends _i1.SmartFake
-    implements _i3.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_37(
+class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
+    implements _i4.GenerateLoginTokenResponse {
+  _FakeGenerateLoginTokenResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -443,9 +445,9 @@ class _FakeGetRoomSummaryResponse$3_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_38 extends _i1.SmartFake
-    implements _i3.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_38(
+class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
+    implements _i4.GetRoomSummaryResponse$3 {
+  _FakeGetRoomSummaryResponse$3_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -454,9 +456,9 @@ class _FakeGetSpaceHierarchyResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_39 extends _i1.SmartFake
-    implements _i3.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_39(
+class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
+    implements _i4.GetSpaceHierarchyResponse {
+  _FakeGetSpaceHierarchyResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -465,9 +467,9 @@ class _FakeGetRelatingEventsResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_40 extends _i1.SmartFake
-    implements _i3.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_40(
+class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
+    implements _i4.GetRelatingEventsResponse {
+  _FakeGetRelatingEventsResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -476,9 +478,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41 extends _i1
-    .SmartFake implements _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
+class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
+    implements _i4.GetRelatingEventsWithRelTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -487,9 +489,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_42 extends _i1.SmartFake
-    implements _i3.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_42(
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
+    .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -498,9 +500,9 @@ class _FakeGetThreadRootsResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_43 extends _i1.SmartFake
-    implements _i3.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_43(
+class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
+    implements _i4.GetThreadRootsResponse {
+  _FakeGetThreadRootsResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -509,9 +511,9 @@ class _FakeGetEventByTimestampResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_44 extends _i1.SmartFake
-    implements _i3.RequestTokenResponse {
-  _FakeRequestTokenResponse_44(
+class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
+    implements _i4.GetEventByTimestampResponse {
+  _FakeGetEventByTimestampResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -520,9 +522,9 @@ class _FakeRequestTokenResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_45 extends _i1.SmartFake
-    implements _i3.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_45(
+class _FakeRequestTokenResponse_45 extends _i1.SmartFake
+    implements _i4.RequestTokenResponse {
+  _FakeRequestTokenResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -531,8 +533,9 @@ class _FakeTokenOwnerInfo_45 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_46 extends _i1.SmartFake implements _i3.WhoIsInfo {
-  _FakeWhoIsInfo_46(
+class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
+    implements _i4.TokenOwnerInfo {
+  _FakeTokenOwnerInfo_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -541,8 +544,8 @@ class _FakeWhoIsInfo_46 extends _i1.SmartFake implements _i3.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_47 extends _i1.SmartFake implements _i3.Capabilities {
-  _FakeCapabilities_47(
+class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -551,8 +554,8 @@ class _FakeCapabilities_47 extends _i1.SmartFake implements _i3.Capabilities {
         );
 }
 
-class _FakeDevice_48 extends _i1.SmartFake implements _i3.Device {
-  _FakeDevice_48(
+class _FakeCapabilities_48 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -561,9 +564,8 @@ class _FakeDevice_48 extends _i1.SmartFake implements _i3.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_49 extends _i1.SmartFake
-    implements _i3.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_49(
+class _FakeDevice_49 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -572,9 +574,9 @@ class _FakeGetRoomIdByAliasResponse_49 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_50 extends _i1.SmartFake
-    implements _i3.GetEventsResponse {
-  _FakeGetEventsResponse_50(
+class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
+    implements _i4.GetRoomIdByAliasResponse {
+  _FakeGetRoomIdByAliasResponse_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -583,9 +585,9 @@ class _FakeGetEventsResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_51 extends _i1.SmartFake
-    implements _i3.PeekEventsResponse {
-  _FakePeekEventsResponse_51(
+class _FakeGetEventsResponse_51 extends _i1.SmartFake
+    implements _i4.GetEventsResponse {
+  _FakeGetEventsResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -594,8 +596,9 @@ class _FakePeekEventsResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_52 extends _i1.SmartFake implements _i3.MatrixEvent {
-  _FakeMatrixEvent_52(
+class _FakePeekEventsResponse_52 extends _i1.SmartFake
+    implements _i4.PeekEventsResponse {
+  _FakePeekEventsResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -604,9 +607,8 @@ class _FakeMatrixEvent_52 extends _i1.SmartFake implements _i3.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_53 extends _i1.SmartFake
-    implements _i3.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_53(
+class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -615,9 +617,9 @@ class _FakeGetKeysChangesResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_54 extends _i1.SmartFake
-    implements _i3.ClaimKeysResponse {
-  _FakeClaimKeysResponse_54(
+class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
+    implements _i4.GetKeysChangesResponse {
+  _FakeGetKeysChangesResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -626,9 +628,9 @@ class _FakeClaimKeysResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_55 extends _i1.SmartFake
-    implements _i3.QueryKeysResponse {
-  _FakeQueryKeysResponse_55(
+class _FakeClaimKeysResponse_55 extends _i1.SmartFake
+    implements _i4.ClaimKeysResponse {
+  _FakeClaimKeysResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -637,9 +639,9 @@ class _FakeQueryKeysResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_56 extends _i1.SmartFake
-    implements _i3.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_56(
+class _FakeQueryKeysResponse_56 extends _i1.SmartFake
+    implements _i4.QueryKeysResponse {
+  _FakeQueryKeysResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -648,9 +650,9 @@ class _FakeGetNotificationsResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_57 extends _i1.SmartFake
-    implements _i3.GetPresenceResponse {
-  _FakeGetPresenceResponse_57(
+class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
+    implements _i4.GetNotificationsResponse {
+  _FakeGetNotificationsResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -659,9 +661,9 @@ class _FakeGetPresenceResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_58 extends _i1.SmartFake
-    implements _i3.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_58(
+class _FakeGetPresenceResponse_58 extends _i1.SmartFake
+    implements _i4.GetPresenceResponse {
+  _FakeGetPresenceResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -670,9 +672,9 @@ class _FakeGetPublicRoomsResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_59 extends _i1.SmartFake
-    implements _i3.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_59(
+class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
+    implements _i4.GetPublicRoomsResponse {
+  _FakeGetPublicRoomsResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -681,8 +683,9 @@ class _FakeQueryPublicRoomsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_60 extends _i1.SmartFake implements _i3.PushRuleSet {
-  _FakePushRuleSet_60(
+class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
+    implements _i4.QueryPublicRoomsResponse {
+  _FakeQueryPublicRoomsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -691,9 +694,8 @@ class _FakePushRuleSet_60 extends _i1.SmartFake implements _i3.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_61 extends _i1.SmartFake
-    implements _i3.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_61(
+class _FakePushRuleSet_61 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -702,8 +704,9 @@ class _FakeGetPushRulesGlobalResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_62 extends _i1.SmartFake implements _i3.PushRule {
-  _FakePushRule_62(
+class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
+    implements _i4.GetPushRulesGlobalResponse {
+  _FakeGetPushRulesGlobalResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -712,9 +715,8 @@ class _FakePushRule_62 extends _i1.SmartFake implements _i3.PushRule {
         );
 }
 
-class _FakeRefreshResponse_63 extends _i1.SmartFake
-    implements _i3.RefreshResponse {
-  _FakeRefreshResponse_63(
+class _FakePushRule_63 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -723,8 +725,9 @@ class _FakeRefreshResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_64 extends _i1.SmartFake implements _i3.RoomKeys {
-  _FakeRoomKeys_64(
+class _FakeRefreshResponse_64 extends _i1.SmartFake
+    implements _i4.RefreshResponse {
+  _FakeRefreshResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -733,8 +736,8 @@ class _FakeRoomKeys_64 extends _i1.SmartFake implements _i3.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_65 extends _i1.SmartFake implements _i3.RoomKeyBackup {
-  _FakeRoomKeyBackup_65(
+class _FakeRoomKeys_65 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -743,9 +746,8 @@ class _FakeRoomKeyBackup_65 extends _i1.SmartFake implements _i3.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_66 extends _i1.SmartFake
-    implements _i3.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_66(
+class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -754,9 +756,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_66 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_67 extends _i1.SmartFake
-    implements _i3.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_67(
+class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
+    implements _i4.GetRoomKeysVersionCurrentResponse {
+  _FakeGetRoomKeysVersionCurrentResponse_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -765,8 +767,9 @@ class _FakeGetRoomKeysVersionResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_68 extends _i1.SmartFake implements _i3.EventContext {
-  _FakeEventContext_68(
+class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
+    implements _i4.GetRoomKeysVersionResponse {
+  _FakeGetRoomKeysVersionResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -775,9 +778,8 @@ class _FakeEventContext_68 extends _i1.SmartFake implements _i3.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_69 extends _i1.SmartFake
-    implements _i3.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_69(
+class _FakeEventContext_69 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -786,8 +788,9 @@ class _FakeGetRoomEventsResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_70 extends _i1.SmartFake implements _i3.SearchResults {
-  _FakeSearchResults_70(
+class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
+    implements _i4.GetRoomEventsResponse {
+  _FakeGetRoomEventsResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -796,9 +799,8 @@ class _FakeSearchResults_70 extends _i1.SmartFake implements _i3.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_71 extends _i1.SmartFake
-    implements _i3.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_71(
+class _FakeSearchResults_71 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -807,9 +809,9 @@ class _FakeGetProtocolMetadataResponse$2_71 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_72 extends _i1.SmartFake
-    implements _i3.OpenIdCredentials {
-  _FakeOpenIdCredentials_72(
+class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
+    implements _i4.GetProtocolMetadataResponse$2 {
+  _FakeGetProtocolMetadataResponse$2_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -818,9 +820,9 @@ class _FakeOpenIdCredentials_72 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_73 extends _i1.SmartFake
-    implements _i3.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_73(
+class _FakeOpenIdCredentials_73 extends _i1.SmartFake
+    implements _i4.OpenIdCredentials {
+  _FakeOpenIdCredentials_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,9 +831,9 @@ class _FakeSearchUserDirectoryResponse_73 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_74 extends _i1.SmartFake
-    implements _i3.CreateContentResponse {
-  _FakeCreateContentResponse_74(
+class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
+    implements _i4.SearchUserDirectoryResponse {
+  _FakeSearchUserDirectoryResponse_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -840,8 +842,9 @@ class _FakeCreateContentResponse_74 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyManager_75 extends _i1.SmartFake implements _i9.KeyManager {
-  _FakeKeyManager_75(
+class _FakeCreateContentResponse_75 extends _i1.SmartFake
+    implements _i4.CreateContentResponse {
+  _FakeCreateContentResponse_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -850,8 +853,8 @@ class _FakeKeyManager_75 extends _i1.SmartFake implements _i9.KeyManager {
         );
 }
 
-class _FakeOlmManager_76 extends _i1.SmartFake implements _i14.OlmManager {
-  _FakeOlmManager_76(
+class _FakeKeyManager_76 extends _i1.SmartFake implements _i10.KeyManager {
+  _FakeKeyManager_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -860,9 +863,8 @@ class _FakeOlmManager_76 extends _i1.SmartFake implements _i14.OlmManager {
         );
 }
 
-class _FakeKeyVerificationManager_77 extends _i1.SmartFake
-    implements _i15.KeyVerificationManager {
-  _FakeKeyVerificationManager_77(
+class _FakeOlmManager_77 extends _i1.SmartFake implements _i15.OlmManager {
+  _FakeOlmManager_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -871,8 +873,9 @@ class _FakeKeyVerificationManager_77 extends _i1.SmartFake
         );
 }
 
-class _FakeCrossSigning_78 extends _i1.SmartFake implements _i16.CrossSigning {
-  _FakeCrossSigning_78(
+class _FakeKeyVerificationManager_78 extends _i1.SmartFake
+    implements _i16.KeyVerificationManager {
+  _FakeKeyVerificationManager_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -881,8 +884,8 @@ class _FakeCrossSigning_78 extends _i1.SmartFake implements _i16.CrossSigning {
         );
 }
 
-class _FakeBootstrap_79 extends _i1.SmartFake implements _i9.Bootstrap {
-  _FakeBootstrap_79(
+class _FakeCrossSigning_79 extends _i1.SmartFake implements _i17.CrossSigning {
+  _FakeCrossSigning_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -891,8 +894,8 @@ class _FakeBootstrap_79 extends _i1.SmartFake implements _i9.Bootstrap {
         );
 }
 
-class _FakeToDeviceEvent_80 extends _i1.SmartFake implements _i3.ToDeviceEvent {
-  _FakeToDeviceEvent_80(
+class _FakeBootstrap_80 extends _i1.SmartFake implements _i10.Bootstrap {
+  _FakeBootstrap_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -901,8 +904,18 @@ class _FakeToDeviceEvent_80 extends _i1.SmartFake implements _i3.ToDeviceEvent {
         );
 }
 
-class _FakeEvent_81 extends _i1.SmartFake implements _i3.Event {
-  _FakeEvent_81(
+class _FakeToDeviceEvent_81 extends _i1.SmartFake implements _i4.ToDeviceEvent {
+  _FakeToDeviceEvent_81(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeEvent_82 extends _i1.SmartFake implements _i4.Event {
+  _FakeEvent_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -914,7 +927,7 @@ class _FakeEvent_81 extends _i1.SmartFake implements _i3.Event {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -929,30 +942,43 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i2.CallPushRuleManager);
 
   @override
+  _i3.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i3.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
       ) as String);
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get isLoggedIn => (super.noSuchMethod(
@@ -969,69 +995,69 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  _i4.UiaService get uia => (super.noSuchMethod(
+  _i5.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_2(
+        returnValue: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_2(
+        returnValueForMissingStub: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i4.UiaService);
+      ) as _i5.UiaService);
 
   @override
-  _i5.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i6.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_3(
+        returnValue: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_3(
+        returnValueForMissingStub: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i5.ChatBackupService);
+      ) as _i6.ChatBackupService);
 
   @override
-  _i6.SelectionService get selection => (super.noSuchMethod(
+  _i7.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_4(
+        returnValue: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_4(
+        returnValueForMissingStub: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i6.SelectionService);
+      ) as _i7.SelectionService);
 
   @override
-  _i7.SyncService get sync => (super.noSuchMethod(
+  _i8.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_5(
+        returnValue: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_5(
+        returnValueForMissingStub: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i7.SyncService);
+      ) as _i8.SyncService);
 
   @override
-  _i8.AuthService get auth => (super.noSuchMethod(
+  _i9.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_6(
+        returnValue: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_6(
+        returnValueForMissingStub: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i8.AuthService);
+      ) as _i9.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1050,6 +1076,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set keyMirror(_i3.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -1059,7 +1094,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set uia(_i4.UiaService? value) => super.noSuchMethod(
+  set uia(_i5.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -1068,7 +1103,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set chatBackup(_i5.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i6.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -1077,7 +1112,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set selection(_i6.SelectionService? value) => super.noSuchMethod(
+  set selection(_i7.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -1086,7 +1121,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set sync(_i7.SyncService? value) => super.noSuchMethod(
+  set sync(_i8.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -1095,7 +1130,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set auth(_i8.AuthService? value) => super.noSuchMethod(
+  set auth(_i9.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -1111,14 +1146,14 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1148,7 +1183,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1158,18 +1193,18 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i12.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<bool> login({
+  _i13.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1184,12 +1219,12 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> completeSsoLogin({
+  _i13.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1202,13 +1237,13 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> completeRegistration(
-    _i3.RegisterResponse? response, {
+  _i13.Future<void> completeRegistration(
+    _i4.RegisterResponse? response, {
     String? password,
   }) =>
       (super.noSuchMethod(
@@ -1217,32 +1252,32 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1251,7 +1286,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1260,17 +1295,17 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1281,7 +1316,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1318,26 +1353,26 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+  _i13.Future<bool> didPushRouteInformation(
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1367,7 +1402,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1376,7 +1411,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1385,16 +1420,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i12.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i13.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i12.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i13.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i12.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i12.Future<_i19.AppExitResponse>);
+            _i13.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i13.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1418,7 +1453,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 /// A class which mocks [ChatBackupService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockChatBackupService extends _i1.Mock implements _i5.ChatBackupService {
+class MockChatBackupService extends _i1.Mock implements _i6.ChatBackupService {
   @override
   bool get chatBackupEnabled => (super.noSuchMethod(
         Invocation.getter(#chatBackupEnabled),
@@ -1441,24 +1476,24 @@ class MockChatBackupService extends _i1.Mock implements _i5.ChatBackupService {
       ) as bool);
 
   @override
-  _i12.Future<void> checkChatBackupStatus() => (super.noSuchMethod(
+  _i13.Future<void> checkChatBackupStatus() => (super.noSuchMethod(
         Invocation.method(
           #checkChatBackupStatus,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> disableChatBackup() => (super.noSuchMethod(
+  _i13.Future<void> disableChatBackup() => (super.noSuchMethod(
         Invocation.method(
           #disableChatBackup,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void resetChatBackupState() => super.noSuchMethod(
@@ -1470,71 +1505,71 @@ class MockChatBackupService extends _i1.Mock implements _i5.ChatBackupService {
       );
 
   @override
-  _i12.Future<void> tryAutoUnlockBackup() => (super.noSuchMethod(
+  _i13.Future<void> tryAutoUnlockBackup() => (super.noSuchMethod(
         Invocation.method(
           #tryAutoUnlockBackup,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> runKeyRecovery({_i9.OpenSSSS? ssssKey}) =>
+  _i13.Future<void> runKeyRecovery({_i10.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
           [],
           {#ssssKey: ssssKey},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> requestMissingRoomKeys({bool? force = false}) =>
+  _i13.Future<void> requestMissingRoomKeys({bool? force = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #requestMissingRoomKeys,
           [],
           {#force: force},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> getStoredRecoveryKey() => (super.noSuchMethod(
+  _i13.Future<String?> getStoredRecoveryKey() => (super.noSuchMethod(
         Invocation.method(
           #getStoredRecoveryKey,
           [],
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> storeRecoveryKey(String? key) => (super.noSuchMethod(
+  _i13.Future<void> storeRecoveryKey(String? key) => (super.noSuchMethod(
         Invocation.method(
           #storeRecoveryKey,
           [key],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deleteStoredRecoveryKey() => (super.noSuchMethod(
+  _i13.Future<void> deleteStoredRecoveryKey() => (super.noSuchMethod(
         Invocation.method(
           #deleteStoredRecoveryKey,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1543,7 +1578,7 @@ class MockChatBackupService extends _i1.Mock implements _i5.ChatBackupService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1573,42 +1608,42 @@ class MockChatBackupService extends _i1.Mock implements _i5.ChatBackupService {
 /// A class which mocks [Bootstrap].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBootstrap extends _i1.Mock implements _i9.Bootstrap {
+class MockBootstrap extends _i1.Mock implements _i10.Bootstrap {
   @override
-  _i9.Encryption get encryption => (super.noSuchMethod(
+  _i10.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_7(
+        returnValue: _FakeEncryption_8(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_7(
+        returnValueForMissingStub: _FakeEncryption_8(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i9.Encryption);
+      ) as _i10.Encryption);
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
-  _i9.BootstrapState get state => (super.noSuchMethod(
+  _i10.BootstrapState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i9.BootstrapState.loading,
-        returnValueForMissingStub: _i9.BootstrapState.loading,
-      ) as _i9.BootstrapState);
+        returnValue: _i10.BootstrapState.loading,
+        returnValueForMissingStub: _i10.BootstrapState.loading,
+      ) as _i10.BootstrapState);
 
   @override
-  set onUpdate(void Function(_i9.Bootstrap)? value) => super.noSuchMethod(
+  set onUpdate(void Function(_i10.Bootstrap)? value) => super.noSuchMethod(
         Invocation.setter(
           #onUpdate,
           value,
@@ -1617,7 +1652,7 @@ class MockBootstrap extends _i1.Mock implements _i9.Bootstrap {
       );
 
   @override
-  set oldSsssKeys(Map<String, _i9.OpenSSSS>? value) => super.noSuchMethod(
+  set oldSsssKeys(Map<String, _i10.OpenSSSS>? value) => super.noSuchMethod(
         Invocation.setter(
           #oldSsssKeys,
           value,
@@ -1626,7 +1661,7 @@ class MockBootstrap extends _i1.Mock implements _i9.Bootstrap {
       );
 
   @override
-  set newSsssKey(_i9.OpenSSSS? value) => super.noSuchMethod(
+  set newSsssKey(_i10.OpenSSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #newSsssKey,
           value,
@@ -1644,7 +1679,7 @@ class MockBootstrap extends _i1.Mock implements _i9.Bootstrap {
       );
 
   @override
-  set state(_i9.BootstrapState? newState) => super.noSuchMethod(
+  set state(_i10.BootstrapState? newState) => super.noSuchMethod(
         Invocation.setter(
           #state,
           newState,
@@ -1678,14 +1713,14 @@ class MockBootstrap extends _i1.Mock implements _i9.Bootstrap {
           #mostUsedKey,
           [secrets],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
             [secrets],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
@@ -1755,7 +1790,7 @@ class MockBootstrap extends _i1.Mock implements _i9.Bootstrap {
       );
 
   @override
-  _i12.Future<void> newSsss([
+  _i13.Future<void> newSsss([
     String? passphrase,
     String? name,
   ]) =>
@@ -1767,19 +1802,19 @@ class MockBootstrap extends _i1.Mock implements _i9.Bootstrap {
             name,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> openExistingSsss() => (super.noSuchMethod(
+  _i13.Future<void> openExistingSsss() => (super.noSuchMethod(
         Invocation.method(
           #openExistingSsss,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void checkCrossSigning() => super.noSuchMethod(
@@ -1791,17 +1826,17 @@ class MockBootstrap extends _i1.Mock implements _i9.Bootstrap {
       );
 
   @override
-  _i12.Future<void> wipeCrossSigning(bool? wipe) => (super.noSuchMethod(
+  _i13.Future<void> wipeCrossSigning(bool? wipe) => (super.noSuchMethod(
         Invocation.method(
           #wipeCrossSigning,
           [wipe],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> askSetupCrossSigning({
+  _i13.Future<void> askSetupCrossSigning({
     bool? setupMasterKey = false,
     bool? setupSelfSigningKey = false,
     bool? setupUserSigningKey = false,
@@ -1816,9 +1851,9 @@ class MockBootstrap extends _i1.Mock implements _i9.Bootstrap {
             #setupUserSigningKey: setupUserSigningKey,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void checkOnlineKeyBackup() => super.noSuchMethod(
@@ -1839,58 +1874,58 @@ class MockBootstrap extends _i1.Mock implements _i9.Bootstrap {
       );
 
   @override
-  _i12.Future<void> askSetupOnlineKeyBackup(bool? setup) => (super.noSuchMethod(
+  _i13.Future<void> askSetupOnlineKeyBackup(bool? setup) => (super.noSuchMethod(
         Invocation.method(
           #askSetupOnlineKeyBackup,
           [setup],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 }
 
 /// A class which mocks [OpenSSSS].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockOpenSSSS extends _i1.Mock implements _i9.OpenSSSS {
+class MockOpenSSSS extends _i1.Mock implements _i10.OpenSSSS {
   @override
-  _i9.SSSS get ssss => (super.noSuchMethod(
+  _i10.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_8(
+        returnValue: _FakeSSSS_9(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_8(
+        returnValueForMissingStub: _FakeSSSS_9(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i9.SSSS);
+      ) as _i10.SSSS);
 
   @override
   String get keyId => (super.noSuchMethod(
         Invocation.getter(#keyId),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
       ) as String);
 
   @override
-  _i3.SecretStorageKeyContent get keyData => (super.noSuchMethod(
+  _i4.SecretStorageKeyContent get keyData => (super.noSuchMethod(
         Invocation.getter(#keyData),
-        returnValue: _FakeSecretStorageKeyContent_9(
+        returnValue: _FakeSecretStorageKeyContent_10(
           this,
           Invocation.getter(#keyData),
         ),
-        returnValueForMissingStub: _FakeSecretStorageKeyContent_9(
+        returnValueForMissingStub: _FakeSecretStorageKeyContent_10(
           this,
           Invocation.getter(#keyData),
         ),
-      ) as _i3.SecretStorageKeyContent);
+      ) as _i4.SecretStorageKeyContent);
 
   @override
   bool get isUnlocked => (super.noSuchMethod(
@@ -1907,7 +1942,7 @@ class MockOpenSSSS extends _i1.Mock implements _i9.OpenSSSS {
       ) as bool);
 
   @override
-  set privateKey(_i22.Uint8List? value) => super.noSuchMethod(
+  set privateKey(_i23.Uint8List? value) => super.noSuchMethod(
         Invocation.setter(
           #privateKey,
           value,
@@ -1916,7 +1951,7 @@ class MockOpenSSSS extends _i1.Mock implements _i9.OpenSSSS {
       );
 
   @override
-  _i12.Future<void> unlock({
+  _i13.Future<void> unlock({
     String? passphrase,
     String? recoveryKey,
     String? keyOrPassphrase,
@@ -1933,27 +1968,27 @@ class MockOpenSSSS extends _i1.Mock implements _i9.OpenSSSS {
             #postUnlock: postUnlock,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setPrivateKey(_i22.Uint8List? key) => (super.noSuchMethod(
+  _i13.Future<void> setPrivateKey(_i23.Uint8List? key) => (super.noSuchMethod(
         Invocation.method(
           #setPrivateKey,
           [key],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> getStored(String? type) => (super.noSuchMethod(
+  _i13.Future<String> getStored(String? type) => (super.noSuchMethod(
         Invocation.method(
           #getStored,
           [type],
         ),
-        returnValue: _i12.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,
@@ -1961,17 +1996,17 @@ class MockOpenSSSS extends _i1.Mock implements _i9.OpenSSSS {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i18.dummyValue<String>(
+            _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,
             [type],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> store(
+  _i13.Future<void> store(
     String? type,
     String? secret, {
     bool? add = false,
@@ -1985,12 +2020,12 @@ class MockOpenSSSS extends _i1.Mock implements _i9.OpenSSSS {
           ],
           {#add: add},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> validateAndStripOtherKeys(
+  _i13.Future<void> validateAndStripOtherKeys(
     String? type,
     String? secret,
   ) =>
@@ -2002,44 +2037,45 @@ class MockOpenSSSS extends _i1.Mock implements _i9.OpenSSSS {
             secret,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> maybeCacheAll() => (super.noSuchMethod(
+  _i13.Future<void> maybeCacheAll() => (super.noSuchMethod(
         Invocation.method(
           #maybeCacheAll,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 }
 
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockClient extends _i1.Mock implements _i3.Client {
+class MockClient extends _i1.Mock implements _i4.Client {
   @override
-  _i3.DatabaseApi get database => (super.noSuchMethod(
+  _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_10(
+        returnValue: _FakeDatabaseApi_11(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_10(
+        returnValueForMissingStub: _FakeDatabaseApi_11(
           this,
           Invocation.getter(#database),
         ),
-      ) as _i3.DatabaseApi);
+      ) as _i4.DatabaseApi);
 
   @override
-  Set<_i9.KeyVerificationMethod> get verificationMethods => (super.noSuchMethod(
+  Set<_i10.KeyVerificationMethod> get verificationMethods =>
+      (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i9.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i9.KeyVerificationMethod>{},
-      ) as Set<_i9.KeyVerificationMethod>);
+        returnValue: <_i10.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i10.KeyVerificationMethod>{},
+      ) as Set<_i10.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -2084,44 +2120,44 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  _i3.ShareKeysWith get shareKeysWith => (super.noSuchMethod(
+  _i4.ShareKeysWith get shareKeysWith => (super.noSuchMethod(
         Invocation.getter(#shareKeysWith),
-        returnValue: _i3.ShareKeysWith.all,
-        returnValueForMissingStub: _i3.ShareKeysWith.all,
-      ) as _i3.ShareKeysWith);
+        returnValue: _i4.ShareKeysWith.all,
+        returnValueForMissingStub: _i4.ShareKeysWith.all,
+      ) as _i4.ShareKeysWith);
 
   @override
-  Map<String, _i3.CommandExecutionCallback> get commands => (super.noSuchMethod(
+  Map<String, _i4.CommandExecutionCallback> get commands => (super.noSuchMethod(
         Invocation.getter(#commands),
-        returnValue: <String, _i3.CommandExecutionCallback>{},
-        returnValueForMissingStub: <String, _i3.CommandExecutionCallback>{},
-      ) as Map<String, _i3.CommandExecutionCallback>);
+        returnValue: <String, _i4.CommandExecutionCallback>{},
+        returnValueForMissingStub: <String, _i4.CommandExecutionCallback>{},
+      ) as Map<String, _i4.CommandExecutionCallback>);
 
   @override
-  _i3.Filter get syncFilter => (super.noSuchMethod(
+  _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_11(
+        returnValue: _FakeFilter_12(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_11(
+        returnValueForMissingStub: _FakeFilter_12(
           this,
           Invocation.getter(#syncFilter),
         ),
-      ) as _i3.Filter);
+      ) as _i4.Filter);
 
   @override
-  _i3.NativeImplementations get nativeImplementations => (super.noSuchMethod(
+  _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_12(
+        returnValue: _FakeNativeImplementations_13(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_12(
+        returnValueForMissingStub: _FakeNativeImplementations_13(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-      ) as _i3.NativeImplementations);
+      ) as _i4.NativeImplementations);
 
   @override
   bool get convertLinebreaksInFormatting => (super.noSuchMethod(
@@ -2133,11 +2169,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_13(
+        returnValue: _FakeDuration_14(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_13(
+        returnValueForMissingStub: _FakeDuration_14(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -2146,11 +2182,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_13(
+        returnValue: _FakeDuration_14(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_13(
+        returnValueForMissingStub: _FakeDuration_14(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -2159,36 +2195,36 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
       ) as String);
 
   @override
-  _i3.LoginState get loginState => (super.noSuchMethod(
+  _i4.LoginState get loginState => (super.noSuchMethod(
         Invocation.getter(#loginState),
-        returnValue: _i3.LoginState.loggedIn,
-        returnValueForMissingStub: _i3.LoginState.loggedIn,
-      ) as _i3.LoginState);
+        returnValue: _i4.LoginState.loggedIn,
+        returnValueForMissingStub: _i4.LoginState.loggedIn,
+      ) as _i4.LoginState);
 
   @override
-  List<_i3.Room> get rooms => (super.noSuchMethod(
+  List<_i4.Room> get rooms => (super.noSuchMethod(
         Invocation.getter(#rooms),
-        returnValue: <_i3.Room>[],
-        returnValueForMissingStub: <_i3.Room>[],
-      ) as List<_i3.Room>);
+        returnValue: <_i4.Room>[],
+        returnValueForMissingStub: <_i4.Room>[],
+      ) as List<_i4.Room>);
 
   @override
-  List<_i3.ArchivedRoom> get archivedRooms => (super.noSuchMethod(
+  List<_i4.ArchivedRoom> get archivedRooms => (super.noSuchMethod(
         Invocation.getter(#archivedRooms),
-        returnValue: <_i3.ArchivedRoom>[],
-        returnValueForMissingStub: <_i3.ArchivedRoom>[],
-      ) as List<_i3.ArchivedRoom>);
+        returnValue: <_i4.ArchivedRoom>[],
+        returnValueForMissingStub: <_i4.ArchivedRoom>[],
+      ) as List<_i4.ArchivedRoom>);
 
   @override
   bool get enableDehydratedDevices => (super.noSuchMethod(
@@ -2200,11 +2236,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -2234,11 +2270,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -2247,11 +2283,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -2265,31 +2301,31 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  Map<String, _i3.BasicEvent> get accountData => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get accountData => (super.noSuchMethod(
         Invocation.getter(#accountData),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  _i3.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
+  _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_14(
+        returnValue: _FakePushruleEvaluator_15(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_14(
+        returnValueForMissingStub: _FakePushruleEvaluator_15(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-      ) as _i3.PushruleEvaluator);
+      ) as _i4.PushruleEvaluator);
 
   @override
-  Map<String, _i3.CachedPresence> get presences => (super.noSuchMethod(
+  Map<String, _i4.CachedPresence> get presences => (super.noSuchMethod(
         Invocation.getter(#presences),
-        returnValue: <String, _i3.CachedPresence>{},
-        returnValueForMissingStub: <String, _i3.CachedPresence>{},
-      ) as Map<String, _i3.CachedPresence>);
+        returnValue: <String, _i4.CachedPresence>{},
+        returnValueForMissingStub: <String, _i4.CachedPresence>{},
+      ) as Map<String, _i4.CachedPresence>);
 
   @override
   Map<String, List<String>> get directChats => (super.noSuchMethod(
@@ -2299,333 +2335,333 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i12.Future<_i3.Profile> get ownProfile => (super.noSuchMethod(
+  _i13.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i12.Future<_i3.Profile>.value(_FakeProfile_15(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.Profile>.value(_FakeProfile_15(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i12.Future<_i3.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i10.CachedStreamController<String> get onUserProfileUpdate =>
+  _i11.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_16<String>(
+        returnValue: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i12.Future<List<_i3.Room>> get archive => (super.noSuchMethod(
+  _i13.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i12.Future<List<_i3.Room>>.value(<_i3.Room>[]),
+        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i3.Room>>.value(<_i3.Room>[]),
-      ) as _i12.Future<List<_i3.Room>>);
+            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i13.Future<List<_i4.Room>>);
 
   @override
-  _i10.CachedStreamController<_i3.EventUpdate> get onEvent =>
+  _i11.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_16<_i3.EventUpdate>(
+        returnValue: _FakeCachedStreamController_17<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i3.EventUpdate>(
+            _FakeCachedStreamController_17<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i10.CachedStreamController<_i3.EventUpdate>);
+      ) as _i11.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i10.CachedStreamController<_i3.Event> get onTimelineEvent =>
+  _i11.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_16<_i3.Event>(
+        returnValue: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i10.CachedStreamController<_i3.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i3.Event> get onHistoryEvent =>
+  _i11.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_16<_i3.Event>(
+        returnValue: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i10.CachedStreamController<_i3.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i3.Event> get onNotification =>
+  _i11.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_16<_i3.Event>(
+        returnValue: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i10.CachedStreamController<_i3.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i3.ToDeviceEvent> get onToDeviceEvent =>
+  _i11.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_16<_i3.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_17<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i3.ToDeviceEvent>(
+            _FakeCachedStreamController_17<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i10.CachedStreamController<_i3.ToDeviceEvent>);
+      ) as _i11.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i10.CachedStreamController<List<_i3.BasicEventWithSender>>
+  _i11.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_16<List<_i3.BasicEventWithSender>>(
+                _FakeCachedStreamController_17<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_16<List<_i3.BasicEventWithSender>>(
+                _FakeCachedStreamController_17<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i10.CachedStreamController<List<_i3.BasicEventWithSender>>);
+          ) as _i11.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i10.CachedStreamController<_i3.LoginState> get onLoginStateChanged =>
+  _i11.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_16<_i3.LoginState>(
+        returnValue: _FakeCachedStreamController_17<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i3.LoginState>(
+            _FakeCachedStreamController_17<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i10.CachedStreamController<_i3.LoginState>);
+      ) as _i11.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i10.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i11.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_16<bool>(
+        returnValue: _FakeCachedStreamController_17<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i10.CachedStreamController<bool>);
+      ) as _i11.CachedStreamController<bool>);
 
   @override
-  _i10.CachedStreamController<_i3.SdkError> get onEncryptionError =>
+  _i11.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_16<_i3.SdkError>(
+        returnValue: _FakeCachedStreamController_17<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i3.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i10.CachedStreamController<_i3.SdkError>);
+      ) as _i11.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i10.CachedStreamController<_i3.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i11.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_16<_i3.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_17<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i3.SyncUpdate>(
+            _FakeCachedStreamController_17<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i10.CachedStreamController<_i3.SyncUpdate>);
+      ) as _i11.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i10.CachedStreamController<_i3.SyncStatusUpdate> get onSyncStatus =>
+  _i11.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_16<_i3.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_17<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i3.SyncStatusUpdate>(
+            _FakeCachedStreamController_17<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i10.CachedStreamController<_i3.SyncStatusUpdate>);
+      ) as _i11.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i10.CachedStreamController<_i3.Presence> get onPresence =>
+  _i11.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_16<_i3.Presence>(
+        returnValue: _FakeCachedStreamController_17<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i3.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i10.CachedStreamController<_i3.Presence>);
+      ) as _i11.CachedStreamController<_i4.Presence>);
 
   @override
-  _i10.CachedStreamController<_i3.CachedPresence> get onPresenceChanged =>
+  _i11.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_16<_i3.CachedPresence>(
+        returnValue: _FakeCachedStreamController_17<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i3.CachedPresence>(
+            _FakeCachedStreamController_17<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i10.CachedStreamController<_i3.CachedPresence>);
+      ) as _i11.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i10.CachedStreamController<_i3.BasicEvent> get onAccountData =>
+  _i11.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_16<_i3.BasicEvent>(
+        returnValue: _FakeCachedStreamController_17<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i3.BasicEvent>(
+            _FakeCachedStreamController_17<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i10.CachedStreamController<_i3.BasicEvent>);
+      ) as _i11.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i10.CachedStreamController<_i9.RoomKeyRequest> get onRoomKeyRequest =>
+  _i11.CachedStreamController<_i10.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_16<_i9.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_17<_i10.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i9.RoomKeyRequest>(
+            _FakeCachedStreamController_17<_i10.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i10.CachedStreamController<_i9.RoomKeyRequest>);
+      ) as _i11.CachedStreamController<_i10.RoomKeyRequest>);
 
   @override
-  _i10.CachedStreamController<_i9.KeyVerification>
+  _i11.CachedStreamController<_i10.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_16<_i9.KeyVerification>(
+            returnValue: _FakeCachedStreamController_17<_i10.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_16<_i9.KeyVerification>(
+                _FakeCachedStreamController_17<_i10.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i10.CachedStreamController<_i9.KeyVerification>);
+          ) as _i11.CachedStreamController<_i10.KeyVerification>);
 
   @override
-  _i10.CachedStreamController<_i3.UiaRequest<dynamic>> get onUiaRequest =>
+  _i11.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_16<_i3.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_17<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i3.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_17<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i10.CachedStreamController<_i3.UiaRequest<dynamic>>);
+      ) as _i11.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i10.CachedStreamController<_i3.Event> get onGroupMember =>
+  _i11.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_16<_i3.Event>(
+        returnValue: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i10.CachedStreamController<_i3.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<String> get onCancelSendEvent =>
+  _i11.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_16<String>(
+        returnValue: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i10.CachedStreamController<({String roomId, _i3.StrippedStateEvent state})>
+  _i11.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_16<
-                ({String roomId, _i3.StrippedStateEvent state})>(
+            returnValue: _FakeCachedStreamController_17<
+                ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_16<
-                ({String roomId, _i3.StrippedStateEvent state})>(
+            returnValueForMissingStub: _FakeCachedStreamController_17<
+                ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i10.CachedStreamController<
-              ({String roomId, _i3.StrippedStateEvent state})>);
+          ) as _i11.CachedStreamController<
+              ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
   int get syncErrorTimeoutSec => (super.noSuchMethod(
@@ -2644,11 +2680,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_17(
+        returnValue: _FakeDateTime_18(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_17(
+        returnValueForMissingStub: _FakeDateTime_18(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2669,33 +2705,33 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  _i3.RoomSorter get sortRoomsBy => (super.noSuchMethod(
+  _i4.RoomSorter get sortRoomsBy => (super.noSuchMethod(
         Invocation.getter(#sortRoomsBy),
         returnValue: (
-          _i3.Room a,
-          _i3.Room b,
+          _i4.Room a,
+          _i4.Room b,
         ) =>
             0,
         returnValueForMissingStub: (
-          _i3.Room a,
-          _i3.Room b,
+          _i4.Room a,
+          _i4.Room b,
         ) =>
             0,
-      ) as _i3.RoomSorter);
+      ) as _i4.RoomSorter);
 
   @override
-  Map<String, _i3.DeviceKeysList> get userDeviceKeys => (super.noSuchMethod(
+  Map<String, _i4.DeviceKeysList> get userDeviceKeys => (super.noSuchMethod(
         Invocation.getter(#userDeviceKeys),
-        returnValue: <String, _i3.DeviceKeysList>{},
-        returnValueForMissingStub: <String, _i3.DeviceKeysList>{},
-      ) as Map<String, _i3.DeviceKeysList>);
+        returnValue: <String, _i4.DeviceKeysList>{},
+        returnValueForMissingStub: <String, _i4.DeviceKeysList>{},
+      ) as Map<String, _i4.DeviceKeysList>);
 
   @override
-  List<_i3.DeviceKeys> get unverifiedDevices => (super.noSuchMethod(
+  List<_i4.DeviceKeys> get unverifiedDevices => (super.noSuchMethod(
         Invocation.getter(#unverifiedDevices),
-        returnValue: <_i3.DeviceKeys>[],
-        returnValueForMissingStub: <_i3.DeviceKeys>[],
-      ) as List<_i3.DeviceKeys>);
+        returnValue: <_i4.DeviceKeys>[],
+        returnValueForMissingStub: <_i4.DeviceKeys>[],
+      ) as List<_i4.DeviceKeys>);
 
   @override
   bool get allPushNotificationsMuted => (super.noSuchMethod(
@@ -2712,7 +2748,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as List<String>);
 
   @override
-  set database(_i3.DatabaseApi? db) => super.noSuchMethod(
+  set database(_i4.DatabaseApi? db) => super.noSuchMethod(
         Invocation.setter(
           #database,
           db,
@@ -2721,7 +2757,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set verificationMethods(Set<_i9.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i10.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2767,7 +2803,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set shareKeysWith(_i3.ShareKeysWith? value) => super.noSuchMethod(
+  set shareKeysWith(_i4.ShareKeysWith? value) => super.noSuchMethod(
         Invocation.setter(
           #shareKeysWith,
           value,
@@ -2776,7 +2812,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set onSoftLogout(_i12.Future<void> Function(_i3.Client)? value) =>
+  set onSoftLogout(_i13.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2787,8 +2823,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
 
   @override
   set customImageResizer(
-          _i12.Future<_i3.MatrixImageFileResizedResponse?> Function(
-                  _i3.MatrixImageFileResizeArguments)?
+          _i13.Future<_i4.MatrixImageFileResizedResponse?> Function(
+                  _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
         Invocation.setter(
@@ -2826,7 +2862,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set rooms(List<_i3.Room>? newList) => super.noSuchMethod(
+  set rooms(List<_i4.Room>? newList) => super.noSuchMethod(
         Invocation.setter(
           #rooms,
           newList,
@@ -2835,7 +2871,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set presences(Map<String, _i3.CachedPresence>? value) => super.noSuchMethod(
+  set presences(Map<String, _i4.CachedPresence>? value) => super.noSuchMethod(
         Invocation.setter(
           #presences,
           value,
@@ -2862,7 +2898,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set syncPresence(_i3.PresenceType? value) => super.noSuchMethod(
+  set syncPresence(_i4.PresenceType? value) => super.noSuchMethod(
         Invocation.setter(
           #syncPresence,
           value,
@@ -2898,7 +2934,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2907,7 +2943,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set roomsLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2916,7 +2952,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set firstSyncReceived(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -2943,20 +2979,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Client get httpClient => (super.noSuchMethod(
+  _i12.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_18(
+        returnValue: _FakeClient_19(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_18(
+        returnValueForMissingStub: _FakeClient_19(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i11.Client);
+      ) as _i12.Client);
 
   @override
-  set httpClient(_i11.Client? value) => super.noSuchMethod(
+  set httpClient(_i12.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -2983,7 +3019,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i12.Future<void> refreshAccessToken(
+  _i13.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2991,9 +3027,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -3011,14 +3047,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -3028,22 +3064,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as String);
 
   @override
-  _i3.Room? getRoomByAlias(String? alias) => (super.noSuchMethod(
+  _i4.Room? getRoomByAlias(String? alias) => (super.noSuchMethod(
         Invocation.method(
           #getRoomByAlias,
           [alias],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.Room?);
+      ) as _i4.Room?);
 
   @override
-  _i3.Room? getRoomById(String? id) => (super.noSuchMethod(
+  _i4.Room? getRoomById(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getRoomById,
           [id],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.Room?);
+      ) as _i4.Room?);
 
   @override
   String? getDirectChatFromUserId(String? userId) => (super.noSuchMethod(
@@ -3055,38 +3091,38 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as String?);
 
   @override
-  _i12.Future<_i3.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i13.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i12.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_19(
+        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_20(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_19(
+        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_20(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i12.Future<_i3.DiscoveryInformation>);
+      ) as _i13.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i12.Future<
+  _i13.Future<
       (
-        _i3.DiscoveryInformation?,
-        _i3.GetVersionsResponse,
-        List<_i3.LoginFlow>,
-        _i3.GetAuthMetadataResponse?
+        _i4.DiscoveryInformation?,
+        _i4.GetVersionsResponse,
+        List<_i4.LoginFlow>,
+        _i4.GetAuthMetadataResponse?
       )> checkHomeserver(
     Uri? homeserverUrl, {
     bool? checkWellKnown = true,
@@ -3103,15 +3139,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i12.Future<
+        returnValue: _i13.Future<
             (
-              _i3.DiscoveryInformation?,
-              _i3.GetVersionsResponse,
-              List<_i3.LoginFlow>,
-              _i3.GetAuthMetadataResponse?
+              _i4.DiscoveryInformation?,
+              _i4.GetVersionsResponse,
+              List<_i4.LoginFlow>,
+              _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_20(
+          _FakeGetVersionsResponse_21(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -3123,18 +3159,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
           ),
-          <_i3.LoginFlow>[],
+          <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i12.Future<
+        returnValueForMissingStub: _i13.Future<
             (
-              _i3.DiscoveryInformation?,
-              _i3.GetVersionsResponse,
-              List<_i3.LoginFlow>,
-              _i3.GetAuthMetadataResponse?
+              _i4.DiscoveryInformation?,
+              _i4.GetVersionsResponse,
+              List<_i4.LoginFlow>,
+              _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_20(
+          _FakeGetVersionsResponse_21(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -3146,19 +3182,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
           ),
-          <_i3.LoginFlow>[],
+          <_i4.LoginFlow>[],
           null
         )),
-      ) as _i12.Future<
+      ) as _i13.Future<
           (
-            _i3.DiscoveryInformation?,
-            _i3.GetVersionsResponse,
-            List<_i3.LoginFlow>,
-            _i3.GetAuthMetadataResponse?
+            _i4.DiscoveryInformation?,
+            _i4.GetVersionsResponse,
+            List<_i4.LoginFlow>,
+            _i4.GetAuthMetadataResponse?
           )>);
 
   @override
-  _i12.Future<_i3.DiscoveryInformation> getWellknown({
+  _i13.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3171,8 +3207,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_19(
+        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_20(
           this,
           Invocation.method(
             #getWellknown,
@@ -3183,8 +3219,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_19(
+        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_20(
           this,
           Invocation.method(
             #getWellknown,
@@ -3195,19 +3231,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.DiscoveryInformation>);
+      ) as _i13.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i12.Future<_i3.RegisterResponse> register({
+  _i13.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
     String? initialDeviceDisplayName,
     bool? inhibitLogin,
     bool? refreshToken,
-    _i3.AuthenticationData? auth,
-    _i3.AccountKind? kind,
-    void Function(_i3.InitState)? onInitStateChanged,
+    _i4.AuthenticationData? auth,
+    _i4.AccountKind? kind,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3226,7 +3262,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i12.Future<_i3.RegisterResponse>.value(_FakeRegisterResponse_21(
+            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_22(
           this,
           Invocation.method(
             #register,
@@ -3245,7 +3281,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RegisterResponse>.value(_FakeRegisterResponse_21(
+            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_22(
           this,
           Invocation.method(
             #register,
@@ -3263,12 +3299,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.RegisterResponse>);
+      ) as _i13.Future<_i4.RegisterResponse>);
 
   @override
-  _i12.Future<_i3.LoginResponse> login(
+  _i13.Future<_i4.LoginResponse> login(
     String? type, {
-    _i3.AuthenticationIdentifier? identifier,
+    _i4.AuthenticationIdentifier? identifier,
     String? password,
     String? token,
     String? deviceId,
@@ -3277,7 +3313,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? user,
     String? medium,
     String? address,
-    void Function(_i3.InitState)? onInitStateChanged,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3296,7 +3332,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i12.Future<_i3.LoginResponse>.value(_FakeLoginResponse_22(
+        returnValue: _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_23(
           this,
           Invocation.method(
             #login,
@@ -3316,7 +3352,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.LoginResponse>.value(_FakeLoginResponse_22(
+            _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_23(
           this,
           Invocation.method(
             #login,
@@ -3335,10 +3371,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.LoginResponse>);
+      ) as _i13.Future<_i4.LoginResponse>);
 
   @override
-  _i12.Future<_i3.GetAuthMetadataResponse> getAuthMetadata({
+  _i13.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3351,8 +3387,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i3.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_23(
+        returnValue: _i13.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_24(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -3364,8 +3400,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_23(
+            _i13.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_24(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -3376,80 +3412,80 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.GetAuthMetadataResponse>);
+      ) as _i13.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> logoutAll() => (super.noSuchMethod(
+  _i13.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<T> uiaRequestBackground<T>(
-          _i12.Future<T> Function(_i3.AuthenticationData?)? request) =>
+  _i13.Future<T> uiaRequestBackground<T>(
+          _i13.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValue: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i12.Future<T>.value(v),
+              (T v) => _i13.Future<T>.value(v),
             ) ??
-            _FakeFuture_24<T>(
+            _FakeFuture_25<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i12.Future<T>.value(v),
+              (T v) => _i13.Future<T>.value(v),
             ) ??
-            _FakeFuture_24<T>(
+            _FakeFuture_25<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i12.Future<T>);
+      ) as _i13.Future<T>);
 
   @override
-  _i12.Future<String> startDirectChat(
+  _i13.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
-    List<_i3.StateEvent>? initialState,
+    List<_i4.StateEvent>? initialState,
     bool? waitForSync = true,
     Map<String, dynamic>? powerLevelContentOverride,
-    _i3.CreateRoomPreset? preset = _i3.CreateRoomPreset.trustedPrivateChat,
+    _i4.CreateRoomPreset? preset = _i4.CreateRoomPreset.trustedPrivateChat,
     bool? skipExistingChat = false,
   }) =>
       (super.noSuchMethod(
@@ -3465,7 +3501,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3481,7 +3517,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i18.dummyValue<String>(
+            _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3496,17 +3532,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<String> createGroupChat({
+  _i13.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
-    _i3.CreateRoomPreset? preset = _i3.CreateRoomPreset.privateChat,
-    List<_i3.StateEvent>? initialState,
-    _i3.Visibility? visibility,
-    _i3.HistoryVisibility? historyVisibility,
+    _i4.CreateRoomPreset? preset = _i4.CreateRoomPreset.privateChat,
+    List<_i4.StateEvent>? initialState,
+    _i4.Visibility? visibility,
+    _i4.HistoryVisibility? historyVisibility,
     bool? waitForSync = true,
     bool? groupCall = false,
     bool? federated = true,
@@ -3530,7 +3566,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3551,7 +3587,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i18.dummyValue<String>(
+            _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3571,10 +3607,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i3.SyncUpdate> waitForRoomInSync(
+  _i13.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -3590,7 +3626,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i12.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_25(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3603,7 +3639,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_25(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3615,27 +3651,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i13.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<String> createSpace({
+  _i13.Future<String> createSpace({
     String? name,
     String? topic,
-    _i3.Visibility? visibility = _i3.Visibility.public,
+    _i4.Visibility? visibility = _i4.Visibility.public,
     String? spaceAliasName,
     List<String>? invite,
-    List<_i3.Invite3pid>? invite3pid,
+    List<_i4.Invite3pid>? invite3pid,
     String? roomVersion,
     bool? waitForSync = false,
   }) =>
@@ -3654,7 +3690,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3672,7 +3708,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i18.dummyValue<String>(
+            _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3689,10 +3725,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i3.Profile> fetchOwnProfileFromServer(
+  _i13.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3700,7 +3736,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i12.Future<_i3.Profile>.value(_FakeProfile_15(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3709,7 +3745,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.Profile>.value(_FakeProfile_15(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3717,10 +3753,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i12.Future<_i3.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i12.Future<_i3.Profile> fetchOwnProfile({
+  _i13.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3733,7 +3769,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i12.Future<_i3.Profile>.value(_FakeProfile_15(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3745,7 +3781,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.Profile>.value(_FakeProfile_15(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3756,10 +3792,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i12.Future<_i3.CachedProfileInformation> getUserProfile(
+  _i13.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3773,8 +3809,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i12.Future<_i3.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_26(
+        returnValue: _i13.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_27(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3786,8 +3822,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_26(
+            _i13.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_27(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3798,10 +3834,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.CachedProfileInformation>);
+      ) as _i13.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i12.Future<_i3.Profile> getProfileFromUserId(
+  _i13.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3819,7 +3855,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i12.Future<_i3.Profile>.value(_FakeProfile_15(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3833,7 +3869,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.Profile>.value(_FakeProfile_15(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3846,17 +3882,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i3.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
+  _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getArchiveRoomFromCache,
           [roomId],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.ArchivedRoom?);
+      ) as _i4.ArchivedRoom?);
 
   @override
   void clearArchivesFromCache() => super.noSuchMethod(
@@ -3868,31 +3904,31 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i12.Future<List<_i3.Room>> loadArchive() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i12.Future<List<_i3.Room>>.value(<_i3.Room>[]),
+        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i3.Room>>.value(<_i3.Room>[]),
-      ) as _i12.Future<List<_i3.Room>>);
+            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i13.Future<List<_i4.Room>>);
 
   @override
-  _i12.Future<List<_i3.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i13.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i12.Future<List<_i3.ArchivedRoom>>.value(<_i3.ArchivedRoom>[]),
+            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i3.ArchivedRoom>>.value(<_i3.ArchivedRoom>[]),
-      ) as _i12.Future<List<_i3.ArchivedRoom>>);
+            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i13.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i12.Future<_i3.GetVersionsResponse> getVersions({
+  _i13.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3905,8 +3941,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i3.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_20(
+        returnValue: _i13.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_21(
           this,
           Invocation.method(
             #getVersions,
@@ -3917,8 +3953,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_20(
+        returnValueForMissingStub: _i13.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_21(
           this,
           Invocation.method(
             #getVersions,
@@ -3929,20 +3965,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.GetVersionsResponse>);
+      ) as _i13.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i12.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i13.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<_i3.MediaConfig> getConfig({
+  _i13.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3955,7 +3991,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i3.MediaConfig>.value(_FakeMediaConfig_27(
+        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
           this,
           Invocation.method(
             #getConfig,
@@ -3967,7 +4003,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.MediaConfig>.value(_FakeMediaConfig_27(
+            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
           this,
           Invocation.method(
             #getConfig,
@@ -3978,10 +4014,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.MediaConfig>);
+      ) as _i13.Future<_i4.MediaConfig>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContent(
+  _i13.Future<_i14.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -4001,7 +4037,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContent,
@@ -4017,7 +4053,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_28(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContent,
@@ -4032,10 +4068,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentOverrideName(
+  _i13.Future<_i14.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4057,7 +4093,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -4074,7 +4110,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_28(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -4090,15 +4126,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentThumbnail(
+  _i13.Future<_i14.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
     int? height, {
-    _i3.Method? method,
+    _i4.Method? method,
     bool? allowRemote,
     int? timeoutMs,
     bool? allowRedirect,
@@ -4121,7 +4157,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -4141,7 +4177,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_28(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -4160,10 +4196,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i3.PreviewForUrl> getUrlPreview(
+  _i13.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -4173,7 +4209,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i12.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_29(
+        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -4182,7 +4218,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_29(
+            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -4190,11 +4226,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i12.Future<_i3.PreviewForUrl>);
+      ) as _i13.Future<_i4.PreviewForUrl>);
 
   @override
-  _i12.Future<Uri> uploadContent(
-    _i22.Uint8List? file, {
+  _i13.Future<Uri> uploadContent(
+    _i23.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -4207,7 +4243,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i12.Future<Uri>.value(_FakeUri_30(
+        returnValue: _i13.Future<Uri>.value(_FakeUri_31(
           this,
           Invocation.method(
             #uploadContent,
@@ -4218,7 +4254,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_30(
+        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_31(
           this,
           Invocation.method(
             #uploadContent,
@@ -4229,10 +4265,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<Uri>);
+      ) as _i13.Future<Uri>);
 
   @override
-  _i12.Future<void> setTyping(
+  _i13.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -4248,43 +4284,43 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> exportDump() => (super.noSuchMethod(
+  _i13.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i13.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> setAvatar(_i3.MatrixFile? file) => (super.noSuchMethod(
+  _i13.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.Event?> getEventByPushNotification(
-    _i3.PushNotification? notification, {
+  _i13.Future<_i4.Event?> getEventByPushNotification(
+    _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
     bool? returnNullIfSeen = true,
@@ -4299,12 +4335,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i12.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i3.Event?>.value(),
-      ) as _i12.Future<_i3.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
-  _i12.Future<void> init({
+  _i13.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -4317,7 +4353,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     bool? waitForFirstSync = true,
     bool? waitUntilLoadCompletedLoaded = true,
     void Function()? onMigration,
-    void Function(_i3.InitState)? onInitStateChanged,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4339,9 +4375,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -4353,42 +4389,42 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i12.Future<void> clear() => (super.noSuchMethod(
+  _i13.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i13.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ensureNotSoftLoggedOut(
+  _i13.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleSync(
-    _i3.SyncUpdate? sync, {
-    _i3.Direction? direction,
+  _i13.Future<void> handleSync(
+    _i4.SyncUpdate? sync, {
+    _i4.Direction? direction,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4396,44 +4432,44 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i3.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
+  _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeysByCurve25519Key,
           [senderKey],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.DeviceKeys?);
+      ) as _i4.DeviceKeys?);
 
   @override
-  _i12.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i13.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i13.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDevice(
+  _i13.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -4447,12 +4483,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             messages,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDevicesOfUserIds(
+  _i13.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4468,13 +4504,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDeviceEncrypted(
-    List<_i3.DeviceKeys>? deviceKeys,
+  _i13.Future<void> sendToDeviceEncrypted(
+    List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
     String? messageId,
@@ -4493,13 +4529,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDeviceEncryptedChunked(
-    List<_i3.DeviceKeys>? deviceKeys,
+  _i13.Future<void> sendToDeviceEncryptedChunked(
+    List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
   ) =>
@@ -4512,28 +4548,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
             message,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i13.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> joinRoom(
+  _i13.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
     String? reason,
-    _i3.ThirdPartySigned? thirdPartySigned,
+    _i4.ThirdPartySigned? thirdPartySigned,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4546,7 +4582,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4560,7 +4596,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i18.dummyValue<String>(
+            _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4573,13 +4609,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> changePassword(
+  _i13.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
     bool? logoutDevices,
   }) =>
       (super.noSuchMethod(
@@ -4592,22 +4628,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> clearCache() => (super.noSuchMethod(
+  _i13.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ignoreUser(
+  _i13.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4617,22 +4653,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i13.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.CachedPresence> fetchCurrentPresence(
+  _i13.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4643,7 +4679,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i12.Future<_i3.CachedPresence>.value(_FakeCachedPresence_31(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_32(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4652,7 +4688,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.CachedPresence>.value(_FakeCachedPresence_31(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_32(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4660,32 +4696,32 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i12.Future<_i3.CachedPresence>);
+      ) as _i13.Future<_i4.CachedPresence>);
 
   @override
-  _i12.Future<void> abortSync() => (super.noSuchMethod(
+  _i13.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i13.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEventWithMetadata(
+  _i13.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4705,14 +4741,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i11.BaseResponse? response,
-    _i22.Uint8List? body,
+    _i12.BaseResponse? response,
+    _i23.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4744,8 +4780,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as Never);
 
   @override
-  _i12.Future<Map<String, Object?>> request(
-    _i3.RequestType? type,
+  _i13.Future<Map<String, Object?>> request(
+    _i4.RequestType? type,
     String? action, {
     dynamic data = '',
     String? contentType = 'application/json',
@@ -4765,14 +4801,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> postPusher(
-    _i3.Pusher? pusher, {
+  _i13.Future<void> postPusher(
+    _i4.Pusher? pusher, {
     bool? append,
   }) =>
       (super.noSuchMethod(
@@ -4781,57 +4817,57 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deletePusher(_i3.PusherId? pusher) => (super.noSuchMethod(
+  _i13.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i13.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i13.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i12.Future<_i3.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_32(
+        returnValue: _i13.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_33(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_32(
+        returnValueForMissingStub: _i13.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_33(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i12.Future<_i3.TurnServerCredentials>);
+      ) as _i13.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i12.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4845,8 +4881,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4858,8 +4894,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4870,14 +4906,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i3.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
-    _i3.KeyBackupData? data,
+    _i4.KeyBackupData? data,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4889,8 +4925,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             data,
           ],
         ),
-        returnValue: _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4903,8 +4939,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4916,10 +4952,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i3.KeyBackupData> getRoomKeysBySessionId(
+  _i13.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4933,7 +4969,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_34(
+        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4945,7 +4981,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_34(
+            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4956,17 +4992,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.KeyBackupData>);
+      ) as _i13.Future<_i4.KeyBackupData>);
 
   @override
-  _i12.Future<_i3.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i13.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i12.Future<_i3.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_35(
+        returnValue: _i13.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_36(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -4974,18 +5010,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_35(
+            _i13.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_36(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i12.Future<_i3.GetWellknownSupportResponse>);
+      ) as _i13.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i12.Future<int> pingAppservice(
+  _i13.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -4995,21 +5031,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i12.Future<int>.value(0),
-        returnValueForMissingStub: _i12.Future<int>.value(0),
-      ) as _i12.Future<int>);
+        returnValue: _i13.Future<int>.value(0),
+        returnValueForMissingStub: _i13.Future<int>.value(0),
+      ) as _i13.Future<int>);
 
   @override
-  _i12.Future<_i3.GenerateLoginTokenResponse> generateLoginToken(
-          {_i3.AuthenticationData? auth}) =>
+  _i13.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+          {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
           #generateLoginToken,
           [],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<_i3.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_36(
+        returnValue: _i13.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_37(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -5018,8 +5054,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_36(
+            _i13.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_37(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -5027,15 +5063,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i12.Future<_i3.GenerateLoginTokenResponse>);
+      ) as _i13.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i12.Future<_i3.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i13.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i12.Future<_i3.MediaConfig>.value(_FakeMediaConfig_27(
+        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -5043,17 +5079,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.MediaConfig>.value(_FakeMediaConfig_27(
+            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i12.Future<_i3.MediaConfig>);
+      ) as _i13.Future<_i4.MediaConfig>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentAuthed(
+  _i13.Future<_i14.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -5067,7 +5103,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -5079,7 +5115,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_28(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -5090,10 +5126,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentOverrideNameAuthed(
+  _i13.Future<_i14.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5109,7 +5145,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -5122,7 +5158,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_28(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -5134,10 +5170,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i3.PreviewForUrl> getUrlPreviewAuthed(
+  _i13.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -5147,7 +5183,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i12.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_29(
+        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -5156,7 +5192,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_29(
+            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -5164,15 +5200,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i12.Future<_i3.PreviewForUrl>);
+      ) as _i13.Future<_i4.PreviewForUrl>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentThumbnailAuthed(
+  _i13.Future<_i14.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
     int? height, {
-    _i3.Method? method,
+    _i4.Method? method,
     int? timeoutMs,
     bool? animated,
   }) =>
@@ -5191,7 +5227,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -5209,7 +5245,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_28(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -5226,21 +5262,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<bool> registrationTokenValidity(String? token) =>
+  _i13.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<_i3.GetRoomSummaryResponse$3> getRoomSummary(
+  _i13.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -5250,8 +5286,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i12.Future<_i3.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_37(
+        returnValue: _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_38(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -5260,8 +5296,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_37(
+            _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_38(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -5269,10 +5305,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#via: via},
           ),
         )),
-      ) as _i12.Future<_i3.GetRoomSummaryResponse$3>);
+      ) as _i13.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i12.Future<_i3.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i13.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -5290,8 +5326,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #from: from,
           },
         ),
-        returnValue: _i12.Future<_i3.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_38(
+        returnValue: _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_39(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -5305,8 +5341,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_38(
+            _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_39(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -5319,16 +5355,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.GetSpaceHierarchyResponse>);
+      ) as _i13.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i12.Future<_i3.GetRelatingEventsResponse> getRelatingEvents(
+  _i13.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
       (super.noSuchMethod(
@@ -5346,8 +5382,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i12.Future<_i3.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_39(
+        returnValue: _i13.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_40(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -5365,8 +5401,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_39(
+            _i13.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_40(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -5383,10 +5419,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.GetRelatingEventsResponse>);
+      ) as _i13.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i12.Future<_i3.GetRelatingEventsWithRelTypeResponse>
+  _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -5394,7 +5430,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
           (super.noSuchMethod(
@@ -5414,8 +5450,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
             returnValue:
-                _i12.Future<_i3.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_40(
+                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_41(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5434,8 +5470,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i12.Future<_i3.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_40(
+                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_41(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5453,10 +5489,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-          ) as _i12.Future<_i3.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i12.Future<_i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i13.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -5465,7 +5501,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
           (super.noSuchMethod(
@@ -5485,9 +5521,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i12.Future<
-                    _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
+            returnValue: _i13.Future<
+                    _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5506,9 +5542,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i12.Future<
-                    _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
+            returnValueForMissingStub: _i13.Future<
+                    _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5527,13 +5563,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-          ) as _i12
-              .Future<_i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
+          ) as _i13
+              .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i12.Future<_i3.GetThreadRootsResponse> getThreadRoots(
+  _i13.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
-    _i3.Include? include,
+    _i4.Include? include,
     int? limit,
     String? from,
   }) =>
@@ -5547,8 +5583,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #from: from,
           },
         ),
-        returnValue: _i12.Future<_i3.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_42(
+        returnValue: _i13.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_43(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5561,8 +5597,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_42(
+            _i13.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_43(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5574,13 +5610,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.GetThreadRootsResponse>);
+      ) as _i13.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i12.Future<_i3.GetEventByTimestampResponse> getEventByTimestamp(
+  _i13.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5591,8 +5627,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             dir,
           ],
         ),
-        returnValue: _i12.Future<_i3.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_43(
+        returnValue: _i13.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_44(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5604,8 +5640,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_43(
+            _i13.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_44(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5616,36 +5652,36 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.GetEventByTimestampResponse>);
+      ) as _i13.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i12.Future<List<_i3.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i13.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i12.Future<List<_i3.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i12.Future<List<_i3.ThirdPartyIdentifier>?>.value(),
-      ) as _i12.Future<List<_i3.ThirdPartyIdentifier>?>);
+            _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i13.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i12.Future<Uri?> post3PIDs(_i3.ThreePidCredentials? threePidCreds) =>
+  _i13.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i12.Future<Uri?>.value(),
-        returnValueForMissingStub: _i12.Future<Uri?>.value(),
-      ) as _i12.Future<Uri?>);
+        returnValue: _i13.Future<Uri?>.value(),
+        returnValueForMissingStub: _i13.Future<Uri?>.value(),
+      ) as _i13.Future<Uri?>);
 
   @override
-  _i12.Future<void> add3PID(
+  _i13.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5656,12 +5692,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> bind3PID(
+  _i13.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5677,14 +5713,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             sid,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.IdServerUnbindResult> delete3pidFromAccount(
+  _i13.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
-    _i3.ThirdPartyIdentifierMedium? medium, {
+    _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
   }) =>
       (super.noSuchMethod(
@@ -5696,14 +5732,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i12.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i3.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5725,8 +5761,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5742,8 +5778,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5759,10 +5795,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i3.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5786,8 +5822,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5804,8 +5840,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5822,12 +5858,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i3.IdServerUnbindResult> unbind3pidFromAccount(
+  _i13.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
-    _i3.ThirdPartyIdentifierMedium? medium, {
+    _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
   }) =>
       (super.noSuchMethod(
@@ -5839,15 +5875,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i12.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i3.IdServerUnbindResult> deactivateAccount({
-    _i3.AuthenticationData? auth,
+  _i13.Future<_i4.IdServerUnbindResult> deactivateAccount({
+    _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
   }) =>
@@ -5861,14 +5897,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i3.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5890,8 +5926,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5907,8 +5943,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5924,10 +5960,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i3.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5951,8 +5987,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5969,8 +6005,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5987,16 +6023,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i3.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i13.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i12.Future<_i3.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_45(
+            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -6004,22 +6040,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_45(
+            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i12.Future<_i3.TokenOwnerInfo>);
+      ) as _i13.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i12.Future<_i3.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i13.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i12.Future<_i3.WhoIsInfo>.value(_FakeWhoIsInfo_46(
+        returnValue: _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_47(
           this,
           Invocation.method(
             #getWhoIs,
@@ -6027,22 +6063,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.WhoIsInfo>.value(_FakeWhoIsInfo_46(
+            _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_47(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i3.WhoIsInfo>);
+      ) as _i13.Future<_i4.WhoIsInfo>);
 
   @override
-  _i12.Future<_i3.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i13.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i12.Future<_i3.Capabilities>.value(_FakeCapabilities_47(
+        returnValue: _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_48(
           this,
           Invocation.method(
             #getCapabilities,
@@ -6050,29 +6086,29 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.Capabilities>.value(_FakeCapabilities_47(
+            _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_48(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i12.Future<_i3.Capabilities>);
+      ) as _i13.Future<_i4.Capabilities>);
 
   @override
-  _i12.Future<String> createRoom({
+  _i13.Future<String> createRoom({
     Map<String, Object?>? creationContent,
-    List<_i3.StateEvent>? initialState,
+    List<_i4.StateEvent>? initialState,
     List<String>? invite,
-    List<_i3.Invite3pid>? invite3pid,
+    List<_i4.Invite3pid>? invite3pid,
     bool? isDirect,
     String? name,
     Map<String, Object?>? powerLevelContentOverride,
-    _i3.CreateRoomPreset? preset,
+    _i4.CreateRoomPreset? preset,
     String? roomAliasName,
     String? roomVersion,
     String? topic,
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6093,7 +6129,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -6115,7 +6151,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i18.dummyValue<String>(
+            _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -6136,12 +6172,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> deleteDevices(
+  _i13.Future<void> deleteDevices(
     List<String>? devices, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6149,24 +6185,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i3.Device>?> getDevices() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i12.Future<List<_i3.Device>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i3.Device>?>.value(),
-      ) as _i12.Future<List<_i3.Device>?>);
+        returnValue: _i13.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.Device>?>.value(),
+      ) as _i13.Future<List<_i4.Device>?>);
 
   @override
-  _i12.Future<void> deleteDevice(
+  _i13.Future<void> deleteDevice(
     String? deviceId, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6174,34 +6210,34 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i13.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i12.Future<_i3.Device>.value(_FakeDevice_48(
+        returnValue: _i13.Future<_i4.Device>.value(_FakeDevice_49(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.Device>.value(_FakeDevice_48(
+        returnValueForMissingStub: _i13.Future<_i4.Device>.value(_FakeDevice_49(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i12.Future<_i3.Device>);
+      ) as _i13.Future<_i4.Device>);
 
   @override
-  _i12.Future<void> updateDevice(
+  _i13.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -6211,15 +6247,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i13.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6231,26 +6267,26 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i3.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i13.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i12.Future<_i3.Visibility?>.value(),
-        returnValueForMissingStub: _i12.Future<_i3.Visibility?>.value(),
-      ) as _i12.Future<_i3.Visibility?>);
+        returnValue: _i13.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Visibility?>.value(),
+      ) as _i13.Future<_i4.Visibility?>);
 
   @override
-  _i12.Future<void> setRoomVisibilityOnDirectory(
+  _i13.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6258,30 +6294,30 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i13.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i13.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i12.Future<_i3.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_49(
+        returnValue: _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_50(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -6289,18 +6325,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_49(
+            _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_50(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i12.Future<_i3.GetRoomIdByAliasResponse>);
+      ) as _i13.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i12.Future<void> setRoomAlias(
+  _i13.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -6312,12 +6348,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             roomId,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.GetEventsResponse> getEvents({
+  _i13.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -6331,7 +6367,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i12.Future<_i3.GetEventsResponse>.value(_FakeGetEventsResponse_50(
+            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_51(
           this,
           Invocation.method(
             #getEvents,
@@ -6343,7 +6379,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetEventsResponse>.value(_FakeGetEventsResponse_50(
+            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_51(
           this,
           Invocation.method(
             #getEvents,
@@ -6354,10 +6390,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.GetEventsResponse>);
+      ) as _i13.Future<_i4.GetEventsResponse>);
 
   @override
-  _i12.Future<_i3.PeekEventsResponse> peekEvents({
+  _i13.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -6372,8 +6408,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i12.Future<_i3.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_51(
+        returnValue: _i13.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_52(
           this,
           Invocation.method(
             #peekEvents,
@@ -6385,8 +6421,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_51(
+        returnValueForMissingStub: _i13.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_52(
           this,
           Invocation.method(
             #peekEvents,
@@ -6398,16 +6434,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.PeekEventsResponse>);
+      ) as _i13.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i12.Future<_i3.MatrixEvent> getOneEvent(String? eventId) =>
+  _i13.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i12.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_52(
+        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
           this,
           Invocation.method(
             #getOneEvent,
@@ -6415,27 +6451,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_52(
+            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i12.Future<_i3.MatrixEvent>);
+      ) as _i13.Future<_i4.MatrixEvent>);
 
   @override
-  _i12.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i13.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i12.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
-      ) as _i12.Future<List<String>>);
+        returnValue: _i13.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
+      ) as _i13.Future<List<String>>);
 
   @override
-  _i12.Future<_i3.GetKeysChangesResponse> getKeysChanges(
+  _i13.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -6447,8 +6483,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             to,
           ],
         ),
-        returnValue: _i12.Future<_i3.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_53(
+        returnValue: _i13.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_54(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6459,8 +6495,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_53(
+            _i13.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_54(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6470,10 +6506,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.GetKeysChangesResponse>);
+      ) as _i13.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i12.Future<_i3.ClaimKeysResponse> claimKeys(
+  _i13.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -6484,7 +6520,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i12.Future<_i3.ClaimKeysResponse>.value(_FakeClaimKeysResponse_54(
+            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
           this,
           Invocation.method(
             #claimKeys,
@@ -6493,7 +6529,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.ClaimKeysResponse>.value(_FakeClaimKeysResponse_54(
+            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
           this,
           Invocation.method(
             #claimKeys,
@@ -6501,14 +6537,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i12.Future<_i3.ClaimKeysResponse>);
+      ) as _i13.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i12.Future<void> uploadCrossSigningKeys({
-    _i3.AuthenticationData? auth,
-    _i3.MatrixCrossSigningKey? masterKey,
-    _i3.MatrixCrossSigningKey? selfSigningKey,
-    _i3.MatrixCrossSigningKey? userSigningKey,
+  _i13.Future<void> uploadCrossSigningKeys({
+    _i4.AuthenticationData? auth,
+    _i4.MatrixCrossSigningKey? masterKey,
+    _i4.MatrixCrossSigningKey? selfSigningKey,
+    _i4.MatrixCrossSigningKey? userSigningKey,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6521,12 +6557,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.QueryKeysResponse> queryKeys(
+  _i13.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -6537,7 +6573,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i12.Future<_i3.QueryKeysResponse>.value(_FakeQueryKeysResponse_55(
+            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
           this,
           Invocation.method(
             #queryKeys,
@@ -6546,7 +6582,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.QueryKeysResponse>.value(_FakeQueryKeysResponse_55(
+            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
           this,
           Invocation.method(
             #queryKeys,
@@ -6554,10 +6590,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i12.Future<_i3.QueryKeysResponse>);
+      ) as _i13.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -6565,15 +6601,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i12.Future<
+            returnValue: _i13.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i12.Future<
+            returnValueForMissingStub: _i13.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i12.Future<Map<String, int>> uploadKeys({
-    _i3.MatrixDeviceKeys? deviceKeys,
+  _i13.Future<Map<String, int>> uploadKeys({
+    _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
   }) =>
@@ -6587,13 +6623,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i12.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i13.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i12.Future<Map<String, int>>);
+            _i13.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i13.Future<Map<String, int>>);
 
   @override
-  _i12.Future<String> knockRoom(
+  _i13.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6607,7 +6643,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6619,7 +6655,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i18.dummyValue<String>(
+            _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6630,20 +6666,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<List<_i3.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i13.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i12.Future<List<_i3.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i3.LoginFlow>?>.value(),
-      ) as _i12.Future<List<_i3.LoginFlow>?>);
+        returnValue: _i13.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i13.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i12.Future<_i3.GetNotificationsResponse> getNotifications({
+  _i13.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6658,8 +6694,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #only: only,
           },
         ),
-        returnValue: _i12.Future<_i3.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_56(
+        returnValue: _i13.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_57(
           this,
           Invocation.method(
             #getNotifications,
@@ -6672,8 +6708,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_56(
+            _i13.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_57(
           this,
           Invocation.method(
             #getNotifications,
@@ -6685,37 +6721,37 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.GetNotificationsResponse>);
+      ) as _i13.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i12.Future<_i3.GetPresenceResponse> getPresence(String? userId) =>
+  _i13.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i12.Future<_i3.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_57(
+        returnValue: _i13.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_58(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_57(
+        returnValueForMissingStub: _i13.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_58(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i3.GetPresenceResponse>);
+      ) as _i13.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i12.Future<void> setPresence(
+  _i13.Future<void> setPresence(
     String? userId,
-    _i3.PresenceType? presence, {
+    _i4.PresenceType? presence, {
     String? statusMsg,
   }) =>
       (super.noSuchMethod(
@@ -6727,12 +6763,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, Object?>> deleteProfileField(
+  _i13.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6745,13 +6781,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getProfileField(
+  _i13.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6764,13 +6800,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<Map<String, Object?>> setProfileField(
+  _i13.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6785,13 +6821,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i3.GetPublicRoomsResponse> getPublicRooms({
+  _i13.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6806,8 +6842,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #server: server,
           },
         ),
-        returnValue: _i12.Future<_i3.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_58(
+        returnValue: _i13.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_59(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6820,8 +6856,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_58(
+            _i13.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_59(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6833,12 +6869,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.GetPublicRoomsResponse>);
+      ) as _i13.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i12.Future<_i3.QueryPublicRoomsResponse> queryPublicRooms({
+  _i13.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
-    _i3.PublicRoomQueryFilter? filter,
+    _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
     int? limit,
     String? since,
@@ -6857,8 +6893,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i12.Future<_i3.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_59(
+        returnValue: _i13.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_60(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6874,8 +6910,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_59(
+            _i13.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_60(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6890,25 +6926,25 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.QueryPublicRoomsResponse>);
+      ) as _i13.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i12.Future<List<_i3.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i12.Future<List<_i3.Pusher>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i3.Pusher>?>.value(),
-      ) as _i12.Future<List<_i3.Pusher>?>);
+        returnValue: _i13.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.Pusher>?>.value(),
+      ) as _i13.Future<List<_i4.Pusher>?>);
 
   @override
-  _i12.Future<_i3.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i13.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i12.Future<_i3.PushRuleSet>.value(_FakePushRuleSet_60(
+        returnValue: _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_61(
           this,
           Invocation.method(
             #getPushRules,
@@ -6916,24 +6952,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.PushRuleSet>.value(_FakePushRuleSet_60(
+            _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_61(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i12.Future<_i3.PushRuleSet>);
+      ) as _i13.Future<_i4.PushRuleSet>);
 
   @override
-  _i12.Future<_i3.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i13.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i12.Future<_i3.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_61(
+        returnValue: _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_62(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -6941,19 +6977,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_61(
+            _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_62(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i12.Future<_i3.GetPushRulesGlobalResponse>);
+      ) as _i13.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i12.Future<void> deletePushRule(
-    _i3.PushRuleKind? kind,
+  _i13.Future<void> deletePushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -6964,13 +7000,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.PushRule> getPushRule(
-    _i3.PushRuleKind? kind,
+  _i13.Future<_i4.PushRule> getPushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -6981,7 +7017,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<_i3.PushRule>.value(_FakePushRule_62(
+        returnValue: _i13.Future<_i4.PushRule>.value(_FakePushRule_63(
           this,
           Invocation.method(
             #getPushRule,
@@ -6992,7 +7028,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.PushRule>.value(_FakePushRule_62(
+            _i13.Future<_i4.PushRule>.value(_FakePushRule_63(
           this,
           Invocation.method(
             #getPushRule,
@@ -7002,16 +7038,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.PushRule>);
+      ) as _i13.Future<_i4.PushRule>);
 
   @override
-  _i12.Future<void> setPushRule(
-    _i3.PushRuleKind? kind,
+  _i13.Future<void> setPushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
     String? before,
     String? after,
-    List<_i3.PushCondition>? conditions,
+    List<_i4.PushCondition>? conditions,
     String? pattern,
   }) =>
       (super.noSuchMethod(
@@ -7029,13 +7065,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<Object?>> getPushRuleActions(
-    _i3.PushRuleKind? kind,
+  _i13.Future<List<Object?>> getPushRuleActions(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -7046,14 +7082,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i13.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i12.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i12.Future<List<Object?>>);
+            _i13.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i13.Future<List<Object?>>);
 
   @override
-  _i12.Future<void> setPushRuleActions(
-    _i3.PushRuleKind? kind,
+  _i13.Future<void> setPushRuleActions(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
   ) =>
@@ -7066,13 +7102,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             actions,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<bool> isPushRuleEnabled(
-    _i3.PushRuleKind? kind,
+  _i13.Future<bool> isPushRuleEnabled(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -7083,13 +7119,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> setPushRuleEnabled(
-    _i3.PushRuleKind? kind,
+  _i13.Future<void> setPushRuleEnabled(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
   ) =>
@@ -7102,19 +7138,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
             enabled,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.RefreshResponse> refresh(String? refreshToken) =>
+  _i13.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i12.Future<_i3.RefreshResponse>.value(_FakeRefreshResponse_63(
+            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_64(
           this,
           Invocation.method(
             #refresh,
@@ -7122,28 +7158,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RefreshResponse>.value(_FakeRefreshResponse_63(
+            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_64(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i12.Future<_i3.RefreshResponse>);
+      ) as _i13.Future<_i4.RefreshResponse>);
 
   @override
-  _i12.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i13.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i12.Future<bool?>.value(),
-        returnValueForMissingStub: _i12.Future<bool?>.value(),
-      ) as _i12.Future<bool?>);
+        returnValue: _i13.Future<bool?>.value(),
+        returnValueForMissingStub: _i13.Future<bool?>.value(),
+      ) as _i13.Future<bool?>);
 
   @override
-  _i12.Future<_i3.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7165,8 +7201,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -7182,8 +7218,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -7199,10 +7235,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i3.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7226,8 +7262,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -7244,8 +7280,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -7262,17 +7298,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -7280,23 +7316,23 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i3.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i13.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i12.Future<_i3.RoomKeys>.value(_FakeRoomKeys_64(
+        returnValue: _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_65(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -7304,19 +7340,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeys>.value(_FakeRoomKeys_64(
+            _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_65(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeys>);
+      ) as _i13.Future<_i4.RoomKeys>);
 
   @override
-  _i12.Future<_i3.RoomKeysUpdateResponse> putRoomKeys(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
-    _i3.RoomKeys? body,
+    _i4.RoomKeys? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7326,8 +7362,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -7338,8 +7374,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -7349,10 +7385,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -7364,8 +7400,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -7376,8 +7412,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -7387,10 +7423,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i3.RoomKeyBackup> getRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -7402,7 +7438,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i3.RoomKeyBackup>.value(_FakeRoomKeyBackup_65(
+        returnValue: _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -7413,7 +7449,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeyBackup>.value(_FakeRoomKeyBackup_65(
+            _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -7423,13 +7459,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeyBackup>);
+      ) as _i13.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i12.Future<_i3.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
-    _i3.RoomKeyBackup? body,
+    _i4.RoomKeyBackup? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7440,8 +7476,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7453,8 +7489,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7465,10 +7501,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7482,8 +7518,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7495,8 +7531,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7507,10 +7543,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i3.KeyBackupData> getRoomKeyBySessionId(
+  _i13.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7524,7 +7560,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_34(
+        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7536,7 +7572,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_34(
+            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7547,14 +7583,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.KeyBackupData>);
+      ) as _i13.Future<_i4.KeyBackupData>);
 
   @override
-  _i12.Future<_i3.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
-    _i3.KeyBackupData? body,
+    _i4.KeyBackupData? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7566,8 +7602,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7580,8 +7616,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7593,18 +7629,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i3.GetRoomKeysVersionCurrentResponse>
+  _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i12.Future<_i3.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_66(
+                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_67(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7612,19 +7648,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i12.Future<_i3.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_66(
+                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_67(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i12.Future<_i3.GetRoomKeysVersionCurrentResponse>);
+          ) as _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i12.Future<String> postRoomKeysVersion(
-    _i3.BackupAlgorithm? algorithm,
+  _i13.Future<String> postRoomKeysVersion(
+    _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
       (super.noSuchMethod(
@@ -7635,7 +7671,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             authData,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7646,7 +7682,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i18.dummyValue<String>(
+            _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7656,29 +7692,29 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i13.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i13.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i12.Future<_i3.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_67(
+        returnValue: _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_68(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7686,20 +7722,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_67(
+            _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_68(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i12.Future<_i3.GetRoomKeysVersionResponse>);
+      ) as _i13.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i13.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
-    _i3.BackupAlgorithm? algorithm,
+    _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
       (super.noSuchMethod(
@@ -7712,24 +7748,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i13.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i12.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
-      ) as _i12.Future<List<String>>);
+        returnValue: _i13.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
+      ) as _i13.Future<List<String>>);
 
   @override
-  _i12.Future<void> ban(
+  _i13.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7743,12 +7779,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.EventContext> getEventContext(
+  _i13.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7766,7 +7802,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<_i3.EventContext>.value(_FakeEventContext_68(
+        returnValue: _i13.Future<_i4.EventContext>.value(_FakeEventContext_69(
           this,
           Invocation.method(
             #getEventContext,
@@ -7781,7 +7817,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.EventContext>.value(_FakeEventContext_68(
+            _i13.Future<_i4.EventContext>.value(_FakeEventContext_69(
           this,
           Invocation.method(
             #getEventContext,
@@ -7795,10 +7831,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.EventContext>);
+      ) as _i13.Future<_i4.EventContext>);
 
   @override
-  _i12.Future<_i3.MatrixEvent> getOneRoomEvent(
+  _i13.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7810,7 +7846,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             eventId,
           ],
         ),
-        returnValue: _i12.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_52(
+        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7821,7 +7857,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_52(
+            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7831,22 +7867,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.MatrixEvent>);
+      ) as _i13.Future<_i4.MatrixEvent>);
 
   @override
-  _i12.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i13.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> inviteBy3PID(
+  _i13.Future<void> inviteBy3PID(
     String? roomId,
-    _i3.Invite3pid? body,
+    _i4.Invite3pid? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7856,12 +7892,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> inviteUser(
+  _i13.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7875,15 +7911,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> joinRoomById(
+  _i13.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
-    _i3.ThirdPartySigned? thirdPartySigned,
+    _i4.ThirdPartySigned? thirdPartySigned,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7894,7 +7930,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7906,7 +7942,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i18.dummyValue<String>(
+            _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7917,23 +7953,23 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<Map<String, _i3.RoomMember>?> getJoinedMembersByRoom(
+  _i13.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i12.Future<Map<String, _i3.RoomMember>?>.value(),
+        returnValue: _i13.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i12.Future<Map<String, _i3.RoomMember>?>.value(),
-      ) as _i12.Future<Map<String, _i3.RoomMember>?>);
+            _i13.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i13.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i12.Future<void> kick(
+  _i13.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7947,12 +7983,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> leaveRoom(
+  _i13.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -7962,16 +7998,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i3.MatrixEvent>?> getMembersByRoom(
+  _i13.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
-    _i3.Membership? membership,
-    _i3.Membership? notMembership,
+    _i4.Membership? membership,
+    _i4.Membership? notMembership,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7983,14 +8019,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i12.Future<List<_i3.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i3.MatrixEvent>?>.value(),
-      ) as _i12.Future<List<_i3.MatrixEvent>?>);
+        returnValue: _i13.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i13.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i12.Future<_i3.GetRoomEventsResponse> getRoomEvents(
+  _i13.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
-    _i3.Direction? dir, {
+    _i4.Direction? dir, {
     String? from,
     String? to,
     int? limit,
@@ -8010,8 +8046,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<_i3.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_69(
+        returnValue: _i13.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_70(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -8027,8 +8063,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_69(
+        returnValueForMissingStub: _i13.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_70(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -8044,10 +8080,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.GetRoomEventsResponse>);
+      ) as _i13.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i12.Future<void> setReadMarker(
+  _i13.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -8063,14 +8099,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> postReceipt(
+  _i13.Future<void> postReceipt(
     String? roomId,
-    _i3.ReceiptType? receiptType,
+    _i4.ReceiptType? receiptType,
     String? eventId, {
     String? threadId,
   }) =>
@@ -8084,12 +8120,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEvent(
+  _i13.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -8105,12 +8141,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> reportRoom(
+  _i13.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -8122,12 +8158,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             reason,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> reportEvent(
+  _i13.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -8145,12 +8181,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #score: score,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> sendMessage(
+  _i13.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -8166,7 +8202,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -8179,7 +8215,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i18.dummyValue<String>(
+            _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -8191,27 +8227,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<List<_i3.MatrixEvent>> getRoomState(String? roomId) =>
+  _i13.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i12.Future<List<_i3.MatrixEvent>>.value(<_i3.MatrixEvent>[]),
+            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i3.MatrixEvent>>.value(<_i3.MatrixEvent>[]),
-      ) as _i12.Future<List<_i3.MatrixEvent>>);
+            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i13.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i13.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
-    _i3.Format? format,
+    _i4.Format? format,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8224,13 +8260,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#format: format},
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<String> setRoomStateWithKey(
+  _i13.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -8246,7 +8282,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -8259,7 +8295,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i18.dummyValue<String>(
+            _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -8271,10 +8307,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> unban(
+  _i13.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8288,12 +8324,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> upgradeRoom(
+  _i13.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -8307,7 +8343,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i12.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -8319,7 +8355,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i18.dummyValue<String>(
+            _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -8330,11 +8366,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i3.SearchResults> search(
-    _i3.Categories? searchCategories, {
+  _i13.Future<_i4.SearchResults> search(
+    _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
       (super.noSuchMethod(
@@ -8343,7 +8379,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i12.Future<_i3.SearchResults>.value(_FakeSearchResults_70(
+        returnValue: _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_71(
           this,
           Invocation.method(
             #search,
@@ -8352,7 +8388,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.SearchResults>.value(_FakeSearchResults_70(
+            _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_71(
           this,
           Invocation.method(
             #search,
@@ -8360,14 +8396,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i12.Future<_i3.SearchResults>);
+      ) as _i13.Future<_i4.SearchResults>);
 
   @override
-  _i12.Future<_i3.SyncUpdate> sync({
+  _i13.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
-    _i3.PresenceType? setPresence,
+    _i4.PresenceType? setPresence,
     int? timeout,
     bool? useStateAfter,
   }) =>
@@ -8384,7 +8420,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i12.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_25(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #sync,
@@ -8400,7 +8436,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_25(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #sync,
@@ -8415,22 +8451,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i3.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<List<_i3.Location>> queryLocationByAlias(String? alias) =>
+  _i13.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i12.Future<List<_i3.Location>>.value(<_i3.Location>[]),
+        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i3.Location>>.value(<_i3.Location>[]),
-      ) as _i12.Future<List<_i3.Location>>);
+            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i13.Future<List<_i4.Location>>);
 
   @override
-  _i12.Future<List<_i3.Location>> queryLocationByProtocol(
+  _i13.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8440,21 +8476,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i12.Future<List<_i3.Location>>.value(<_i3.Location>[]),
+        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i3.Location>>.value(<_i3.Location>[]),
-      ) as _i12.Future<List<_i3.Location>>);
+            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i13.Future<List<_i4.Location>>);
 
   @override
-  _i12.Future<_i3.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i13.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i12.Future<_i3.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_71(
+        returnValue: _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_72(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -8462,45 +8498,45 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_71(
+            _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_72(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i12.Future<_i3.GetProtocolMetadataResponse$2>);
+      ) as _i13.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i12.Future<Map<String, _i3.GetProtocolsResponse$2>> getProtocols() =>
+  _i13.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i12.Future<Map<String, _i3.GetProtocolsResponse$2>>.value(
-            <String, _i3.GetProtocolsResponse$2>{}),
+        returnValue: _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, _i3.GetProtocolsResponse$2>>.value(
-                <String, _i3.GetProtocolsResponse$2>{}),
-      ) as _i12.Future<Map<String, _i3.GetProtocolsResponse$2>>);
+            _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+                <String, _i4.GetProtocolsResponse$2>{}),
+      ) as _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i12.Future<List<_i3.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i12.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
-      ) as _i12.Future<List<_i3.ThirdPartyUser>>);
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i12.Future<List<_i3.ThirdPartyUser>> queryUserByProtocol(
+  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8511,13 +8547,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i12.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
-      ) as _i12.Future<List<_i3.ThirdPartyUser>>);
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getAccountData(
+  _i13.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -8530,13 +8566,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> setAccountData(
+  _i13.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -8550,14 +8586,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> defineFilter(
+  _i13.Future<String> defineFilter(
     String? userId,
-    _i3.Filter? body,
+    _i4.Filter? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8567,7 +8603,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8578,7 +8614,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i18.dummyValue<String>(
+            _i13.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8588,10 +8624,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i3.Filter> getFilter(
+  _i13.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8603,7 +8639,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             filterId,
           ],
         ),
-        returnValue: _i12.Future<_i3.Filter>.value(_FakeFilter_11(
+        returnValue: _i13.Future<_i4.Filter>.value(_FakeFilter_12(
           this,
           Invocation.method(
             #getFilter,
@@ -8613,7 +8649,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.Filter>.value(_FakeFilter_11(
+        returnValueForMissingStub: _i13.Future<_i4.Filter>.value(_FakeFilter_12(
           this,
           Invocation.method(
             #getFilter,
@@ -8623,10 +8659,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.Filter>);
+      ) as _i13.Future<_i4.Filter>);
 
   @override
-  _i12.Future<_i3.OpenIdCredentials> requestOpenIdToken(
+  _i13.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8639,7 +8675,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i12.Future<_i3.OpenIdCredentials>.value(_FakeOpenIdCredentials_72(
+            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8650,7 +8686,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.OpenIdCredentials>.value(_FakeOpenIdCredentials_72(
+            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8660,10 +8696,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i3.OpenIdCredentials>);
+      ) as _i13.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i12.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i13.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8678,13 +8714,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> setAccountDataPerRoom(
+  _i13.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8700,12 +8736,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, _i3.Tag>?> getRoomTags(
+  _i13.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8717,12 +8753,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             roomId,
           ],
         ),
-        returnValue: _i12.Future<Map<String, _i3.Tag>?>.value(),
-        returnValueForMissingStub: _i12.Future<Map<String, _i3.Tag>?>.value(),
-      ) as _i12.Future<Map<String, _i3.Tag>?>);
+        returnValue: _i13.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i13.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i13.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i12.Future<void> deleteRoomTag(
+  _i13.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8736,16 +8772,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             tag,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setRoomTag(
+  _i13.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
-    _i3.Tag? body,
+    _i4.Tag? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8757,12 +8793,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.SearchUserDirectoryResponse> searchUserDirectory(
+  _i13.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8772,8 +8808,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i12.Future<_i3.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_73(
+        returnValue: _i13.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_74(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8782,8 +8818,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_73(
+            _i13.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_74(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8791,10 +8827,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i12.Future<_i3.SearchUserDirectoryResponse>);
+      ) as _i13.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> reportUser(
+  _i13.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8807,40 +8843,40 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i3.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i13.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i12.Future<_i3.CreateContentResponse>.value(
-            _FakeCreateContentResponse_74(
+        returnValue: _i13.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_75(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.CreateContentResponse>.value(
-            _FakeCreateContentResponse_74(
+        returnValueForMissingStub: _i13.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_75(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i12.Future<_i3.CreateContentResponse>);
+      ) as _i13.Future<_i4.CreateContentResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> uploadContentToMXC(
+  _i13.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i22.Uint8List? body, {
+    _i23.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8858,28 +8894,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [Encryption].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEncryption extends _i1.Mock implements _i9.Encryption {
+class MockEncryption extends _i1.Mock implements _i10.Encryption {
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get debug => (super.noSuchMethod(
@@ -8896,85 +8932,85 @@ class MockEncryption extends _i1.Mock implements _i9.Encryption {
       ) as bool);
 
   @override
-  _i9.KeyManager get keyManager => (super.noSuchMethod(
+  _i10.KeyManager get keyManager => (super.noSuchMethod(
         Invocation.getter(#keyManager),
-        returnValue: _FakeKeyManager_75(
+        returnValue: _FakeKeyManager_76(
           this,
           Invocation.getter(#keyManager),
         ),
-        returnValueForMissingStub: _FakeKeyManager_75(
+        returnValueForMissingStub: _FakeKeyManager_76(
           this,
           Invocation.getter(#keyManager),
         ),
-      ) as _i9.KeyManager);
+      ) as _i10.KeyManager);
 
   @override
-  _i14.OlmManager get olmManager => (super.noSuchMethod(
+  _i15.OlmManager get olmManager => (super.noSuchMethod(
         Invocation.getter(#olmManager),
-        returnValue: _FakeOlmManager_76(
+        returnValue: _FakeOlmManager_77(
           this,
           Invocation.getter(#olmManager),
         ),
-        returnValueForMissingStub: _FakeOlmManager_76(
+        returnValueForMissingStub: _FakeOlmManager_77(
           this,
           Invocation.getter(#olmManager),
         ),
-      ) as _i14.OlmManager);
+      ) as _i15.OlmManager);
 
   @override
-  _i15.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
+  _i16.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
         Invocation.getter(#keyVerificationManager),
-        returnValue: _FakeKeyVerificationManager_77(
+        returnValue: _FakeKeyVerificationManager_78(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-        returnValueForMissingStub: _FakeKeyVerificationManager_77(
+        returnValueForMissingStub: _FakeKeyVerificationManager_78(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-      ) as _i15.KeyVerificationManager);
+      ) as _i16.KeyVerificationManager);
 
   @override
-  _i16.CrossSigning get crossSigning => (super.noSuchMethod(
+  _i17.CrossSigning get crossSigning => (super.noSuchMethod(
         Invocation.getter(#crossSigning),
-        returnValue: _FakeCrossSigning_78(
+        returnValue: _FakeCrossSigning_79(
           this,
           Invocation.getter(#crossSigning),
         ),
-        returnValueForMissingStub: _FakeCrossSigning_78(
+        returnValueForMissingStub: _FakeCrossSigning_79(
           this,
           Invocation.getter(#crossSigning),
         ),
-      ) as _i16.CrossSigning);
+      ) as _i17.CrossSigning);
 
   @override
-  _i9.SSSS get ssss => (super.noSuchMethod(
+  _i10.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_8(
+        returnValue: _FakeSSSS_9(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_8(
+        returnValueForMissingStub: _FakeSSSS_9(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i9.SSSS);
+      ) as _i10.SSSS);
 
   @override
   String get ourDeviceId => (super.noSuchMethod(
         Invocation.getter(#ourDeviceId),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
       ) as String);
 
   @override
-  set keyManager(_i9.KeyManager? value) => super.noSuchMethod(
+  set keyManager(_i10.KeyManager? value) => super.noSuchMethod(
         Invocation.setter(
           #keyManager,
           value,
@@ -8983,7 +9019,7 @@ class MockEncryption extends _i1.Mock implements _i9.Encryption {
       );
 
   @override
-  set olmManager(_i14.OlmManager? value) => super.noSuchMethod(
+  set olmManager(_i15.OlmManager? value) => super.noSuchMethod(
         Invocation.setter(
           #olmManager,
           value,
@@ -8992,7 +9028,7 @@ class MockEncryption extends _i1.Mock implements _i9.Encryption {
       );
 
   @override
-  set keyVerificationManager(_i15.KeyVerificationManager? value) =>
+  set keyVerificationManager(_i16.KeyVerificationManager? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #keyVerificationManager,
@@ -9002,7 +9038,7 @@ class MockEncryption extends _i1.Mock implements _i9.Encryption {
       );
 
   @override
-  set crossSigning(_i16.CrossSigning? value) => super.noSuchMethod(
+  set crossSigning(_i17.CrossSigning? value) => super.noSuchMethod(
         Invocation.setter(
           #crossSigning,
           value,
@@ -9011,7 +9047,7 @@ class MockEncryption extends _i1.Mock implements _i9.Encryption {
       );
 
   @override
-  set ssss(_i9.SSSS? value) => super.noSuchMethod(
+  set ssss(_i10.SSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #ssss,
           value,
@@ -9029,7 +9065,7 @@ class MockEncryption extends _i1.Mock implements _i9.Encryption {
       );
 
   @override
-  _i12.Future<void> init(
+  _i13.Future<void> init(
     String? olmAccount, {
     String? deviceId,
     String? pickleKey,
@@ -9045,19 +9081,19 @@ class MockEncryption extends _i1.Mock implements _i9.Encryption {
             #dehydratedDeviceAlgorithm: dehydratedDeviceAlgorithm,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i9.Bootstrap bootstrap({void Function(_i9.Bootstrap)? onUpdate}) =>
+  _i10.Bootstrap bootstrap({void Function(_i10.Bootstrap)? onUpdate}) =>
       (super.noSuchMethod(
         Invocation.method(
           #bootstrap,
           [],
           {#onUpdate: onUpdate},
         ),
-        returnValue: _FakeBootstrap_79(
+        returnValue: _FakeBootstrap_80(
           this,
           Invocation.method(
             #bootstrap,
@@ -9065,7 +9101,7 @@ class MockEncryption extends _i1.Mock implements _i9.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-        returnValueForMissingStub: _FakeBootstrap_79(
+        returnValueForMissingStub: _FakeBootstrap_80(
           this,
           Invocation.method(
             #bootstrap,
@@ -9073,7 +9109,7 @@ class MockEncryption extends _i1.Mock implements _i9.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-      ) as _i9.Bootstrap);
+      ) as _i10.Bootstrap);
 
   @override
   void handleDeviceOneTimeKeysCount(
@@ -9101,20 +9137,20 @@ class MockEncryption extends _i1.Mock implements _i9.Encryption {
       );
 
   @override
-  _i12.Future<void> handleToDeviceEvent(_i3.ToDeviceEvent? event) =>
+  _i13.Future<void> handleToDeviceEvent(_i4.ToDeviceEvent? event) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleToDeviceEvent,
           [event],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleEventUpdate(
-    _i3.Event? event,
-    _i3.EventUpdateType? type,
+  _i13.Future<void> handleEventUpdate(
+    _i4.Event? event,
+    _i4.EventUpdateType? type,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9124,19 +9160,19 @@ class MockEncryption extends _i1.Mock implements _i9.Encryption {
             type,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i3.ToDeviceEvent> decryptToDeviceEvent(
-          _i3.ToDeviceEvent? event) =>
+  _i13.Future<_i4.ToDeviceEvent> decryptToDeviceEvent(
+          _i4.ToDeviceEvent? event) =>
       (super.noSuchMethod(
         Invocation.method(
           #decryptToDeviceEvent,
           [event],
         ),
-        returnValue: _i12.Future<_i3.ToDeviceEvent>.value(_FakeToDeviceEvent_80(
+        returnValue: _i13.Future<_i4.ToDeviceEvent>.value(_FakeToDeviceEvent_81(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -9144,42 +9180,42 @@ class MockEncryption extends _i1.Mock implements _i9.Encryption {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i3.ToDeviceEvent>.value(_FakeToDeviceEvent_80(
+            _i13.Future<_i4.ToDeviceEvent>.value(_FakeToDeviceEvent_81(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
             [event],
           ),
         )),
-      ) as _i12.Future<_i3.ToDeviceEvent>);
+      ) as _i13.Future<_i4.ToDeviceEvent>);
 
   @override
-  _i3.Event decryptRoomEventSync(_i3.Event? event) => (super.noSuchMethod(
+  _i4.Event decryptRoomEventSync(_i4.Event? event) => (super.noSuchMethod(
         Invocation.method(
           #decryptRoomEventSync,
           [event],
         ),
-        returnValue: _FakeEvent_81(
+        returnValue: _FakeEvent_82(
           this,
           Invocation.method(
             #decryptRoomEventSync,
             [event],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_81(
+        returnValueForMissingStub: _FakeEvent_82(
           this,
           Invocation.method(
             #decryptRoomEventSync,
             [event],
           ),
         ),
-      ) as _i3.Event);
+      ) as _i4.Event);
 
   @override
-  _i12.Future<_i3.Event> decryptRoomEvent(
-    _i3.Event? event, {
+  _i13.Future<_i4.Event> decryptRoomEvent(
+    _i4.Event? event, {
     bool? store = false,
-    _i3.EventUpdateType? updateType = _i3.EventUpdateType.timeline,
+    _i4.EventUpdateType? updateType = _i4.EventUpdateType.timeline,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9190,7 +9226,7 @@ class MockEncryption extends _i1.Mock implements _i9.Encryption {
             #updateType: updateType,
           },
         ),
-        returnValue: _i12.Future<_i3.Event>.value(_FakeEvent_81(
+        returnValue: _i13.Future<_i4.Event>.value(_FakeEvent_82(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -9201,7 +9237,7 @@ class MockEncryption extends _i1.Mock implements _i9.Encryption {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i3.Event>.value(_FakeEvent_81(
+        returnValueForMissingStub: _i13.Future<_i4.Event>.value(_FakeEvent_82(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -9212,10 +9248,10 @@ class MockEncryption extends _i1.Mock implements _i9.Encryption {
             },
           ),
         )),
-      ) as _i12.Future<_i3.Event>);
+      ) as _i13.Future<_i4.Event>);
 
   @override
-  _i12.Future<Map<String, dynamic>> encryptGroupMessagePayload(
+  _i13.Future<Map<String, dynamic>> encryptGroupMessagePayload(
     String? roomId,
     Map<String, dynamic>? payload, {
     String? type = 'm.room.message',
@@ -9230,15 +9266,15 @@ class MockEncryption extends _i1.Mock implements _i9.Encryption {
           {#type: type},
         ),
         returnValue:
-            _i12.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
+            _i13.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
-      ) as _i12.Future<Map<String, dynamic>>);
+            _i13.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
+      ) as _i13.Future<Map<String, dynamic>>);
 
   @override
-  _i12.Future<
+  _i13.Future<
       Map<String, Map<String, Map<String, dynamic>>>> encryptToDeviceMessage(
-    List<_i3.DeviceKeys>? deviceKeys,
+    List<_i4.DeviceKeys>? deviceKeys,
     String? type,
     Map<String, dynamic>? payload,
   ) =>
@@ -9252,63 +9288,63 @@ class MockEncryption extends _i1.Mock implements _i9.Encryption {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
+            _i13.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
                 <String, Map<String, Map<String, dynamic>>>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
+            _i13.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
                 <String, Map<String, Map<String, dynamic>>>{}),
-      ) as _i12.Future<Map<String, Map<String, Map<String, dynamic>>>>);
+      ) as _i13.Future<Map<String, Map<String, Map<String, dynamic>>>>);
 
   @override
-  _i12.Future<void> autovalidateMasterOwnKey() => (super.noSuchMethod(
+  _i13.Future<void> autovalidateMasterOwnKey() => (super.noSuchMethod(
         Invocation.method(
           #autovalidateMasterOwnKey,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> dispose() => (super.noSuchMethod(
+  _i13.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 }
 
 /// A class which mocks [CrossSigning].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCrossSigning extends _i1.Mock implements _i16.CrossSigning {
+class MockCrossSigning extends _i1.Mock implements _i17.CrossSigning {
   @override
-  _i9.Encryption get encryption => (super.noSuchMethod(
+  _i10.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_7(
+        returnValue: _FakeEncryption_8(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_7(
+        returnValueForMissingStub: _FakeEncryption_8(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i9.Encryption);
+      ) as _i10.Encryption);
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get enabled => (super.noSuchMethod(
@@ -9318,21 +9354,21 @@ class MockCrossSigning extends _i1.Mock implements _i16.CrossSigning {
       ) as bool);
 
   @override
-  _i12.Future<bool> isCached() => (super.noSuchMethod(
+  _i13.Future<bool> isCached() => (super.noSuchMethod(
         Invocation.method(
           #isCached,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> selfSign({
+  _i13.Future<void> selfSign({
     String? passphrase,
     String? recoveryKey,
     String? keyOrPassphrase,
-    _i9.OpenSSSS? openSsss,
+    _i10.OpenSSSS? openSsss,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9345,12 +9381,12 @@ class MockCrossSigning extends _i1.Mock implements _i16.CrossSigning {
             #openSsss: openSsss,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  bool signable(List<_i3.SignableKey>? keys) => (super.noSuchMethod(
+  bool signable(List<_i4.SignableKey>? keys) => (super.noSuchMethod(
         Invocation.method(
           #signable,
           [keys],
@@ -9360,12 +9396,12 @@ class MockCrossSigning extends _i1.Mock implements _i16.CrossSigning {
       ) as bool);
 
   @override
-  _i12.Future<void> sign(List<_i3.SignableKey>? keys) => (super.noSuchMethod(
+  _i13.Future<void> sign(List<_i4.SignableKey>? keys) => (super.noSuchMethod(
         Invocation.method(
           #sign,
           [keys],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 }

--- a/test/widgets/registration_controller_test.mocks.dart
+++ b/test/widgets/registration_controller_test.mocks.dart
@@ -4,29 +4,31 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/models/server_auth_capabilities.dart' as _i13;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/models/server_auth_capabilities.dart' as _i14;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -745,8 +747,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -755,8 +758,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -765,9 +768,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -776,9 +778,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -787,8 +789,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -797,8 +800,8 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -807,9 +810,19 @@ class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
         );
 }
 
-class _FakeServerAuthCapabilities_72 extends _i1.SmartFake
-    implements _i13.ServerAuthCapabilities {
-  _FakeServerAuthCapabilities_72(
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeServerAuthCapabilities_73 extends _i1.SmartFake
+    implements _i14.ServerAuthCapabilities {
+  _FakeServerAuthCapabilities_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -836,12 +849,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -961,11 +974,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1002,11 +1015,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1036,11 +1049,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1049,11 +1062,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1339,34 +1352,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1522,7 +1535,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1811,14 +1824,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2206,8 +2219,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2223,8 +2236,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2265,7 +2278,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2281,7 +2294,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2330,7 +2343,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2351,7 +2364,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2454,7 +2467,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2472,7 +2485,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2991,7 +3004,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3343,7 +3356,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3357,7 +3370,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3508,7 +3521,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4886,7 +4899,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4908,7 +4921,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5402,7 +5415,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5414,7 +5427,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6422,7 +6435,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6433,7 +6446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6681,7 +6694,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6693,7 +6706,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6953,7 +6966,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6966,7 +6979,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7033,7 +7046,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7046,7 +7059,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7094,7 +7107,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7106,7 +7119,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7354,7 +7367,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7365,7 +7378,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7627,7 +7640,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7654,7 +7667,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7669,13 +7682,26 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7684,11 +7710,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7709,69 +7735,69 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7790,6 +7816,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7799,7 +7834,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7808,7 +7843,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7817,7 +7852,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7826,7 +7861,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7835,7 +7870,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7888,7 +7923,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -7982,7 +8017,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -7991,7 +8026,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8010,7 +8045,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8021,7 +8056,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8069,7 +8104,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8107,7 +8142,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8116,7 +8151,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8125,16 +8160,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8158,7 +8193,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 /// A class which mocks [AuthService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAuthService extends _i1.Mock implements _i12.AuthService {
+class MockAuthService extends _i1.Mock implements _i13.AuthService {
   @override
   bool get isLoggedIn => (super.noSuchMethod(
         Invocation.getter(#isLoggedIn),
@@ -8284,7 +8319,7 @@ class MockAuthService extends _i1.Mock implements _i12.AuthService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i13.ServerAuthCapabilities> getServerAuthCapabilities(
+  _i5.Future<_i14.ServerAuthCapabilities> getServerAuthCapabilities(
     String? homeserver, {
     required bool? isLoggedIn,
   }) =>
@@ -8294,8 +8329,8 @@ class MockAuthService extends _i1.Mock implements _i12.AuthService {
           [homeserver],
           {#isLoggedIn: isLoggedIn},
         ),
-        returnValue: _i5.Future<_i13.ServerAuthCapabilities>.value(
-            _FakeServerAuthCapabilities_72(
+        returnValue: _i5.Future<_i14.ServerAuthCapabilities>.value(
+            _FakeServerAuthCapabilities_73(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8304,8 +8339,8 @@ class MockAuthService extends _i1.Mock implements _i12.AuthService {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i13.ServerAuthCapabilities>.value(
-                _FakeServerAuthCapabilities_72(
+            _i5.Future<_i14.ServerAuthCapabilities>.value(
+                _FakeServerAuthCapabilities_73(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8313,7 +8348,7 @@ class MockAuthService extends _i1.Mock implements _i12.AuthService {
             {#isLoggedIn: isLoggedIn},
           ),
         )),
-      ) as _i5.Future<_i13.ServerAuthCapabilities>);
+      ) as _i5.Future<_i14.ServerAuthCapabilities>);
 
   @override
   bool isPermanentAuthFailure(Object? error) => (super.noSuchMethod(
@@ -8356,7 +8391,7 @@ class MockAuthService extends _i1.Mock implements _i12.AuthService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8365,7 +8400,7 @@ class MockAuthService extends _i1.Mock implements _i12.AuthService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/test/widgets/room_context_menu_test.mocks.dart
+++ b/test/widgets/room_context_menu_test.mocks.dart
@@ -4,30 +4,32 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i15;
-import 'dart:ui' as _i17;
+import 'dart:typed_data' as _i16;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i13;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i14;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i20;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -746,8 +748,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,8 +759,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,9 +769,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -777,9 +779,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -788,8 +790,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,8 +801,8 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,8 +811,8 @@ class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
         );
 }
 
-class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_72(
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -818,9 +821,19 @@ class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_73 extends _i1.SmartFake
+class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_74 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_73(
+  _FakeLatestReceiptState_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,8 +842,8 @@ class _FakeLatestReceiptState_73 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_74(
+class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -839,8 +852,8 @@ class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_75 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_75(
+class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,12 +880,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i13.KeyVerificationMethod> get verificationMethods =>
+  Set<_i14.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i13.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i13.KeyVerificationMethod>{},
-      ) as Set<_i13.KeyVerificationMethod>);
+        returnValue: <_i14.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
+      ) as Set<_i14.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -992,11 +1005,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1033,11 +1046,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1067,11 +1080,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1080,11 +1093,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1370,34 +1383,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i13.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i13.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i13.KeyVerification>
+  _i3.CachedStreamController<_i14.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i13.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i13.KeyVerification>(
+                _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i13.KeyVerification>);
+          ) as _i3.CachedStreamController<_i14.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1553,7 +1566,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i13.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1842,14 +1855,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2237,8 +2250,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2254,8 +2267,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2296,7 +2309,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2312,7 +2325,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2361,7 +2374,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2382,7 +2395,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2485,7 +2498,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2503,7 +2516,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3022,7 +3035,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i15.Uint8List? file, {
+    _i16.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3374,7 +3387,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3388,7 +3401,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3539,7 +3552,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i15.Uint8List? body,
+    _i16.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4917,7 +4930,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4939,7 +4952,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5433,7 +5446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5445,7 +5458,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6453,7 +6466,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6464,7 +6477,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6712,7 +6725,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6724,7 +6737,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6984,7 +6997,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6997,7 +7010,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7064,7 +7077,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7077,7 +7090,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7125,7 +7138,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7137,7 +7150,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7385,7 +7398,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7396,7 +7409,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7658,7 +7671,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i15.Uint8List? body, {
+    _i16.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7685,7 +7698,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7700,13 +7713,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7715,11 +7741,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7740,69 +7766,69 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7821,6 +7847,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7830,7 +7865,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7839,7 +7874,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7848,7 +7883,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7857,7 +7892,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7866,7 +7901,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7919,7 +7954,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8013,7 +8048,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8022,7 +8057,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8041,7 +8076,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8052,7 +8087,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8100,7 +8135,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8138,7 +8173,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8147,7 +8182,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8156,16 +8191,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i5.Future<_i17.AppExitResponse>);
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8193,11 +8228,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8227,11 +8262,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_72(
+        returnValue: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_72(
+        returnValueForMissingStub: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
@@ -8284,11 +8319,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8324,11 +8359,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8344,11 +8379,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8357,11 +8392,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8384,11 +8419,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -8404,11 +8439,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8451,11 +8486,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_73(
+        returnValue: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_73(
+        returnValueForMissingStub: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8667,18 +8702,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i20.SpaceParent>[],
-        returnValueForMissingStub: <_i20.SpaceParent>[],
-      ) as List<_i20.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i20.SpaceChild>[],
-        returnValueForMissingStub: <_i20.SpaceChild>[],
-      ) as List<_i20.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8845,14 +8880,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8900,7 +8935,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8908,7 +8943,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8923,7 +8958,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8931,7 +8966,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9015,7 +9050,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9023,7 +9058,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9265,7 +9300,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9276,7 +9311,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9365,15 +9400,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i21.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i21.TimelineChunk?>.value(),
-      ) as _i5.Future<_i21.TimelineChunk?>);
+        returnValue: _i5.Future<_i22.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i22.TimelineChunk?>.value(),
+      ) as _i5.Future<_i22.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9414,7 +9449,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9431,7 +9466,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9495,14 +9530,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9518,14 +9553,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9581,7 +9616,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9589,7 +9624,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/room_details_panel_test.mocks.dart
+++ b/test/widgets/room_details_panel_test.mocks.dart
@@ -4,30 +4,32 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i15;
-import 'dart:ui' as _i17;
+import 'dart:typed_data' as _i16;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i13;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i14;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i20;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -746,8 +748,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,8 +759,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,9 +769,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -777,9 +779,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -788,8 +790,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,8 +801,8 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,8 +811,8 @@ class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
         );
 }
 
-class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_72(
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -818,9 +821,19 @@ class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_73 extends _i1.SmartFake
+class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_74 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_73(
+  _FakeLatestReceiptState_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,8 +842,8 @@ class _FakeLatestReceiptState_73 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_74(
+class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -839,8 +852,8 @@ class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_75 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_75(
+class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,12 +880,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i13.KeyVerificationMethod> get verificationMethods =>
+  Set<_i14.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i13.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i13.KeyVerificationMethod>{},
-      ) as Set<_i13.KeyVerificationMethod>);
+        returnValue: <_i14.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
+      ) as Set<_i14.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -992,11 +1005,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1033,11 +1046,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1067,11 +1080,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1080,11 +1093,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1370,34 +1383,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i13.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i13.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i13.KeyVerification>
+  _i3.CachedStreamController<_i14.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i13.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i13.KeyVerification>(
+                _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i13.KeyVerification>);
+          ) as _i3.CachedStreamController<_i14.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1553,7 +1566,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i13.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1842,14 +1855,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2237,8 +2250,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2254,8 +2267,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2296,7 +2309,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2312,7 +2325,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2361,7 +2374,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2382,7 +2395,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2485,7 +2498,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2503,7 +2516,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3022,7 +3035,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i15.Uint8List? file, {
+    _i16.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3374,7 +3387,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3388,7 +3401,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3539,7 +3552,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i15.Uint8List? body,
+    _i16.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4917,7 +4930,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4939,7 +4952,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5433,7 +5446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5445,7 +5458,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6453,7 +6466,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6464,7 +6477,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6712,7 +6725,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6724,7 +6737,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6984,7 +6997,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6997,7 +7010,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7064,7 +7077,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7077,7 +7090,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7125,7 +7138,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7137,7 +7150,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7385,7 +7398,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7396,7 +7409,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7658,7 +7671,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i15.Uint8List? body, {
+    _i16.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7685,7 +7698,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7700,13 +7713,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7715,11 +7741,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7740,69 +7766,69 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7821,6 +7847,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7830,7 +7865,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7839,7 +7874,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7848,7 +7883,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7857,7 +7892,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7866,7 +7901,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7919,7 +7954,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8013,7 +8048,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8022,7 +8057,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8041,7 +8076,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8052,7 +8087,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8100,7 +8135,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8138,7 +8173,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8147,7 +8182,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8156,16 +8191,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i5.Future<_i17.AppExitResponse>);
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8193,11 +8228,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8227,11 +8262,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_72(
+        returnValue: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_72(
+        returnValueForMissingStub: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
@@ -8284,11 +8319,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8324,11 +8359,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8344,11 +8379,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8357,11 +8392,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8384,11 +8419,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -8404,11 +8439,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8451,11 +8486,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_73(
+        returnValue: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_73(
+        returnValueForMissingStub: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8667,18 +8702,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i20.SpaceParent>[],
-        returnValueForMissingStub: <_i20.SpaceParent>[],
-      ) as List<_i20.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i20.SpaceChild>[],
-        returnValueForMissingStub: <_i20.SpaceChild>[],
-      ) as List<_i20.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8845,14 +8880,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8900,7 +8935,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8908,7 +8943,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8923,7 +8958,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8931,7 +8966,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9015,7 +9050,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9023,7 +9058,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9265,7 +9300,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9276,7 +9311,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9365,15 +9400,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i21.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i21.TimelineChunk?>.value(),
-      ) as _i5.Future<_i21.TimelineChunk?>);
+        returnValue: _i5.Future<_i22.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i22.TimelineChunk?>.value(),
+      ) as _i5.Future<_i22.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9414,7 +9449,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9431,7 +9466,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9495,14 +9530,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9518,14 +9553,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9581,7 +9616,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9589,7 +9624,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/room_members_section_test.mocks.dart
+++ b/test/widgets/room_members_section_test.mocks.dart
@@ -4,30 +4,32 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i15;
-import 'dart:ui' as _i17;
+import 'dart:typed_data' as _i16;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i13;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i14;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i20;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -746,8 +748,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,8 +759,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,9 +769,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -777,9 +779,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -788,8 +790,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,8 +801,8 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,8 +811,8 @@ class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
         );
 }
 
-class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_72(
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -818,9 +821,19 @@ class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_73 extends _i1.SmartFake
+class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_74 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_73(
+  _FakeLatestReceiptState_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,8 +842,8 @@ class _FakeLatestReceiptState_73 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_74(
+class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -839,8 +852,8 @@ class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_75 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_75(
+class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -849,8 +862,8 @@ class _FakeUser_75 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_76 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_76(
+class _FakeRoom_77 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -877,12 +890,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i13.KeyVerificationMethod> get verificationMethods =>
+  Set<_i14.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i13.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i13.KeyVerificationMethod>{},
-      ) as Set<_i13.KeyVerificationMethod>);
+        returnValue: <_i14.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
+      ) as Set<_i14.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1002,11 +1015,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1043,11 +1056,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1077,11 +1090,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1090,11 +1103,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1380,34 +1393,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i13.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i13.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i13.KeyVerification>
+  _i3.CachedStreamController<_i14.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i13.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i13.KeyVerification>(
+                _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i13.KeyVerification>);
+          ) as _i3.CachedStreamController<_i14.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1563,7 +1576,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i13.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1852,14 +1865,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2247,8 +2260,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2264,8 +2277,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2306,7 +2319,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2322,7 +2335,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2371,7 +2384,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2392,7 +2405,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2495,7 +2508,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2513,7 +2526,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3032,7 +3045,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i15.Uint8List? file, {
+    _i16.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3384,7 +3397,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3398,7 +3411,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3549,7 +3562,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i15.Uint8List? body,
+    _i16.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4927,7 +4940,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4949,7 +4962,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5443,7 +5456,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5455,7 +5468,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6463,7 +6476,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6474,7 +6487,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6722,7 +6735,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6734,7 +6747,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6994,7 +7007,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7007,7 +7020,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7074,7 +7087,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7087,7 +7100,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7135,7 +7148,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7147,7 +7160,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7395,7 +7408,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7406,7 +7419,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7668,7 +7681,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i15.Uint8List? body, {
+    _i16.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7695,7 +7708,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7710,13 +7723,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7725,11 +7751,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7750,69 +7776,69 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7831,6 +7857,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7840,7 +7875,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7849,7 +7884,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7858,7 +7893,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7867,7 +7902,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7876,7 +7911,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7929,7 +7964,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8023,7 +8058,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8032,7 +8067,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8051,7 +8086,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8062,7 +8097,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8110,7 +8145,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8148,7 +8183,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8157,7 +8192,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8166,16 +8201,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i5.Future<_i17.AppExitResponse>);
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8203,11 +8238,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8237,11 +8272,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_72(
+        returnValue: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_72(
+        returnValueForMissingStub: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
@@ -8294,11 +8329,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8334,11 +8369,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8354,11 +8389,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8367,11 +8402,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8394,11 +8429,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -8414,11 +8449,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8461,11 +8496,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_73(
+        returnValue: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_73(
+        returnValueForMissingStub: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8677,18 +8712,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i20.SpaceParent>[],
-        returnValueForMissingStub: <_i20.SpaceParent>[],
-      ) as List<_i20.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i20.SpaceChild>[],
-        returnValueForMissingStub: <_i20.SpaceChild>[],
-      ) as List<_i20.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8855,14 +8890,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8910,7 +8945,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8918,7 +8953,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8933,7 +8968,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8941,7 +8976,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9025,7 +9060,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9033,7 +9068,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9275,7 +9310,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9286,7 +9321,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9375,15 +9410,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i21.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i21.TimelineChunk?>.value(),
-      ) as _i5.Future<_i21.TimelineChunk?>);
+        returnValue: _i5.Future<_i22.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i22.TimelineChunk?>.value(),
+      ) as _i5.Future<_i22.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9424,7 +9459,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9441,7 +9476,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9505,14 +9540,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9528,14 +9563,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9591,7 +9626,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9599,7 +9634,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9911,11 +9946,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_76(
+        returnValue: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_76(
+        returnValueForMissingStub: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
@@ -9924,11 +9959,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -9994,11 +10029,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -10023,11 +10058,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10045,11 +10080,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10096,7 +10131,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -10108,7 +10143,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -10178,7 +10213,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -10191,7 +10226,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/room_section_header_test.mocks.dart
+++ b/test/widgets/room_section_header_test.mocks.dart
@@ -4,33 +4,35 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/material.dart' as _i22;
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/material.dart' as _i23;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
-import 'package:kohera/core/services/preferences_service.dart' as _i21;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
+import 'package:kohera/core/services/preferences_service.dart' as _i22;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
-import 'package:kohera/core/theme/custom_theme.dart' as _i13;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
+import 'package:kohera/core/theme/custom_theme.dart' as _i14;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i25;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -749,8 +751,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -759,8 +762,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -769,9 +772,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -780,9 +782,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -791,8 +793,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -801,8 +804,8 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -811,8 +814,8 @@ class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
         );
 }
 
-class _FakeCustomTheme_72 extends _i1.SmartFake implements _i13.CustomTheme {
-  _FakeCustomTheme_72(
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -821,8 +824,8 @@ class _FakeCustomTheme_72 extends _i1.SmartFake implements _i13.CustomTheme {
         );
 }
 
-class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_73(
+class _FakeCustomTheme_73 extends _i1.SmartFake implements _i14.CustomTheme {
+  _FakeCustomTheme_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -831,9 +834,19 @@ class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_74 extends _i1.SmartFake
+class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_74(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_75 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_74(
+  _FakeLatestReceiptState_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,8 +855,8 @@ class _FakeLatestReceiptState_74 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_75(
+class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,8 +865,8 @@ class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_76(
+class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -880,12 +893,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1005,11 +1018,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1046,11 +1059,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1080,11 +1093,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1093,11 +1106,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1383,34 +1396,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1566,7 +1579,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1855,14 +1868,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2250,8 +2263,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2267,8 +2280,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2309,7 +2322,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2325,7 +2338,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2374,7 +2387,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2395,7 +2408,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2498,7 +2511,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2516,7 +2529,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3035,7 +3048,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3387,7 +3400,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3401,7 +3414,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3552,7 +3565,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4930,7 +4943,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4952,7 +4965,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5446,7 +5459,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5458,7 +5471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6466,7 +6479,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6477,7 +6490,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6725,7 +6738,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6737,7 +6750,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6997,7 +7010,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7010,7 +7023,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7077,7 +7090,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7090,7 +7103,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7138,7 +7151,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7150,7 +7163,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7398,7 +7411,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7409,7 +7422,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7671,7 +7684,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7698,7 +7711,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7713,13 +7726,26 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7728,11 +7754,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7753,69 +7779,69 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7834,6 +7860,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7843,7 +7878,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7852,7 +7887,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7861,7 +7896,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7870,7 +7905,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7879,7 +7914,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7932,7 +7967,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8026,7 +8061,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8035,7 +8070,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8054,7 +8089,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8065,7 +8100,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8113,7 +8148,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8151,7 +8186,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8160,7 +8195,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8169,16 +8204,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8203,60 +8238,60 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockPreferencesService extends _i1.Mock
-    implements _i21.PreferencesService {
+    implements _i22.PreferencesService {
   @override
-  _i21.MessageDensity get messageDensity => (super.noSuchMethod(
+  _i22.MessageDensity get messageDensity => (super.noSuchMethod(
         Invocation.getter(#messageDensity),
-        returnValue: _i21.MessageDensity.compact,
-        returnValueForMissingStub: _i21.MessageDensity.compact,
-      ) as _i21.MessageDensity);
+        returnValue: _i22.MessageDensity.compact,
+        returnValueForMissingStub: _i22.MessageDensity.compact,
+      ) as _i22.MessageDensity);
 
   @override
-  _i21.MobileTab get lastMobileTab => (super.noSuchMethod(
+  _i22.MobileTab get lastMobileTab => (super.noSuchMethod(
         Invocation.getter(#lastMobileTab),
-        returnValue: _i21.MobileTab.inbox,
-        returnValueForMissingStub: _i21.MobileTab.inbox,
-      ) as _i21.MobileTab);
+        returnValue: _i22.MobileTab.inbox,
+        returnValueForMissingStub: _i22.MobileTab.inbox,
+      ) as _i22.MobileTab);
 
   @override
-  _i22.ThemeMode get themeMode => (super.noSuchMethod(
+  _i23.ThemeMode get themeMode => (super.noSuchMethod(
         Invocation.getter(#themeMode),
-        returnValue: _i22.ThemeMode.system,
-        returnValueForMissingStub: _i22.ThemeMode.system,
-      ) as _i22.ThemeMode);
+        returnValue: _i23.ThemeMode.system,
+        returnValueForMissingStub: _i23.ThemeMode.system,
+      ) as _i23.ThemeMode);
 
   @override
   String get themeModeLabel => (super.noSuchMethod(
         Invocation.getter(#themeModeLabel),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#themeModeLabel),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#themeModeLabel),
         ),
       ) as String);
 
   @override
-  _i13.CustomTheme get customTheme => (super.noSuchMethod(
+  _i14.CustomTheme get customTheme => (super.noSuchMethod(
         Invocation.getter(#customTheme),
-        returnValue: _FakeCustomTheme_72(
+        returnValue: _FakeCustomTheme_73(
           this,
           Invocation.getter(#customTheme),
         ),
-        returnValueForMissingStub: _FakeCustomTheme_72(
+        returnValueForMissingStub: _FakeCustomTheme_73(
           this,
           Invocation.getter(#customTheme),
         ),
-      ) as _i13.CustomTheme);
+      ) as _i14.CustomTheme);
 
   @override
-  _i22.ThemeMode get customThemeMode => (super.noSuchMethod(
+  _i23.ThemeMode get customThemeMode => (super.noSuchMethod(
         Invocation.getter(#customThemeMode),
-        returnValue: _i22.ThemeMode.system,
-        returnValueForMissingStub: _i22.ThemeMode.system,
-      ) as _i22.ThemeMode);
+        returnValue: _i23.ThemeMode.system,
+        returnValueForMissingStub: _i23.ThemeMode.system,
+      ) as _i23.ThemeMode);
 
   @override
   Set<String> get collapsedSpaceSections => (super.noSuchMethod(
@@ -8287,20 +8322,20 @@ class MockPreferencesService extends _i1.Mock
       ) as double);
 
   @override
-  _i21.NotificationLevel get notificationLevel => (super.noSuchMethod(
+  _i22.NotificationLevel get notificationLevel => (super.noSuchMethod(
         Invocation.getter(#notificationLevel),
-        returnValue: _i21.NotificationLevel.all,
-        returnValueForMissingStub: _i21.NotificationLevel.all,
-      ) as _i21.NotificationLevel);
+        returnValue: _i22.NotificationLevel.all,
+        returnValueForMissingStub: _i22.NotificationLevel.all,
+      ) as _i22.NotificationLevel);
 
   @override
   String get notificationLevelLabel => (super.noSuchMethod(
         Invocation.getter(#notificationLevelLabel),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#notificationLevelLabel),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#notificationLevelLabel),
         ),
@@ -8454,11 +8489,11 @@ class MockPreferencesService extends _i1.Mock
       ) as bool);
 
   @override
-  _i21.AudioQuality get audioQuality => (super.noSuchMethod(
+  _i22.AudioQuality get audioQuality => (super.noSuchMethod(
         Invocation.getter(#audioQuality),
-        returnValue: _i21.AudioQuality.speech,
-        returnValueForMissingStub: _i21.AudioQuality.speech,
-      ) as _i21.AudioQuality);
+        returnValue: _i22.AudioQuality.speech,
+        returnValueForMissingStub: _i22.AudioQuality.speech,
+      ) as _i22.AudioQuality);
 
   @override
   bool get highPassFilter => (super.noSuchMethod(
@@ -8470,6 +8505,13 @@ class MockPreferencesService extends _i1.Mock
   @override
   bool get pttSoundEnabled => (super.noSuchMethod(
         Invocation.getter(#pttSoundEnabled),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get hasVersionBumped => (super.noSuchMethod(
+        Invocation.getter(#hasVersionBumped),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
@@ -8502,7 +8544,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setMessageDensity(_i21.MessageDensity? density) =>
+  _i5.Future<void> setMessageDensity(_i22.MessageDensity? density) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMessageDensity,
@@ -8513,7 +8555,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setLastMobileTab(_i21.MobileTab? tab) => (super.noSuchMethod(
+  _i5.Future<void> setLastMobileTab(_i22.MobileTab? tab) => (super.noSuchMethod(
         Invocation.method(
           #setLastMobileTab,
           [tab],
@@ -8523,7 +8565,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setThemeMode(_i22.ThemeMode? mode) => (super.noSuchMethod(
+  _i5.Future<void> setThemeMode(_i23.ThemeMode? mode) => (super.noSuchMethod(
         Invocation.method(
           #setThemeMode,
           [mode],
@@ -8543,7 +8585,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setCustomTheme(_i13.CustomTheme? theme) =>
+  _i5.Future<void> setCustomTheme(_i14.CustomTheme? theme) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCustomTheme,
@@ -8554,7 +8596,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setCustomThemeMode(_i22.ThemeMode? mode) =>
+  _i5.Future<void> setCustomThemeMode(_i23.ThemeMode? mode) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCustomThemeMode,
@@ -8606,7 +8648,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setNotificationLevel(_i21.NotificationLevel? level) =>
+  _i5.Future<void> setNotificationLevel(_i22.NotificationLevel? level) =>
       (super.noSuchMethod(
         Invocation.method(
           #setNotificationLevel,
@@ -8885,7 +8927,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setAudioQuality(_i21.AudioQuality? quality) =>
+  _i5.Future<void> setAudioQuality(_i22.AudioQuality? quality) =>
       (super.noSuchMethod(
         Invocation.method(
           #setAudioQuality,
@@ -8916,7 +8958,17 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  _i5.Future<void> markVersionSeen(String? version) => (super.noSuchMethod(
+        Invocation.method(
+          #markVersionSeen,
+          [version],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8925,7 +8977,7 @@ class MockPreferencesService extends _i1.Mock
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8959,11 +9011,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8993,11 +9045,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_73(
+        returnValue: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_73(
+        returnValueForMissingStub: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
@@ -9050,11 +9102,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -9090,11 +9142,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -9110,11 +9162,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -9123,11 +9175,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -9150,11 +9202,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -9170,11 +9222,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -9217,11 +9269,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_74(
+        returnValue: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_74(
+        returnValueForMissingStub: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -9433,18 +9485,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9611,14 +9663,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9666,7 +9718,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9674,7 +9726,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9689,7 +9741,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9697,7 +9749,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9781,7 +9833,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9789,7 +9841,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -10031,7 +10083,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10042,7 +10094,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10131,15 +10183,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i25.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i24.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i24.TimelineChunk?>.value(),
-      ) as _i5.Future<_i24.TimelineChunk?>);
+        returnValue: _i5.Future<_i25.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i25.TimelineChunk?>.value(),
+      ) as _i5.Future<_i25.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -10180,7 +10232,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -10197,7 +10249,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -10261,14 +10313,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -10284,14 +10336,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -10347,7 +10399,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10355,7 +10407,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/room_tile_test.mocks.dart
+++ b/test/widgets/room_tile_test.mocks.dart
@@ -3,39 +3,41 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i11;
-import 'dart:typed_data' as _i21;
-import 'dart:ui' as _i15;
+import 'dart:async' as _i12;
+import 'dart:typed_data' as _i22;
+import 'dart:ui' as _i16;
 
-import 'package:flutter/services.dart' as _i16;
-import 'package:flutter/widgets.dart' as _i17;
-import 'package:http/http.dart' as _i10;
-import 'package:kohera/core/services/call_service.dart' as _i22;
-import 'package:kohera/core/services/matrix_service.dart' as _i13;
-import 'package:kohera/core/services/preferences_service.dart' as _i28;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i8;
+import 'package:flutter/services.dart' as _i17;
+import 'package:flutter/widgets.dart' as _i18;
+import 'package:http/http.dart' as _i11;
+import 'package:kohera/core/services/call_service.dart' as _i23;
+import 'package:kohera/core/services/matrix_service.dart' as _i14;
+import 'package:kohera/core/services/preferences_service.dart' as _i29;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i5;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i7;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i4;
-import 'package:kohera/features/calling/models/call_participant.dart' as _i25;
-import 'package:kohera/features/calling/models/call_state.dart' as _i27;
-import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i26;
-import 'package:kohera/features/calling/services/livekit_service.dart' as _i23;
-import 'package:kohera/features/calling/services/ringtone_service.dart' as _i29;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i7;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
+import 'package:kohera/features/calling/models/call_participant.dart' as _i26;
+import 'package:kohera/features/calling/models/call_state.dart' as _i28;
+import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i27;
+import 'package:kohera/features/calling/services/livekit_service.dart' as _i24;
+import 'package:kohera/features/calling/services/ringtone_service.dart' as _i30;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
-import 'package:livekit_client/livekit_client.dart' as _i24;
-import 'package:matrix/encryption.dart' as _i20;
-import 'package:matrix/matrix.dart' as _i3;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i12;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i9;
-import 'package:matrix/src/utils/space_child.dart' as _i18;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i3;
+import 'package:livekit_client/livekit_client.dart' as _i25;
+import 'package:matrix/encryption.dart' as _i21;
+import 'package:matrix/matrix.dart' as _i4;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i13;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i20;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i10;
+import 'package:matrix/src/utils/space_child.dart' as _i19;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -63,8 +65,9 @@ class _FakeCallPushRuleManager_0 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
-  _FakeClient_1(
+class _FakeMegolmKeyMirror_1 extends _i1.SmartFake
+    implements _i3.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_1(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -73,8 +76,8 @@ class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
         );
 }
 
-class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
-  _FakeUiaService_2(
+class _FakeClient_2 extends _i1.SmartFake implements _i4.Client {
+  _FakeClient_2(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -83,9 +86,8 @@ class _FakeUiaService_2 extends _i1.SmartFake implements _i4.UiaService {
         );
 }
 
-class _FakeChatBackupService_3 extends _i1.SmartFake
-    implements _i5.ChatBackupService {
-  _FakeChatBackupService_3(
+class _FakeUiaService_3 extends _i1.SmartFake implements _i5.UiaService {
+  _FakeUiaService_3(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -94,9 +96,9 @@ class _FakeChatBackupService_3 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_4 extends _i1.SmartFake
-    implements _i6.SelectionService {
-  _FakeSelectionService_4(
+class _FakeChatBackupService_4 extends _i1.SmartFake
+    implements _i6.ChatBackupService {
+  _FakeChatBackupService_4(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -105,8 +107,9 @@ class _FakeSelectionService_4 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
-  _FakeSyncService_5(
+class _FakeSelectionService_5 extends _i1.SmartFake
+    implements _i7.SelectionService {
+  _FakeSelectionService_5(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -115,8 +118,8 @@ class _FakeSyncService_5 extends _i1.SmartFake implements _i7.SyncService {
         );
 }
 
-class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
-  _FakeAuthService_6(
+class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
+  _FakeSyncService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -125,8 +128,8 @@ class _FakeAuthService_6 extends _i1.SmartFake implements _i8.AuthService {
         );
 }
 
-class _FakeRoomSummary_7 extends _i1.SmartFake implements _i3.RoomSummary {
-  _FakeRoomSummary_7(
+class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
+  _FakeAuthService_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -135,9 +138,8 @@ class _FakeRoomSummary_7 extends _i1.SmartFake implements _i3.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_8<T> extends _i1.SmartFake
-    implements _i9.CachedStreamController<T> {
-  _FakeCachedStreamController_8(
+class _FakeRoomSummary_8 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -146,8 +148,9 @@ class _FakeCachedStreamController_8<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_9 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_9(
+class _FakeCachedStreamController_9<T> extends _i1.SmartFake
+    implements _i10.CachedStreamController<T> {
+  _FakeCachedStreamController_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -156,9 +159,8 @@ class _FakeDateTime_9 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_10 extends _i1.SmartFake
-    implements _i3.LatestReceiptState {
-  _FakeLatestReceiptState_10(
+class _FakeDateTime_10 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -167,8 +169,9 @@ class _FakeLatestReceiptState_10 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_11 extends _i1.SmartFake implements _i3.SyncUpdate {
-  _FakeSyncUpdate_11(
+class _FakeLatestReceiptState_11 extends _i1.SmartFake
+    implements _i4.LatestReceiptState {
+  _FakeLatestReceiptState_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -177,8 +180,8 @@ class _FakeSyncUpdate_11 extends _i1.SmartFake implements _i3.SyncUpdate {
         );
 }
 
-class _FakeTimeline_12 extends _i1.SmartFake implements _i3.Timeline {
-  _FakeTimeline_12(
+class _FakeSyncUpdate_12 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -187,8 +190,8 @@ class _FakeTimeline_12 extends _i1.SmartFake implements _i3.Timeline {
         );
 }
 
-class _FakeUser_13 extends _i1.SmartFake implements _i3.User {
-  _FakeUser_13(
+class _FakeTimeline_13 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -197,8 +200,8 @@ class _FakeUser_13 extends _i1.SmartFake implements _i3.User {
         );
 }
 
-class _FakeUri_14 extends _i1.SmartFake implements Uri {
-  _FakeUri_14(
+class _FakeUser_14 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -207,8 +210,8 @@ class _FakeUri_14 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_15 extends _i1.SmartFake implements _i3.DatabaseApi {
-  _FakeDatabaseApi_15(
+class _FakeUri_15 extends _i1.SmartFake implements Uri {
+  _FakeUri_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -217,8 +220,8 @@ class _FakeDatabaseApi_15 extends _i1.SmartFake implements _i3.DatabaseApi {
         );
 }
 
-class _FakeFilter_16 extends _i1.SmartFake implements _i3.Filter {
-  _FakeFilter_16(
+class _FakeDatabaseApi_16 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -227,9 +230,8 @@ class _FakeFilter_16 extends _i1.SmartFake implements _i3.Filter {
         );
 }
 
-class _FakeNativeImplementations_17 extends _i1.SmartFake
-    implements _i3.NativeImplementations {
-  _FakeNativeImplementations_17(
+class _FakeFilter_17 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -238,8 +240,9 @@ class _FakeNativeImplementations_17 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_18 extends _i1.SmartFake implements Duration {
-  _FakeDuration_18(
+class _FakeNativeImplementations_18 extends _i1.SmartFake
+    implements _i4.NativeImplementations {
+  _FakeNativeImplementations_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -248,9 +251,8 @@ class _FakeDuration_18 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_19 extends _i1.SmartFake
-    implements _i3.PushruleEvaluator {
-  _FakePushruleEvaluator_19(
+class _FakeDuration_19 extends _i1.SmartFake implements Duration {
+  _FakeDuration_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -259,8 +261,9 @@ class _FakePushruleEvaluator_19 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_20 extends _i1.SmartFake implements _i3.Profile {
-  _FakeProfile_20(
+class _FakePushruleEvaluator_20 extends _i1.SmartFake
+    implements _i4.PushruleEvaluator {
+  _FakePushruleEvaluator_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -269,8 +272,8 @@ class _FakeProfile_20 extends _i1.SmartFake implements _i3.Profile {
         );
 }
 
-class _FakeClient_21 extends _i1.SmartFake implements _i10.Client {
-  _FakeClient_21(
+class _FakeProfile_21 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -279,9 +282,8 @@ class _FakeClient_21 extends _i1.SmartFake implements _i10.Client {
         );
 }
 
-class _FakeDiscoveryInformation_22 extends _i1.SmartFake
-    implements _i3.DiscoveryInformation {
-  _FakeDiscoveryInformation_22(
+class _FakeClient_22 extends _i1.SmartFake implements _i11.Client {
+  _FakeClient_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -290,9 +292,9 @@ class _FakeDiscoveryInformation_22 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_23 extends _i1.SmartFake
-    implements _i3.GetVersionsResponse {
-  _FakeGetVersionsResponse_23(
+class _FakeDiscoveryInformation_23 extends _i1.SmartFake
+    implements _i4.DiscoveryInformation {
+  _FakeDiscoveryInformation_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -301,9 +303,9 @@ class _FakeGetVersionsResponse_23 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_24 extends _i1.SmartFake
-    implements _i3.RegisterResponse {
-  _FakeRegisterResponse_24(
+class _FakeGetVersionsResponse_24 extends _i1.SmartFake
+    implements _i4.GetVersionsResponse {
+  _FakeGetVersionsResponse_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -312,8 +314,9 @@ class _FakeRegisterResponse_24 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_25 extends _i1.SmartFake implements _i3.LoginResponse {
-  _FakeLoginResponse_25(
+class _FakeRegisterResponse_25 extends _i1.SmartFake
+    implements _i4.RegisterResponse {
+  _FakeRegisterResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -322,9 +325,8 @@ class _FakeLoginResponse_25 extends _i1.SmartFake implements _i3.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_26 extends _i1.SmartFake
-    implements _i3.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_26(
+class _FakeLoginResponse_26 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -333,8 +335,9 @@ class _FakeGetAuthMetadataResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_27<T1> extends _i1.SmartFake implements _i11.Future<T1> {
-  _FakeFuture_27(
+class _FakeGetAuthMetadataResponse_27 extends _i1.SmartFake
+    implements _i4.GetAuthMetadataResponse {
+  _FakeGetAuthMetadataResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -343,9 +346,8 @@ class _FakeFuture_27<T1> extends _i1.SmartFake implements _i11.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_28 extends _i1.SmartFake
-    implements _i3.CachedProfileInformation {
-  _FakeCachedProfileInformation_28(
+class _FakeFuture_28<T1> extends _i1.SmartFake implements _i12.Future<T1> {
+  _FakeFuture_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -354,8 +356,9 @@ class _FakeCachedProfileInformation_28 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_29 extends _i1.SmartFake implements _i3.MediaConfig {
-  _FakeMediaConfig_29(
+class _FakeCachedProfileInformation_29 extends _i1.SmartFake
+    implements _i4.CachedProfileInformation {
+  _FakeCachedProfileInformation_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -364,8 +367,8 @@ class _FakeMediaConfig_29 extends _i1.SmartFake implements _i3.MediaConfig {
         );
 }
 
-class _FakeFileResponse_30 extends _i1.SmartFake implements _i12.FileResponse {
-  _FakeFileResponse_30(
+class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -374,8 +377,8 @@ class _FakeFileResponse_30 extends _i1.SmartFake implements _i12.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_31 extends _i1.SmartFake implements _i3.PreviewForUrl {
-  _FakePreviewForUrl_31(
+class _FakeFileResponse_31 extends _i1.SmartFake implements _i13.FileResponse {
+  _FakeFileResponse_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -384,9 +387,8 @@ class _FakePreviewForUrl_31 extends _i1.SmartFake implements _i3.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_32 extends _i1.SmartFake
-    implements _i3.CachedPresence {
-  _FakeCachedPresence_32(
+class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -395,9 +397,9 @@ class _FakeCachedPresence_32 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_33 extends _i1.SmartFake
-    implements _i3.TurnServerCredentials {
-  _FakeTurnServerCredentials_33(
+class _FakeCachedPresence_33 extends _i1.SmartFake
+    implements _i4.CachedPresence {
+  _FakeCachedPresence_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -406,9 +408,9 @@ class _FakeTurnServerCredentials_33 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
-    implements _i3.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_34(
+class _FakeTurnServerCredentials_34 extends _i1.SmartFake
+    implements _i4.TurnServerCredentials {
+  _FakeTurnServerCredentials_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -417,8 +419,9 @@ class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i3.KeyBackupData {
-  _FakeKeyBackupData_35(
+class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
+    implements _i4.RoomKeysUpdateResponse {
+  _FakeRoomKeysUpdateResponse_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -427,9 +430,8 @@ class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i3.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
-    implements _i3.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_36(
+class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -438,9 +440,9 @@ class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
-    implements _i3.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_37(
+class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
+    implements _i4.GetWellknownSupportResponse {
+  _FakeGetWellknownSupportResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -449,9 +451,9 @@ class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
-    implements _i3.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_38(
+class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
+    implements _i4.GenerateLoginTokenResponse {
+  _FakeGenerateLoginTokenResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -460,9 +462,9 @@ class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
-    implements _i3.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_39(
+class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
+    implements _i4.GetRoomSummaryResponse$3 {
+  _FakeGetRoomSummaryResponse$3_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -471,9 +473,9 @@ class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
-    implements _i3.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_40(
+class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
+    implements _i4.GetSpaceHierarchyResponse {
+  _FakeGetSpaceHierarchyResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -482,9 +484,9 @@ class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
-    implements _i3.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_41(
+class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
+    implements _i4.GetRelatingEventsResponse {
+  _FakeGetRelatingEventsResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -493,9 +495,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
-    .SmartFake implements _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
+    implements _i4.GetRelatingEventsWithRelTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -504,9 +506,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
-    implements _i3.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_43(
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
+    .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -515,9 +517,9 @@ class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
-    implements _i3.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_44(
+class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
+    implements _i4.GetThreadRootsResponse {
+  _FakeGetThreadRootsResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -526,9 +528,9 @@ class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_45 extends _i1.SmartFake
-    implements _i3.RequestTokenResponse {
-  _FakeRequestTokenResponse_45(
+class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
+    implements _i4.GetEventByTimestampResponse {
+  _FakeGetEventByTimestampResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -537,9 +539,9 @@ class _FakeRequestTokenResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
-    implements _i3.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_46(
+class _FakeRequestTokenResponse_46 extends _i1.SmartFake
+    implements _i4.RequestTokenResponse {
+  _FakeRequestTokenResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -548,8 +550,9 @@ class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i3.WhoIsInfo {
-  _FakeWhoIsInfo_47(
+class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
+    implements _i4.TokenOwnerInfo {
+  _FakeTokenOwnerInfo_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -558,8 +561,8 @@ class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i3.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_48 extends _i1.SmartFake implements _i3.Capabilities {
-  _FakeCapabilities_48(
+class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -568,8 +571,8 @@ class _FakeCapabilities_48 extends _i1.SmartFake implements _i3.Capabilities {
         );
 }
 
-class _FakeDevice_49 extends _i1.SmartFake implements _i3.Device {
-  _FakeDevice_49(
+class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -578,9 +581,8 @@ class _FakeDevice_49 extends _i1.SmartFake implements _i3.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
-    implements _i3.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_50(
+class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -589,9 +591,9 @@ class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_51 extends _i1.SmartFake
-    implements _i3.GetEventsResponse {
-  _FakeGetEventsResponse_51(
+class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
+    implements _i4.GetRoomIdByAliasResponse {
+  _FakeGetRoomIdByAliasResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -600,9 +602,9 @@ class _FakeGetEventsResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_52 extends _i1.SmartFake
-    implements _i3.PeekEventsResponse {
-  _FakePeekEventsResponse_52(
+class _FakeGetEventsResponse_52 extends _i1.SmartFake
+    implements _i4.GetEventsResponse {
+  _FakeGetEventsResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -611,8 +613,9 @@ class _FakePeekEventsResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i3.MatrixEvent {
-  _FakeMatrixEvent_53(
+class _FakePeekEventsResponse_53 extends _i1.SmartFake
+    implements _i4.PeekEventsResponse {
+  _FakePeekEventsResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -621,9 +624,8 @@ class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i3.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
-    implements _i3.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_54(
+class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -632,9 +634,9 @@ class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_55 extends _i1.SmartFake
-    implements _i3.ClaimKeysResponse {
-  _FakeClaimKeysResponse_55(
+class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
+    implements _i4.GetKeysChangesResponse {
+  _FakeGetKeysChangesResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -643,9 +645,9 @@ class _FakeClaimKeysResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_56 extends _i1.SmartFake
-    implements _i3.QueryKeysResponse {
-  _FakeQueryKeysResponse_56(
+class _FakeClaimKeysResponse_56 extends _i1.SmartFake
+    implements _i4.ClaimKeysResponse {
+  _FakeClaimKeysResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -654,9 +656,9 @@ class _FakeQueryKeysResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
-    implements _i3.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_57(
+class _FakeQueryKeysResponse_57 extends _i1.SmartFake
+    implements _i4.QueryKeysResponse {
+  _FakeQueryKeysResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -665,9 +667,9 @@ class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_58 extends _i1.SmartFake
-    implements _i3.GetPresenceResponse {
-  _FakeGetPresenceResponse_58(
+class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
+    implements _i4.GetNotificationsResponse {
+  _FakeGetNotificationsResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -676,9 +678,9 @@ class _FakeGetPresenceResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
-    implements _i3.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_59(
+class _FakeGetPresenceResponse_59 extends _i1.SmartFake
+    implements _i4.GetPresenceResponse {
+  _FakeGetPresenceResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -687,9 +689,9 @@ class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
-    implements _i3.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_60(
+class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
+    implements _i4.GetPublicRoomsResponse {
+  _FakeGetPublicRoomsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -698,8 +700,9 @@ class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_61 extends _i1.SmartFake implements _i3.PushRuleSet {
-  _FakePushRuleSet_61(
+class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
+    implements _i4.QueryPublicRoomsResponse {
+  _FakeQueryPublicRoomsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -708,9 +711,8 @@ class _FakePushRuleSet_61 extends _i1.SmartFake implements _i3.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
-    implements _i3.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_62(
+class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -719,8 +721,9 @@ class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_63 extends _i1.SmartFake implements _i3.PushRule {
-  _FakePushRule_63(
+class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
+    implements _i4.GetPushRulesGlobalResponse {
+  _FakeGetPushRulesGlobalResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -729,9 +732,8 @@ class _FakePushRule_63 extends _i1.SmartFake implements _i3.PushRule {
         );
 }
 
-class _FakeRefreshResponse_64 extends _i1.SmartFake
-    implements _i3.RefreshResponse {
-  _FakeRefreshResponse_64(
+class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -740,8 +742,9 @@ class _FakeRefreshResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_65 extends _i1.SmartFake implements _i3.RoomKeys {
-  _FakeRoomKeys_65(
+class _FakeRefreshResponse_65 extends _i1.SmartFake
+    implements _i4.RefreshResponse {
+  _FakeRefreshResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -750,8 +753,8 @@ class _FakeRoomKeys_65 extends _i1.SmartFake implements _i3.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i3.RoomKeyBackup {
-  _FakeRoomKeyBackup_66(
+class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -760,9 +763,8 @@ class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i3.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
-    implements _i3.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_67(
+class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -771,9 +773,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
-    implements _i3.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_68(
+class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
+    implements _i4.GetRoomKeysVersionCurrentResponse {
+  _FakeGetRoomKeysVersionCurrentResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -782,8 +784,9 @@ class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_69 extends _i1.SmartFake implements _i3.EventContext {
-  _FakeEventContext_69(
+class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
+    implements _i4.GetRoomKeysVersionResponse {
+  _FakeGetRoomKeysVersionResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -792,9 +795,8 @@ class _FakeEventContext_69 extends _i1.SmartFake implements _i3.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
-    implements _i3.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_70(
+class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -803,8 +805,9 @@ class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_71 extends _i1.SmartFake implements _i3.SearchResults {
-  _FakeSearchResults_71(
+class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
+    implements _i4.GetRoomEventsResponse {
+  _FakeGetRoomEventsResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -813,9 +816,8 @@ class _FakeSearchResults_71 extends _i1.SmartFake implements _i3.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
-    implements _i3.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_72(
+class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -824,9 +826,9 @@ class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_73 extends _i1.SmartFake
-    implements _i3.OpenIdCredentials {
-  _FakeOpenIdCredentials_73(
+class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
+    implements _i4.GetProtocolMetadataResponse$2 {
+  _FakeGetProtocolMetadataResponse$2_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -835,9 +837,9 @@ class _FakeOpenIdCredentials_73 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
-    implements _i3.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_74(
+class _FakeOpenIdCredentials_74 extends _i1.SmartFake
+    implements _i4.OpenIdCredentials {
+  _FakeOpenIdCredentials_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -846,9 +848,9 @@ class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_75 extends _i1.SmartFake
-    implements _i3.CreateContentResponse {
-  _FakeCreateContentResponse_75(
+class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
+    implements _i4.SearchUserDirectoryResponse {
+  _FakeSearchUserDirectoryResponse_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -857,8 +859,9 @@ class _FakeCreateContentResponse_75 extends _i1.SmartFake
         );
 }
 
-class _FakeRoom_76 extends _i1.SmartFake implements _i3.Room {
-  _FakeRoom_76(
+class _FakeCreateContentResponse_76 extends _i1.SmartFake
+    implements _i4.CreateContentResponse {
+  _FakeCreateContentResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,8 +870,8 @@ class _FakeRoom_76 extends _i1.SmartFake implements _i3.Room {
         );
 }
 
-class _FakeMatrixFile_77 extends _i1.SmartFake implements _i3.MatrixFile {
-  _FakeMatrixFile_77(
+class _FakeRoom_77 extends _i1.SmartFake implements _i4.Room {
+  _FakeRoom_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -877,8 +880,8 @@ class _FakeMatrixFile_77 extends _i1.SmartFake implements _i3.MatrixFile {
         );
 }
 
-class _FakeEvent_78 extends _i1.SmartFake implements _i3.Event {
-  _FakeEvent_78(
+class _FakeMatrixFile_78 extends _i1.SmartFake implements _i4.MatrixFile {
+  _FakeMatrixFile_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -887,8 +890,18 @@ class _FakeEvent_78 extends _i1.SmartFake implements _i3.Event {
         );
 }
 
-class _FakeResponse_79 extends _i1.SmartFake implements _i10.Response {
-  _FakeResponse_79(
+class _FakeEvent_79 extends _i1.SmartFake implements _i4.Event {
+  _FakeEvent_79(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeResponse_80 extends _i1.SmartFake implements _i11.Response {
+  _FakeResponse_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -900,7 +913,7 @@ class _FakeResponse_79 extends _i1.SmartFake implements _i10.Response {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -915,30 +928,43 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as _i2.CallPushRuleManager);
 
   @override
+  _i3.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_1(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i3.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
       ) as String);
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get isLoggedIn => (super.noSuchMethod(
@@ -955,69 +981,69 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  _i4.UiaService get uia => (super.noSuchMethod(
+  _i5.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_2(
+        returnValue: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_2(
+        returnValueForMissingStub: _FakeUiaService_3(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i4.UiaService);
+      ) as _i5.UiaService);
 
   @override
-  _i5.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i6.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_3(
+        returnValue: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_3(
+        returnValueForMissingStub: _FakeChatBackupService_4(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i5.ChatBackupService);
+      ) as _i6.ChatBackupService);
 
   @override
-  _i6.SelectionService get selection => (super.noSuchMethod(
+  _i7.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_4(
+        returnValue: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_4(
+        returnValueForMissingStub: _FakeSelectionService_5(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i6.SelectionService);
+      ) as _i7.SelectionService);
 
   @override
-  _i7.SyncService get sync => (super.noSuchMethod(
+  _i8.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_5(
+        returnValue: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_5(
+        returnValueForMissingStub: _FakeSyncService_6(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i7.SyncService);
+      ) as _i8.SyncService);
 
   @override
-  _i8.AuthService get auth => (super.noSuchMethod(
+  _i9.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_6(
+        returnValue: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_6(
+        returnValueForMissingStub: _FakeAuthService_7(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i8.AuthService);
+      ) as _i9.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1036,6 +1062,15 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
+  set keyMirror(_i3.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -1045,7 +1080,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set uia(_i4.UiaService? value) => super.noSuchMethod(
+  set uia(_i5.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -1054,7 +1089,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set chatBackup(_i5.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i6.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -1063,7 +1098,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set selection(_i6.SelectionService? value) => super.noSuchMethod(
+  set selection(_i7.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -1072,7 +1107,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set sync(_i7.SyncService? value) => super.noSuchMethod(
+  set sync(_i8.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -1081,7 +1116,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  set auth(_i8.AuthService? value) => super.noSuchMethod(
+  set auth(_i9.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -1097,14 +1132,14 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  _i11.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1134,7 +1169,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i15.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i16.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1144,18 +1179,18 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i12.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<bool> login({
+  _i12.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1170,12 +1205,12 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<bool> completeSsoLogin({
+  _i12.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1188,13 +1223,13 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> completeRegistration(
-    _i3.RegisterResponse? response, {
+  _i12.Future<void> completeRegistration(
+    _i4.RegisterResponse? response, {
     String? password,
   }) =>
       (super.noSuchMethod(
@@ -1203,32 +1238,32 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> logout() => (super.noSuchMethod(
+  _i12.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i12.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  void addListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1237,7 +1272,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void removeListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1246,17 +1281,17 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i16.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i17.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1267,7 +1302,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i16.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i17.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1304,26 +1339,26 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<bool> didPushRouteInformation(
-          _i17.RouteInformation? routeInformation) =>
+  _i12.Future<bool> didPushRouteInformation(
+          _i18.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1353,7 +1388,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i15.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i16.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1362,7 +1397,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i15.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i16.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1371,16 +1406,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i11.Future<_i15.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i12.Future<_i16.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
-      ) as _i11.Future<_i15.AppExitResponse>);
+            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
+      ) as _i12.Future<_i16.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1404,26 +1439,26 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
 /// A class which mocks [Room].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockRoom extends _i1.Mock implements _i3.Room {
+class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
       ) as String);
 
   @override
-  _i3.Membership get membership => (super.noSuchMethod(
+  _i4.Membership get membership => (super.noSuchMethod(
         Invocation.getter(#membership),
-        returnValue: _i3.Membership.ban,
-        returnValueForMissingStub: _i3.Membership.ban,
-      ) as _i3.Membership);
+        returnValue: _i4.Membership.ban,
+        returnValueForMissingStub: _i4.Membership.ban,
+      ) as _i4.Membership);
 
   @override
   int get notificationCount => (super.noSuchMethod(
@@ -1440,47 +1475,47 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i3.RoomSummary get summary => (super.noSuchMethod(
+  _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_7(
+        returnValue: _FakeRoomSummary_8(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_7(
+        returnValueForMissingStub: _FakeRoomSummary_8(
           this,
           Invocation.getter(#summary),
         ),
-      ) as _i3.RoomSummary);
+      ) as _i4.RoomSummary);
 
   @override
-  Map<String, Map<String, _i3.StrippedStateEvent>> get states =>
+  Map<String, Map<String, _i4.StrippedStateEvent>> get states =>
       (super.noSuchMethod(
         Invocation.getter(#states),
-        returnValue: <String, Map<String, _i3.StrippedStateEvent>>{},
+        returnValue: <String, Map<String, _i4.StrippedStateEvent>>{},
         returnValueForMissingStub: <String,
-            Map<String, _i3.StrippedStateEvent>>{},
-      ) as Map<String, Map<String, _i3.StrippedStateEvent>>);
+            Map<String, _i4.StrippedStateEvent>>{},
+      ) as Map<String, Map<String, _i4.StrippedStateEvent>>);
 
   @override
-  Map<String, _i3.BasicEvent> get ephemerals => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get ephemerals => (super.noSuchMethod(
         Invocation.getter(#ephemerals),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  Map<String, _i3.BasicEvent> get roomAccountData => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get roomAccountData => (super.noSuchMethod(
         Invocation.getter(#roomAccountData),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i11.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i12.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i11.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i11.Completer<dynamic>>[],
-      ) as List<_i11.Completer<dynamic>>);
+        returnValue: <_i12.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i12.Completer<dynamic>>[],
+      ) as List<_i12.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1499,51 +1534,51 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i9.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i10.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i9.CachedStreamController<String> get onSessionKeyReceived =>
+  _i10.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1559,11 +1594,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1572,11 +1607,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1590,24 +1625,24 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i3.User> get typingUsers => (super.noSuchMethod(
+  List<_i4.User> get typingUsers => (super.noSuchMethod(
         Invocation.getter(#typingUsers),
-        returnValue: <_i3.User>[],
-        returnValueForMissingStub: <_i3.User>[],
-      ) as List<_i3.User>);
+        returnValue: <_i4.User>[],
+        returnValueForMissingStub: <_i4.User>[],
+      ) as List<_i4.User>);
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get isAbandonedDMRoom => (super.noSuchMethod(
@@ -1619,11 +1654,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1632,22 +1667,22 @@ class MockRoom extends _i1.Mock implements _i3.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_9(
+        returnValue: _FakeDateTime_10(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_9(
+        returnValueForMissingStub: _FakeDateTime_10(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
       ) as DateTime);
 
   @override
-  Map<String, _i3.Tag> get tags => (super.noSuchMethod(
+  Map<String, _i4.Tag> get tags => (super.noSuchMethod(
         Invocation.getter(#tags),
-        returnValue: <String, _i3.Tag>{},
-        returnValueForMissingStub: <String, _i3.Tag>{},
-      ) as Map<String, _i3.Tag>);
+        returnValue: <String, _i4.Tag>{},
+        returnValueForMissingStub: <String, _i4.Tag>{},
+      ) as Map<String, _i4.Tag>);
 
   @override
   bool get markedUnread => (super.noSuchMethod(
@@ -1664,17 +1699,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.LatestReceiptState get receiptState => (super.noSuchMethod(
+  _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_10(
+        returnValue: _FakeLatestReceiptState_11(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_10(
+        returnValueForMissingStub: _FakeLatestReceiptState_11(
           this,
           Invocation.getter(#receiptState),
         ),
-      ) as _i3.LatestReceiptState);
+      ) as _i4.LatestReceiptState);
 
   @override
   bool get isUnread => (super.noSuchMethod(
@@ -1691,18 +1726,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i11.Future<_i3.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i12.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -1712,20 +1747,20 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  Map<String, _i3.MatrixFile> get sendingFilePlaceholders =>
+  Map<String, _i4.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
-        returnValue: <String, _i3.MatrixFile>{},
-        returnValueForMissingStub: <String, _i3.MatrixFile>{},
-      ) as Map<String, _i3.MatrixFile>);
+        returnValue: <String, _i4.MatrixFile>{},
+        returnValueForMissingStub: <String, _i4.MatrixFile>{},
+      ) as Map<String, _i4.MatrixFile>);
 
   @override
-  Map<String, _i3.MatrixImageFile> get sendingFileThumbnails =>
+  Map<String, _i4.MatrixImageFile> get sendingFileThumbnails =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFileThumbnails),
-        returnValue: <String, _i3.MatrixImageFile>{},
-        returnValueForMissingStub: <String, _i3.MatrixImageFile>{},
-      ) as Map<String, _i3.MatrixImageFile>);
+        returnValue: <String, _i4.MatrixImageFile>{},
+        returnValueForMissingStub: <String, _i4.MatrixImageFile>{},
+      ) as Map<String, _i4.MatrixImageFile>);
 
   @override
   bool get isFederated => (super.noSuchMethod(
@@ -1826,11 +1861,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.PushRuleState get pushRuleState => (super.noSuchMethod(
+  _i4.PushRuleState get pushRuleState => (super.noSuchMethod(
         Invocation.getter(#pushRuleState),
-        returnValue: _i3.PushRuleState.notify,
-        returnValueForMissingStub: _i3.PushRuleState.notify,
-      ) as _i3.PushRuleState);
+        returnValue: _i4.PushRuleState.notify,
+        returnValueForMissingStub: _i4.PushRuleState.notify,
+      ) as _i4.PushRuleState);
 
   @override
   bool get canChangeJoinRules => (super.noSuchMethod(
@@ -1840,11 +1875,11 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i3.GuestAccess get guestAccess => (super.noSuchMethod(
+  _i4.GuestAccess get guestAccess => (super.noSuchMethod(
         Invocation.getter(#guestAccess),
-        returnValue: _i3.GuestAccess.canJoin,
-        returnValueForMissingStub: _i3.GuestAccess.canJoin,
-      ) as _i3.GuestAccess);
+        returnValue: _i4.GuestAccess.canJoin,
+        returnValueForMissingStub: _i4.GuestAccess.canJoin,
+      ) as _i4.GuestAccess);
 
   @override
   bool get canChangeGuestAccess => (super.noSuchMethod(
@@ -1882,21 +1917,21 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i19.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i18.SpaceParent>[],
-        returnValueForMissingStub: <_i18.SpaceParent>[],
-      ) as List<_i18.SpaceParent>);
+        returnValue: <_i19.SpaceParent>[],
+        returnValueForMissingStub: <_i19.SpaceParent>[],
+      ) as List<_i19.SpaceParent>);
 
   @override
-  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i19.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i18.SpaceChild>[],
-        returnValueForMissingStub: <_i18.SpaceChild>[],
-      ) as List<_i18.SpaceChild>);
+        returnValue: <_i19.SpaceChild>[],
+        returnValueForMissingStub: <_i19.SpaceChild>[],
+      ) as List<_i19.SpaceChild>);
 
   @override
-  set membership(_i3.Membership? value) => super.noSuchMethod(
+  set membership(_i4.Membership? value) => super.noSuchMethod(
         Invocation.setter(
           #membership,
           value,
@@ -1932,7 +1967,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set summary(_i3.RoomSummary? value) => super.noSuchMethod(
+  set summary(_i4.RoomSummary? value) => super.noSuchMethod(
         Invocation.setter(
           #summary,
           value,
@@ -1941,7 +1976,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set states(Map<String, Map<String, _i3.StrippedStateEvent>>? value) =>
+  set states(Map<String, Map<String, _i4.StrippedStateEvent>>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #states,
@@ -1951,7 +1986,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set ephemerals(Map<String, _i3.BasicEvent>? value) => super.noSuchMethod(
+  set ephemerals(Map<String, _i4.BasicEvent>? value) => super.noSuchMethod(
         Invocation.setter(
           #ephemerals,
           value,
@@ -1960,7 +1995,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set roomAccountData(Map<String, _i3.BasicEvent>? value) => super.noSuchMethod(
+  set roomAccountData(Map<String, _i4.BasicEvent>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomAccountData,
           value,
@@ -1978,7 +2013,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set lastEvent(_i3.Event? value) => super.noSuchMethod(
+  set lastEvent(_i4.Event? value) => super.noSuchMethod(
         Invocation.setter(
           #lastEvent,
           value,
@@ -1987,7 +2022,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  set receiptState(_i3.LatestReceiptState? value) => super.noSuchMethod(
+  set receiptState(_i4.LatestReceiptState? value) => super.noSuchMethod(
         Invocation.setter(
           #receiptState,
           value,
@@ -2006,17 +2041,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i11.Future<void> postLoad() => (super.noSuchMethod(
+  _i12.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i3.StrippedStateEvent? getState(
+  _i4.StrippedStateEvent? getState(
     String? typeKey, [
     String? stateKey = '',
   ]) =>
@@ -2029,10 +2064,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.StrippedStateEvent?);
+      ) as _i4.StrippedStateEvent?);
 
   @override
-  void setState(_i3.StrippedStateEvent? state) => super.noSuchMethod(
+  void setState(_i4.StrippedStateEvent? state) => super.noSuchMethod(
         Invocation.method(
           #setState,
           [state],
@@ -2041,33 +2076,33 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  _i11.Future<List<_i3.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i12.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
+        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
-      ) as _i11.Future<List<_i3.User>>);
+            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i12.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
-          [_i3.MatrixLocalizations? i18n =
-              const _i3.MatrixDefaultLocalizations()]) =>
+          [_i4.MatrixLocalizations? i18n =
+              const _i4.MatrixDefaultLocalizations()]) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2077,18 +2112,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as String);
 
   @override
-  _i11.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i12.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Event?> refreshLastEvent(
+  _i12.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2096,12 +2131,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
-  void setEphemeral(_i3.BasicEvent? ephemeral) => super.noSuchMethod(
+  void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
         Invocation.method(
           #setEphemeral,
           [ephemeral],
@@ -2110,12 +2145,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       );
 
   @override
-  _i11.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i12.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2123,22 +2158,22 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i12.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2146,17 +2181,17 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> addTag(
+  _i12.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2166,27 +2201,27 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i12.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i12.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2194,43 +2229,43 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i12.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i12.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i12.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2238,14 +2273,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2257,10 +2292,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as String?);
 
   @override
-  _i11.Future<String?> sendTextEvent(
+  _i12.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     bool? parseMarkdown = true,
     bool? parseCommands = true,
@@ -2289,12 +2324,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendReaction(
+  _i12.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2308,12 +2343,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendLocation(
+  _i12.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2327,18 +2362,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> sendFileEvent(
-    _i3.MatrixFile? file, {
+  _i12.Future<String?> sendFileEvent(
+    _i4.MatrixFile? file, {
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     int? shrinkImageMaxDimension,
-    _i3.MatrixImageFile? thumbnail,
+    _i4.MatrixImageFile? thumbnail,
     Map<String, dynamic>? extraContent,
     String? threadRootEventId,
     String? threadLastEventId,
@@ -2360,29 +2395,29 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<_i3.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i12.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i11.Future<_i3.EncryptionHealthState>.value(
-            _i3.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i11.Future<_i3.EncryptionHealthState>.value(
-            _i3.EncryptionHealthState.allVerified),
-      ) as _i11.Future<_i3.EncryptionHealthState>);
+        returnValue: _i12.Future<_i4.EncryptionHealthState>.value(
+            _i4.EncryptionHealthState.allVerified),
+        returnValueForMissingStub: _i12.Future<_i4.EncryptionHealthState>.value(
+            _i4.EncryptionHealthState.allVerified),
+      ) as _i12.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i11.Future<String?> sendEvent(
+  _i12.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
-    _i3.Event? inReplyTo,
+    _i4.Event? inReplyTo,
     String? editEventId,
     String? threadRootEventId,
     String? threadLastEventId,
@@ -2402,73 +2437,73 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i12.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> leave() => (super.noSuchMethod(
+  _i12.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> forget() => (super.noSuchMethod(
+  _i12.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> setPower(
+  _i12.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2480,7 +2515,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             power,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2491,7 +2526,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2501,10 +2536,10 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> invite(
+  _i12.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2514,16 +2549,16 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<int> requestHistory({
+  _i12.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
-    dynamic direction = _i3.Direction.b,
-    _i3.StateFilter? filter,
+    dynamic direction = _i4.Direction.b,
+    _i4.StateFilter? filter,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2536,32 +2571,32 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<int>.value(0),
-        returnValueForMissingStub: _i11.Future<int>.value(0),
-      ) as _i11.Future<int>);
+        returnValue: _i12.Future<int>.value(0),
+        returnValueForMissingStub: _i12.Future<int>.value(0),
+      ) as _i12.Future<int>);
 
   @override
-  _i11.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i12.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i12.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setReadMarker(
+  _i12.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2575,25 +2610,25 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #public: public,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
+  _i12.Future<_i20.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i11.Future<_i19.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i11.Future<_i19.TimelineChunk?>.value(),
-      ) as _i11.Future<_i19.TimelineChunk?>);
+        returnValue: _i12.Future<_i20.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i12.Future<_i20.TimelineChunk?>.value(),
+      ) as _i12.Future<_i20.TimelineChunk?>);
 
   @override
-  _i11.Future<void> postReceipt(
+  _i12.Future<void> postReceipt(
     String? eventId, {
-    _i3.ReceiptType? type = _i3.ReceiptType.mRead,
+    _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2601,12 +2636,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Timeline> getTimeline({
+  _i12.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2629,7 +2664,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i11.Future<_i3.Timeline>.value(_FakeTimeline_12(
+        returnValue: _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
           this,
           Invocation.method(
             #getTimeline,
@@ -2646,7 +2681,7 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Timeline>.value(_FakeTimeline_12(
+            _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
           this,
           Invocation.method(
             #getTimeline,
@@ -2662,30 +2697,30 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Timeline>);
+      ) as _i12.Future<_i4.Timeline>);
 
   @override
-  List<_i3.User> getParticipants(
-          [List<_i3.Membership>? membershipFilter = const [
-            _i3.Membership.join,
-            _i3.Membership.invite,
-            _i3.Membership.knock,
+  List<_i4.User> getParticipants(
+          [List<_i4.Membership>? membershipFilter = const [
+            _i4.Membership.join,
+            _i4.Membership.invite,
+            _i4.Membership.knock,
           ]]) =>
       (super.noSuchMethod(
         Invocation.method(
           #getParticipants,
           [membershipFilter],
         ),
-        returnValue: <_i3.User>[],
-        returnValueForMissingStub: <_i3.User>[],
-      ) as List<_i3.User>);
+        returnValue: <_i4.User>[],
+        returnValueForMissingStub: <_i4.User>[],
+      ) as List<_i4.User>);
 
   @override
-  _i11.Future<List<_i3.User>> requestParticipants([
-    List<_i3.Membership>? membershipFilter = const [
-      _i3.Membership.join,
-      _i3.Membership.invite,
-      _i3.Membership.knock,
+  _i12.Future<List<_i4.User>> requestParticipants([
+    List<_i4.Membership>? membershipFilter = const [
+      _i4.Membership.join,
+      _i4.Membership.invite,
+      _i4.Membership.knock,
     ],
     bool? suppressWarning = false,
     bool? cache,
@@ -2699,58 +2734,58 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             cache,
           ],
         ),
-        returnValue: _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
+        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.User>>.value(<_i3.User>[]),
-      ) as _i11.Future<List<_i3.User>>);
+            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i12.Future<List<_i4.User>>);
 
   @override
-  _i3.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
+  _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
         Invocation.method(
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_13(
+        returnValue: _FakeUser_14(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_13(
+        returnValueForMissingStub: _FakeUser_14(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-      ) as _i3.User);
+      ) as _i4.User);
 
   @override
-  _i3.User unsafeGetUserFromMemoryOrFallback(String? mxID) =>
+  _i4.User unsafeGetUserFromMemoryOrFallback(String? mxID) =>
       (super.noSuchMethod(
         Invocation.method(
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_13(
+        returnValue: _FakeUser_14(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_13(
+        returnValueForMissingStub: _FakeUser_14(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-      ) as _i3.User);
+      ) as _i4.User);
 
   @override
-  _i11.Future<_i3.User?> requestUser(
+  _i12.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2766,19 +2801,19 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i11.Future<_i3.User?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.User?>.value(),
-      ) as _i11.Future<_i3.User?>);
+        returnValue: _i12.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.User?>.value(),
+      ) as _i12.Future<_i4.User?>);
 
   @override
-  _i11.Future<_i3.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i12.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2791,12 +2826,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i11.Future<String> setAvatar(_i3.MatrixFile? file) => (super.noSuchMethod(
+  _i12.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2804,14 +2839,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2834,14 +2869,14 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as int);
 
   @override
-  _i11.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i12.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -2880,18 +2915,18 @@ class MockRoom extends _i1.Mock implements _i3.Room {
       ) as bool);
 
   @override
-  _i11.Future<void> setPushRuleState(_i3.PushRuleState? newState) =>
+  _i12.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEvent(
+  _i12.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -2905,12 +2940,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> setTyping(
+  _i12.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -2920,13 +2955,13 @@ class MockRoom extends _i1.Mock implements _i3.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setJoinRules(
-    _i3.JoinRules? joinRules, {
+  _i12.Future<void> setJoinRules(
+    _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
   }) =>
@@ -2939,59 +2974,59 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setGuestAccess(_i3.GuestAccess? guestAccess) =>
+  _i12.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setHistoryVisibility(
-          _i3.HistoryVisibility? historyVisibility) =>
+  _i12.Future<void> setHistoryVisibility(
+          _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i12.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i12.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i11.Future<List<_i3.DeviceKeys>>.value(<_i3.DeviceKeys>[]),
+            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.DeviceKeys>>.value(<_i3.DeviceKeys>[]),
-      ) as _i11.Future<List<_i3.DeviceKeys>>);
+            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i12.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i11.Future<void> requestSessionKey(
+  _i12.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -3003,12 +3038,12 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             senderKey,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setSpaceChild(
+  _i12.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3024,51 +3059,51 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i12.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i11.Future<Uri>);
+      ) as _i12.Future<Uri>);
 
   @override
-  _i11.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i12.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<
+  _i12.Future<
       ({
-        List<_i3.Event> events,
+        List<_i4.Event> events,
         String? nextBatch,
         DateTime? searchedUntil
       })> searchEvents({
     String? searchTerm,
-    bool Function(_i3.Event)? searchFunc,
+    bool Function(_i4.Event)? searchFunc,
     String? nextBatch,
     int? limit = 1000,
     Set<String>? includeEventTypes = const {
@@ -3088,23 +3123,23 @@ class MockRoom extends _i1.Mock implements _i3.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i11.Future<
+        returnValue: _i12.Future<
                 ({
-                  List<_i3.Event> events,
+                  List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
-            (events: <_i3.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i11.Future<
+            (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
+        returnValueForMissingStub: _i12.Future<
                 ({
-                  List<_i3.Event> events,
+                  List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
-            (events: <_i3.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i11.Future<
+            (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
+      ) as _i12.Future<
           ({
-            List<_i3.Event> events,
+            List<_i4.Event> events,
             String? nextBatch,
             DateTime? searchedUntil
           })>);
@@ -3113,27 +3148,27 @@ class MockRoom extends _i1.Mock implements _i3.Room {
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockClient extends _i1.Mock implements _i3.Client {
+class MockClient extends _i1.Mock implements _i4.Client {
   @override
-  _i3.DatabaseApi get database => (super.noSuchMethod(
+  _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_15(
+        returnValue: _FakeDatabaseApi_16(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_15(
+        returnValueForMissingStub: _FakeDatabaseApi_16(
           this,
           Invocation.getter(#database),
         ),
-      ) as _i3.DatabaseApi);
+      ) as _i4.DatabaseApi);
 
   @override
-  Set<_i20.KeyVerificationMethod> get verificationMethods =>
+  Set<_i21.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i20.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
-      ) as Set<_i20.KeyVerificationMethod>);
+        returnValue: <_i21.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i21.KeyVerificationMethod>{},
+      ) as Set<_i21.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3178,44 +3213,44 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  _i3.ShareKeysWith get shareKeysWith => (super.noSuchMethod(
+  _i4.ShareKeysWith get shareKeysWith => (super.noSuchMethod(
         Invocation.getter(#shareKeysWith),
-        returnValue: _i3.ShareKeysWith.all,
-        returnValueForMissingStub: _i3.ShareKeysWith.all,
-      ) as _i3.ShareKeysWith);
+        returnValue: _i4.ShareKeysWith.all,
+        returnValueForMissingStub: _i4.ShareKeysWith.all,
+      ) as _i4.ShareKeysWith);
 
   @override
-  Map<String, _i3.CommandExecutionCallback> get commands => (super.noSuchMethod(
+  Map<String, _i4.CommandExecutionCallback> get commands => (super.noSuchMethod(
         Invocation.getter(#commands),
-        returnValue: <String, _i3.CommandExecutionCallback>{},
-        returnValueForMissingStub: <String, _i3.CommandExecutionCallback>{},
-      ) as Map<String, _i3.CommandExecutionCallback>);
+        returnValue: <String, _i4.CommandExecutionCallback>{},
+        returnValueForMissingStub: <String, _i4.CommandExecutionCallback>{},
+      ) as Map<String, _i4.CommandExecutionCallback>);
 
   @override
-  _i3.Filter get syncFilter => (super.noSuchMethod(
+  _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_16(
+        returnValue: _FakeFilter_17(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_16(
+        returnValueForMissingStub: _FakeFilter_17(
           this,
           Invocation.getter(#syncFilter),
         ),
-      ) as _i3.Filter);
+      ) as _i4.Filter);
 
   @override
-  _i3.NativeImplementations get nativeImplementations => (super.noSuchMethod(
+  _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_17(
+        returnValue: _FakeNativeImplementations_18(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_17(
+        returnValueForMissingStub: _FakeNativeImplementations_18(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-      ) as _i3.NativeImplementations);
+      ) as _i4.NativeImplementations);
 
   @override
   bool get convertLinebreaksInFormatting => (super.noSuchMethod(
@@ -3227,11 +3262,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_18(
+        returnValue: _FakeDuration_19(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_18(
+        returnValueForMissingStub: _FakeDuration_19(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3240,11 +3275,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_18(
+        returnValue: _FakeDuration_19(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_18(
+        returnValueForMissingStub: _FakeDuration_19(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3253,36 +3288,36 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
       ) as String);
 
   @override
-  _i3.LoginState get loginState => (super.noSuchMethod(
+  _i4.LoginState get loginState => (super.noSuchMethod(
         Invocation.getter(#loginState),
-        returnValue: _i3.LoginState.loggedIn,
-        returnValueForMissingStub: _i3.LoginState.loggedIn,
-      ) as _i3.LoginState);
+        returnValue: _i4.LoginState.loggedIn,
+        returnValueForMissingStub: _i4.LoginState.loggedIn,
+      ) as _i4.LoginState);
 
   @override
-  List<_i3.Room> get rooms => (super.noSuchMethod(
+  List<_i4.Room> get rooms => (super.noSuchMethod(
         Invocation.getter(#rooms),
-        returnValue: <_i3.Room>[],
-        returnValueForMissingStub: <_i3.Room>[],
-      ) as List<_i3.Room>);
+        returnValue: <_i4.Room>[],
+        returnValueForMissingStub: <_i4.Room>[],
+      ) as List<_i4.Room>);
 
   @override
-  List<_i3.ArchivedRoom> get archivedRooms => (super.noSuchMethod(
+  List<_i4.ArchivedRoom> get archivedRooms => (super.noSuchMethod(
         Invocation.getter(#archivedRooms),
-        returnValue: <_i3.ArchivedRoom>[],
-        returnValueForMissingStub: <_i3.ArchivedRoom>[],
-      ) as List<_i3.ArchivedRoom>);
+        returnValue: <_i4.ArchivedRoom>[],
+        returnValueForMissingStub: <_i4.ArchivedRoom>[],
+      ) as List<_i4.ArchivedRoom>);
 
   @override
   bool get enableDehydratedDevices => (super.noSuchMethod(
@@ -3294,11 +3329,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3328,11 +3363,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3341,11 +3376,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3359,31 +3394,31 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  Map<String, _i3.BasicEvent> get accountData => (super.noSuchMethod(
+  Map<String, _i4.BasicEvent> get accountData => (super.noSuchMethod(
         Invocation.getter(#accountData),
-        returnValue: <String, _i3.BasicEvent>{},
-        returnValueForMissingStub: <String, _i3.BasicEvent>{},
-      ) as Map<String, _i3.BasicEvent>);
+        returnValue: <String, _i4.BasicEvent>{},
+        returnValueForMissingStub: <String, _i4.BasicEvent>{},
+      ) as Map<String, _i4.BasicEvent>);
 
   @override
-  _i3.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
+  _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_19(
+        returnValue: _FakePushruleEvaluator_20(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_19(
+        returnValueForMissingStub: _FakePushruleEvaluator_20(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-      ) as _i3.PushruleEvaluator);
+      ) as _i4.PushruleEvaluator);
 
   @override
-  Map<String, _i3.CachedPresence> get presences => (super.noSuchMethod(
+  Map<String, _i4.CachedPresence> get presences => (super.noSuchMethod(
         Invocation.getter(#presences),
-        returnValue: <String, _i3.CachedPresence>{},
-        returnValueForMissingStub: <String, _i3.CachedPresence>{},
-      ) as Map<String, _i3.CachedPresence>);
+        returnValue: <String, _i4.CachedPresence>{},
+        returnValueForMissingStub: <String, _i4.CachedPresence>{},
+      ) as Map<String, _i4.CachedPresence>);
 
   @override
   Map<String, List<String>> get directChats => (super.noSuchMethod(
@@ -3393,333 +3428,333 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i11.Future<_i3.Profile> get ownProfile => (super.noSuchMethod(
+  _i12.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i9.CachedStreamController<String> get onUserProfileUpdate =>
+  _i10.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i11.Future<List<_i3.Room>> get archive => (super.noSuchMethod(
+  _i12.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
+        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
-      ) as _i11.Future<List<_i3.Room>>);
+            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i12.Future<List<_i4.Room>>);
 
   @override
-  _i9.CachedStreamController<_i3.EventUpdate> get onEvent =>
+  _i10.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.EventUpdate>(
+        returnValue: _FakeCachedStreamController_9<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.EventUpdate>(
+            _FakeCachedStreamController_9<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.EventUpdate>);
+      ) as _i10.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onTimelineEvent =>
+  _i10.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onHistoryEvent =>
+  _i10.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onNotification =>
+  _i10.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<_i3.ToDeviceEvent> get onToDeviceEvent =>
+  _i10.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_8<_i3.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.ToDeviceEvent>(
+            _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i9.CachedStreamController<_i3.ToDeviceEvent>);
+      ) as _i10.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i9.CachedStreamController<List<_i3.BasicEventWithSender>> get onCallEvents =>
-      (super.noSuchMethod(
-        Invocation.getter(#onCallEvents),
-        returnValue:
-            _FakeCachedStreamController_8<List<_i3.BasicEventWithSender>>(
-          this,
-          Invocation.getter(#onCallEvents),
-        ),
-        returnValueForMissingStub:
-            _FakeCachedStreamController_8<List<_i3.BasicEventWithSender>>(
-          this,
-          Invocation.getter(#onCallEvents),
-        ),
-      ) as _i9.CachedStreamController<List<_i3.BasicEventWithSender>>);
+  _i10.CachedStreamController<List<_i4.BasicEventWithSender>>
+      get onCallEvents => (super.noSuchMethod(
+            Invocation.getter(#onCallEvents),
+            returnValue:
+                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+              this,
+              Invocation.getter(#onCallEvents),
+            ),
+            returnValueForMissingStub:
+                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+              this,
+              Invocation.getter(#onCallEvents),
+            ),
+          ) as _i10.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i9.CachedStreamController<_i3.LoginState> get onLoginStateChanged =>
+  _i10.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_8<_i3.LoginState>(
+        returnValue: _FakeCachedStreamController_9<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.LoginState>(
+            _FakeCachedStreamController_9<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i9.CachedStreamController<_i3.LoginState>);
+      ) as _i10.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i9.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i10.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_8<bool>(
+        returnValue: _FakeCachedStreamController_9<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i9.CachedStreamController<bool>);
+      ) as _i10.CachedStreamController<bool>);
 
   @override
-  _i9.CachedStreamController<_i3.SdkError> get onEncryptionError =>
+  _i10.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_8<_i3.SdkError>(
+        returnValue: _FakeCachedStreamController_9<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i9.CachedStreamController<_i3.SdkError>);
+      ) as _i10.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i9.CachedStreamController<_i3.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i10.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_8<_i3.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_9<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.SyncUpdate>(
+            _FakeCachedStreamController_9<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i9.CachedStreamController<_i3.SyncUpdate>);
+      ) as _i10.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.SyncStatusUpdate> get onSyncStatus =>
+  _i10.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_8<_i3.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.SyncStatusUpdate>(
+            _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i9.CachedStreamController<_i3.SyncStatusUpdate>);
+      ) as _i10.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i9.CachedStreamController<_i3.Presence> get onPresence =>
+  _i10.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_8<_i3.Presence>(
+        returnValue: _FakeCachedStreamController_9<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i9.CachedStreamController<_i3.Presence>);
+      ) as _i10.CachedStreamController<_i4.Presence>);
 
   @override
-  _i9.CachedStreamController<_i3.CachedPresence> get onPresenceChanged =>
+  _i10.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_8<_i3.CachedPresence>(
+        returnValue: _FakeCachedStreamController_9<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.CachedPresence>(
+            _FakeCachedStreamController_9<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i9.CachedStreamController<_i3.CachedPresence>);
+      ) as _i10.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i9.CachedStreamController<_i3.BasicEvent> get onAccountData =>
+  _i10.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_8<_i3.BasicEvent>(
+        returnValue: _FakeCachedStreamController_9<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.BasicEvent>(
+            _FakeCachedStreamController_9<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i9.CachedStreamController<_i3.BasicEvent>);
+      ) as _i10.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i9.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
+  _i10.CachedStreamController<_i21.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i20.RoomKeyRequest>(
+            _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i9.CachedStreamController<_i20.RoomKeyRequest>);
+      ) as _i10.CachedStreamController<_i21.RoomKeyRequest>);
 
   @override
-  _i9.CachedStreamController<_i20.KeyVerification>
+  _i10.CachedStreamController<_i21.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_8<_i20.KeyVerification>(
+            returnValue: _FakeCachedStreamController_9<_i21.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_8<_i20.KeyVerification>(
+                _FakeCachedStreamController_9<_i21.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i9.CachedStreamController<_i20.KeyVerification>);
+          ) as _i10.CachedStreamController<_i21.KeyVerification>);
 
   @override
-  _i9.CachedStreamController<_i3.UiaRequest<dynamic>> get onUiaRequest =>
+  _i10.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_8<_i3.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_8<_i3.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i9.CachedStreamController<_i3.UiaRequest<dynamic>>);
+      ) as _i10.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i9.CachedStreamController<_i3.Event> get onGroupMember =>
+  _i10.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_8<_i3.Event>(
+        returnValue: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<_i3.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i9.CachedStreamController<_i3.Event>);
+      ) as _i10.CachedStreamController<_i4.Event>);
 
   @override
-  _i9.CachedStreamController<String> get onCancelSendEvent =>
+  _i10.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_8<String>(
+        returnValue: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_8<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i9.CachedStreamController<String>);
+      ) as _i10.CachedStreamController<String>);
 
   @override
-  _i9.CachedStreamController<({String roomId, _i3.StrippedStateEvent state})>
+  _i10.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_8<
-                ({String roomId, _i3.StrippedStateEvent state})>(
+            returnValue: _FakeCachedStreamController_9<
+                ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_8<
-                ({String roomId, _i3.StrippedStateEvent state})>(
+            returnValueForMissingStub: _FakeCachedStreamController_9<
+                ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i9.CachedStreamController<
-              ({String roomId, _i3.StrippedStateEvent state})>);
+          ) as _i10.CachedStreamController<
+              ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
   int get syncErrorTimeoutSec => (super.noSuchMethod(
@@ -3738,11 +3773,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_9(
+        returnValue: _FakeDateTime_10(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_9(
+        returnValueForMissingStub: _FakeDateTime_10(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3763,33 +3798,33 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as bool);
 
   @override
-  _i3.RoomSorter get sortRoomsBy => (super.noSuchMethod(
+  _i4.RoomSorter get sortRoomsBy => (super.noSuchMethod(
         Invocation.getter(#sortRoomsBy),
         returnValue: (
-          _i3.Room a,
-          _i3.Room b,
+          _i4.Room a,
+          _i4.Room b,
         ) =>
             0,
         returnValueForMissingStub: (
-          _i3.Room a,
-          _i3.Room b,
+          _i4.Room a,
+          _i4.Room b,
         ) =>
             0,
-      ) as _i3.RoomSorter);
+      ) as _i4.RoomSorter);
 
   @override
-  Map<String, _i3.DeviceKeysList> get userDeviceKeys => (super.noSuchMethod(
+  Map<String, _i4.DeviceKeysList> get userDeviceKeys => (super.noSuchMethod(
         Invocation.getter(#userDeviceKeys),
-        returnValue: <String, _i3.DeviceKeysList>{},
-        returnValueForMissingStub: <String, _i3.DeviceKeysList>{},
-      ) as Map<String, _i3.DeviceKeysList>);
+        returnValue: <String, _i4.DeviceKeysList>{},
+        returnValueForMissingStub: <String, _i4.DeviceKeysList>{},
+      ) as Map<String, _i4.DeviceKeysList>);
 
   @override
-  List<_i3.DeviceKeys> get unverifiedDevices => (super.noSuchMethod(
+  List<_i4.DeviceKeys> get unverifiedDevices => (super.noSuchMethod(
         Invocation.getter(#unverifiedDevices),
-        returnValue: <_i3.DeviceKeys>[],
-        returnValueForMissingStub: <_i3.DeviceKeys>[],
-      ) as List<_i3.DeviceKeys>);
+        returnValue: <_i4.DeviceKeys>[],
+        returnValueForMissingStub: <_i4.DeviceKeys>[],
+      ) as List<_i4.DeviceKeys>);
 
   @override
   bool get allPushNotificationsMuted => (super.noSuchMethod(
@@ -3806,7 +3841,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as List<String>);
 
   @override
-  set database(_i3.DatabaseApi? db) => super.noSuchMethod(
+  set database(_i4.DatabaseApi? db) => super.noSuchMethod(
         Invocation.setter(
           #database,
           db,
@@ -3815,7 +3850,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i21.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3861,7 +3896,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set shareKeysWith(_i3.ShareKeysWith? value) => super.noSuchMethod(
+  set shareKeysWith(_i4.ShareKeysWith? value) => super.noSuchMethod(
         Invocation.setter(
           #shareKeysWith,
           value,
@@ -3870,7 +3905,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set onSoftLogout(_i11.Future<void> Function(_i3.Client)? value) =>
+  set onSoftLogout(_i12.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3881,8 +3916,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
 
   @override
   set customImageResizer(
-          _i11.Future<_i3.MatrixImageFileResizedResponse?> Function(
-                  _i3.MatrixImageFileResizeArguments)?
+          _i12.Future<_i4.MatrixImageFileResizedResponse?> Function(
+                  _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
         Invocation.setter(
@@ -3920,7 +3955,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set rooms(List<_i3.Room>? newList) => super.noSuchMethod(
+  set rooms(List<_i4.Room>? newList) => super.noSuchMethod(
         Invocation.setter(
           #rooms,
           newList,
@@ -3929,7 +3964,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set presences(Map<String, _i3.CachedPresence>? value) => super.noSuchMethod(
+  set presences(Map<String, _i4.CachedPresence>? value) => super.noSuchMethod(
         Invocation.setter(
           #presences,
           value,
@@ -3956,7 +3991,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set syncPresence(_i3.PresenceType? value) => super.noSuchMethod(
+  set syncPresence(_i4.PresenceType? value) => super.noSuchMethod(
         Invocation.setter(
           #syncPresence,
           value,
@@ -3992,7 +4027,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -4001,7 +4036,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set roomsLoading(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -4010,7 +4045,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  set firstSyncReceived(_i11.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i12.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4037,20 +4072,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i10.Client get httpClient => (super.noSuchMethod(
+  _i11.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_21(
+        returnValue: _FakeClient_22(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_21(
+        returnValueForMissingStub: _FakeClient_22(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i10.Client);
+      ) as _i11.Client);
 
   @override
-  set httpClient(_i10.Client? value) => super.noSuchMethod(
+  set httpClient(_i11.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4077,7 +4112,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<void> refreshAccessToken(
+  _i12.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4085,9 +4120,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4105,14 +4140,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4122,22 +4157,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as String);
 
   @override
-  _i3.Room? getRoomByAlias(String? alias) => (super.noSuchMethod(
+  _i4.Room? getRoomByAlias(String? alias) => (super.noSuchMethod(
         Invocation.method(
           #getRoomByAlias,
           [alias],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.Room?);
+      ) as _i4.Room?);
 
   @override
-  _i3.Room? getRoomById(String? id) => (super.noSuchMethod(
+  _i4.Room? getRoomById(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getRoomById,
           [id],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.Room?);
+      ) as _i4.Room?);
 
   @override
   String? getDirectChatFromUserId(String? userId) => (super.noSuchMethod(
@@ -4149,38 +4184,38 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as String?);
 
   @override
-  _i11.Future<_i3.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i12.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i11.Future<_i3.DiscoveryInformation>);
+      ) as _i12.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i11.Future<
+  _i12.Future<
       (
-        _i3.DiscoveryInformation?,
-        _i3.GetVersionsResponse,
-        List<_i3.LoginFlow>,
-        _i3.GetAuthMetadataResponse?
+        _i4.DiscoveryInformation?,
+        _i4.GetVersionsResponse,
+        List<_i4.LoginFlow>,
+        _i4.GetAuthMetadataResponse?
       )> checkHomeserver(
     Uri? homeserverUrl, {
     bool? checkWellKnown = true,
@@ -4197,15 +4232,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i11.Future<
+        returnValue: _i12.Future<
             (
-              _i3.DiscoveryInformation?,
-              _i3.GetVersionsResponse,
-              List<_i3.LoginFlow>,
-              _i3.GetAuthMetadataResponse?
+              _i4.DiscoveryInformation?,
+              _i4.GetVersionsResponse,
+              List<_i4.LoginFlow>,
+              _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_23(
+          _FakeGetVersionsResponse_24(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4217,18 +4252,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
           ),
-          <_i3.LoginFlow>[],
+          <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i11.Future<
+        returnValueForMissingStub: _i12.Future<
             (
-              _i3.DiscoveryInformation?,
-              _i3.GetVersionsResponse,
-              List<_i3.LoginFlow>,
-              _i3.GetAuthMetadataResponse?
+              _i4.DiscoveryInformation?,
+              _i4.GetVersionsResponse,
+              List<_i4.LoginFlow>,
+              _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_23(
+          _FakeGetVersionsResponse_24(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4240,19 +4275,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
           ),
-          <_i3.LoginFlow>[],
+          <_i4.LoginFlow>[],
           null
         )),
-      ) as _i11.Future<
+      ) as _i12.Future<
           (
-            _i3.DiscoveryInformation?,
-            _i3.GetVersionsResponse,
-            List<_i3.LoginFlow>,
-            _i3.GetAuthMetadataResponse?
+            _i4.DiscoveryInformation?,
+            _i4.GetVersionsResponse,
+            List<_i4.LoginFlow>,
+            _i4.GetAuthMetadataResponse?
           )>);
 
   @override
-  _i11.Future<_i3.DiscoveryInformation> getWellknown({
+  _i12.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4265,8 +4300,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getWellknown,
@@ -4277,8 +4312,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getWellknown,
@@ -4289,19 +4324,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.DiscoveryInformation>);
+      ) as _i12.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i11.Future<_i3.RegisterResponse> register({
+  _i12.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
     String? initialDeviceDisplayName,
     bool? inhibitLogin,
     bool? refreshToken,
-    _i3.AuthenticationData? auth,
-    _i3.AccountKind? kind,
-    void Function(_i3.InitState)? onInitStateChanged,
+    _i4.AuthenticationData? auth,
+    _i4.AccountKind? kind,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4320,7 +4355,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<_i3.RegisterResponse>.value(_FakeRegisterResponse_24(
+            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
           this,
           Invocation.method(
             #register,
@@ -4339,7 +4374,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RegisterResponse>.value(_FakeRegisterResponse_24(
+            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
           this,
           Invocation.method(
             #register,
@@ -4357,12 +4392,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RegisterResponse>);
+      ) as _i12.Future<_i4.RegisterResponse>);
 
   @override
-  _i11.Future<_i3.LoginResponse> login(
+  _i12.Future<_i4.LoginResponse> login(
     String? type, {
-    _i3.AuthenticationIdentifier? identifier,
+    _i4.AuthenticationIdentifier? identifier,
     String? password,
     String? token,
     String? deviceId,
@@ -4371,7 +4406,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? user,
     String? medium,
     String? address,
-    void Function(_i3.InitState)? onInitStateChanged,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4390,7 +4425,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i11.Future<_i3.LoginResponse>.value(_FakeLoginResponse_25(
+        returnValue: _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
           this,
           Invocation.method(
             #login,
@@ -4410,7 +4445,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.LoginResponse>.value(_FakeLoginResponse_25(
+            _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
           this,
           Invocation.method(
             #login,
@@ -4429,10 +4464,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.LoginResponse>);
+      ) as _i12.Future<_i4.LoginResponse>);
 
   @override
-  _i11.Future<_i3.GetAuthMetadataResponse> getAuthMetadata({
+  _i12.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4445,8 +4480,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_26(
+        returnValue: _i12.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_27(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4458,8 +4493,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_26(
+            _i12.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_27(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4470,80 +4505,80 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetAuthMetadataResponse>);
+      ) as _i12.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i11.Future<void> logout() => (super.noSuchMethod(
+  _i12.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> logoutAll() => (super.noSuchMethod(
+  _i12.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<T> uiaRequestBackground<T>(
-          _i11.Future<T> Function(_i3.AuthenticationData?)? request) =>
+  _i12.Future<T> uiaRequestBackground<T>(
+          _i12.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i11.Future<T>.value(v),
+              (T v) => _i12.Future<T>.value(v),
             ) ??
-            _FakeFuture_27<T>(
+            _FakeFuture_28<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i11.Future<T>.value(v),
+              (T v) => _i12.Future<T>.value(v),
             ) ??
-            _FakeFuture_27<T>(
+            _FakeFuture_28<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i11.Future<T>);
+      ) as _i12.Future<T>);
 
   @override
-  _i11.Future<String> startDirectChat(
+  _i12.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
-    List<_i3.StateEvent>? initialState,
+    List<_i4.StateEvent>? initialState,
     bool? waitForSync = true,
     Map<String, dynamic>? powerLevelContentOverride,
-    _i3.CreateRoomPreset? preset = _i3.CreateRoomPreset.trustedPrivateChat,
+    _i4.CreateRoomPreset? preset = _i4.CreateRoomPreset.trustedPrivateChat,
     bool? skipExistingChat = false,
   }) =>
       (super.noSuchMethod(
@@ -4559,7 +4594,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4575,7 +4610,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4590,17 +4625,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<String> createGroupChat({
+  _i12.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
-    _i3.CreateRoomPreset? preset = _i3.CreateRoomPreset.privateChat,
-    List<_i3.StateEvent>? initialState,
-    _i3.Visibility? visibility,
-    _i3.HistoryVisibility? historyVisibility,
+    _i4.CreateRoomPreset? preset = _i4.CreateRoomPreset.privateChat,
+    List<_i4.StateEvent>? initialState,
+    _i4.Visibility? visibility,
+    _i4.HistoryVisibility? historyVisibility,
     bool? waitForSync = true,
     bool? groupCall = false,
     bool? federated = true,
@@ -4624,7 +4659,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4645,7 +4680,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4665,10 +4700,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> waitForRoomInSync(
+  _i12.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4684,7 +4719,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4697,7 +4732,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4709,27 +4744,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i12.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<String> createSpace({
+  _i12.Future<String> createSpace({
     String? name,
     String? topic,
-    _i3.Visibility? visibility = _i3.Visibility.public,
+    _i4.Visibility? visibility = _i4.Visibility.public,
     String? spaceAliasName,
     List<String>? invite,
-    List<_i3.Invite3pid>? invite3pid,
+    List<_i4.Invite3pid>? invite3pid,
     String? roomVersion,
     bool? waitForSync = false,
   }) =>
@@ -4748,7 +4783,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4766,7 +4801,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4783,10 +4818,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.Profile> fetchOwnProfileFromServer(
+  _i12.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4794,7 +4829,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4803,7 +4838,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4811,10 +4846,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i11.Future<_i3.Profile> fetchOwnProfile({
+  _i12.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4827,7 +4862,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4839,7 +4874,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4850,10 +4885,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i11.Future<_i3.CachedProfileInformation> getUserProfile(
+  _i12.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4867,8 +4902,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i11.Future<_i3.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_28(
+        returnValue: _i12.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_29(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4880,8 +4915,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_28(
+            _i12.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_29(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4892,10 +4927,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.CachedProfileInformation>);
+      ) as _i12.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i11.Future<_i3.Profile> getProfileFromUserId(
+  _i12.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4913,7 +4948,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4927,7 +4962,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Profile>.value(_FakeProfile_20(
+            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4940,17 +4975,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.Profile>);
+      ) as _i12.Future<_i4.Profile>);
 
   @override
-  _i3.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
+  _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getArchiveRoomFromCache,
           [roomId],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.ArchivedRoom?);
+      ) as _i4.ArchivedRoom?);
 
   @override
   void clearArchivesFromCache() => super.noSuchMethod(
@@ -4962,31 +4997,31 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<List<_i3.Room>> loadArchive() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
+        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Room>>.value(<_i3.Room>[]),
-      ) as _i11.Future<List<_i3.Room>>);
+            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i12.Future<List<_i4.Room>>);
 
   @override
-  _i11.Future<List<_i3.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i12.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i11.Future<List<_i3.ArchivedRoom>>.value(<_i3.ArchivedRoom>[]),
+            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ArchivedRoom>>.value(<_i3.ArchivedRoom>[]),
-      ) as _i11.Future<List<_i3.ArchivedRoom>>);
+            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i12.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i11.Future<_i3.GetVersionsResponse> getVersions({
+  _i12.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4999,8 +5034,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_23(
+        returnValue: _i12.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_24(
           this,
           Invocation.method(
             #getVersions,
@@ -5011,8 +5046,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_23(
+        returnValueForMissingStub: _i12.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_24(
           this,
           Invocation.method(
             #getVersions,
@@ -5023,20 +5058,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetVersionsResponse>);
+      ) as _i12.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i11.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i12.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<_i3.MediaConfig> getConfig({
+  _i12.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5049,7 +5084,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfig,
@@ -5061,7 +5096,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfig,
@@ -5072,10 +5107,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.MediaConfig>);
+      ) as _i12.Future<_i4.MediaConfig>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContent(
+  _i12.Future<_i13.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5095,7 +5130,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContent,
@@ -5111,7 +5146,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContent,
@@ -5126,10 +5161,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentOverrideName(
+  _i12.Future<_i13.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5151,7 +5186,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5168,7 +5203,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5184,15 +5219,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentThumbnail(
+  _i12.Future<_i13.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
     int? height, {
-    _i3.Method? method,
+    _i4.Method? method,
     bool? allowRemote,
     int? timeoutMs,
     bool? allowRedirect,
@@ -5215,7 +5250,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5235,7 +5270,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5254,10 +5289,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i3.PreviewForUrl> getUrlPreview(
+  _i12.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5267,7 +5302,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5276,7 +5311,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5284,11 +5319,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i11.Future<_i3.PreviewForUrl>);
+      ) as _i12.Future<_i4.PreviewForUrl>);
 
   @override
-  _i11.Future<Uri> uploadContent(
-    _i21.Uint8List? file, {
+  _i12.Future<Uri> uploadContent(
+    _i22.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5301,7 +5336,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #uploadContent,
@@ -5312,7 +5347,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<Uri>.value(_FakeUri_14(
+        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
           this,
           Invocation.method(
             #uploadContent,
@@ -5323,10 +5358,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<Uri>);
+      ) as _i12.Future<Uri>);
 
   @override
-  _i11.Future<void> setTyping(
+  _i12.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5342,43 +5377,43 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> exportDump() => (super.noSuchMethod(
+  _i12.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i12.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> setAvatar(_i3.MatrixFile? file) => (super.noSuchMethod(
+  _i12.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Event?> getEventByPushNotification(
-    _i3.PushNotification? notification, {
+  _i12.Future<_i4.Event?> getEventByPushNotification(
+    _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
     bool? returnNullIfSeen = true,
@@ -5393,12 +5428,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
-  _i11.Future<void> init({
+  _i12.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5411,7 +5446,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     bool? waitForFirstSync = true,
     bool? waitUntilLoadCompletedLoaded = true,
     void Function()? onMigration,
-    void Function(_i3.InitState)? onInitStateChanged,
+    void Function(_i4.InitState)? onInitStateChanged,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5433,9 +5468,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5447,42 +5482,42 @@ class MockClient extends _i1.Mock implements _i3.Client {
       );
 
   @override
-  _i11.Future<void> clear() => (super.noSuchMethod(
+  _i12.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i12.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ensureNotSoftLoggedOut(
+  _i12.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> handleSync(
-    _i3.SyncUpdate? sync, {
-    _i3.Direction? direction,
+  _i12.Future<void> handleSync(
+    _i4.SyncUpdate? sync, {
+    _i4.Direction? direction,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5490,44 +5525,44 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i3.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
+  _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
       (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeysByCurve25519Key,
           [senderKey],
         ),
         returnValueForMissingStub: null,
-      ) as _i3.DeviceKeys?);
+      ) as _i4.DeviceKeys?);
 
   @override
-  _i11.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i12.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i12.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDevice(
+  _i12.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5541,12 +5576,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             messages,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDevicesOfUserIds(
+  _i12.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5562,13 +5597,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDeviceEncrypted(
-    List<_i3.DeviceKeys>? deviceKeys,
+  _i12.Future<void> sendToDeviceEncrypted(
+    List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
     String? messageId,
@@ -5587,13 +5622,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> sendToDeviceEncryptedChunked(
-    List<_i3.DeviceKeys>? deviceKeys,
+  _i12.Future<void> sendToDeviceEncryptedChunked(
+    List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
   ) =>
@@ -5606,28 +5641,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
             message,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i12.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> joinRoom(
+  _i12.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
     String? reason,
-    _i3.ThirdPartySigned? thirdPartySigned,
+    _i4.ThirdPartySigned? thirdPartySigned,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5640,7 +5675,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5654,7 +5689,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5667,13 +5702,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> changePassword(
+  _i12.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
     bool? logoutDevices,
   }) =>
       (super.noSuchMethod(
@@ -5686,22 +5721,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> clearCache() => (super.noSuchMethod(
+  _i12.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ignoreUser(
+  _i12.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5711,22 +5746,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i12.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.CachedPresence> fetchCurrentPresence(
+  _i12.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5737,7 +5772,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i11.Future<_i3.CachedPresence>.value(_FakeCachedPresence_32(
+            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5746,7 +5781,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.CachedPresence>.value(_FakeCachedPresence_32(
+            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5754,32 +5789,32 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i11.Future<_i3.CachedPresence>);
+      ) as _i12.Future<_i4.CachedPresence>);
 
   @override
-  _i11.Future<void> abortSync() => (super.noSuchMethod(
+  _i12.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i12.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEventWithMetadata(
+  _i12.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5799,14 +5834,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i10.BaseResponse? response,
-    _i21.Uint8List? body,
+    _i11.BaseResponse? response,
+    _i22.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5838,8 +5873,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
       ) as Never);
 
   @override
-  _i11.Future<Map<String, Object?>> request(
-    _i3.RequestType? type,
+  _i12.Future<Map<String, Object?>> request(
+    _i4.RequestType? type,
     String? action, {
     dynamic data = '',
     String? contentType = 'application/json',
@@ -5859,14 +5894,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> postPusher(
-    _i3.Pusher? pusher, {
+  _i12.Future<void> postPusher(
+    _i4.Pusher? pusher, {
     bool? append,
   }) =>
       (super.noSuchMethod(
@@ -5875,57 +5910,57 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deletePusher(_i3.PusherId? pusher) => (super.noSuchMethod(
+  _i12.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i12.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i12.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i11.Future<_i3.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_33(
+        returnValue: _i12.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_34(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_33(
+        returnValueForMissingStub: _i12.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_34(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.TurnServerCredentials>);
+      ) as _i12.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5939,8 +5974,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5952,8 +5987,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5964,14 +5999,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
-    _i3.KeyBackupData? data,
+    _i4.KeyBackupData? data,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5983,8 +6018,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             data,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5997,8 +6032,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6010,10 +6045,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.KeyBackupData> getRoomKeysBySessionId(
+  _i12.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6027,7 +6062,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6039,7 +6074,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6050,17 +6085,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.KeyBackupData>);
+      ) as _i12.Future<_i4.KeyBackupData>);
 
   @override
-  _i11.Future<_i3.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i12.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i11.Future<_i3.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_36(
+        returnValue: _i12.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_37(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6068,18 +6103,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_36(
+            _i12.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_37(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.GetWellknownSupportResponse>);
+      ) as _i12.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i11.Future<int> pingAppservice(
+  _i12.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6089,21 +6124,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i11.Future<int>.value(0),
-        returnValueForMissingStub: _i11.Future<int>.value(0),
-      ) as _i11.Future<int>);
+        returnValue: _i12.Future<int>.value(0),
+        returnValueForMissingStub: _i12.Future<int>.value(0),
+      ) as _i12.Future<int>);
 
   @override
-  _i11.Future<_i3.GenerateLoginTokenResponse> generateLoginToken(
-          {_i3.AuthenticationData? auth}) =>
+  _i12.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+          {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
           #generateLoginToken,
           [],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<_i3.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_37(
+        returnValue: _i12.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_38(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6112,8 +6147,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_37(
+            _i12.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_38(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6121,15 +6156,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i11.Future<_i3.GenerateLoginTokenResponse>);
+      ) as _i12.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i11.Future<_i3.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i12.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6137,17 +6172,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MediaConfig>.value(_FakeMediaConfig_29(
+            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.MediaConfig>);
+      ) as _i12.Future<_i4.MediaConfig>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentAuthed(
+  _i12.Future<_i13.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6161,7 +6196,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6173,7 +6208,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6184,10 +6219,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentOverrideNameAuthed(
+  _i12.Future<_i13.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6203,7 +6238,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6216,7 +6251,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6228,10 +6263,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<_i3.PreviewForUrl> getUrlPreviewAuthed(
+  _i12.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6241,7 +6276,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6250,7 +6285,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PreviewForUrl>.value(_FakePreviewForUrl_31(
+            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6258,15 +6293,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i11.Future<_i3.PreviewForUrl>);
+      ) as _i12.Future<_i4.PreviewForUrl>);
 
   @override
-  _i11.Future<_i12.FileResponse> getContentThumbnailAuthed(
+  _i12.Future<_i13.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
     int? height, {
-    _i3.Method? method,
+    _i4.Method? method,
     int? timeoutMs,
     bool? animated,
   }) =>
@@ -6285,7 +6320,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6303,7 +6338,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i12.FileResponse>.value(_FakeFileResponse_30(
+            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6320,21 +6355,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i12.FileResponse>);
+      ) as _i12.Future<_i13.FileResponse>);
 
   @override
-  _i11.Future<bool> registrationTokenValidity(String? token) =>
+  _i12.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<_i3.GetRoomSummaryResponse$3> getRoomSummary(
+  _i12.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6344,8 +6379,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i11.Future<_i3.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_38(
+        returnValue: _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_39(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6354,8 +6389,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_38(
+            _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_39(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6363,10 +6398,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#via: via},
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomSummaryResponse$3>);
+      ) as _i12.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i11.Future<_i3.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i12.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6384,8 +6419,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #from: from,
           },
         ),
-        returnValue: _i11.Future<_i3.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_39(
+        returnValue: _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_40(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6399,8 +6434,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_39(
+            _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_40(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6413,16 +6448,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetSpaceHierarchyResponse>);
+      ) as _i12.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsResponse> getRelatingEvents(
+  _i12.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
       (super.noSuchMethod(
@@ -6440,8 +6475,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i11.Future<_i3.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_40(
+        returnValue: _i12.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_41(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6459,8 +6494,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_40(
+            _i12.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_41(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6477,10 +6512,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetRelatingEventsResponse>);
+      ) as _i12.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>
+  _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6488,7 +6523,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
           (super.noSuchMethod(
@@ -6508,8 +6543,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
               },
             ),
             returnValue:
-                _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_41(
+                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6528,8 +6563,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_41(
+                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6547,10 +6582,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-          ) as _i11.Future<_i3.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i11.Future<_i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i12.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6559,7 +6594,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
     String? from,
     String? to,
     int? limit,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
     bool? recurse,
   }) =>
           (super.noSuchMethod(
@@ -6579,9 +6614,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i11.Future<
-                    _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+            returnValue: _i12.Future<
+                    _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6600,9 +6635,9 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i11.Future<
-                    _i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+            returnValueForMissingStub: _i12.Future<
+                    _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6621,13 +6656,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
                 },
               ),
             )),
-          ) as _i11
-              .Future<_i3.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
+          ) as _i12
+              .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i11.Future<_i3.GetThreadRootsResponse> getThreadRoots(
+  _i12.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
-    _i3.Include? include,
+    _i4.Include? include,
     int? limit,
     String? from,
   }) =>
@@ -6641,8 +6676,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #from: from,
           },
         ),
-        returnValue: _i11.Future<_i3.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_43(
+        returnValue: _i12.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_44(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6655,8 +6690,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_43(
+            _i12.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_44(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6668,13 +6703,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetThreadRootsResponse>);
+      ) as _i12.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i11.Future<_i3.GetEventByTimestampResponse> getEventByTimestamp(
+  _i12.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
-    _i3.Direction? dir,
+    _i4.Direction? dir,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6685,8 +6720,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             dir,
           ],
         ),
-        returnValue: _i11.Future<_i3.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_44(
+        returnValue: _i12.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_45(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6698,8 +6733,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_44(
+            _i12.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_45(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6710,36 +6745,36 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.GetEventByTimestampResponse>);
+      ) as _i12.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i12.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyIdentifier>?>.value(),
-      ) as _i11.Future<List<_i3.ThirdPartyIdentifier>?>);
+            _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i12.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i11.Future<Uri?> post3PIDs(_i3.ThreePidCredentials? threePidCreds) =>
+  _i12.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i11.Future<Uri?>.value(),
-        returnValueForMissingStub: _i11.Future<Uri?>.value(),
-      ) as _i11.Future<Uri?>);
+        returnValue: _i12.Future<Uri?>.value(),
+        returnValueForMissingStub: _i12.Future<Uri?>.value(),
+      ) as _i12.Future<Uri?>);
 
   @override
-  _i11.Future<void> add3PID(
+  _i12.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6750,12 +6785,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> bind3PID(
+  _i12.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6771,14 +6806,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             sid,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> delete3pidFromAccount(
+  _i12.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
-    _i3.ThirdPartyIdentifierMedium? medium, {
+    _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
   }) =>
       (super.noSuchMethod(
@@ -6790,14 +6825,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6819,8 +6854,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6836,8 +6871,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6853,10 +6888,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6880,8 +6915,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6898,8 +6933,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6916,12 +6951,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> unbind3pidFromAccount(
+  _i12.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
-    _i3.ThirdPartyIdentifierMedium? medium, {
+    _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
   }) =>
       (super.noSuchMethod(
@@ -6933,15 +6968,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.IdServerUnbindResult> deactivateAccount({
-    _i3.AuthenticationData? auth,
+  _i12.Future<_i4.IdServerUnbindResult> deactivateAccount({
+    _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
   }) =>
@@ -6955,14 +6990,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i11.Future<_i3.IdServerUnbindResult>.value(
-            _i3.IdServerUnbindResult.noSupport),
-      ) as _i11.Future<_i3.IdServerUnbindResult>);
+        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+            _i4.IdServerUnbindResult.noSupport),
+      ) as _i12.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6984,8 +7019,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7001,8 +7036,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7018,10 +7053,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7045,8 +7080,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7063,8 +7098,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7081,16 +7116,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i12.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i11.Future<_i3.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
+            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7098,22 +7133,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
+            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.TokenOwnerInfo>);
+      ) as _i12.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i11.Future<_i3.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i12.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i11.Future<_i3.WhoIsInfo>.value(_FakeWhoIsInfo_47(
+        returnValue: _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7121,22 +7156,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.WhoIsInfo>.value(_FakeWhoIsInfo_47(
+            _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i11.Future<_i3.WhoIsInfo>);
+      ) as _i12.Future<_i4.WhoIsInfo>);
 
   @override
-  _i11.Future<_i3.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i12.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i11.Future<_i3.Capabilities>.value(_FakeCapabilities_48(
+        returnValue: _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7144,29 +7179,29 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.Capabilities>.value(_FakeCapabilities_48(
+            _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.Capabilities>);
+      ) as _i12.Future<_i4.Capabilities>);
 
   @override
-  _i11.Future<String> createRoom({
+  _i12.Future<String> createRoom({
     Map<String, Object?>? creationContent,
-    List<_i3.StateEvent>? initialState,
+    List<_i4.StateEvent>? initialState,
     List<String>? invite,
-    List<_i3.Invite3pid>? invite3pid,
+    List<_i4.Invite3pid>? invite3pid,
     bool? isDirect,
     String? name,
     Map<String, Object?>? powerLevelContentOverride,
-    _i3.CreateRoomPreset? preset,
+    _i4.CreateRoomPreset? preset,
     String? roomAliasName,
     String? roomVersion,
     String? topic,
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7187,7 +7222,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7209,7 +7244,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7230,12 +7265,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> deleteDevices(
+  _i12.Future<void> deleteDevices(
     List<String>? devices, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7243,24 +7278,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.Device>?> getDevices() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Device>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.Device>?>.value(),
-      ) as _i11.Future<List<_i3.Device>?>);
+        returnValue: _i12.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.Device>?>.value(),
+      ) as _i12.Future<List<_i4.Device>?>);
 
   @override
-  _i11.Future<void> deleteDevice(
+  _i12.Future<void> deleteDevice(
     String? deviceId, {
-    _i3.AuthenticationData? auth,
+    _i4.AuthenticationData? auth,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7268,34 +7303,34 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i12.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i11.Future<_i3.Device>.value(_FakeDevice_49(
+        returnValue: _i12.Future<_i4.Device>.value(_FakeDevice_50(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.Device>.value(_FakeDevice_49(
+        returnValueForMissingStub: _i12.Future<_i4.Device>.value(_FakeDevice_50(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i11.Future<_i3.Device>);
+      ) as _i12.Future<_i4.Device>);
 
   @override
-  _i11.Future<void> updateDevice(
+  _i12.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7305,15 +7340,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i12.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7325,26 +7360,26 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i12.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i11.Future<_i3.Visibility?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Visibility?>.value(),
-      ) as _i11.Future<_i3.Visibility?>);
+        returnValue: _i12.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Visibility?>.value(),
+      ) as _i12.Future<_i4.Visibility?>);
 
   @override
-  _i11.Future<void> setRoomVisibilityOnDirectory(
+  _i12.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
-    _i3.Visibility? visibility,
+    _i4.Visibility? visibility,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7352,30 +7387,30 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i12.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i12.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i11.Future<_i3.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_50(
+        returnValue: _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_51(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7383,18 +7418,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_50(
+            _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_51(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomIdByAliasResponse>);
+      ) as _i12.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i11.Future<void> setRoomAlias(
+  _i12.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7406,12 +7441,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             roomId,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetEventsResponse> getEvents({
+  _i12.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7425,7 +7460,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<_i3.GetEventsResponse>.value(_FakeGetEventsResponse_51(
+            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
           this,
           Invocation.method(
             #getEvents,
@@ -7437,7 +7472,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetEventsResponse>.value(_FakeGetEventsResponse_51(
+            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
           this,
           Invocation.method(
             #getEvents,
@@ -7448,10 +7483,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetEventsResponse>);
+      ) as _i12.Future<_i4.GetEventsResponse>);
 
   @override
-  _i11.Future<_i3.PeekEventsResponse> peekEvents({
+  _i12.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7466,8 +7501,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i11.Future<_i3.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_52(
+        returnValue: _i12.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_53(
           this,
           Invocation.method(
             #peekEvents,
@@ -7479,8 +7514,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_52(
+        returnValueForMissingStub: _i12.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_53(
           this,
           Invocation.method(
             #peekEvents,
@@ -7492,16 +7527,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.PeekEventsResponse>);
+      ) as _i12.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i11.Future<_i3.MatrixEvent> getOneEvent(String? eventId) =>
+  _i12.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7509,27 +7544,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i11.Future<_i3.MatrixEvent>);
+      ) as _i12.Future<_i4.MatrixEvent>);
 
   @override
-  _i11.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i12.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i11.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i11.Future<List<String>>.value(<String>[]),
-      ) as _i11.Future<List<String>>);
+        returnValue: _i12.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
+      ) as _i12.Future<List<String>>);
 
   @override
-  _i11.Future<_i3.GetKeysChangesResponse> getKeysChanges(
+  _i12.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7541,8 +7576,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             to,
           ],
         ),
-        returnValue: _i11.Future<_i3.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_54(
+        returnValue: _i12.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_55(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7553,8 +7588,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_54(
+            _i12.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_55(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7564,10 +7599,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.GetKeysChangesResponse>);
+      ) as _i12.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i11.Future<_i3.ClaimKeysResponse> claimKeys(
+  _i12.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7578,7 +7613,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i11.Future<_i3.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
+            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
           this,
           Invocation.method(
             #claimKeys,
@@ -7587,7 +7622,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
+            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
           this,
           Invocation.method(
             #claimKeys,
@@ -7595,14 +7630,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i11.Future<_i3.ClaimKeysResponse>);
+      ) as _i12.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i11.Future<void> uploadCrossSigningKeys({
-    _i3.AuthenticationData? auth,
-    _i3.MatrixCrossSigningKey? masterKey,
-    _i3.MatrixCrossSigningKey? selfSigningKey,
-    _i3.MatrixCrossSigningKey? userSigningKey,
+  _i12.Future<void> uploadCrossSigningKeys({
+    _i4.AuthenticationData? auth,
+    _i4.MatrixCrossSigningKey? masterKey,
+    _i4.MatrixCrossSigningKey? selfSigningKey,
+    _i4.MatrixCrossSigningKey? userSigningKey,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -7615,12 +7650,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.QueryKeysResponse> queryKeys(
+  _i12.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7631,7 +7666,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i11.Future<_i3.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
+            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
           this,
           Invocation.method(
             #queryKeys,
@@ -7640,7 +7675,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
+            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
           this,
           Invocation.method(
             #queryKeys,
@@ -7648,10 +7683,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i11.Future<_i3.QueryKeysResponse>);
+      ) as _i12.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i11.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7659,15 +7694,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i11.Future<
+            returnValue: _i12.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i11.Future<
+            returnValueForMissingStub: _i12.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i11.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i11.Future<Map<String, int>> uploadKeys({
-    _i3.MatrixDeviceKeys? deviceKeys,
+  _i12.Future<Map<String, int>> uploadKeys({
+    _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
   }) =>
@@ -7681,13 +7716,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i11.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i12.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i11.Future<Map<String, int>>);
+            _i12.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i12.Future<Map<String, int>>);
 
   @override
-  _i11.Future<String> knockRoom(
+  _i12.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7701,7 +7736,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7713,7 +7748,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7724,20 +7759,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<List<_i3.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i12.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.LoginFlow>?>.value(),
-      ) as _i11.Future<List<_i3.LoginFlow>?>);
+        returnValue: _i12.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i12.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i11.Future<_i3.GetNotificationsResponse> getNotifications({
+  _i12.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7752,8 +7787,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #only: only,
           },
         ),
-        returnValue: _i11.Future<_i3.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_57(
+        returnValue: _i12.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_58(
           this,
           Invocation.method(
             #getNotifications,
@@ -7766,8 +7801,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_57(
+            _i12.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_58(
           this,
           Invocation.method(
             #getNotifications,
@@ -7779,37 +7814,37 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetNotificationsResponse>);
+      ) as _i12.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i11.Future<_i3.GetPresenceResponse> getPresence(String? userId) =>
+  _i12.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i11.Future<_i3.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_58(
+        returnValue: _i12.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_59(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_58(
+        returnValueForMissingStub: _i12.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_59(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i11.Future<_i3.GetPresenceResponse>);
+      ) as _i12.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i11.Future<void> setPresence(
+  _i12.Future<void> setPresence(
     String? userId,
-    _i3.PresenceType? presence, {
+    _i4.PresenceType? presence, {
     String? statusMsg,
   }) =>
       (super.noSuchMethod(
@@ -7821,12 +7856,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, Object?>> deleteProfileField(
+  _i12.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7839,13 +7874,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getProfileField(
+  _i12.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7858,13 +7893,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<Map<String, Object?>> setProfileField(
+  _i12.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7879,13 +7914,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.GetPublicRoomsResponse> getPublicRooms({
+  _i12.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7900,8 +7935,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #server: server,
           },
         ),
-        returnValue: _i11.Future<_i3.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_59(
+        returnValue: _i12.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_60(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7914,8 +7949,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_59(
+            _i12.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_60(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7927,12 +7962,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetPublicRoomsResponse>);
+      ) as _i12.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i11.Future<_i3.QueryPublicRoomsResponse> queryPublicRooms({
+  _i12.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
-    _i3.PublicRoomQueryFilter? filter,
+    _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
     int? limit,
     String? since,
@@ -7951,8 +7986,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i11.Future<_i3.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_60(
+        returnValue: _i12.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_61(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7968,8 +8003,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_60(
+            _i12.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_61(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7984,25 +8019,25 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.QueryPublicRoomsResponse>);
+      ) as _i12.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i11.Future<List<_i3.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i12.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i11.Future<List<_i3.Pusher>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.Pusher>?>.value(),
-      ) as _i11.Future<List<_i3.Pusher>?>);
+        returnValue: _i12.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.Pusher>?>.value(),
+      ) as _i12.Future<List<_i4.Pusher>?>);
 
   @override
-  _i11.Future<_i3.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i12.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i11.Future<_i3.PushRuleSet>.value(_FakePushRuleSet_61(
+        returnValue: _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
           this,
           Invocation.method(
             #getPushRules,
@@ -8010,24 +8045,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PushRuleSet>.value(_FakePushRuleSet_61(
+            _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.PushRuleSet>);
+      ) as _i12.Future<_i4.PushRuleSet>);
 
   @override
-  _i11.Future<_i3.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i12.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i11.Future<_i3.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_62(
+        returnValue: _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_63(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8035,19 +8070,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_62(
+            _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_63(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.GetPushRulesGlobalResponse>);
+      ) as _i12.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i11.Future<void> deletePushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> deletePushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8058,13 +8093,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.PushRule> getPushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<_i4.PushRule> getPushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8075,7 +8110,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<_i3.PushRule>.value(_FakePushRule_63(
+        returnValue: _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
           this,
           Invocation.method(
             #getPushRule,
@@ -8086,7 +8121,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.PushRule>.value(_FakePushRule_63(
+            _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
           this,
           Invocation.method(
             #getPushRule,
@@ -8096,16 +8131,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.PushRule>);
+      ) as _i12.Future<_i4.PushRule>);
 
   @override
-  _i11.Future<void> setPushRule(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRule(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
     String? before,
     String? after,
-    List<_i3.PushCondition>? conditions,
+    List<_i4.PushCondition>? conditions,
     String? pattern,
   }) =>
       (super.noSuchMethod(
@@ -8123,13 +8158,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<Object?>> getPushRuleActions(
-    _i3.PushRuleKind? kind,
+  _i12.Future<List<Object?>> getPushRuleActions(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8140,14 +8175,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i12.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i11.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i11.Future<List<Object?>>);
+            _i12.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i12.Future<List<Object?>>);
 
   @override
-  _i11.Future<void> setPushRuleActions(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRuleActions(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
   ) =>
@@ -8160,13 +8195,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             actions,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<bool> isPushRuleEnabled(
-    _i3.PushRuleKind? kind,
+  _i12.Future<bool> isPushRuleEnabled(
+    _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
       (super.noSuchMethod(
@@ -8177,13 +8212,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ruleId,
           ],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> setPushRuleEnabled(
-    _i3.PushRuleKind? kind,
+  _i12.Future<void> setPushRuleEnabled(
+    _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
   ) =>
@@ -8196,19 +8231,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
             enabled,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.RefreshResponse> refresh(String? refreshToken) =>
+  _i12.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i11.Future<_i3.RefreshResponse>.value(_FakeRefreshResponse_64(
+            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
           this,
           Invocation.method(
             #refresh,
@@ -8216,28 +8251,28 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RefreshResponse>.value(_FakeRefreshResponse_64(
+            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i11.Future<_i3.RefreshResponse>);
+      ) as _i12.Future<_i4.RefreshResponse>);
 
   @override
-  _i11.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i12.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i11.Future<bool?>.value(),
-        returnValueForMissingStub: _i11.Future<bool?>.value(),
-      ) as _i11.Future<bool?>);
+        returnValue: _i12.Future<bool?>.value(),
+        returnValueForMissingStub: _i12.Future<bool?>.value(),
+      ) as _i12.Future<bool?>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8259,8 +8294,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8276,8 +8311,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8293,10 +8328,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8320,8 +8355,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8338,8 +8373,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8356,17 +8391,17 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.RequestTokenResponse>);
+      ) as _i12.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8374,23 +8409,23 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i12.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i11.Future<_i3.RoomKeys>.value(_FakeRoomKeys_65(
+        returnValue: _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8398,19 +8433,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeys>.value(_FakeRoomKeys_65(
+            _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeys>);
+      ) as _i12.Future<_i4.RoomKeys>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeys(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
-    _i3.RoomKeys? body,
+    _i4.RoomKeys? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8420,8 +8455,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8432,8 +8467,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8443,10 +8478,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8458,8 +8493,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8470,8 +8505,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8481,10 +8516,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeyBackup> getRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8496,7 +8531,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
+        returnValue: _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8507,7 +8542,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
+            _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8517,13 +8552,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeyBackup>);
+      ) as _i12.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
-    _i3.RoomKeyBackup? body,
+    _i4.RoomKeyBackup? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8534,8 +8569,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8547,8 +8582,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8559,10 +8594,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8576,8 +8611,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8589,8 +8624,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8601,10 +8636,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.KeyBackupData> getRoomKeyBySessionId(
+  _i12.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8618,7 +8653,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             version,
           ],
         ),
-        returnValue: _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8630,7 +8665,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.KeyBackupData>.value(_FakeKeyBackupData_35(
+            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8641,14 +8676,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.KeyBackupData>);
+      ) as _i12.Future<_i4.KeyBackupData>);
 
   @override
-  _i11.Future<_i3.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
-    _i3.KeyBackupData? body,
+    _i4.KeyBackupData? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8660,8 +8695,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8674,8 +8709,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8687,18 +8722,18 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.RoomKeysUpdateResponse>);
+      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>
+  _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_67(
+                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_68(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8706,19 +8741,19 @@ class MockClient extends _i1.Mock implements _i3.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_67(
+                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_68(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i11.Future<_i3.GetRoomKeysVersionCurrentResponse>);
+          ) as _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i11.Future<String> postRoomKeysVersion(
-    _i3.BackupAlgorithm? algorithm,
+  _i12.Future<String> postRoomKeysVersion(
+    _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
       (super.noSuchMethod(
@@ -8729,7 +8764,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             authData,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8740,7 +8775,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8750,29 +8785,29 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i12.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i12.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i11.Future<_i3.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_68(
+        returnValue: _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_69(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8780,20 +8815,20 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_68(
+            _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_69(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomKeysVersionResponse>);
+      ) as _i12.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i12.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
-    _i3.BackupAlgorithm? algorithm,
+    _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
       (super.noSuchMethod(
@@ -8806,24 +8841,24 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i12.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i11.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i11.Future<List<String>>.value(<String>[]),
-      ) as _i11.Future<List<String>>);
+        returnValue: _i12.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
+      ) as _i12.Future<List<String>>);
 
   @override
-  _i11.Future<void> ban(
+  _i12.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8837,12 +8872,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.EventContext> getEventContext(
+  _i12.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8860,7 +8895,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<_i3.EventContext>.value(_FakeEventContext_69(
+        returnValue: _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
           this,
           Invocation.method(
             #getEventContext,
@@ -8875,7 +8910,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.EventContext>.value(_FakeEventContext_69(
+            _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
           this,
           Invocation.method(
             #getEventContext,
@@ -8889,10 +8924,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.EventContext>);
+      ) as _i12.Future<_i4.EventContext>);
 
   @override
-  _i11.Future<_i3.MatrixEvent> getOneRoomEvent(
+  _i12.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8904,7 +8939,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             eventId,
           ],
         ),
-        returnValue: _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8915,7 +8950,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MatrixEvent>.value(_FakeMatrixEvent_53(
+            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8925,22 +8960,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.MatrixEvent>);
+      ) as _i12.Future<_i4.MatrixEvent>);
 
   @override
-  _i11.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i12.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> inviteBy3PID(
+  _i12.Future<void> inviteBy3PID(
     String? roomId,
-    _i3.Invite3pid? body,
+    _i4.Invite3pid? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8950,12 +8985,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> inviteUser(
+  _i12.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8969,15 +9004,15 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> joinRoomById(
+  _i12.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
-    _i3.ThirdPartySigned? thirdPartySigned,
+    _i4.ThirdPartySigned? thirdPartySigned,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8988,7 +9023,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9000,7 +9035,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9011,23 +9046,23 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<Map<String, _i3.RoomMember>?> getJoinedMembersByRoom(
+  _i12.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i11.Future<Map<String, _i3.RoomMember>?>.value(),
+        returnValue: _i12.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i11.Future<Map<String, _i3.RoomMember>?>.value(),
-      ) as _i11.Future<Map<String, _i3.RoomMember>?>);
+            _i12.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i12.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i11.Future<void> kick(
+  _i12.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9041,12 +9076,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> leaveRoom(
+  _i12.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9056,16 +9091,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<List<_i3.MatrixEvent>?> getMembersByRoom(
+  _i12.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
-    _i3.Membership? membership,
-    _i3.Membership? notMembership,
+    _i4.Membership? membership,
+    _i4.Membership? notMembership,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9077,14 +9112,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i11.Future<List<_i3.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i11.Future<List<_i3.MatrixEvent>?>.value(),
-      ) as _i11.Future<List<_i3.MatrixEvent>?>);
+        returnValue: _i12.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i12.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i12.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i11.Future<_i3.GetRoomEventsResponse> getRoomEvents(
+  _i12.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
-    _i3.Direction? dir, {
+    _i4.Direction? dir, {
     String? from,
     String? to,
     int? limit,
@@ -9104,8 +9139,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i11.Future<_i3.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_70(
+        returnValue: _i12.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_71(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9121,8 +9156,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_70(
+        returnValueForMissingStub: _i12.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_71(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9138,10 +9173,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.GetRoomEventsResponse>);
+      ) as _i12.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i11.Future<void> setReadMarker(
+  _i12.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9157,14 +9192,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> postReceipt(
+  _i12.Future<void> postReceipt(
     String? roomId,
-    _i3.ReceiptType? receiptType,
+    _i4.ReceiptType? receiptType,
     String? eventId, {
     String? threadId,
   }) =>
@@ -9178,12 +9213,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> redactEvent(
+  _i12.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9199,12 +9234,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<void> reportRoom(
+  _i12.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9216,12 +9251,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             reason,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> reportEvent(
+  _i12.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9239,12 +9274,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #score: score,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> sendMessage(
+  _i12.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9260,7 +9295,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9273,7 +9308,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9285,27 +9320,27 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<List<_i3.MatrixEvent>> getRoomState(String? roomId) =>
+  _i12.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i11.Future<List<_i3.MatrixEvent>>.value(<_i3.MatrixEvent>[]),
+            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.MatrixEvent>>.value(<_i3.MatrixEvent>[]),
-      ) as _i11.Future<List<_i3.MatrixEvent>>);
+            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i12.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i12.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
-    _i3.Format? format,
+    _i4.Format? format,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9318,13 +9353,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#format: format},
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<String> setRoomStateWithKey(
+  _i12.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9340,7 +9375,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9353,7 +9388,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9365,10 +9400,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<void> unban(
+  _i12.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9382,12 +9417,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> upgradeRoom(
+  _i12.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9401,7 +9436,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9413,7 +9448,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9424,11 +9459,11 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.SearchResults> search(
-    _i3.Categories? searchCategories, {
+  _i12.Future<_i4.SearchResults> search(
+    _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
       (super.noSuchMethod(
@@ -9437,7 +9472,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i11.Future<_i3.SearchResults>.value(_FakeSearchResults_71(
+        returnValue: _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
           this,
           Invocation.method(
             #search,
@@ -9446,7 +9481,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SearchResults>.value(_FakeSearchResults_71(
+            _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
           this,
           Invocation.method(
             #search,
@@ -9454,14 +9489,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i11.Future<_i3.SearchResults>);
+      ) as _i12.Future<_i4.SearchResults>);
 
   @override
-  _i11.Future<_i3.SyncUpdate> sync({
+  _i12.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
-    _i3.PresenceType? setPresence,
+    _i4.PresenceType? setPresence,
     int? timeout,
     bool? useStateAfter,
   }) =>
@@ -9478,7 +9513,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #sync,
@@ -9494,7 +9529,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SyncUpdate>.value(_FakeSyncUpdate_11(
+            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
           this,
           Invocation.method(
             #sync,
@@ -9509,22 +9544,22 @@ class MockClient extends _i1.Mock implements _i3.Client {
             },
           ),
         )),
-      ) as _i11.Future<_i3.SyncUpdate>);
+      ) as _i12.Future<_i4.SyncUpdate>);
 
   @override
-  _i11.Future<List<_i3.Location>> queryLocationByAlias(String? alias) =>
+  _i12.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
+        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
-      ) as _i11.Future<List<_i3.Location>>);
+            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i12.Future<List<_i4.Location>>);
 
   @override
-  _i11.Future<List<_i3.Location>> queryLocationByProtocol(
+  _i12.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9534,21 +9569,21 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
+        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.Location>>.value(<_i3.Location>[]),
-      ) as _i11.Future<List<_i3.Location>>);
+            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i12.Future<List<_i4.Location>>);
 
   @override
-  _i11.Future<_i3.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i12.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i11.Future<_i3.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_72(
+        returnValue: _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_73(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9556,45 +9591,45 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_72(
+            _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_73(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i11.Future<_i3.GetProtocolMetadataResponse$2>);
+      ) as _i12.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i11.Future<Map<String, _i3.GetProtocolsResponse$2>> getProtocols() =>
+  _i12.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>.value(
-            <String, _i3.GetProtocolsResponse$2>{}),
+        returnValue: _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>.value(
-                <String, _i3.GetProtocolsResponse$2>{}),
-      ) as _i11.Future<Map<String, _i3.GetProtocolsResponse$2>>);
+            _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+                <String, _i4.GetProtocolsResponse$2>{}),
+      ) as _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
-      ) as _i11.Future<List<_i3.ThirdPartyUser>>);
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i11.Future<List<_i3.ThirdPartyUser>> queryUserByProtocol(
+  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9605,13 +9640,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i11.Future<List<_i3.ThirdPartyUser>>.value(<_i3.ThirdPartyUser>[]),
-      ) as _i11.Future<List<_i3.ThirdPartyUser>>);
+            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i11.Future<Map<String, Object?>> getAccountData(
+  _i12.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9624,13 +9659,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> setAccountData(
+  _i12.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9644,14 +9679,14 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> defineFilter(
+  _i12.Future<String> defineFilter(
     String? userId,
-    _i3.Filter? body,
+    _i4.Filter? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9661,7 +9696,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9672,7 +9707,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9682,10 +9717,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.Filter> getFilter(
+  _i12.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9697,7 +9732,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             filterId,
           ],
         ),
-        returnValue: _i11.Future<_i3.Filter>.value(_FakeFilter_16(
+        returnValue: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
           this,
           Invocation.method(
             #getFilter,
@@ -9707,7 +9742,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.Filter>.value(_FakeFilter_16(
+        returnValueForMissingStub: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
           this,
           Invocation.method(
             #getFilter,
@@ -9717,10 +9752,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.Filter>);
+      ) as _i12.Future<_i4.Filter>);
 
   @override
-  _i11.Future<_i3.OpenIdCredentials> requestOpenIdToken(
+  _i12.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9733,7 +9768,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<_i3.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
+            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9744,7 +9779,7 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
+            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9754,10 +9789,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             ],
           ),
         )),
-      ) as _i11.Future<_i3.OpenIdCredentials>);
+      ) as _i12.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i11.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i12.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9772,13 +9807,13 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<void> setAccountDataPerRoom(
+  _i12.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9794,12 +9829,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<Map<String, _i3.Tag>?> getRoomTags(
+  _i12.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9811,12 +9846,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             roomId,
           ],
         ),
-        returnValue: _i11.Future<Map<String, _i3.Tag>?>.value(),
-        returnValueForMissingStub: _i11.Future<Map<String, _i3.Tag>?>.value(),
-      ) as _i11.Future<Map<String, _i3.Tag>?>);
+        returnValue: _i12.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i12.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i12.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i11.Future<void> deleteRoomTag(
+  _i12.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9830,16 +9865,16 @@ class MockClient extends _i1.Mock implements _i3.Client {
             tag,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setRoomTag(
+  _i12.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
-    _i3.Tag? body,
+    _i4.Tag? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9851,12 +9886,12 @@ class MockClient extends _i1.Mock implements _i3.Client {
             body,
           ],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<_i3.SearchUserDirectoryResponse> searchUserDirectory(
+  _i12.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9866,8 +9901,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i11.Future<_i3.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_74(
+        returnValue: _i12.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_75(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9876,8 +9911,8 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_74(
+            _i12.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_75(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9885,10 +9920,10 @@ class MockClient extends _i1.Mock implements _i3.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i11.Future<_i3.SearchUserDirectoryResponse>);
+      ) as _i12.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> reportUser(
+  _i12.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9901,40 +9936,40 @@ class MockClient extends _i1.Mock implements _i3.Client {
           ],
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 
   @override
-  _i11.Future<_i3.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i12.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i11.Future<_i3.CreateContentResponse>.value(
-            _FakeCreateContentResponse_75(
+        returnValue: _i12.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_76(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i11.Future<_i3.CreateContentResponse>.value(
-            _FakeCreateContentResponse_75(
+        returnValueForMissingStub: _i12.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_76(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.CreateContentResponse>);
+      ) as _i12.Future<_i4.CreateContentResponse>);
 
   @override
-  _i11.Future<Map<String, Object?>> uploadContentToMXC(
+  _i12.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i21.Uint8List? body, {
+    _i22.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -9952,61 +9987,61 @@ class MockClient extends _i1.Mock implements _i3.Client {
           },
         ),
         returnValue:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i11.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i11.Future<Map<String, Object?>>);
+            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i12.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [Event].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEvent extends _i1.Mock implements _i3.Event {
+class MockEvent extends _i1.Mock implements _i4.Event {
   @override
-  _i3.User get sender => (super.noSuchMethod(
+  _i4.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_13(
+        returnValue: _FakeUser_14(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_13(
+        returnValueForMissingStub: _FakeUser_14(
           this,
           Invocation.getter(#sender),
         ),
-      ) as _i3.User);
+      ) as _i4.User);
 
   @override
-  _i3.User get senderFromMemoryOrFallback => (super.noSuchMethod(
+  _i4.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_13(
+        returnValue: _FakeUser_14(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_13(
+        returnValueForMissingStub: _FakeUser_14(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-      ) as _i3.User);
+      ) as _i4.User);
 
   @override
-  _i3.Room get room => (super.noSuchMethod(
+  _i4.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_76(
+        returnValue: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_76(
+        returnValueForMissingStub: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
-      ) as _i3.Room);
+      ) as _i4.Room);
 
   @override
-  _i3.EventStatus get status => (super.noSuchMethod(
+  _i4.EventStatus get status => (super.noSuchMethod(
         Invocation.getter(#status),
-        returnValue: _i3.EventStatus.error,
-        returnValueForMissingStub: _i3.EventStatus.error,
-      ) as _i3.EventStatus);
+        returnValue: _i4.EventStatus.error,
+        returnValueForMissingStub: _i4.EventStatus.error,
+      ) as _i4.EventStatus);
 
   @override
   bool get redacted => (super.noSuchMethod(
@@ -10016,26 +10051,26 @@ class MockEvent extends _i1.Mock implements _i3.Event {
       ) as bool);
 
   @override
-  _i3.User get asUser => (super.noSuchMethod(
+  _i4.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_13(
+        returnValue: _FakeUser_14(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_13(
+        returnValueForMissingStub: _FakeUser_14(
           this,
           Invocation.getter(#asUser),
         ),
-      ) as _i3.User);
+      ) as _i4.User);
 
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10044,11 +10079,11 @@ class MockEvent extends _i1.Mock implements _i3.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10057,11 +10092,11 @@ class MockEvent extends _i1.Mock implements _i3.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10070,11 +10105,11 @@ class MockEvent extends _i1.Mock implements _i3.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10083,22 +10118,22 @@ class MockEvent extends _i1.Mock implements _i3.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
       ) as String);
 
   @override
-  List<_i3.Receipt> get receipts => (super.noSuchMethod(
+  List<_i4.Receipt> get receipts => (super.noSuchMethod(
         Invocation.getter(#receipts),
-        returnValue: <_i3.Receipt>[],
-        returnValueForMissingStub: <_i3.Receipt>[],
-      ) as List<_i3.Receipt>);
+        returnValue: <_i4.Receipt>[],
+        returnValueForMissingStub: <_i4.Receipt>[],
+      ) as List<_i4.Receipt>);
 
   @override
   bool get canRedact => (super.noSuchMethod(
@@ -10152,11 +10187,11 @@ class MockEvent extends _i1.Mock implements _i3.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10165,11 +10200,11 @@ class MockEvent extends _i1.Mock implements _i3.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10211,7 +10246,7 @@ class MockEvent extends _i1.Mock implements _i3.Event {
       ) as ({bool room, List<String> userIds}));
 
   @override
-  set status(_i3.EventStatus? value) => super.noSuchMethod(
+  set status(_i4.EventStatus? value) => super.noSuchMethod(
         Invocation.setter(
           #status,
           value,
@@ -10222,11 +10257,11 @@ class MockEvent extends _i1.Mock implements _i3.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10235,11 +10270,11 @@ class MockEvent extends _i1.Mock implements _i3.Event {
   @override
   DateTime get originServerTs => (super.noSuchMethod(
         Invocation.getter(#originServerTs),
-        returnValue: _FakeDateTime_9(
+        returnValue: _FakeDateTime_10(
           this,
           Invocation.getter(#originServerTs),
         ),
-        returnValueForMissingStub: _FakeDateTime_9(
+        returnValueForMissingStub: _FakeDateTime_10(
           this,
           Invocation.getter(#originServerTs),
         ),
@@ -10311,11 +10346,11 @@ class MockEvent extends _i1.Mock implements _i3.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10333,11 +10368,11 @@ class MockEvent extends _i1.Mock implements _i3.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10369,14 +10404,14 @@ class MockEvent extends _i1.Mock implements _i3.Event {
       );
 
   @override
-  _i11.Future<_i3.User?> fetchSenderUser() => (super.noSuchMethod(
+  _i12.Future<_i4.User?> fetchSenderUser() => (super.noSuchMethod(
         Invocation.method(
           #fetchSenderUser,
           [],
         ),
-        returnValue: _i11.Future<_i3.User?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.User?>.value(),
-      ) as _i11.Future<_i3.User?>);
+        returnValue: _i12.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.User?>.value(),
+      ) as _i12.Future<_i4.User?>);
 
   @override
   Map<String, dynamic> toJson() => (super.noSuchMethod(
@@ -10389,7 +10424,7 @@ class MockEvent extends _i1.Mock implements _i3.Event {
       ) as Map<String, dynamic>);
 
   @override
-  void setRedactionEvent(_i3.Event? redactedBecause) => super.noSuchMethod(
+  void setRedactionEvent(_i4.Event? redactedBecause) => super.noSuchMethod(
         Invocation.method(
           #setRedactionEvent,
           [redactedBecause],
@@ -10398,38 +10433,38 @@ class MockEvent extends _i1.Mock implements _i3.Event {
       );
 
   @override
-  _i11.Future<bool> remove() => (super.noSuchMethod(
+  _i12.Future<bool> remove() => (super.noSuchMethod(
         Invocation.method(
           #remove,
           [],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<void> cancelSend() => (super.noSuchMethod(
+  _i12.Future<void> cancelSend() => (super.noSuchMethod(
         Invocation.method(
           #cancelSend,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String?> sendAgain({String? txid}) => (super.noSuchMethod(
+  _i12.Future<String?> sendAgain({String? txid}) => (super.noSuchMethod(
         Invocation.method(
           #sendAgain,
           [],
           {#txid: txid},
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<String?> redactEvent({
+  _i12.Future<String?> redactEvent({
     String? reason,
     String? txid,
   }) =>
@@ -10442,30 +10477,30 @@ class MockEvent extends _i1.Mock implements _i3.Event {
             #txid: txid,
           },
         ),
-        returnValue: _i11.Future<String?>.value(),
-        returnValueForMissingStub: _i11.Future<String?>.value(),
-      ) as _i11.Future<String?>);
+        returnValue: _i12.Future<String?>.value(),
+        returnValueForMissingStub: _i12.Future<String?>.value(),
+      ) as _i12.Future<String?>);
 
   @override
-  _i11.Future<_i3.Event?> getReplyEvent(_i3.Timeline? timeline) =>
+  _i12.Future<_i4.Event?> getReplyEvent(_i4.Timeline? timeline) =>
       (super.noSuchMethod(
         Invocation.method(
           #getReplyEvent,
           [timeline],
         ),
-        returnValue: _i11.Future<_i3.Event?>.value(),
-        returnValueForMissingStub: _i11.Future<_i3.Event?>.value(),
-      ) as _i11.Future<_i3.Event?>);
+        returnValue: _i12.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
+      ) as _i12.Future<_i4.Event?>);
 
   @override
-  _i11.Future<void> requestKey() => (super.noSuchMethod(
+  _i12.Future<void> requestKey() => (super.noSuchMethod(
         Invocation.method(
           #requestKey,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   Uri? attachmentOrThumbnailMxcUrl({bool? getThumbnail = false}) =>
@@ -10479,12 +10514,12 @@ class MockEvent extends _i1.Mock implements _i3.Event {
       ) as Uri?);
 
   @override
-  _i11.Future<Uri?> getAttachmentUri({
+  _i12.Future<Uri?> getAttachmentUri({
     bool? getThumbnail = false,
     bool? useThumbnailMxcUrl = false,
     double? width = 800.0,
     double? height = 800.0,
-    _i3.ThumbnailMethod? method = _i3.ThumbnailMethod.scale,
+    _i4.ThumbnailMethod? method = _i4.ThumbnailMethod.scale,
     int? minNoThumbSize = 81920,
     bool? animated = false,
   }) =>
@@ -10502,9 +10537,9 @@ class MockEvent extends _i1.Mock implements _i3.Event {
             #animated: animated,
           },
         ),
-        returnValue: _i11.Future<Uri?>.value(),
-        returnValueForMissingStub: _i11.Future<Uri?>.value(),
-      ) as _i11.Future<Uri?>);
+        returnValue: _i12.Future<Uri?>.value(),
+        returnValueForMissingStub: _i12.Future<Uri?>.value(),
+      ) as _i12.Future<Uri?>);
 
   @override
   Uri? getAttachmentUrl({
@@ -10512,7 +10547,7 @@ class MockEvent extends _i1.Mock implements _i3.Event {
     bool? useThumbnailMxcUrl = false,
     double? width = 800.0,
     double? height = 800.0,
-    _i3.ThumbnailMethod? method = _i3.ThumbnailMethod.scale,
+    _i4.ThumbnailMethod? method = _i4.ThumbnailMethod.scale,
     int? minNoThumbSize = 81920,
     bool? animated = false,
   }) =>
@@ -10534,21 +10569,21 @@ class MockEvent extends _i1.Mock implements _i3.Event {
       ) as Uri?);
 
   @override
-  _i11.Future<bool> isAttachmentInLocalStore({bool? getThumbnail = false}) =>
+  _i12.Future<bool> isAttachmentInLocalStore({bool? getThumbnail = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #isAttachmentInLocalStore,
           [],
           {#getThumbnail: getThumbnail},
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<_i3.MatrixFile> downloadAndDecryptAttachment({
+  _i12.Future<_i4.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i11.Future<_i21.Uint8List> Function(Uri)? downloadCallback,
+    _i12.Future<_i22.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10563,7 +10598,7 @@ class MockEvent extends _i1.Mock implements _i3.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i11.Future<_i3.MatrixFile>.value(_FakeMatrixFile_77(
+        returnValue: _i12.Future<_i4.MatrixFile>.value(_FakeMatrixFile_78(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10577,7 +10612,7 @@ class MockEvent extends _i1.Mock implements _i3.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.MatrixFile>.value(_FakeMatrixFile_77(
+            _i12.Future<_i4.MatrixFile>.value(_FakeMatrixFile_78(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10590,11 +10625,11 @@ class MockEvent extends _i1.Mock implements _i3.Event {
             },
           ),
         )),
-      ) as _i11.Future<_i3.MatrixFile>);
+      ) as _i12.Future<_i4.MatrixFile>);
 
   @override
-  _i11.Future<String> calcLocalizedBody(
-    _i3.MatrixLocalizations? i18n, {
+  _i12.Future<String> calcLocalizedBody(
+    _i4.MatrixLocalizations? i18n, {
     bool? withSenderNamePrefix = false,
     bool? hideReply = false,
     bool? hideEdit = false,
@@ -10613,7 +10648,7 @@ class MockEvent extends _i1.Mock implements _i3.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10628,7 +10663,7 @@ class MockEvent extends _i1.Mock implements _i3.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10642,11 +10677,11 @@ class MockEvent extends _i1.Mock implements _i3.Event {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
   String getLocalizedBody(
-    _i3.MatrixLocalizations? i18n, {
+    _i4.MatrixLocalizations? i18n, {
     bool? withSenderNamePrefix = false,
     bool? hideReply = false,
     bool? hideEdit = false,
@@ -10665,7 +10700,7 @@ class MockEvent extends _i1.Mock implements _i3.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10679,7 +10714,7 @@ class MockEvent extends _i1.Mock implements _i3.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10697,7 +10732,7 @@ class MockEvent extends _i1.Mock implements _i3.Event {
 
   @override
   String calcLocalizedBodyFallback(
-    _i3.MatrixLocalizations? i18n, {
+    _i4.MatrixLocalizations? i18n, {
     bool? withSenderNamePrefix = false,
     bool? hideReply = false,
     bool? hideEdit = false,
@@ -10716,7 +10751,7 @@ class MockEvent extends _i1.Mock implements _i3.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10730,7 +10765,7 @@ class MockEvent extends _i1.Mock implements _i3.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10764,7 +10799,7 @@ class MockEvent extends _i1.Mock implements _i3.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10777,7 +10812,7 @@ class MockEvent extends _i1.Mock implements _i3.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10815,7 +10850,7 @@ class MockEvent extends _i1.Mock implements _i3.Event {
 
   @override
   bool hasAggregatedEvents(
-    _i3.Timeline? timeline,
+    _i4.Timeline? timeline,
     String? type,
   ) =>
       (super.noSuchMethod(
@@ -10831,8 +10866,8 @@ class MockEvent extends _i1.Mock implements _i3.Event {
       ) as bool);
 
   @override
-  Set<_i3.Event> aggregatedEvents(
-    _i3.Timeline? timeline,
+  Set<_i4.Event> aggregatedEvents(
+    _i4.Timeline? timeline,
     String? type,
   ) =>
       (super.noSuchMethod(
@@ -10843,58 +10878,58 @@ class MockEvent extends _i1.Mock implements _i3.Event {
             type,
           ],
         ),
-        returnValue: <_i3.Event>{},
-        returnValueForMissingStub: <_i3.Event>{},
-      ) as Set<_i3.Event>);
+        returnValue: <_i4.Event>{},
+        returnValueForMissingStub: <_i4.Event>{},
+      ) as Set<_i4.Event>);
 
   @override
-  _i3.Event getDisplayEvent(_i3.Timeline? timeline) => (super.noSuchMethod(
+  _i4.Event getDisplayEvent(_i4.Timeline? timeline) => (super.noSuchMethod(
         Invocation.method(
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_78(
+        returnValue: _FakeEvent_79(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_78(
+        returnValueForMissingStub: _FakeEvent_79(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-      ) as _i3.Event);
+      ) as _i4.Event);
 }
 
 /// A class which mocks [User].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockUser extends _i1.Mock implements _i3.User {
+class MockUser extends _i1.Mock implements _i4.User {
   @override
-  _i3.Room get room => (super.noSuchMethod(
+  _i4.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_76(
+        returnValue: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_76(
+        returnValueForMissingStub: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
-      ) as _i3.Room);
+      ) as _i4.Room);
 
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -10908,26 +10943,26 @@ class MockUser extends _i1.Mock implements _i3.User {
       ) as int);
 
   @override
-  _i3.Membership get membership => (super.noSuchMethod(
+  _i4.Membership get membership => (super.noSuchMethod(
         Invocation.getter(#membership),
-        returnValue: _i3.Membership.ban,
-        returnValueForMissingStub: _i3.Membership.ban,
-      ) as _i3.Membership);
+        returnValue: _i4.Membership.ban,
+        returnValueForMissingStub: _i4.Membership.ban,
+      ) as _i4.Membership);
 
   @override
-  _i11.Future<_i3.CachedPresence> get currentPresence => (super.noSuchMethod(
+  _i12.Future<_i4.CachedPresence> get currentPresence => (super.noSuchMethod(
         Invocation.getter(#currentPresence),
         returnValue:
-            _i11.Future<_i3.CachedPresence>.value(_FakeCachedPresence_32(
+            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.getter(#currentPresence),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.CachedPresence>.value(_FakeCachedPresence_32(
+            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.getter(#currentPresence),
         )),
-      ) as _i11.Future<_i3.CachedPresence>);
+      ) as _i12.Future<_i4.CachedPresence>);
 
   @override
   bool get canBan => (super.noSuchMethod(
@@ -10960,11 +10995,11 @@ class MockUser extends _i1.Mock implements _i3.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -10989,11 +11024,11 @@ class MockUser extends _i1.Mock implements _i3.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11011,11 +11046,11 @@ class MockUser extends _i1.Mock implements _i3.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11050,7 +11085,7 @@ class MockUser extends _i1.Mock implements _i3.User {
   String calcDisplayname({
     bool? formatLocalpart,
     bool? mxidLocalPartFallback,
-    _i3.MatrixLocalizations? i18n = const _i3.MatrixDefaultLocalizations(),
+    _i4.MatrixLocalizations? i18n = const _i4.MatrixDefaultLocalizations(),
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -11062,7 +11097,7 @@ class MockUser extends _i1.Mock implements _i3.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11074,7 +11109,7 @@ class MockUser extends _i1.Mock implements _i3.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11089,49 +11124,49 @@ class MockUser extends _i1.Mock implements _i3.User {
       ) as String);
 
   @override
-  _i11.Future<void> kick() => (super.noSuchMethod(
+  _i12.Future<void> kick() => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> ban() => (super.noSuchMethod(
+  _i12.Future<void> ban() => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> unban() => (super.noSuchMethod(
+  _i12.Future<void> unban() => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setPower(int? power) => (super.noSuchMethod(
+  _i12.Future<void> setPower(int? power) => (super.noSuchMethod(
         Invocation.method(
           #setPower,
           [power],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<String> startDirectChat({
+  _i12.Future<String> startDirectChat({
     bool? enableEncryption,
-    List<_i3.StateEvent>? initialState,
+    List<_i4.StateEvent>? initialState,
     bool? waitForSync = true,
   }) =>
       (super.noSuchMethod(
@@ -11144,7 +11179,7 @@ class MockUser extends _i1.Mock implements _i3.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i11.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11157,7 +11192,7 @@ class MockUser extends _i1.Mock implements _i3.User {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<String>.value(_i14.dummyValue<String>(
+            _i12.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11169,16 +11204,16 @@ class MockUser extends _i1.Mock implements _i3.User {
             },
           ),
         )),
-      ) as _i11.Future<String>);
+      ) as _i12.Future<String>);
 
   @override
-  _i11.Future<_i3.CachedPresence> fetchCurrentPresence() => (super.noSuchMethod(
+  _i12.Future<_i4.CachedPresence> fetchCurrentPresence() => (super.noSuchMethod(
         Invocation.method(
           #fetchCurrentPresence,
           [],
         ),
         returnValue:
-            _i11.Future<_i3.CachedPresence>.value(_FakeCachedPresence_32(
+            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -11186,14 +11221,14 @@ class MockUser extends _i1.Mock implements _i3.User {
           ),
         )),
         returnValueForMissingStub:
-            _i11.Future<_i3.CachedPresence>.value(_FakeCachedPresence_32(
+            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.method(
             #fetchCurrentPresence,
             [],
           ),
         )),
-      ) as _i11.Future<_i3.CachedPresence>);
+      ) as _i12.Future<_i4.CachedPresence>);
 
   @override
   Map<String, Object?> toJson() => (super.noSuchMethod(
@@ -11209,19 +11244,19 @@ class MockUser extends _i1.Mock implements _i3.User {
 /// A class which mocks [CallService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCallService extends _i1.Mock implements _i22.CallService {
+class MockCallService extends _i1.Mock implements _i23.CallService {
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_1(
+        returnValueForMissingStub: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
   bool get initialized => (super.noSuchMethod(
@@ -11231,36 +11266,36 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       ) as bool);
 
   @override
-  _i23.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
+  _i24.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
         Invocation.getter(#httpPostForTest),
         returnValue: (
-          _i10.Client httpClient,
+          _i11.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i11.Future<_i10.Response>.value(_FakeResponse_79(
+            _i12.Future<_i11.Response>.value(_FakeResponse_80(
           this,
           Invocation.getter(#httpPostForTest),
         )),
         returnValueForMissingStub: (
-          _i10.Client httpClient,
+          _i11.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i11.Future<_i10.Response>.value(_FakeResponse_79(
+            _i12.Future<_i11.Response>.value(_FakeResponse_80(
           this,
           Invocation.getter(#httpPostForTest),
         )),
-      ) as _i23.HttpPostFunction);
+      ) as _i24.HttpPostFunction);
 
   @override
-  List<_i24.RemoteParticipant> get participants => (super.noSuchMethod(
+  List<_i25.RemoteParticipant> get participants => (super.noSuchMethod(
         Invocation.getter(#participants),
-        returnValue: <_i24.RemoteParticipant>[],
-        returnValueForMissingStub: <_i24.RemoteParticipant>[],
-      ) as List<_i24.RemoteParticipant>);
+        returnValue: <_i25.RemoteParticipant>[],
+        returnValueForMissingStub: <_i25.RemoteParticipant>[],
+      ) as List<_i25.RemoteParticipant>);
 
   @override
   bool get isMicEnabled => (super.noSuchMethod(
@@ -11291,14 +11326,14 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       ) as bool);
 
   @override
-  List<_i24.Participant<_i24.TrackPublication<_i24.Track>>>
+  List<_i25.Participant<_i25.TrackPublication<_i25.Track>>>
       get activeSpeakers => (super.noSuchMethod(
             Invocation.getter(#activeSpeakers),
-            returnValue: <_i24
-                .Participant<_i24.TrackPublication<_i24.Track>>>[],
-            returnValueForMissingStub: <_i24
-                .Participant<_i24.TrackPublication<_i24.Track>>>[],
-          ) as List<_i24.Participant<_i24.TrackPublication<_i24.Track>>>);
+            returnValue: <_i25
+                .Participant<_i25.TrackPublication<_i25.Track>>>[],
+            returnValueForMissingStub: <_i25
+                .Participant<_i25.TrackPublication<_i25.Track>>>[],
+          ) as List<_i25.Participant<_i25.TrackPublication<_i25.Track>>>);
 
   @override
   bool get isCallingAvailable => (super.noSuchMethod(
@@ -11308,11 +11343,11 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       ) as bool);
 
   @override
-  List<_i25.CallParticipant> get allParticipants => (super.noSuchMethod(
+  List<_i26.CallParticipant> get allParticipants => (super.noSuchMethod(
         Invocation.getter(#allParticipants),
-        returnValue: <_i25.CallParticipant>[],
-        returnValueForMissingStub: <_i25.CallParticipant>[],
-      ) as List<_i25.CallParticipant>);
+        returnValue: <_i26.CallParticipant>[],
+        returnValueForMissingStub: <_i26.CallParticipant>[],
+      ) as List<_i26.CallParticipant>);
 
   @override
   bool get isSpeakerOn => (super.noSuchMethod(
@@ -11322,29 +11357,29 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       ) as bool);
 
   @override
-  _i11.Stream<_i26.IncomingCallInfo> get incomingCallStream =>
+  _i12.Stream<_i27.IncomingCallInfo> get incomingCallStream =>
       (super.noSuchMethod(
         Invocation.getter(#incomingCallStream),
-        returnValue: _i11.Stream<_i26.IncomingCallInfo>.empty(),
-        returnValueForMissingStub: _i11.Stream<_i26.IncomingCallInfo>.empty(),
-      ) as _i11.Stream<_i26.IncomingCallInfo>);
+        returnValue: _i12.Stream<_i27.IncomingCallInfo>.empty(),
+        returnValueForMissingStub: _i12.Stream<_i27.IncomingCallInfo>.empty(),
+      ) as _i12.Stream<_i27.IncomingCallInfo>);
 
   @override
-  _i11.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
+  _i12.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
         Invocation.getter(#nativeAcceptedCallStream),
-        returnValue: _i11.Stream<String>.empty(),
-        returnValueForMissingStub: _i11.Stream<String>.empty(),
-      ) as _i11.Stream<String>);
+        returnValue: _i12.Stream<String>.empty(),
+        returnValueForMissingStub: _i12.Stream<String>.empty(),
+      ) as _i12.Stream<String>);
 
   @override
-  _i27.KoheraCallState get callState => (super.noSuchMethod(
+  _i28.KoheraCallState get callState => (super.noSuchMethod(
         Invocation.getter(#callState),
-        returnValue: _i27.KoheraCallState.idle,
-        returnValueForMissingStub: _i27.KoheraCallState.idle,
-      ) as _i27.KoheraCallState);
+        returnValue: _i28.KoheraCallState.idle,
+        returnValueForMissingStub: _i28.KoheraCallState.idle,
+      ) as _i28.KoheraCallState);
 
   @override
-  set preferencesService(_i28.PreferencesService? prefs) => super.noSuchMethod(
+  set preferencesService(_i29.PreferencesService? prefs) => super.noSuchMethod(
         Invocation.setter(
           #preferencesService,
           prefs,
@@ -11353,7 +11388,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  set ringtoneService(_i29.RingtoneService? service) => super.noSuchMethod(
+  set ringtoneService(_i30.RingtoneService? service) => super.noSuchMethod(
         Invocation.setter(
           #ringtoneService,
           service,
@@ -11362,7 +11397,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  set roomFactoryForTest(_i23.LiveKitRoomFactory? factory) =>
+  set roomFactoryForTest(_i24.LiveKitRoomFactory? factory) =>
       super.noSuchMethod(
         Invocation.setter(
           #roomFactoryForTest,
@@ -11372,7 +11407,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  set httpPostForTest(_i23.HttpPostFunction? fn) => super.noSuchMethod(
+  set httpPostForTest(_i24.HttpPostFunction? fn) => super.noSuchMethod(
         Invocation.setter(
           #httpPostForTest,
           fn,
@@ -11406,27 +11441,27 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  _i11.Future<void> toggleMicrophone() => (super.noSuchMethod(
+  _i12.Future<void> toggleMicrophone() => (super.noSuchMethod(
         Invocation.method(
           #toggleMicrophone,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> toggleCamera() => (super.noSuchMethod(
+  _i12.Future<void> toggleCamera() => (super.noSuchMethod(
         Invocation.method(
           #toggleCamera,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> toggleScreenShare({
+  _i12.Future<void> toggleScreenShare({
     String? sourceId,
     bool? captureScreenAudio = false,
   }) =>
@@ -11439,39 +11474,39 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
             #captureScreenAudio: captureScreenAudio,
           },
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> toggleScreenAudio() => (super.noSuchMethod(
+  _i12.Future<void> toggleScreenAudio() => (super.noSuchMethod(
         Invocation.method(
           #toggleScreenAudio,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
+  _i12.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
         Invocation.method(
           #setOutputVolume,
           [volume],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> toggleSpeaker() => (super.noSuchMethod(
+  _i12.Future<void> toggleSpeaker() => (super.noSuchMethod(
         Invocation.method(
           #toggleSpeaker,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void setVoipPushHandlesCallKit(bool? value) => super.noSuchMethod(
@@ -11492,7 +11527,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  void updateClient(_i3.Client? newClient) => super.noSuchMethod(
+  void updateClient(_i4.Client? newClient) => super.noSuchMethod(
         Invocation.method(
           #updateClient,
           [newClient],
@@ -11501,7 +11536,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i15.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i16.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -11529,36 +11564,36 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  _i11.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
+  _i12.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #joinCall,
           [roomId],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> leaveCall() => (super.noSuchMethod(
+  _i12.Future<void> leaveCall() => (super.noSuchMethod(
         Invocation.method(
           #leaveCall,
           [],
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
-  _i11.Future<void> acceptCall({bool? withVideo = false}) =>
+  _i12.Future<void> acceptCall({bool? withVideo = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #acceptCall,
           [],
           {#withVideo: withVideo},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   void declineCall() => super.noSuchMethod(
@@ -11580,9 +11615,9 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  _i11.Future<void> initiateCall(
+  _i12.Future<void> initiateCall(
     String? roomId, {
-    _i26.CallType? type = _i26.CallType.voice,
+    _i27.CallType? type = _i27.CallType.voice,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -11590,9 +11625,9 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
           [roomId],
           {#type: type},
         ),
-        returnValue: _i11.Future<void>.value(),
-        returnValueForMissingStub: _i11.Future<void>.value(),
-      ) as _i11.Future<void>);
+        returnValue: _i12.Future<void>.value(),
+        returnValueForMissingStub: _i12.Future<void>.value(),
+      ) as _i12.Future<void>);
 
   @override
   bool roomHasActiveCall(String? roomId) => (super.noSuchMethod(
@@ -11685,7 +11720,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  void addListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -11694,7 +11729,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  void removeListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -11703,17 +11738,17 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  _i11.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i16.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i17.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -11724,7 +11759,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i16.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i17.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -11761,26 +11796,26 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  _i11.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
-  _i11.Future<bool> didPushRouteInformation(
-          _i17.RouteInformation? routeInformation) =>
+  _i12.Future<bool> didPushRouteInformation(
+          _i18.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i11.Future<bool>.value(false),
-        returnValueForMissingStub: _i11.Future<bool>.value(false),
-      ) as _i11.Future<bool>);
+        returnValue: _i12.Future<bool>.value(false),
+        returnValueForMissingStub: _i12.Future<bool>.value(false),
+      ) as _i12.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -11810,7 +11845,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  void didChangeLocales(List<_i15.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i16.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -11819,7 +11854,7 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  void didChangeViewFocus(_i15.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i16.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -11828,16 +11863,16 @@ class MockCallService extends _i1.Mock implements _i22.CallService {
       );
 
   @override
-  _i11.Future<_i15.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i12.Future<_i16.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i11.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
-      ) as _i11.Future<_i15.AppExitResponse>);
+            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
+      ) as _i12.Future<_i16.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/space_action_dialog_test.mocks.dart
+++ b/test/widgets/space_action_dialog_test.mocks.dart
@@ -4,30 +4,32 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i15;
-import 'dart:ui' as _i17;
+import 'dart:typed_data' as _i16;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i13;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i14;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i20;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -746,8 +748,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,8 +759,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,9 +769,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -777,9 +779,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -788,8 +790,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,8 +801,8 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,8 +811,8 @@ class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
         );
 }
 
-class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_72(
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -818,9 +821,19 @@ class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_73 extends _i1.SmartFake
+class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_74 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_73(
+  _FakeLatestReceiptState_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,8 +842,8 @@ class _FakeLatestReceiptState_73 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_74(
+class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -839,8 +852,8 @@ class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_75 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_75(
+class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,12 +880,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i13.KeyVerificationMethod> get verificationMethods =>
+  Set<_i14.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i13.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i13.KeyVerificationMethod>{},
-      ) as Set<_i13.KeyVerificationMethod>);
+        returnValue: <_i14.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
+      ) as Set<_i14.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -992,11 +1005,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1033,11 +1046,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1067,11 +1080,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1080,11 +1093,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1370,34 +1383,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i13.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i13.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i13.KeyVerification>
+  _i3.CachedStreamController<_i14.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i13.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i13.KeyVerification>(
+                _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i13.KeyVerification>);
+          ) as _i3.CachedStreamController<_i14.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1553,7 +1566,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i13.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1842,14 +1855,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2237,8 +2250,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2254,8 +2267,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2296,7 +2309,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2312,7 +2325,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2361,7 +2374,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2382,7 +2395,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2485,7 +2498,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2503,7 +2516,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3022,7 +3035,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i15.Uint8List? file, {
+    _i16.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3374,7 +3387,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3388,7 +3401,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3539,7 +3552,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i15.Uint8List? body,
+    _i16.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4917,7 +4930,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4939,7 +4952,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5433,7 +5446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5445,7 +5458,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6453,7 +6466,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6464,7 +6477,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6712,7 +6725,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6724,7 +6737,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6984,7 +6997,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6997,7 +7010,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7064,7 +7077,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7077,7 +7090,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7125,7 +7138,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7137,7 +7150,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7385,7 +7398,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7396,7 +7409,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7658,7 +7671,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i15.Uint8List? body, {
+    _i16.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7685,7 +7698,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7700,13 +7713,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7715,11 +7741,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7740,69 +7766,69 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7821,6 +7847,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7830,7 +7865,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7839,7 +7874,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7848,7 +7883,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7857,7 +7892,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7866,7 +7901,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7919,7 +7954,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8013,7 +8048,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8022,7 +8057,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8041,7 +8076,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8052,7 +8087,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8100,7 +8135,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8138,7 +8173,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8147,7 +8182,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8156,16 +8191,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i5.Future<_i17.AppExitResponse>);
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8193,11 +8228,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8227,11 +8262,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_72(
+        returnValue: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_72(
+        returnValueForMissingStub: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
@@ -8284,11 +8319,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8324,11 +8359,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8344,11 +8379,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8357,11 +8392,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8384,11 +8419,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -8404,11 +8439,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8451,11 +8486,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_73(
+        returnValue: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_73(
+        returnValueForMissingStub: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8667,18 +8702,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i20.SpaceParent>[],
-        returnValueForMissingStub: <_i20.SpaceParent>[],
-      ) as List<_i20.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i20.SpaceChild>[],
-        returnValueForMissingStub: <_i20.SpaceChild>[],
-      ) as List<_i20.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8845,14 +8880,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8900,7 +8935,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8908,7 +8943,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8923,7 +8958,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8931,7 +8966,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9015,7 +9050,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9023,7 +9058,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9265,7 +9300,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9276,7 +9311,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9365,15 +9400,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i21.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i21.TimelineChunk?>.value(),
-      ) as _i5.Future<_i21.TimelineChunk?>);
+        returnValue: _i5.Future<_i22.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i22.TimelineChunk?>.value(),
+      ) as _i5.Future<_i22.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9414,7 +9449,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9431,7 +9466,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9495,14 +9530,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9518,14 +9553,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9581,7 +9616,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9589,7 +9624,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/space_context_menu_test.mocks.dart
+++ b/test/widgets/space_context_menu_test.mocks.dart
@@ -4,30 +4,32 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i15;
-import 'dart:ui' as _i17;
+import 'dart:typed_data' as _i16;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i13;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i14;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i20;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -746,8 +748,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,8 +759,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,9 +769,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -777,9 +779,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -788,8 +790,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,8 +801,8 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,8 +811,8 @@ class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
         );
 }
 
-class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_72(
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -818,9 +821,19 @@ class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_73 extends _i1.SmartFake
+class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_74 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_73(
+  _FakeLatestReceiptState_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,8 +842,8 @@ class _FakeLatestReceiptState_73 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_74(
+class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -839,8 +852,8 @@ class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_75 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_75(
+class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -849,8 +862,8 @@ class _FakeUser_75 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_76 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_76(
+class _FakeRoom_77 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -859,8 +872,8 @@ class _FakeRoom_76 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeMatrixFile_77 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_77(
+class _FakeMatrixFile_78 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -869,8 +882,8 @@ class _FakeMatrixFile_77 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_78 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_78(
+class _FakeEvent_79 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -897,12 +910,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i13.KeyVerificationMethod> get verificationMethods =>
+  Set<_i14.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i13.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i13.KeyVerificationMethod>{},
-      ) as Set<_i13.KeyVerificationMethod>);
+        returnValue: <_i14.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
+      ) as Set<_i14.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1022,11 +1035,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1063,11 +1076,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1097,11 +1110,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1110,11 +1123,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1400,34 +1413,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i13.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i13.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i13.KeyVerification>
+  _i3.CachedStreamController<_i14.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i13.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i13.KeyVerification>(
+                _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i13.KeyVerification>);
+          ) as _i3.CachedStreamController<_i14.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1583,7 +1596,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i13.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1872,14 +1885,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2267,8 +2280,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2284,8 +2297,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2326,7 +2339,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2342,7 +2355,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2391,7 +2404,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2412,7 +2425,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2515,7 +2528,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2533,7 +2546,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3052,7 +3065,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i15.Uint8List? file, {
+    _i16.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3404,7 +3417,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3418,7 +3431,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3569,7 +3582,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i15.Uint8List? body,
+    _i16.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4947,7 +4960,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4969,7 +4982,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5463,7 +5476,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5475,7 +5488,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6483,7 +6496,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6494,7 +6507,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6742,7 +6755,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6754,7 +6767,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7014,7 +7027,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7027,7 +7040,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7094,7 +7107,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7107,7 +7120,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7155,7 +7168,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7167,7 +7180,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7415,7 +7428,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7426,7 +7439,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7688,7 +7701,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i15.Uint8List? body, {
+    _i16.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7715,7 +7728,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7730,13 +7743,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7745,11 +7771,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7770,69 +7796,69 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7851,6 +7877,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7860,7 +7895,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7869,7 +7904,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7878,7 +7913,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7887,7 +7922,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7896,7 +7931,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7949,7 +7984,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8043,7 +8078,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8052,7 +8087,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8071,7 +8106,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8082,7 +8117,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8130,7 +8165,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8168,7 +8203,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8177,7 +8212,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8186,16 +8221,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i5.Future<_i17.AppExitResponse>);
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8223,11 +8258,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8257,11 +8292,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_72(
+        returnValue: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_72(
+        returnValueForMissingStub: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
@@ -8314,11 +8349,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8354,11 +8389,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8374,11 +8409,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8387,11 +8422,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8414,11 +8449,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -8434,11 +8469,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8481,11 +8516,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_73(
+        returnValue: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_73(
+        returnValueForMissingStub: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8697,18 +8732,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i20.SpaceParent>[],
-        returnValueForMissingStub: <_i20.SpaceParent>[],
-      ) as List<_i20.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i20.SpaceChild>[],
-        returnValueForMissingStub: <_i20.SpaceChild>[],
-      ) as List<_i20.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8875,14 +8910,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8930,7 +8965,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8938,7 +8973,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8953,7 +8988,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8961,7 +8996,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9045,7 +9080,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9053,7 +9088,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9295,7 +9330,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9306,7 +9341,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9395,15 +9430,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i21.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i21.TimelineChunk?>.value(),
-      ) as _i5.Future<_i21.TimelineChunk?>);
+        returnValue: _i5.Future<_i22.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i22.TimelineChunk?>.value(),
+      ) as _i5.Future<_i22.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9444,7 +9479,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9461,7 +9496,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9525,14 +9560,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9548,14 +9583,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9611,7 +9646,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9619,7 +9654,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9931,11 +9966,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.getter(#sender),
         ),
@@ -9944,11 +9979,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -9957,11 +9992,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_76(
+        returnValue: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_76(
+        returnValueForMissingStub: _FakeRoom_77(
           this,
           Invocation.getter(#room),
         ),
@@ -9984,11 +10019,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.getter(#asUser),
         ),
@@ -9997,11 +10032,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10010,11 +10045,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10023,11 +10058,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10036,11 +10071,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10049,11 +10084,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10118,11 +10153,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10131,11 +10166,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10188,11 +10223,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10277,11 +10312,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10299,11 +10334,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10514,7 +10549,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i15.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i16.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10529,7 +10564,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_77(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_78(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10543,7 +10578,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_77(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_78(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10579,7 +10614,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10594,7 +10629,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10631,7 +10666,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10645,7 +10680,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10682,7 +10717,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10696,7 +10731,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10730,7 +10765,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10743,7 +10778,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10819,14 +10854,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_78(
+        returnValue: _FakeEvent_79(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_78(
+        returnValueForMissingStub: _FakeEvent_79(
           this,
           Invocation.method(
             #getDisplayEvent,

--- a/test/widgets/space_details_panel_test.mocks.dart
+++ b/test/widgets/space_details_panel_test.mocks.dart
@@ -4,30 +4,32 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i15;
-import 'dart:ui' as _i17;
+import 'dart:typed_data' as _i16;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i13;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i14;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i20;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -746,8 +748,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,8 +759,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,9 +769,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -777,9 +779,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -788,8 +790,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,8 +801,8 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,8 +811,8 @@ class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
         );
 }
 
-class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_72(
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -818,9 +821,19 @@ class _FakeRoomSummary_72 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_73 extends _i1.SmartFake
+class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_74 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_73(
+  _FakeLatestReceiptState_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,8 +842,8 @@ class _FakeLatestReceiptState_73 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_74(
+class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -839,8 +852,8 @@ class _FakeTimeline_74 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_75 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_75(
+class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,12 +880,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i13.KeyVerificationMethod> get verificationMethods =>
+  Set<_i14.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i13.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i13.KeyVerificationMethod>{},
-      ) as Set<_i13.KeyVerificationMethod>);
+        returnValue: <_i14.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
+      ) as Set<_i14.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -992,11 +1005,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1033,11 +1046,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1067,11 +1080,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1080,11 +1093,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1370,34 +1383,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i13.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i13.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i13.KeyVerification>
+  _i3.CachedStreamController<_i14.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i13.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i13.KeyVerification>(
+                _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i13.KeyVerification>);
+          ) as _i3.CachedStreamController<_i14.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1553,7 +1566,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i13.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1842,14 +1855,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2237,8 +2250,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2254,8 +2267,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2296,7 +2309,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2312,7 +2325,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2361,7 +2374,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2382,7 +2395,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2485,7 +2498,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2503,7 +2516,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3022,7 +3035,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i15.Uint8List? file, {
+    _i16.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3374,7 +3387,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3388,7 +3401,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3539,7 +3552,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i15.Uint8List? body,
+    _i16.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4917,7 +4930,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4939,7 +4952,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5433,7 +5446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5445,7 +5458,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6453,7 +6466,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6464,7 +6477,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6712,7 +6725,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6724,7 +6737,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6984,7 +6997,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6997,7 +7010,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7064,7 +7077,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7077,7 +7090,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7125,7 +7138,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7137,7 +7150,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7385,7 +7398,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7396,7 +7409,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7658,7 +7671,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i15.Uint8List? body, {
+    _i16.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7685,7 +7698,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7700,13 +7713,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7715,11 +7741,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7740,69 +7766,69 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7821,6 +7847,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7830,7 +7865,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7839,7 +7874,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7848,7 +7883,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7857,7 +7892,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7866,7 +7901,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7919,7 +7954,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8013,7 +8048,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8022,7 +8057,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8041,7 +8076,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8052,7 +8087,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8100,7 +8135,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8138,7 +8173,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8147,7 +8182,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8156,16 +8191,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i5.Future<_i17.AppExitResponse>);
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8193,11 +8228,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8227,11 +8262,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_72(
+        returnValue: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_72(
+        returnValueForMissingStub: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
@@ -8284,11 +8319,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8324,11 +8359,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8344,11 +8379,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8357,11 +8392,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8384,11 +8419,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -8404,11 +8439,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8451,11 +8486,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_73(
+        returnValue: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_73(
+        returnValueForMissingStub: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8667,18 +8702,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i20.SpaceParent>[],
-        returnValueForMissingStub: <_i20.SpaceParent>[],
-      ) as List<_i20.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i20.SpaceChild>[],
-        returnValueForMissingStub: <_i20.SpaceChild>[],
-      ) as List<_i20.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8845,14 +8880,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8900,7 +8935,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8908,7 +8943,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8923,7 +8958,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8931,7 +8966,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9015,7 +9050,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9023,7 +9058,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9265,7 +9300,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9276,7 +9311,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9365,15 +9400,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i21.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i21.TimelineChunk?>.value(),
-      ) as _i5.Future<_i21.TimelineChunk?>);
+        returnValue: _i5.Future<_i22.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i22.TimelineChunk?>.value(),
+      ) as _i5.Future<_i22.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9414,7 +9449,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9431,7 +9466,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_74(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -9495,14 +9530,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9518,14 +9553,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_75(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_75(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9581,7 +9616,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9589,7 +9624,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/space_discovery_search_test.mocks.dart
+++ b/test/widgets/space_discovery_search_test.mocks.dart
@@ -4,28 +4,30 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i15;
-import 'dart:ui' as _i17;
+import 'dart:typed_data' as _i16;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i13;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i14;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -744,8 +746,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -754,8 +757,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -764,9 +767,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -775,9 +777,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -786,8 +788,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -796,8 +799,18 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -824,12 +837,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i13.KeyVerificationMethod> get verificationMethods =>
+  Set<_i14.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i13.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i13.KeyVerificationMethod>{},
-      ) as Set<_i13.KeyVerificationMethod>);
+        returnValue: <_i14.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
+      ) as Set<_i14.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -949,11 +962,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -990,11 +1003,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1024,11 +1037,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1037,11 +1050,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1327,34 +1340,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i13.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i13.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i13.KeyVerification>
+  _i3.CachedStreamController<_i14.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i13.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i13.KeyVerification>(
+                _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i13.KeyVerification>);
+          ) as _i3.CachedStreamController<_i14.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1510,7 +1523,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i13.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1799,14 +1812,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2194,8 +2207,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2211,8 +2224,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2253,7 +2266,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2269,7 +2282,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2318,7 +2331,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2339,7 +2352,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2442,7 +2455,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2460,7 +2473,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2979,7 +2992,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i15.Uint8List? file, {
+    _i16.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3331,7 +3344,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3345,7 +3358,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3496,7 +3509,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i15.Uint8List? body,
+    _i16.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4874,7 +4887,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4896,7 +4909,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5390,7 +5403,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5402,7 +5415,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6410,7 +6423,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6421,7 +6434,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6669,7 +6682,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6681,7 +6694,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6941,7 +6954,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6954,7 +6967,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7021,7 +7034,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7034,7 +7047,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7082,7 +7095,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7094,7 +7107,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7342,7 +7355,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7353,7 +7366,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7615,7 +7628,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i15.Uint8List? body, {
+    _i16.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7642,7 +7655,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7657,13 +7670,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7672,11 +7698,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7697,69 +7723,69 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7778,6 +7804,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7787,7 +7822,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7796,7 +7831,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7805,7 +7840,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7814,7 +7849,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7823,7 +7858,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7876,7 +7911,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -7970,7 +8005,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -7979,7 +8014,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -7998,7 +8033,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8009,7 +8044,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8057,7 +8092,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8095,7 +8130,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8104,7 +8139,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8113,16 +8148,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i5.Future<_i17.AppExitResponse>);
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/space_discovery_server_test.mocks.dart
+++ b/test/widgets/space_discovery_server_test.mocks.dart
@@ -4,28 +4,30 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i15;
-import 'dart:ui' as _i17;
+import 'dart:typed_data' as _i16;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i13;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i14;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -744,8 +746,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -754,8 +757,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -764,9 +767,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -775,9 +777,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -786,8 +788,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -796,8 +799,18 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -824,12 +837,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i13.KeyVerificationMethod> get verificationMethods =>
+  Set<_i14.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i13.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i13.KeyVerificationMethod>{},
-      ) as Set<_i13.KeyVerificationMethod>);
+        returnValue: <_i14.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
+      ) as Set<_i14.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -949,11 +962,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -990,11 +1003,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1024,11 +1037,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1037,11 +1050,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1327,34 +1340,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i13.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i13.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i13.KeyVerification>
+  _i3.CachedStreamController<_i14.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i13.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i13.KeyVerification>(
+                _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i13.KeyVerification>);
+          ) as _i3.CachedStreamController<_i14.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1510,7 +1523,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i13.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1799,14 +1812,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2194,8 +2207,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2211,8 +2224,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2253,7 +2266,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2269,7 +2282,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2318,7 +2331,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2339,7 +2352,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2442,7 +2455,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2460,7 +2473,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2979,7 +2992,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i15.Uint8List? file, {
+    _i16.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3331,7 +3344,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3345,7 +3358,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3496,7 +3509,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i15.Uint8List? body,
+    _i16.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4874,7 +4887,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4896,7 +4909,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5390,7 +5403,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5402,7 +5415,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6410,7 +6423,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6421,7 +6434,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6669,7 +6682,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6681,7 +6694,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6941,7 +6954,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6954,7 +6967,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7021,7 +7034,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7034,7 +7047,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7082,7 +7095,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7094,7 +7107,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7342,7 +7355,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7353,7 +7366,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7615,7 +7628,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i15.Uint8List? body, {
+    _i16.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7642,7 +7655,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7657,13 +7670,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7672,11 +7698,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7697,69 +7723,69 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7778,6 +7804,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7787,7 +7822,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7796,7 +7831,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7805,7 +7840,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7814,7 +7849,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7823,7 +7858,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7876,7 +7911,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -7970,7 +8005,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -7979,7 +8014,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -7998,7 +8033,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8009,7 +8044,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8057,7 +8092,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8095,7 +8130,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8104,7 +8139,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8113,16 +8148,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i5.Future<_i17.AppExitResponse>);
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/space_discovery_servers_edit_test.mocks.dart
+++ b/test/widgets/space_discovery_servers_edit_test.mocks.dart
@@ -4,28 +4,30 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i15;
-import 'dart:ui' as _i17;
+import 'dart:typed_data' as _i16;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i13;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i14;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -744,8 +746,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -754,8 +757,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -764,9 +767,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -775,9 +777,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -786,8 +788,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -796,8 +799,18 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -824,12 +837,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i13.KeyVerificationMethod> get verificationMethods =>
+  Set<_i14.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i13.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i13.KeyVerificationMethod>{},
-      ) as Set<_i13.KeyVerificationMethod>);
+        returnValue: <_i14.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
+      ) as Set<_i14.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -949,11 +962,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -990,11 +1003,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1024,11 +1037,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1037,11 +1050,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1327,34 +1340,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i13.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i13.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i13.KeyVerification>
+  _i3.CachedStreamController<_i14.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i13.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i13.KeyVerification>(
+                _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i13.KeyVerification>);
+          ) as _i3.CachedStreamController<_i14.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1510,7 +1523,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i13.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1799,14 +1812,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2194,8 +2207,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2211,8 +2224,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2253,7 +2266,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2269,7 +2282,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2318,7 +2331,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2339,7 +2352,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2442,7 +2455,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2460,7 +2473,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2979,7 +2992,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i15.Uint8List? file, {
+    _i16.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3331,7 +3344,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3345,7 +3358,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3496,7 +3509,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i15.Uint8List? body,
+    _i16.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4874,7 +4887,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4896,7 +4909,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5390,7 +5403,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5402,7 +5415,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6410,7 +6423,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6421,7 +6434,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6669,7 +6682,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6681,7 +6694,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6941,7 +6954,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6954,7 +6967,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7021,7 +7034,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7034,7 +7047,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7082,7 +7095,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7094,7 +7107,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7342,7 +7355,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7353,7 +7366,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7615,7 +7628,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i15.Uint8List? body, {
+    _i16.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7642,7 +7655,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7657,13 +7670,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7672,11 +7698,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7697,69 +7723,69 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7778,6 +7804,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7787,7 +7822,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7796,7 +7831,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7805,7 +7840,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7814,7 +7849,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7823,7 +7858,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7876,7 +7911,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -7970,7 +8005,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -7979,7 +8014,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -7998,7 +8033,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8009,7 +8044,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8057,7 +8092,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8095,7 +8130,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8104,7 +8139,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8113,16 +8148,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i5.Future<_i17.AppExitResponse>);
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/verification_request_listener_test.mocks.dart
+++ b/test/widgets/verification_request_listener_test.mocks.dart
@@ -4,28 +4,30 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i15;
-import 'dart:ui' as _i17;
+import 'dart:typed_data' as _i16;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i9;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
-import 'package:matrix/encryption.dart' as _i13;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i14;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -744,8 +746,9 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_66(
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -754,8 +757,8 @@ class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
-  _FakeUiaService_67(
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -764,9 +767,8 @@ class _FakeUiaService_67 extends _i1.SmartFake implements _i8.UiaService {
         );
 }
 
-class _FakeChatBackupService_68 extends _i1.SmartFake
-    implements _i9.ChatBackupService {
-  _FakeChatBackupService_68(
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -775,9 +777,9 @@ class _FakeChatBackupService_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSelectionService_69 extends _i1.SmartFake
-    implements _i10.SelectionService {
-  _FakeSelectionService_69(
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -786,8 +788,9 @@ class _FakeSelectionService_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
-  _FakeSyncService_70(
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -796,8 +799,18 @@ class _FakeSyncService_70 extends _i1.SmartFake implements _i11.SyncService {
         );
 }
 
-class _FakeAuthService_71 extends _i1.SmartFake implements _i12.AuthService {
-  _FakeAuthService_71(
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -824,12 +837,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i13.KeyVerificationMethod> get verificationMethods =>
+  Set<_i14.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i13.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i13.KeyVerificationMethod>{},
-      ) as Set<_i13.KeyVerificationMethod>);
+        returnValue: <_i14.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
+      ) as Set<_i14.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -949,11 +962,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -990,11 +1003,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1024,11 +1037,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1037,11 +1050,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1327,34 +1340,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i13.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i13.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i13.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i13.KeyVerification>
+  _i3.CachedStreamController<_i14.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i13.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i13.KeyVerification>(
+                _FakeCachedStreamController_6<_i14.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i13.KeyVerification>);
+          ) as _i3.CachedStreamController<_i14.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1510,7 +1523,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i13.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1799,14 +1812,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2194,8 +2207,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2211,8 +2224,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i14.ifNotNull(
-              _i14.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2253,7 +2266,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2269,7 +2282,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2318,7 +2331,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2339,7 +2352,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2442,7 +2455,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2460,7 +2473,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2979,7 +2992,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i15.Uint8List? file, {
+    _i16.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3331,7 +3344,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3345,7 +3358,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3496,7 +3509,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i15.Uint8List? body,
+    _i16.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4874,7 +4887,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4896,7 +4909,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5390,7 +5403,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5402,7 +5415,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6410,7 +6423,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6421,7 +6434,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6669,7 +6682,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6681,7 +6694,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6941,7 +6954,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6954,7 +6967,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7021,7 +7034,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7034,7 +7047,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7082,7 +7095,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7094,7 +7107,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7342,7 +7355,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7353,7 +7366,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i14.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7615,7 +7628,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i15.Uint8List? body, {
+    _i16.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7642,7 +7655,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7657,13 +7670,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i7.CallPushRuleManager);
 
   @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7672,11 +7698,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_66(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_66(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -7697,69 +7723,69 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i8.UiaService get uia => (super.noSuchMethod(
+  _i9.UiaService get uia => (super.noSuchMethod(
         Invocation.getter(#uia),
-        returnValue: _FakeUiaService_67(
+        returnValue: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-        returnValueForMissingStub: _FakeUiaService_67(
+        returnValueForMissingStub: _FakeUiaService_68(
           this,
           Invocation.getter(#uia),
         ),
-      ) as _i8.UiaService);
+      ) as _i9.UiaService);
 
   @override
-  _i9.ChatBackupService get chatBackup => (super.noSuchMethod(
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
         Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_68(
+        returnValue: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-        returnValueForMissingStub: _FakeChatBackupService_68(
+        returnValueForMissingStub: _FakeChatBackupService_69(
           this,
           Invocation.getter(#chatBackup),
         ),
-      ) as _i9.ChatBackupService);
+      ) as _i10.ChatBackupService);
 
   @override
-  _i10.SelectionService get selection => (super.noSuchMethod(
+  _i11.SelectionService get selection => (super.noSuchMethod(
         Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_69(
+        returnValue: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-        returnValueForMissingStub: _FakeSelectionService_69(
+        returnValueForMissingStub: _FakeSelectionService_70(
           this,
           Invocation.getter(#selection),
         ),
-      ) as _i10.SelectionService);
+      ) as _i11.SelectionService);
 
   @override
-  _i11.SyncService get sync => (super.noSuchMethod(
+  _i12.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_70(
+        returnValue: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_70(
+        returnValueForMissingStub: _FakeSyncService_71(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i11.SyncService);
+      ) as _i12.SyncService);
 
   @override
-  _i12.AuthService get auth => (super.noSuchMethod(
+  _i13.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_71(
+        returnValue: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_71(
+        returnValueForMissingStub: _FakeAuthService_72(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i12.AuthService);
+      ) as _i13.AuthService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7778,6 +7804,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   set isLoggedInForTest(bool? value) => super.noSuchMethod(
         Invocation.setter(
           #isLoggedInForTest,
@@ -7787,7 +7822,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set uia(_i8.UiaService? value) => super.noSuchMethod(
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
         Invocation.setter(
           #uia,
           value,
@@ -7796,7 +7831,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set chatBackup(_i9.ChatBackupService? value) => super.noSuchMethod(
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
         Invocation.setter(
           #chatBackup,
           value,
@@ -7805,7 +7840,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set selection(_i10.SelectionService? value) => super.noSuchMethod(
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
         Invocation.setter(
           #selection,
           value,
@@ -7814,7 +7849,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set sync(_i11.SyncService? value) => super.noSuchMethod(
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7823,7 +7858,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  set auth(_i12.AuthService? value) => super.noSuchMethod(
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7876,7 +7911,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -7970,7 +8005,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -7979,7 +8014,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -7998,7 +8033,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8009,7 +8044,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8057,7 +8092,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8095,7 +8130,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8104,7 +8139,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8113,16 +8148,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i5.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i5.Future<_i17.AppExitResponse>);
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8146,7 +8181,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
 /// A class which mocks [ChatBackupService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockChatBackupService extends _i1.Mock implements _i9.ChatBackupService {
+class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
   @override
   bool get chatBackupEnabled => (super.noSuchMethod(
         Invocation.getter(#chatBackupEnabled),
@@ -8208,7 +8243,7 @@ class MockChatBackupService extends _i1.Mock implements _i9.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> runKeyRecovery({_i13.OpenSSSS? ssssKey}) =>
+  _i5.Future<void> runKeyRecovery({_i14.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
@@ -8262,7 +8297,7 @@ class MockChatBackupService extends _i1.Mock implements _i9.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8271,7 +8306,7 @@ class MockChatBackupService extends _i1.Mock implements _i9.ChatBackupService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],


### PR DESCRIPTION
## Summary

- Restore iOS Matrix sqlite DB to app sandbox; stop sharing it through the App Group container.
- Add `MegolmKeyMirror` that replicates only inbound megolm sessions into a small sqlite mirror in the App Group, opened/closed per write so no lock is held across iOS suspension.
- Update `MegolmDecryptor.swift` to read from the new `kohera_<client>_keys.db` mirror; query logic unchanged.
- Migrate existing App Group DBs on first launch (copy into sandbox, mirror keys, delete).

Closes #411.

## Why

Crash on TestFlight build 24, iOS 26.4.2: `EXC_CRASH (SIGKILL)`, `Termination Reason: RUNNINGBOARD 0xdead10cc`. Apple sends 0xdead10cc when an app is suspended while holding a file lock on a file in a shared container. The matrix sdk's persistent WAL handle did exactly that every backgrounding.

## Test plan

- [x] `flutter analyze lib/` — clean (only pre-existing avoid_slow_async_io infos on File.exists).
- [x] `flutter test` — 1643 passed.
- [ ] Manual TestFlight pass: install over an existing build, confirm chats + devices restored from sandbox copy and encrypted pushes still decrypt via NSE.
- [ ] Background app for >30 min on iOS device, confirm no 0xdead10cc on resume.
- [ ] Fresh install on iOS, log in, send/receive E2EE message, confirm push decrypts.