### PR TITLE
fix(spaces): expose space context menu on mobile + polish drawer

### DIFF
--- a/lib/features/home/widgets/mobile_space_drawer.dart
+++ b/lib/features/home/widgets/mobile_space_drawer.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kohera/core/routing/route_names.dart';
+import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/rooms/widgets/invite_dialog.dart';
 import 'package:kohera/features/spaces/widgets/space_action_dialog.dart';
@@ -10,6 +11,62 @@ import 'package:kohera/features/spaces/widgets/space_context_menu.dart';
 import 'package:kohera/shared/widgets/room_avatar.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
+
+enum _AddSpaceAction { create, join, discover }
+
+Future<void> _showAddSpaceChooser(BuildContext context) async {
+  final cs = Theme.of(context).colorScheme;
+  final action = await showDialog<_AddSpaceAction>(
+    context: context,
+    builder: (ctx) => SimpleDialog(
+      title: const Text('Add space'),
+      children: [
+        SimpleDialogOption(
+          onPressed: () => Navigator.pop(ctx, _AddSpaceAction.create),
+          child: Row(
+            children: [
+              Icon(Icons.add_circle_outline, color: cs.primary),
+              const SizedBox(width: 16),
+              const Text('Create space'),
+            ],
+          ),
+        ),
+        SimpleDialogOption(
+          onPressed: () => Navigator.pop(ctx, _AddSpaceAction.join),
+          child: Row(
+            children: [
+              Icon(Icons.tag, color: cs.primary),
+              const SizedBox(width: 16),
+              const Text('Join with address'),
+            ],
+          ),
+        ),
+        SimpleDialogOption(
+          onPressed: () => Navigator.pop(ctx, _AddSpaceAction.discover),
+          child: Row(
+            children: [
+              Icon(Icons.travel_explore, color: cs.primary),
+              const SizedBox(width: 16),
+              const Text('Explore spaces'),
+            ],
+          ),
+        ),
+      ],
+    ),
+  );
+
+  if (action == null || !context.mounted) return;
+  final matrix = context.read<MatrixService>();
+  Navigator.of(context).pop();
+  switch (action) {
+    case _AddSpaceAction.create:
+      await CreateSpaceDialog.show(context, matrixService: matrix);
+    case _AddSpaceAction.join:
+      await JoinSpaceDialog.show(context, matrixService: matrix);
+    case _AddSpaceAction.discover:
+      await SpaceDiscoveryDialog.show(context, matrixService: matrix);
+  }
+}
 
 class MobileSpaceDrawer extends StatelessWidget {
   const MobileSpaceDrawer({super.key});
@@ -119,31 +176,11 @@ class MobileSpaceDrawer extends StatelessWidget {
               ),
             ),
             const Divider(height: 1),
-            Builder(
-              builder: (btnContext) => ListTile(
-                leading: Icon(Icons.add_circle_outline, color: cs.primary),
-                title: const Text('Add space'),
-                subtitle: const Text('Create, join, or explore'),
-                onTap: () {
-                  final box = btnContext.findRenderObject()! as RenderBox;
-                  final overlay = Overlay.of(btnContext)
-                      .context
-                      .findRenderObject()! as RenderBox;
-                  final topLeft = box.localToGlobal(
-                    Offset.zero,
-                    ancestor: overlay,
-                  );
-                  unawaited(showSpaceActionMenu(
-                    btnContext,
-                    RelativeRect.fromLTRB(
-                      topLeft.dx,
-                      topLeft.dy,
-                      overlay.size.width - topLeft.dx - box.size.width,
-                      overlay.size.height - topLeft.dy - box.size.height,
-                    ),
-                  ),);
-                },
-              ),
+            ListTile(
+              leading: Icon(Icons.add_circle_outline, color: cs.primary),
+              title: const Text('Add space'),
+              subtitle: const Text('Create, join, or explore'),
+              onTap: () => unawaited(_showAddSpaceChooser(context)),
             ),
           ],
         ),

--- a/lib/features/home/widgets/mobile_space_drawer.dart
+++ b/lib/features/home/widgets/mobile_space_drawer.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kohera/core/routing/route_names.dart';
-import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/rooms/widgets/invite_dialog.dart';
 import 'package:kohera/features/spaces/widgets/space_action_dialog.dart';
