### PR TITLE
feat(whats-new): surface update-available banner

### DIFF
--- a/lib/core/services/preferences_service.dart
+++ b/lib/core/services/preferences_service.dart
@@ -77,6 +77,7 @@ class PreferencesService extends ChangeNotifier {
   static const _themePresetKey = 'theme_preset';
   static const _lastMobileTabKey = 'last_mobile_tab';
   static const _lastSeenVersionKey = 'last_seen_version';
+  static const _lastDismissedUpdateKey = 'last_dismissed_update';
 
   /// Initialise the underlying [SharedPreferences] instance.
   /// Must be called (and awaited) before reading any values.
@@ -658,5 +659,31 @@ class PreferencesService extends ChangeNotifier {
     await _prefs?.setString(_lastSeenVersionKey, version);
     debugPrint('[Kohera] Marked version $version as seen');
     notifyListeners();
+  }
+
+  // ── Update-available detection ───────────────────────────────
+
+  String? get lastDismissedUpdateTag =>
+      _prefs?.getString(_lastDismissedUpdateKey);
+
+  Future<void> markUpdateDismissed(String tag) async {
+    await _prefs?.setString(_lastDismissedUpdateKey, tag);
+    debugPrint('[Kohera] Dismissed update notice for $tag');
+    notifyListeners();
+  }
+
+  /// Returns true when [latestTag] (e.g. `v1.5.0` or `1.5.0`) is strictly
+  /// newer than the installed [currentVersion] and has not been dismissed.
+  bool isUpdateAvailable(String? latestTag) {
+    final current = _currentVersion;
+    if (latestTag == null || latestTag.isEmpty || current == null) return false;
+    if (lastDismissedUpdateTag == latestTag) return false;
+    final stripped =
+        latestTag.startsWith('v') ? latestTag.substring(1) : latestTag;
+    try {
+      return Version.parse(stripped) > Version.parse(current);
+    } on FormatException {
+      return false;
+    }
   }
 }

