### PR TITLE
feat(outbox): drain queue on connectivity restore

### DIFF
--- a/lib/core/services/matrix_service.dart
+++ b/lib/core/services/matrix_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:kohera/core/services/session_backup.dart';
 import 'package:kohera/core/services/sub_services/auth_service.dart';
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart';
+import 'package:kohera/core/services/sub_services/outbox_connectivity.dart';
 import 'package:kohera/core/services/sub_services/outbox_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/core/services/sub_services/sync_service.dart';
@@ -62,7 +63,11 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
     );
     callPushRuleManager = CallPushRuleManager(client: _client);
     keyMirror = MegolmKeyMirror(client: _client, clientName: clientName);
-    outbox = OutboxService(client: _client, clientName: clientName);
+    outbox = OutboxService(
+      client: _client,
+      clientName: clientName,
+      connectivity: RealOutboxConnectivity(),
+    );
     auth.addListener(_onAuthChanged);
   }
 

--- a/lib/core/services/sub_services/outbox_connectivity.dart
+++ b/lib/core/services/sub_services/outbox_connectivity.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+abstract class OutboxConnectivity {
+  Stream<bool> get onlineChanges;
+  Future<bool> isOnline();
+  Future<void> dispose();
+}
+
+class RealOutboxConnectivity implements OutboxConnectivity {
+  RealOutboxConnectivity() : _connectivity = Connectivity();
+
+  final Connectivity _connectivity;
+
+  @override
+  Stream<bool> get onlineChanges =>
+      _connectivity.onConnectivityChanged.map(_anyOnline);
+
+  @override
+  Future<bool> isOnline() async {
+    final results = await _connectivity.checkConnectivity();
+    return _anyOnline(results);
+  }
+
+  static bool _anyOnline(List<ConnectivityResult> results) =>
+      results.any((r) => r != ConnectivityResult.none);
+
+  @override
+  Future<void> dispose() async {}
+}

--- a/lib/core/services/sub_services/outbox_service.dart
+++ b/lib/core/services/sub_services/outbox_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
+import 'package:kohera/core/services/sub_services/outbox_connectivity.dart';
 import 'package:kohera/core/services/sub_services/outbox_database.dart';
 import 'package:matrix/matrix.dart';
 
@@ -44,27 +45,37 @@ class OutboxService extends ChangeNotifier {
     required Client client,
     required String clientName,
     OutboxDatabase? databaseOverride,
+    OutboxConnectivity? connectivity,
     @visibleForTesting math.Random? random,
     @visibleForTesting Duration Function(int attempts)? backoffOverride,
     @visibleForTesting int? recentTimelineLookback,
+    @visibleForTesting Duration? connectivityDebounce,
   })  : _client = client,
         _db = databaseOverride ?? OutboxDatabase(clientName: clientName),
+        _connectivity = connectivity,
         _random = random ?? math.Random(),
         _backoffOverride = backoffOverride,
-        _recentLookback = recentTimelineLookback ?? 50;
+        _recentLookback = recentTimelineLookback ?? 50,
+        _connectivityDebounce =
+            connectivityDebounce ?? const Duration(seconds: 2);
 
   static const int kMaxAttempts = 8;
   static const Duration kMaxBackoff = Duration(seconds: 60);
 
   final Client _client;
   final OutboxDatabase _db;
+  final OutboxConnectivity? _connectivity;
   final math.Random _random;
   final Duration Function(int)? _backoffOverride;
   final int _recentLookback;
+  final Duration _connectivityDebounce;
 
   final Map<String, _Entry> _entries = {};
   StreamSubscription<SyncUpdate>? _syncSub;
   StreamSubscription<Event>? _timelineSub;
+  StreamSubscription<bool>? _connectivitySub;
+  Timer? _drainDebounceTimer;
+  bool _wasOffline = false;
   bool _started = false;
   bool _scanned = false;
   bool _disposed = false;