@@ -12,60 +11,32 @@ import 'package:kohera/shared/widgets/room_avatar.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 
-enum _AddSpaceAction { create, join, discover }
-
 Future<void> _showAddSpaceChooser(BuildContext context) async {
   final cs = Theme.of(context).colorScheme;
-  final action = await showDialog<_AddSpaceAction>(
+  final action = await showDialog<SpaceAction>(
     context: context,
     builder: (ctx) => SimpleDialog(
       title: const Text('Add space'),
       children: [
-        SimpleDialogOption(
-          onPressed: () => Navigator.pop(ctx, _AddSpaceAction.create),
-          child: Row(
-            children: [
-              Icon(Icons.add_circle_outline, color: cs.primary),
-              const SizedBox(width: 16),
-              const Text('Create space'),
-            ],
+        for (final entry in spaceActionEntries)
+          SimpleDialogOption(
+            onPressed: () => Navigator.pop(ctx, entry.action),
+            child: Row(
+              children: [
+                Icon(entry.icon, color: cs.primary),
+                const SizedBox(width: 16),
+                Text(entry.label),
+              ],
+            ),
           ),
-        ),
-        SimpleDialogOption(
-          onPressed: () => Navigator.pop(ctx, _AddSpaceAction.join),
-          child: Row(
-            children: [
-              Icon(Icons.tag, color: cs.primary),
-              const SizedBox(width: 16),
-              const Text('Join with address'),
-            ],
-          ),
-        ),
-        SimpleDialogOption(
-          onPressed: () => Navigator.pop(ctx, _AddSpaceAction.discover),
-          child: Row(
-            children: [
-              Icon(Icons.travel_explore, color: cs.primary),
-              const SizedBox(width: 16),
-              const Text('Explore spaces'),
-            ],
-          ),
-        ),
       ],
     ),
   );
 
   if (action == null || !context.mounted) return;
-  final matrix = context.read<MatrixService>();
   Navigator.of(context).pop();
-  switch (action) {
-    case _AddSpaceAction.create:
-      await CreateSpaceDialog.show(context, matrixService: matrix);
-    case _AddSpaceAction.join:
-      await JoinSpaceDialog.show(context, matrixService: matrix);
-    case _AddSpaceAction.discover:
-      await SpaceDiscoveryDialog.show(context, matrixService: matrix);
-  }
+  if (!context.mounted) return;
+  await runSpaceAction(context, action);
 }
 
 class MobileSpaceDrawer extends StatelessWidget {

--- a/lib/features/home/widgets/mobile_space_drawer.dart
+++ b/lib/features/home/widgets/mobile_space_drawer.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kohera/core/routing/route_names.dart';
-import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/rooms/widgets/invite_dialog.dart';
 import 'package:kohera/features/spaces/widgets/space_action_dialog.dart';
@@ -26,14 +25,16 @@ class MobileSpaceDrawer extends StatelessWidget {
 
     return Drawer(
       child: SafeArea(
-        child: ListView(
-          padding: EdgeInsets.zero,
+        child: Column(
           children: [
             Padding(
               padding: const EdgeInsets.fromLTRB(20, 20, 20, 8),
-              child: Text(
-                'Spaces',
-                style: tt.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  'Spaces',
+                  style: tt.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+                ),
               ),
             ),
             ListTile(
@@ -49,93 +50,100 @@ class MobileSpaceDrawer extends StatelessWidget {
                 context.goNamed(Routes.home);
               },
             ),
-            if (topLevel.isNotEmpty) const Divider(height: 8),
-            for (final space in topLevel)
-              _SpaceTile(
-                space: space,
-                selected: selection.selectedSpaceIds.contains(space.id),
-                unread: selection.unreadCountForSpace(space.id),
+            const Divider(height: 8),
+            Expanded(
+              child: ListView(
+                padding: EdgeInsets.zero,
+                children: [
+                  for (final space in topLevel)
+                    _SpaceTile(
+                      space: space,
+                      selected: selection.selectedSpaceIds.contains(space.id),
+                      unread: selection.unreadCountForSpace(space.id),
+                      onTap: () {
+                        selection.selectSpace(space.id);
+                        Navigator.of(context).pop();
+                        context.goNamed(Routes.home);
+                      },
+                      onMenuRequested: (anchorContext) {
+                        final box =
+                            anchorContext.findRenderObject()! as RenderBox;
+                        final overlay = Overlay.of(anchorContext)
+                            .context
+                            .findRenderObject()! as RenderBox;
+                        final position = box.localToGlobal(
+                          Offset(box.size.width / 2, box.size.height / 2),
+                          ancestor: overlay,
+                        );
+                        unawaited(showSpaceContextMenu(
+                          anchorContext,
+                          RelativeRect.fromSize(
+                              position & Size.zero, overlay.size,),
+                          space,
+                        ),);
+                      },
+                    ),
+                  if (invited.isNotEmpty) ...[
+                    const Divider(height: 8),
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(20, 8, 20, 4),
+                      child: Text(
+                        'Invited',
+                        style: tt.labelLarge?.copyWith(
+                          color: cs.onSurfaceVariant,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                    for (final space in invited)
+                      ListTile(
+                        leading: Opacity(
+                          opacity: 0.7,
+                          child: RoomAvatarWidget(room: space, size: 36),
+                        ),
+                        title: Text(space.getLocalizedDisplayname()),
+                        onTap: () async {
+                          final result =
+                              await InviteDialog.show(context, room: space);
+                          if (result == true && context.mounted) {
+                            selection.selectSpace(space.id);
+                            if (context.mounted) {
+                              Navigator.of(context).pop();
+                              context.goNamed(Routes.home);
+                            }
+                          }
+                        },
+                      ),
+                  ],
+                ],
+              ),
+            ),
+            const Divider(height: 1),
+            Builder(
+              builder: (btnContext) => ListTile(
+                leading: Icon(Icons.add_circle_outline, color: cs.primary),
+                title: const Text('Add space'),
+                subtitle: const Text('Create, join, or explore'),
                 onTap: () {
-                  selection.selectSpace(space.id);
-                  Navigator.of(context).pop();
-                  context.goNamed(Routes.home);
-                },
-                onLongPress: (tileContext) {
-                  final box = tileContext.findRenderObject()! as RenderBox;
-                  final overlay = Overlay.of(tileContext)
+                  final box = btnContext.findRenderObject()! as RenderBox;
+                  final overlay = Overlay.of(btnContext)
                       .context
                       .findRenderObject()! as RenderBox;
-                  final position = box.localToGlobal(
-                    Offset(box.size.width / 2, box.size.height / 2),
+                  final topLeft = box.localToGlobal(
+                    Offset.zero,
                     ancestor: overlay,
                   );
-                  unawaited(showSpaceContextMenu(
-                    tileContext,
-                    RelativeRect.fromSize(position & Size.zero, overlay.size),
-                    space,
+                  unawaited(showSpaceActionMenu(
+                    btnContext,
+                    RelativeRect.fromLTRB(
+                      topLeft.dx,
+                      topLeft.dy,
+                      overlay.size.width - topLeft.dx - box.size.width,
+                      overlay.size.height - topLeft.dy - box.size.height,
+                    ),
                   ),);
                 },
               ),
-            if (invited.isNotEmpty) ...[
-              const Divider(height: 8),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(20, 8, 20, 4),
-                child: Text(
-                  'Invited',
-                  style: tt.labelLarge?.copyWith(
-                    color: cs.onSurfaceVariant,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ),
-              for (final space in invited)
-                ListTile(
-                  leading: Opacity(
-                    opacity: 0.7,
-                    child: RoomAvatarWidget(room: space, size: 36),
-                  ),
-                  title: Text(space.getLocalizedDisplayname()),
-                  onTap: () async {
-                    final result = await InviteDialog.show(context, room: space);
-                    if (result == true && context.mounted) {
-                      selection.selectSpace(space.id);
-                      if (context.mounted) {
-                        Navigator.of(context).pop();
-                        context.goNamed(Routes.home);
-                      }
-                    }
-                  },
-                ),
-            ],
-            const Divider(height: 8),
-            ListTile(
-              leading: Icon(Icons.add_circle_outline, color: cs.primary),
-              title: const Text('Create space'),
-              onTap: () {
-                final matrix = context.read<MatrixService>();
-                Navigator.of(context).pop();
-                unawaited(CreateSpaceDialog.show(context, matrixService: matrix));
-              },
-            ),
-            ListTile(
-              leading: Icon(Icons.tag, color: cs.primary),
-              title: const Text('Join space'),
-              onTap: () {
-                final matrix = context.read<MatrixService>();
-                Navigator.of(context).pop();
-                unawaited(JoinSpaceDialog.show(context, matrixService: matrix));
-              },
-            ),
-            ListTile(
-              leading: Icon(Icons.travel_explore, color: cs.primary),
-              title: const Text('Explore spaces'),
-              onTap: () {
-                final matrix = context.read<MatrixService>();
-                Navigator.of(context).pop();
-                unawaited(
-                  SpaceDiscoveryDialog.show(context, matrixService: matrix),
-                );
-              },
             ),
           ],
         ),
@@ -150,43 +158,70 @@ class _SpaceTile extends StatelessWidget {
     required this.selected,
     required this.unread,
     required this.onTap,
-    this.onLongPress,
+    this.onMenuRequested,
   });
 
   final Room space;
   final bool selected;
   final int unread;
   final VoidCallback onTap;
-  final void Function(BuildContext tileContext)? onLongPress;
+  final void Function(BuildContext anchorContext)? onMenuRequested;
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     return Builder(
-      builder: (tileContext) => ListTile(
-        leading: RoomAvatarWidget(room: space, size: 36),
-        title: Text(space.getLocalizedDisplayname()),
-        selected: selected,
-        trailing: unread > 0
-            ? Container(
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-                decoration: BoxDecoration(
-                  color: cs.primary,
-                  borderRadius: BorderRadius.circular(10),
-                ),
-                child: Text(
-                  unread > 99 ? '99+' : '$unread',
-                  style: TextStyle(
-                    color: cs.onPrimary,
-                    fontSize: 12,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              )
-            : null,
-        onTap: onTap,
-        onLongPress: onLongPress == null ? null : () => onLongPress!(tileContext),
-      ),
+      builder: (tileContext) {
+        Widget? trailing;
+        if (unread > 0) {
+          trailing = Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+            decoration: BoxDecoration(
+              color: cs.primary,
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Text(
+              unread > 99 ? '99+' : '$unread',
+              style: TextStyle(
+                color: cs.onPrimary,
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          );
+        }
+        if (onMenuRequested != null) {
+          final menuButton = Builder(
+            builder: (btnContext) => IconButton(
+              icon: const Icon(Icons.more_vert),
+              tooltip: 'Space options',
+              onPressed: () => onMenuRequested!(btnContext),
+            ),
+          );
+          trailing = trailing == null
+              ? menuButton
+              : Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [trailing, const SizedBox(width: 4), menuButton],
+                );
+        }
+
+        return GestureDetector(
+          onSecondaryTapUp: onMenuRequested == null
+              ? null
+              : (_) => onMenuRequested!(tileContext),
+          child: ListTile(
+            leading: RoomAvatarWidget(room: space, size: 36),
+            title: Text(space.getLocalizedDisplayname()),
+            selected: selected,
+            trailing: trailing,
+            onTap: onTap,
+            onLongPress: onMenuRequested == null
+                ? null
+                : () => onMenuRequested!(tileContext),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/features/home/widgets/mobile_space_drawer.dart
+++ b/lib/features/home/widgets/mobile_space_drawer.dart
@@ -7,6 +7,7 @@ import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/rooms/widgets/invite_dialog.dart';
 import 'package:kohera/features/spaces/widgets/space_action_dialog.dart';
+import 'package:kohera/features/spaces/widgets/space_context_menu.dart';
 import 'package:kohera/shared/widgets/room_avatar.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
@@ -58,6 +59,21 @@ class MobileSpaceDrawer extends StatelessWidget {
                   selection.selectSpace(space.id);
                   Navigator.of(context).pop();
                   context.goNamed(Routes.home);
+                },
+                onLongPress: (tileContext) {
+                  final box = tileContext.findRenderObject()! as RenderBox;
+                  final overlay = Overlay.of(tileContext)
+                      .context
+                      .findRenderObject()! as RenderBox;
+                  final position = box.localToGlobal(
+                    Offset(box.size.width / 2, box.size.height / 2),
+                    ancestor: overlay,
+                  );
+                  unawaited(showSpaceContextMenu(
+                    tileContext,
+                    RelativeRect.fromSize(position & Size.zero, overlay.size),
+                    space,
+                  ),);
                 },
               ),
             if (invited.isNotEmpty) ...[
@@ -134,38 +150,43 @@ class _SpaceTile extends StatelessWidget {
     required this.selected,
     required this.unread,
     required this.onTap,
+    this.onLongPress,
   });
 
   final Room space;
   final bool selected;
   final int unread;
   final VoidCallback onTap;
+  final void Function(BuildContext tileContext)? onLongPress;
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    return ListTile(
-      leading: RoomAvatarWidget(room: space, size: 36),
-      title: Text(space.getLocalizedDisplayname()),
-      selected: selected,
-      trailing: unread > 0
-          ? Container(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-              decoration: BoxDecoration(
-                color: cs.primary,
-                borderRadius: BorderRadius.circular(10),
-              ),
-              child: Text(
-                unread > 99 ? '99+' : '$unread',
-                style: TextStyle(
-                  color: cs.onPrimary,
-                  fontSize: 12,
-                  fontWeight: FontWeight.w600,
+    return Builder(
+      builder: (tileContext) => ListTile(
+        leading: RoomAvatarWidget(room: space, size: 36),
+        title: Text(space.getLocalizedDisplayname()),
+        selected: selected,
+        trailing: unread > 0
+            ? Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                decoration: BoxDecoration(
+                  color: cs.primary,
+                  borderRadius: BorderRadius.circular(10),
                 ),
-              ),
-            )
-          : null,
-      onTap: onTap,
+                child: Text(
+                  unread > 99 ? '99+' : '$unread',
+                  style: TextStyle(
+                    color: cs.onPrimary,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              )
+            : null,
+        onTap: onTap,
+        onLongPress: onLongPress == null ? null : () => onLongPress!(tileContext),
+      ),
     );
   }
 }

--- a/lib/features/rooms/widgets/new_room_dialog.dart
+++ b/lib/features/rooms/widgets/new_room_dialog.dart
@@ -61,19 +61,25 @@ class _NewRoomDialogState extends State<NewRoomDialog> {
   }
 
   void _initTargetSpaces() {
-    final selected = widget.parentSpaceIds ?? widget.matrixService.selection.selectedSpaceIds;
-    final eligible = <String>[];
-    for (final id in selected) {
-      final space = widget.matrixService.client.getRoomById(id);
-      if (space != null && space.canChangeStateEvent('m.space.child')) {
-        eligible.add(id);
-      }
-    }
+    final eligible = _eligibleParentSpaces();
     if (eligible.isEmpty) {
       _addToSpace = false;
     } else {
-      _targetSpaceIds.addAll(eligible);
+      _targetSpaceIds.addAll(eligible.map((s) => s.id));
     }
+  }
+
+  List<Room> _eligibleParentSpaces() {
+    final source = widget.parentSpaceIds ??
+        widget.matrixService.selection.selectedSpaceIds;
+    final eligible = <Room>[];
+    for (final id in source) {
+      final space = widget.matrixService.client.getRoomById(id);
+      if (space != null && space.canChangeStateEvent('m.space.child')) {
+        eligible.add(space);
+      }
+    }
+    return eligible;
   }
 
   void _onFocusChanged() {
@@ -223,39 +229,22 @@ class _NewRoomDialogState extends State<NewRoomDialog> {
   }
 
   List<Widget> _buildSpaceSelection() {
-    final selected = widget.matrixService.selection.selectedSpaceIds;
-    final eligible = <Room>[];
-    for (final id in selected) {
-      final space = widget.matrixService.client.getRoomById(id);
-      if (space != null && space.canChangeStateEvent('m.space.child')) {
-        eligible.add(space);
-      }
-    }
-    if (eligible.isEmpty) return [];
-
-    if (eligible.length == 1) {
-      final space = eligible.first;
-      return [
-        CheckboxListTile(
-          value: _addToSpace && _targetSpaceIds.contains(space.id),
-          onChanged: _loading
-              ? null
-              : (v) => setState(() {
-                    _addToSpace = v ?? false;
-                    if (_addToSpace) {
-                      _targetSpaceIds.add(space.id);
-                    } else {
-                      _targetSpaceIds.remove(space.id);
-                    }
-                  }),
-          title: Text('Add to ${space.getLocalizedDisplayname()}'),
-          contentPadding: EdgeInsets.zero,
-          controlAffinity: ListTileControlAffinity.leading,
-        ),
-      ];
-    }
+    final eligible = _eligibleParentSpaces();
+    if (eligible.length < 2) return [];
 
     return [
+      const SizedBox(height: 8),
+      Align(
+        alignment: Alignment.centerLeft,
+        child: Text(
+          'Add to spaces',
+          style: TextStyle(
+            fontSize: 12,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ),
       for (final space in eligible)
         CheckboxListTile(
           value: _targetSpaceIds.contains(space.id),
@@ -269,9 +258,10 @@ class _NewRoomDialogState extends State<NewRoomDialog> {
                     }
                     _addToSpace = _targetSpaceIds.isNotEmpty;
                   }),
-          title: Text('Add to ${space.getLocalizedDisplayname()}'),
+          title: Text(space.getLocalizedDisplayname()),
           contentPadding: EdgeInsets.zero,
           controlAffinity: ListTileControlAffinity.leading,
+          dense: true,
         ),
     ];
   }
@@ -358,8 +348,13 @@ class _NewRoomDialogState extends State<NewRoomDialog> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
 
+    final eligible = _eligibleParentSpaces();
+    final titleSuffix = eligible.length == 1
+        ? ' in ${eligible.first.getLocalizedDisplayname()}'
+        : '';
+
     return AlertDialog(
-      title: const Text('New Room'),
+      title: Text('New Room$titleSuffix'),
       content: SizedBox(
         width: 400,
         child: SingleChildScrollView(

--- a/lib/features/spaces/widgets/space_action_dialog.dart
+++ b/lib/features/spaces/widgets/space_action_dialog.dart
@@ -10,63 +10,77 @@ import 'package:kohera/shared/widgets/mxc_image.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 
-// ── Popover menu ────────────────────────────────────────────────
+// ── Add-space actions (shared by desktop popover and mobile dialog) ──
 
-enum _SpaceAction { create, join, discover }
+enum SpaceAction { create, join, discover }
 
-/// Shows a two-option popover anchored to the right of the "+" rail icon.
+class SpaceActionEntry {
+  const SpaceActionEntry({
+    required this.action,
+    required this.icon,
+    required this.label,
+  });
+
+  final SpaceAction action;
+  final IconData icon;
+  final String label;
+}
+
+const spaceActionEntries = <SpaceActionEntry>[
+  SpaceActionEntry(
+    action: SpaceAction.create,
+    icon: Icons.add_circle_outline,
+    label: 'Create space',
+  ),
+  SpaceActionEntry(
+    action: SpaceAction.join,
+    icon: Icons.tag,
+    label: 'Join with address',
+  ),
+  SpaceActionEntry(
+    action: SpaceAction.discover,
+    icon: Icons.travel_explore,
+    label: 'Explore spaces',
+  ),
+];
+
+Future<void> runSpaceAction(BuildContext context, SpaceAction action) async {
+  final matrix = context.read<MatrixService>();
+  switch (action) {
+    case SpaceAction.create:
+      await CreateSpaceDialog.show(context, matrixService: matrix);
+    case SpaceAction.join:
+      await JoinSpaceDialog.show(context, matrixService: matrix);
+    case SpaceAction.discover:
+      await SpaceDiscoveryDialog.show(context, matrixService: matrix);
+  }
+}
+
+/// Shows a popover anchored to the right of the "+" rail icon.
 Future<void> showSpaceActionMenu(
   BuildContext context,
   RelativeRect position,
 ) async {
-  final action = await showMenu<_SpaceAction>(
+  final action = await showMenu<SpaceAction>(
     context: context,
     position: position,
-    items: const [
-      PopupMenuItem(
-        value: _SpaceAction.create,
-        child: Row(
-          children: [
-            Icon(Icons.add_circle_outline),
-            SizedBox(width: 10),
-            Text('Create Space'),
-          ],
+    items: [
+      for (final entry in spaceActionEntries)
+        PopupMenuItem(
+          value: entry.action,
+          child: Row(
+            children: [
+              Icon(entry.icon),
+              const SizedBox(width: 10),
+              Text(entry.label),
+            ],
+          ),
         ),
-      ),
-      PopupMenuItem(
-        value: _SpaceAction.join,
-        child: Row(
-          children: [
-            Icon(Icons.tag),
-            SizedBox(width: 10),
-            Text('Join with Address'),
-          ],
-        ),
-      ),
-      PopupMenuItem(
-        value: _SpaceAction.discover,
-        child: Row(
-          children: [
-            Icon(Icons.explore_outlined),
-            SizedBox(width: 10),
-            Text('Explore spaces'),
-          ],
-        ),
-      ),
     ],
   );
 
   if (action == null || !context.mounted) return;
-
-  final matrix = context.read<MatrixService>();
-  switch (action) {
-    case _SpaceAction.create:
-      await CreateSpaceDialog.show(context, matrixService: matrix);
-    case _SpaceAction.join:
-      await JoinSpaceDialog.show(context, matrixService: matrix);
-    case _SpaceAction.discover:
-      await SpaceDiscoveryDialog.show(context, matrixService: matrix);
-  }
+  await runSpaceAction(context, action);
 }
 
 // ── Create Space dialog ─────────────────────────────────────────

--- a/test/e2e/room_management_test.dart
+++ b/test/e2e/room_management_test.dart
@@ -358,7 +358,7 @@ void main() {
       await tester.tap(find.text('Open'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Add to My Space'), findsOneWidget);
+      expect(find.text('New Room in My Space'), findsOneWidget);
 
       await tester.enterText(
         find.widgetWithText(TextField, 'Name'),

--- a/test/widgets/mobile_space_drawer_test.dart
+++ b/test/widgets/mobile_space_drawer_test.dart
@@ -76,8 +76,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Home'), findsOneWidget);
-      expect(find.text('Create space'), findsOneWidget);
-      expect(find.text('Join space'), findsOneWidget);
+      expect(find.text('Add space'), findsOneWidget);
     });
 
     testWidgets('Home tile tap clears space selection', (tester) async {


### PR DESCRIPTION
## Summary
- Adds long-press, right-click, and a trailing more_vert button to space tiles in `MobileSpaceDrawer`, so mobile users can finally reach the space context menu (Invite people, Space settings, Create room, etc.). Previously this menu was only reachable via `SpaceRail`, which is desktop-only.
- Restructures the drawer into a `Column` with an `Expanded` scrolling spaces list, so spaces grow to fill the drawer instead of pushing the bottom actions off-screen as the list grows.
- Collapses the three pinned bottom tiles (Create / Join / Explore) into a single "Add space" entry that opens `showSpaceActionMenu`, matching the pattern desktop's `+` rail icon already uses and saving ~110px of fixed chrome on short screens.

## Test plan
- [ ] Open the drawer on a narrow layout — spaces list scrolls; "Add space" stays pinned at the bottom.
- [x] Long-press a space tile — context menu appears with "Invite people".
- [ ] Tap the trailing more_vert on a space tile — same menu.
- [ ] Right-click a space tile (resized desktop window in narrow mode) — same menu.
- [ ] "Invite people" → enter mxid → invite succeeds, snackbar shown.
- [ ] Tap "Add space" → popup with Create / Join / Explore options.
- [ ] With many spaces, list scrolls in the middle while header/Home and Add space stay pinned.