### PR TITLE
fix(chat): fall back to mxc thumbnail when video has no thumbnail_url

### DIFF
--- a/lib/features/chat/widgets/video_bubble.dart
+++ b/lib/features/chat/widgets/video_bubble.dart
@@ -84,11 +84,23 @@ class _VideoBubbleState extends State<VideoBubble> {
           });
         }
       } else {
-        final uri = await widget.event.getAttachmentUri(
+        var uri = await widget.event.getAttachmentUri(
           getThumbnail: true,
           width: 280,
           height: 260,
         );
+        if (uri == null) {
+          // Fallback: derive a server-generated thumbnail directly from the
+          // attachment mxc URL when the event has no explicit thumbnail_url.
+          final mxc = widget.event.attachmentMxcUrl;
+          if (mxc != null) {
+            uri = await mxc.getThumbnailUri(
+              widget.event.room.client,
+              width: 280,
+              height: 260,
+            );
+          }
+        }
         if (mounted) {
           setState(() {
             _thumbUrl = uri?.toString();


### PR DESCRIPTION
## Summary
- Videos uploaded without a client-generated thumbnail (no \`thumbnail_url\` in event content) rendered as the grey placeholder because \`event.getAttachmentUri(getThumbnail: true)\` could return null.
- Fall back to deriving a server-generated thumbnail directly from the attachment mxc URL via \`mxc.getThumbnailUri(client, ...)\`. Encrypted videos still skip the fallback (server can't thumbnail encrypted blobs).

Closes #220.

## Test plan
- [x] Send an MP4 from a client that doesn't generate a thumbnail (e.g. Kohera's file-upload path) into an unencrypted room → bubble shows a thumbnail, not the placeholder.
- [x] Send an MP4 with an explicit \`thumbnail_url\` → still renders correctly (regression check).
- [x] Send an MP4 in an E2EE room → falls through to existing encrypted path; behavior unchanged.
- [x] \`flutter analyze\` clean.