--- a/lib/features/whats_new/widgets/whats_new_banner.dart
+++ b/lib/features/whats_new/widgets/whats_new_banner.dart
@@ -47,7 +47,12 @@ class _WhatsNewBannerState extends State<WhatsNewBanner> {
 
   Future<void> _loadNotes() async {
     if (!mounted) return;
-    final service = context.read<GitHubReleasesService>();
+    final GitHubReleasesService service;
+    try {
+      service = context.read<GitHubReleasesService>();
+    } on ProviderNotFoundException {
+      return;
+    }
     final notes = await service.fetchLatest();
     if (!mounted) return;
     setState(() => _notes = notes);

--- a/lib/features/whats_new/widgets/whats_new_banner.dart
+++ b/lib/features/whats_new/widgets/whats_new_banner.dart
@@ -6,13 +6,27 @@ import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/github_releases_service.dart';
 import 'package:kohera/core/services/preferences_service.dart';
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 
-/// Dismissible banner that announces a new app release.
+typedef WhatsNewLinkLauncher = Future<bool> Function(Uri uri);
+
+/// Dismissible banner with two modes:
 ///
-/// Visible only when [PreferencesService.hasVersionBumped] is `true` AND
-/// release notes have been fetched, so it never flickers on slow networks.
+/// 1. **Post-update** — installed version > last-seen version. Shows
+///    "What's new in vX" linking to the in-app release notes screen.
+/// 2. **Update-available** — latest GitHub release tag > installed
+///    version. Shows "Update available vX" linking to the GitHub
+///    release page.
+///
+/// Hidden until release notes have been fetched, so it never flickers
+/// on slow networks.
 class WhatsNewBanner extends StatefulWidget {
-  const WhatsNewBanner({super.key});
+  const WhatsNewBanner({
+    super.key,
+    @visibleForTesting this.linkLauncher,
+  });
+
+  final WhatsNewLinkLauncher? linkLauncher;
 
   @override
   State<WhatsNewBanner> createState() => _WhatsNewBannerState();
@@ -25,8 +39,7 @@ class _WhatsNewBannerState extends State<WhatsNewBanner> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final prefs = context.read<PreferencesService>();
-    if (prefs.hasVersionBumped && !_attempted) {
+    if (!_attempted) {
       _attempted = true;
       unawaited(_loadNotes());
     }
@@ -40,7 +53,7 @@ class _WhatsNewBannerState extends State<WhatsNewBanner> {
     setState(() => _notes = notes);
   }
 
-  Future<void> _dismiss() async {
+  Future<void> _dismissPostUpdate() async {
     final prefs = context.read<PreferencesService>();
     final current = prefs.currentVersion;
     if (current == null) return;
@@ -51,45 +64,89 @@ class _WhatsNewBannerState extends State<WhatsNewBanner> {
     }
   }
 
-  void _viewDetails() {
+  Future<void> _dismissUpdateAvailable() async {
+    final prefs = context.read<PreferencesService>();
+    final tag = _notes?.tagName;
+    if (tag == null || tag.isEmpty) return;
+    try {
+      await prefs.markUpdateDismissed(tag);
+    } catch (e) {
+      debugPrint('[Kohera] Failed to dismiss update notice: $e');
+    }
+  }
+
+  void _viewReleaseNotes() {
     unawaited(context.pushNamed(Routes.whatsNew));
+  }
+
+  Future<void> _openLatestRelease() async {
+    final url = _notes?.htmlUrl;
+    if (url == null || url.isEmpty) return;
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    final launcher = widget.linkLauncher ??
+        (u) => launchUrl(u, mode: LaunchMode.externalApplication);
+    unawaited(launcher(uri));
   }
 
   @override
   Widget build(BuildContext context) {
-    final hasBump = context.select<PreferencesService, bool>(
-      (p) => p.hasVersionBumped,
-    );
-    final currentVersion = context.select<PreferencesService, String?>(
-      (p) => p.currentVersion,
-    );
+    final prefs = context.watch<PreferencesService>();
     final notes = _notes;
-    final visible = hasBump && notes != null && currentVersion != null;
+    final currentVersion = prefs.currentVersion;
+
+    Widget? content;
+    if (notes != null && currentVersion != null) {
+      if (prefs.hasVersionBumped) {
+        content = _BannerContent(
+          key: const ValueKey('post-update'),
+          icon: Icons.auto_awesome,
+          label: "What's new in v$currentVersion",
+          semanticsLabel:
+              "What's new in v$currentVersion. Tap View for details.",
+          actionLabel: 'View',
+          onAction: _viewReleaseNotes,
+          onDismiss: _dismissPostUpdate,
+        );
+      } else if (prefs.isUpdateAvailable(notes.tagName)) {
+        content = _BannerContent(
+          key: const ValueKey('update-available'),
+          icon: Icons.system_update_alt,
+          label: 'Update available · ${notes.tagName}',
+          semanticsLabel:
+              'Update available ${notes.tagName}. Tap Open to view the release.',
+          actionLabel: 'Open',
+          onAction: _openLatestRelease,
+          onDismiss: _dismissUpdateAvailable,
+        );
+      }
+    }
 
     return AnimatedSize(
       duration: const Duration(milliseconds: 200),
       curve: Curves.easeInOut,
       alignment: Alignment.topCenter,
-      child: visible
-          ? _BannerContent(
-              versionLabel: 'v$currentVersion',
-              onView: _viewDetails,
-              onDismiss: _dismiss,
-            )
-          : const SizedBox.shrink(),
+      child: content ?? const SizedBox.shrink(),
     );
   }
 }
 
 class _BannerContent extends StatelessWidget {
   const _BannerContent({
-    required this.versionLabel,
-    required this.onView,
+    required this.icon,
+    required this.label,
+    required this.semanticsLabel,
+    required this.actionLabel,
+    required this.onAction,
     required this.onDismiss,
+    super.key,
   });
 
-  final String versionLabel;
-  final VoidCallback onView;
+  final IconData icon;
+  final String label;
+  final String semanticsLabel;
+  final String actionLabel;
+  final VoidCallback onAction;
   final VoidCallback onDismiss;
 
   @override
@@ -100,10 +157,10 @@ class _BannerContent extends StatelessWidget {
     return Material(
       color: Colors.transparent,
       child: Semantics(
-        label: "What's new in $versionLabel. Tap View for details.",
+        label: semanticsLabel,
         button: true,
         child: InkWell(
-          onTap: onView,
+          onTap: onAction,
           child: Container(
             constraints: const BoxConstraints(minHeight: 48),
             padding: const EdgeInsets.only(left: 12, right: 4),
@@ -113,11 +170,11 @@ class _BannerContent extends StatelessWidget {
             ),
             child: Row(
               children: [
-                Icon(Icons.auto_awesome, size: 18, color: cs.primary),
+                Icon(icon, size: 18, color: cs.primary),
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
-                    "What's new in $versionLabel",
+                    label,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: tt.bodySmall?.copyWith(
@@ -127,8 +184,8 @@ class _BannerContent extends StatelessWidget {
                   ),
                 ),
                 TextButton(
-                  onPressed: onView,
-                  child: const Text('View'),
+                  onPressed: onAction,
+                  child: Text(actionLabel),
                 ),
                 IconButton(
                   tooltip: 'Dismiss',

--- a/test/features/whats_new/whats_new_banner_test.dart
+++ b/test/features/whats_new/whats_new_banner_test.dart
@@ -165,6 +165,85 @@ void main() {
     expect(find.text('detail-page-stub'), findsOneWidget);
   });
 
+  testWidgets('shows update-available when latest tag is newer than installed',
+      (tester) async {
+    final prefs = await _prefsWith(current: '1.0.0');
+    final releases = _releasesService(cacheDir: tempDir);
+
+    await tester.runAsync(() async {
+      await tester.pumpWidget(_harness(prefs: prefs, releases: releases));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Update available'), findsOneWidget);
+    expect(find.text('Open'), findsOneWidget);
+  });
+
+  testWidgets('Open launches the GitHub release URL externally',
+      (tester) async {
+    final prefs = await _prefsWith(current: '1.0.0');
+    final releases = _releasesService(cacheDir: tempDir);
+    final launched = <Uri>[];
+
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, __) => Scaffold(
+            body: Column(
+              children: [
+                WhatsNewBanner(
+                  linkLauncher: (uri) async {
+                    launched.add(uri);
+                    return true;
+                  },
+                ),
+                const Expanded(child: SizedBox()),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+
+    await tester.runAsync(() async {
+      await tester.pumpWidget(
+        _harness(prefs: prefs, releases: releases, router: router),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    expect(
+      launched.single.toString(),
+      'https://github.com/Quantumheart/Kohera/releases/tag/v1.4.0',
+    );
+  });
+
+  testWidgets('dismissing update-available persists tag and hides banner',
+      (tester) async {
+    final prefs = await _prefsWith(current: '1.0.0');
+    final releases = _releasesService(cacheDir: tempDir);
+
+    await tester.runAsync(() async {
+      await tester.pumpWidget(_harness(prefs: prefs, releases: releases));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Update available'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Dismiss'));
+    await tester.pumpAndSettle();
+
+    expect(prefs.lastDismissedUpdateTag, 'v1.4.0');
+    expect(find.textContaining('Update available'), findsNothing);
+  });
+
   testWidgets('stays hidden when release notes fail to load', (tester) async {
     final prefs = await _prefsWith(lastSeen: '1.0.0', current: '1.4.0');
     final releases = _releasesService(


### PR DESCRIPTION
## Summary
- `WhatsNewBanner` now has a second mode: when GitHub's latest release tag is newer than the installed version, it shows "Update available · vX" and opens the GitHub release page externally.
- `PreferencesService` gains `lastDismissedUpdateTag` / `markUpdateDismissed()` / `isUpdateAvailable(tag)` so a dismissed update stays hidden until a newer tag is published.
- Banner now fetches release notes unconditionally on mount (was gated on `hasVersionBumped`), relying on the service's existing 6h TTL + ETag revalidation to keep this cheap.

Existing post-update banner behavior (in-app release notes after a local version bump) is unchanged.

## Test plan
- [x] `flutter test test/features/whats_new/whats_new_banner_test.dart` (8/8 pass, including 3 new tests for update-available render, external launch, and dismiss persistence)
- [x] `flutter analyze` on touched files — clean
- [x] Manual: run on Linux with a stale local version, confirm banner appears and "Open" launches the GitHub release page in browser
- [x] Manual: dismiss banner, restart app, confirm it stays hidden until a newer tag is published

## Notes / follow-ups
- No `AppLifecycleState.resumed` hook — relies on cold-start fetch + 6h cache TTL. Add later if needed.
- For store-distributed builds (Play/App Store/web), gate this behind a build flag and use the platform update API instead. Not relevant until those targets ship.