### PR TITLE
fix(chat): always show threads button in app bar

### DIFF
--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -354,7 +354,7 @@ class _ChatScreenState extends State<ChatScreen>
         onSearch: _openSearch,
         onPinnedEvent: (event) =>
             _messageListKey.currentState?.navigateToEvent(event),
-        onShowThreads: summaries.isEmpty ? null : _openThreadList,
+        onShowThreads: _openThreadList,
         threadUnreadCount: totalThreadUnread(summaries),
       );
     }


### PR DESCRIPTION
## Summary
- Threads button in `ChatAppBar` was hidden whenever the `summaries` list was empty, so it flickered in/out as thread summaries loaded asynchronously.
- Always pass `_openThreadList` so button stays visible. Empty thread list screen handles the no-threads case.

## Test plan
- [ ] Open a room with no known threads — button visible, opens empty thread list.
- [ ] Open a room with threads — button visible with unread badge as before.
- [ ] Narrow layout — button still relocates to overflow menu (unchanged).