@@ -86,10 +97,50 @@ class OutboxService extends ChangeNotifier {
     debugPrint('[Kohera] outbox: start');
     _timelineSub = _client.onTimelineEvent.stream.listen(_onTimelineEvent);
     _syncSub = _client.onSync.stream.listen((_) {
-      if (_scanned) return;
-      _scanned = true;
-      unawaited(_initialScan());
+      if (!_scanned) {
+        _scanned = true;
+        unawaited(_initialScan());
+      }
+      if (_wasOffline) {
+        debugPrint('[Kohera] outbox: sync resumed after offline, draining');
+        _wasOffline = false;
+        _scheduleDrain(immediate: true);
+      }
     });
+    final c = _connectivity;
+    if (c != null) {
+      _wasOffline = !(await c.isOnline());
+      _connectivitySub = c.onlineChanges.listen((online) {
+        debugPrint('[Kohera] outbox: connectivity online=$online');
+        if (!online) {
+          _wasOffline = true;
+          return;
+        }
+        if (_wasOffline) {
+          _wasOffline = false;
+          _scheduleDrain();
+        }
+      });
+    }
+  }
+
+  void _scheduleDrain({bool immediate = false}) {
+    if (_disposed) return;
+    _drainDebounceTimer?.cancel();
+    final delay = immediate ? Duration.zero : _connectivityDebounce;
+    _drainDebounceTimer = Timer(delay, () {
+      if (_disposed) return;
+      _drain();
+    });
+  }
+
+  void _drain() {
+    debugPrint('[Kohera] outbox: drain (${_entries.length} entries)');
+    for (final entry in _entries.values.toList()) {
+      if (entry.inFlight || entry.finalFailed) continue;
+      entry.nextRetryAt = DateTime.now();
+      _scheduleRetry(entry);
+    }
   }
 
   Future<void> _initialScan() async {
@@ -294,6 +345,9 @@ class OutboxService extends ChangeNotifier {
   @visibleForTesting
   Future<void> retryNowForTest(String txid) => _retry(txid);
 
+  @visibleForTesting
+  void drainNowForTest() => _drain();
+
   @override
   void dispose() {
     _disposed = true;
@@ -302,11 +356,17 @@ class OutboxService extends ChangeNotifier {
       e.timer?.cancel();
     }
     _entries.clear();
+    _drainDebounceTimer?.cancel();
+    _drainDebounceTimer = null;
     unawaited(_syncSub?.cancel());
     unawaited(_timelineSub?.cancel());
+    unawaited(_connectivitySub?.cancel());
     _syncSub = null;
     _timelineSub = null;
+    _connectivitySub = null;
     unawaited(_db.close());
+    final c = _connectivity;
+    if (c != null) unawaited(c.dispose());
     super.dispose();
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -226,7 +226,7 @@ packages:
     source: hosted
     version: "1.19.1"
   connectivity_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: connectivity_plus
       sha256: "33bae12a398f841c6cda09d1064212957265869104c478e5ad51e2fb26c3973c"
@@ -913,10 +913,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1678,18 +1678,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.15"
   timezone:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   cached_network_image_platform_interface: ^4.0.0
   canonical_json: ^1.1.2
   clock: ^1.1.1
+  connectivity_plus: ^7.0.0
   desktop_drop: ^0.7.0
   desktop_notifications: ^0.6.3
   dynamic_color: ^1.7.0

--- a/test/services/outbox_service_test.dart
+++ b/test/services/outbox_service_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/services/sub_services/outbox_connectivity.dart';
 import 'package:kohera/core/services/sub_services/outbox_database.dart';
 import 'package:kohera/core/services/sub_services/outbox_service.dart';
 import 'package:matrix/matrix.dart';
@@ -31,6 +32,29 @@ class _StubDatabase extends Fake implements DatabaseApi {
       onlySending
           ? (sendingByRoom[room.id] ?? const [])
           : (allByRoom[room.id] ?? const []);
+}
+
+class _FakeConnectivity implements OutboxConnectivity {
+  _FakeConnectivity({bool initiallyOnline = true}) : _online = initiallyOnline;
+
+  final StreamController<bool> _ctrl = StreamController<bool>.broadcast();
+  bool _online;
+
+  @override
+  Stream<bool> get onlineChanges => _ctrl.stream;
+
+  @override
+  Future<bool> isOnline() async => _online;
+
+  void emit(bool online) {
+    _online = online;
+    _ctrl.add(online);
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _ctrl.close();
+  }
 }
 
 class _MemoryOutboxDb extends OutboxDatabase {
@@ -236,6 +260,78 @@ void main() {
       final a3 = mid(3).inMilliseconds;
       expect(a1, inInclusiveRange(2 * 750, 2 * 1250));
       expect(a3, inInclusiveRange(8 * 750, 8 * 1250));
+      service.dispose();
+    });
+  });
+
+  test('connectivity: offline→online drain after debounce', () {
+    fakeAsync((async) {
+      final stuck = _stubEvent(
+        txid: 'tx6',
+        eventId: r'$tx6',
+        status: EventStatus.error,
+      );
+      when(client.database).thenReturn(
+        _StubDatabase(sendingByRoom: {'!r:s': [stuck]}),
+      );
+      final fakeConn = _FakeConnectivity(initiallyOnline: false);
+      final service = OutboxService(
+        client: client,
+        clientName: 'test',
+        databaseOverride: _MemoryOutboxDb(),
+        connectivity: fakeConn,
+        backoffOverride: (_) => const Duration(hours: 1),
+        connectivityDebounce: const Duration(milliseconds: 500),
+      );
+      unawaited(service.start());
+      unawaited(service.runScanForTest());
+      async.elapse(const Duration(seconds: 1));
+      clearInteractions(stuck);
+
+      fakeConn.emit(true);
+      async.elapse(const Duration(milliseconds: 100));
+      verifyNever(stuck.sendAgain(txid: anyNamed('txid')));
+      async.elapse(const Duration(milliseconds: 600));
+      verify(stuck.sendAgain(txid: 'tx6')).called(greaterThanOrEqualTo(1));
+      service.dispose();
+    });
+  });
+
+  test('connectivity: rapid flaps debounced to single drain', () {
+    fakeAsync((async) {
+      final stuck = _stubEvent(
+        txid: 'tx7',
+        eventId: r'$tx7',
+        status: EventStatus.error,
+      );
+      when(client.database).thenReturn(
+        _StubDatabase(sendingByRoom: {'!r:s': [stuck]}),
+      );
+      final fakeConn = _FakeConnectivity(initiallyOnline: false);
+      final service = OutboxService(
+        client: client,
+        clientName: 'test',
+        databaseOverride: _MemoryOutboxDb(),
+        connectivity: fakeConn,
+        backoffOverride: (_) => const Duration(hours: 1),
+        connectivityDebounce: const Duration(milliseconds: 500),
+      );
+      unawaited(service.start());
+      unawaited(service.runScanForTest());
+      async.elapse(const Duration(seconds: 1));
+      clearInteractions(stuck);
+
+      fakeConn.emit(true);
+      async.elapse(const Duration(milliseconds: 100));
+      fakeConn.emit(false);
+      async.elapse(const Duration(milliseconds: 100));
+      fakeConn.emit(true);
+      async.elapse(const Duration(milliseconds: 100));
+      fakeConn.emit(false);
+      async.elapse(const Duration(milliseconds: 100));
+      fakeConn.emit(true);
+      async.elapse(const Duration(milliseconds: 600));
+      verify(stuck.sendAgain(txid: 'tx7')).called(1);
       service.dispose();
     });
   });


### PR DESCRIPTION
Closes part of #422. Builds on #427.

## Summary
- New `OutboxConnectivity` adapter; `RealOutboxConnectivity` wraps `connectivity_plus` 7.x and exposes `Stream<bool> onlineChanges` + `Future<bool> isOnline()`.
- `OutboxService` accepts an optional `OutboxConnectivity`. On true offline → online transition, debounces 2s then drains: every non-`finalFailed`, non-in-flight entry has its `nextRetryAt` set to now and timer rescheduled, so stuck events retry immediately without waiting out their full backoff window.
- Sync-resume fallback: if a sync event arrives while `_wasOffline=true`, drain immediately. Covers platforms where `connectivity_plus` is unreliable (Linux/web).
- Initial offline state seeded from `isOnline()` on `start()` so the first sync post-login can also trigger a drain.

## Test plan
- [x] `flutter analyze` clean
- [x] New tests: offline→online drains after debounce, rapid flaps collapse to single drain
- [x] `flutter test` full suite (1655 tests)

## Out of scope (deferred)
- #424 file persistence + E2 ciphertext store
- #425 timeline pending/failed UI + retry/discard
- #426 cross-account global outbox view