### PR TITLE
feat(invite): suggest users in invite-to-room dialog

### DIFF
--- a/lib/features/rooms/widgets/invite_user_dialog.dart
+++ b/lib/features/rooms/widgets/invite_user_dialog.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:kohera/core/utils/known_contacts.dart';
 import 'package:matrix/matrix.dart' hide Visibility;
 
 /// A reusable dialog that prompts for a Matrix user ID to invite to a room.
@@ -29,10 +32,143 @@ class InviteUserDialog extends StatefulWidget {
 class _InviteUserDialogState extends State<InviteUserDialog> {
   static final _mxidRegex = RegExp(r'^@[^:]+:.+$');
   String? _error;
+  bool _searching = false;
+  List<Profile> _searchResults = [];
+  Timer? _debounce;
+  int _searchGeneration = 0;
+  List<Profile>? _cachedContacts;
+  Set<String>? _cachedMemberIds;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_onTextChanged);
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_onTextChanged);
+    _debounce?.cancel();
+    super.dispose();
+  }
+
+  // ── Suggestions data ────────────────────────────────────────
+
+  Set<String> _memberIds() {
+    return _cachedMemberIds ??= {
+      for (final u in widget.room.getParticipants()) u.id,
+    };
+  }
+
+  List<Profile> _knownContacts() {
+    final members = _memberIds();
+    return _cachedContacts ??= knownContacts(widget.room.client)
+        .where((p) => !members.contains(p.userId))
+        .toList();
+  }
+
+  // ── Search ──────────────────────────────────────────────────
+
+  void _onTextChanged() {
+    _debounce?.cancel();
+    final query = widget.controller.text.trim();
+    _searchGeneration++;
+    if (query.isEmpty) {
+      if (_searchResults.isNotEmpty || _searching) {
+        setState(() {
+          _searchResults = [];
+          _searching = false;
+        });
+      } else {
+        setState(() {});
+      }
+      return;
+    }
+    setState(() {});
+    _debounce = Timer(const Duration(milliseconds: 300), () {
+      unawaited(_searchDirectory(query));
+    });
+  }
+
+  Future<void> _searchDirectory(String query) async {
+    final gen = _searchGeneration;
+    setState(() {
+      _searching = true;
+    });
+
+    try {
+      final response = await widget.room.client
+          .searchUserDirectory(query, limit: 20);
+      if (!mounted || gen != _searchGeneration) return;
+      setState(() {
+        _searchResults = response.results;
+        _searching = false;
+      });
+    } catch (e) {
+      debugPrint('[Kohera] Invite user search failed: $e');
+      if (!mounted || gen != _searchGeneration) return;
+      setState(() => _searching = false);
+    }
+  }
+
+  // ── Submit ──────────────────────────────────────────────────
+
+  void _submit([String? override]) {
+    final mxid = (override ?? widget.controller.text).trim();
+    if (mxid.isEmpty) {
+      setState(() => _error = 'Please enter a Matrix ID');
+      return;
+    }
+    if (!_mxidRegex.hasMatch(mxid)) {
+      setState(() => _error = 'Invalid Matrix ID (use @user:server)');
+      return;
+    }
+    Navigator.pop(context, mxid);
+  }
+
+  // ── Suggestion tiles ────────────────────────────────────────
+
+  List<Widget> _suggestionTiles(ColorScheme cs) {
+    final query = widget.controller.text.trim();
+    final members = _memberIds();
+    final List<Profile> profiles;
+    if (query.isEmpty) {
+      profiles = _knownContacts();
+    } else {
+      profiles = _searchResults
+          .where((p) => !members.contains(p.userId))
+          .toList();
+    }
+    if (profiles.isEmpty) return const [];
+
+    final tiles = <Widget>[];
+    if (query.isEmpty) {
+      tiles.add(Padding(
+        padding: const EdgeInsets.only(left: 4, top: 8, bottom: 4),
+        child: Align(
+          alignment: Alignment.centerLeft,
+          child: Text(
+            'Recent contacts',
+            style: TextStyle(
+              fontSize: 12,
+              color: cs.onSurfaceVariant,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+      ),);
+    }
+    for (final p in profiles) {
+      tiles.add(_SuggestionTile(profile: p, onTap: () => _submit(p.userId)));
+    }
+    return tiles;
+  }
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
+    final tiles = _suggestionTiles(cs);
+
     return AlertDialog(
       title: const Text('Invite user'),
       content: SizedBox(
@@ -47,15 +183,33 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
                 labelText: 'Matrix ID',
                 hintText: '@user:server.com',
                 border: OutlineInputBorder(),
+                prefixIcon: Icon(Icons.search_rounded),
               ),
               onSubmitted: (_) => _submit(),
             ),
+            if (_searching)
+              const Padding(
+                padding: EdgeInsets.only(top: 4),
+                child: LinearProgressIndicator(),
+              ),
+            if (tiles.isNotEmpty)
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxHeight: 240),
+                child: ListView(
+                  shrinkWrap: true,
+                  padding: EdgeInsets.zero,
+                  children: tiles,
+                ),
+              ),
             if (_error != null)
               Padding(
                 padding: const EdgeInsets.only(top: 8),
-                child: Text(
-                  _error!,
-                  style: TextStyle(color: cs.error, fontSize: 13),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    _error!,
+                    style: TextStyle(color: cs.error, fontSize: 13),
+                  ),
                 ),
               ),
           ],
@@ -73,17 +227,47 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
       ],
     );
   }
+}
 
-  void _submit() {
-    final mxid = widget.controller.text.trim();
-    if (mxid.isEmpty) {
-      setState(() => _error = 'Please enter a Matrix ID');
-      return;
-    }
-    if (!_mxidRegex.hasMatch(mxid)) {
-      setState(() => _error = 'Invalid Matrix ID (use @user:server)');
-      return;
-    }
-    Navigator.pop(context, mxid);
+// ── Suggestion tile ───────────────────────────────────────────
+
+class _SuggestionTile extends StatelessWidget {
+  const _SuggestionTile({required this.profile, required this.onTap});
+
+  final Profile profile;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final name = profile.displayName;
+    final firstChar = (name ?? profile.userId).isNotEmpty
+        ? (name ?? profile.userId).characters.first.toUpperCase()
+        : '?';
+    return ListTile(
+      dense: true,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 4),
+      leading: CircleAvatar(
+        radius: 16,
+        backgroundColor: cs.primaryContainer,
+        child: Text(
+          firstChar,
+          style: TextStyle(color: cs.onPrimaryContainer, fontSize: 13),
+        ),
+      ),
+      title: Text(
+        name ?? profile.userId,
+        overflow: TextOverflow.ellipsis,
+        style: const TextStyle(fontSize: 14),
+      ),
+      subtitle: name != null
+          ? Text(
+              profile.userId,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(fontSize: 11),
+            )
+          : null,
+      onTap: onTap,
+    );
   }
 }

--- a/lib/features/rooms/widgets/invite_user_dialog.dart
+++ b/lib/features/rooms/widgets/invite_user_dialog.dart
@@ -8,21 +8,16 @@ import 'package:matrix/matrix.dart' hide Visibility;
 ///
 /// Returns the validated MXID string on success, or `null` if cancelled.
 class InviteUserDialog extends StatefulWidget {
-  const InviteUserDialog._({
-    required this.room,
-    required this.controller,
-  });
+  const InviteUserDialog._({required this.room});
 
   final Room room;
-  final TextEditingController controller;
 
   /// Shows the invite dialog and returns the entered MXID, or `null`.
   static Future<String?> show(BuildContext context, {required Room room}) {
-    final controller = TextEditingController();
     return showDialog<String>(
       context: context,
-      builder: (_) => InviteUserDialog._(room: room, controller: controller),
-    ).whenComplete(controller.dispose);
+      builder: (_) => InviteUserDialog._(room: room),
+    );
   }
 
   @override
@@ -30,7 +25,10 @@ class InviteUserDialog extends StatefulWidget {
 }
 
 class _InviteUserDialogState extends State<InviteUserDialog> {
+  static const _dialogWidth = 400.0;
   static final _mxidRegex = RegExp(r'^@[^:]+:.+$');
+  final _controller = TextEditingController();
+  String _query = '';
   String? _error;
   bool _searching = false;
   List<Profile> _searchResults = [];
@@ -40,14 +38,8 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
   Set<String>? _cachedMemberIds;
 
   @override
-  void initState() {
-    super.initState();
-    widget.controller.addListener(_onTextChanged);
-  }
-
-  @override
   void dispose() {
-    widget.controller.removeListener(_onTextChanged);
+    _controller.dispose();
     _debounce?.cancel();
     super.dispose();
   }
@@ -69,22 +61,19 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
 
   // ── Search ──────────────────────────────────────────────────
 
-  void _onTextChanged() {
+  void _onTextChanged(String value) {
     _debounce?.cancel();
-    final query = widget.controller.text.trim();
+    final query = value.trim();
     _searchGeneration++;
-    if (query.isEmpty) {
-      if (_searchResults.isNotEmpty || _searching) {
-        setState(() {
-          _searchResults = [];
-          _searching = false;
-        });
-      } else {
-        setState(() {});
+    setState(() {
+      _query = query;
+      _error = null;
+      if (query.isEmpty) {
+        _searchResults = [];
+        _searching = false;
       }
-      return;
-    }
-    setState(() {});
+    });
+    if (query.isEmpty) return;
     _debounce = Timer(const Duration(milliseconds: 300), () {
       unawaited(_searchDirectory(query));
     });
@@ -114,7 +103,7 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
   // ── Submit ──────────────────────────────────────────────────
 
   void _submit([String? override]) {
-    final mxid = (override ?? widget.controller.text).trim();
+    final mxid = (override ?? _controller.text).trim();
     if (mxid.isEmpty) {
       setState(() => _error = 'Please enter a Matrix ID');
       return;
@@ -126,113 +115,99 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
     Navigator.pop(context, mxid);
   }
 
-  // ── Suggestion tiles ────────────────────────────────────────
+  // ── Suggestion list ─────────────────────────────────────────
 
-  List<Widget> _suggestionTiles(ColorScheme cs) {
-    final query = widget.controller.text.trim();
+  List<Profile> _suggestions() {
+    if (_query.isEmpty) return _knownContacts();
     final members = _memberIds();
-    final List<Profile> profiles;
-    if (query.isEmpty) {
-      profiles = _knownContacts();
-    } else {
-      profiles = _searchResults
-          .where((p) => !members.contains(p.userId))
-          .toList();
-    }
-    if (profiles.isEmpty) return const [];
-
-    final tiles = <Widget>[];
-    if (query.isEmpty) {
-      tiles.add(Padding(
-        padding: const EdgeInsets.only(left: 4, top: 8, bottom: 4),
-        child: Align(
-          alignment: Alignment.centerLeft,
-          child: Text(
-            'Recent contacts',
-            style: TextStyle(
-              fontSize: 12,
-              color: cs.onSurfaceVariant,
-              fontWeight: FontWeight.w500,
-            ),
-          ),
-        ),
-      ),);
-    }
-    for (final p in profiles) {
-      tiles.add(_SuggestionTile(profile: p, onTap: () => _submit(p.userId)));
-    }
-    return tiles;
+    return _searchResults.where((p) => !members.contains(p.userId)).toList();
   }
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final tiles = _suggestionTiles(cs);
+    final suggestions = _suggestions();
+    final showHeader = _query.isEmpty && suggestions.isNotEmpty;
 
-    return AlertDialog(
+    return SimpleDialog(
       title: const Text('Invite user'),
-      content: SizedBox(
-        width: 400,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            TextField(
-              controller: widget.controller,
+      contentPadding: const EdgeInsets.only(top: 12, bottom: 8),
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(24, 0, 24, 4),
+          child: SizedBox(
+            width: _dialogWidth,
+            child: TextField(
+              controller: _controller,
               autofocus: true,
-              decoration: const InputDecoration(
-                labelText: 'Matrix ID',
+              decoration: InputDecoration(
+                labelText: 'Matrix ID or display name',
                 hintText: '@user:server.com',
-                border: OutlineInputBorder(),
-                prefixIcon: Icon(Icons.search_rounded),
+                border: const OutlineInputBorder(),
+                prefixIcon: const Icon(Icons.search_rounded),
+                errorText: _error,
               ),
+              onChanged: _onTextChanged,
               onSubmitted: (_) => _submit(),
             ),
-            if (_searching)
-              const Padding(
-                padding: EdgeInsets.only(top: 4),
-                child: LinearProgressIndicator(),
-              ),
-            if (tiles.isNotEmpty)
-              ConstrainedBox(
-                constraints: const BoxConstraints(maxHeight: 240),
-                child: ListView(
-                  shrinkWrap: true,
-                  padding: EdgeInsets.zero,
-                  children: tiles,
+          ),
+        ),
+        SizedBox(
+          width: _dialogWidth,
+          height: 4,
+          child: _searching ? const LinearProgressIndicator() : null,
+        ),
+        if (showHeader)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(24, 8, 24, 4),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                'Recent contacts',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: cs.onSurfaceVariant,
+                  fontWeight: FontWeight.w500,
                 ),
               ),
-            if (_error != null)
-              Padding(
-                padding: const EdgeInsets.only(top: 8),
-                child: Align(
-                  alignment: Alignment.centerLeft,
-                  child: Text(
-                    _error!,
-                    style: TextStyle(color: cs.error, fontSize: 13),
-                  ),
-                ),
+            ),
+          ),
+        if (suggestions.isNotEmpty)
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 280),
+            child: SizedBox(
+              width: _dialogWidth,
+              child: ListView.builder(
+                shrinkWrap: true,
+                padding: EdgeInsets.zero,
+                itemCount: suggestions.length,
+                itemBuilder: (context, i) {
+                  final p = suggestions[i];
+                  return _SuggestionOption(
+                    profile: p,
+                    onTap: () => _submit(p.userId),
+                  );
+                },
               ),
-          ],
-        ),
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(context),
-          child: const Text('Cancel'),
-        ),
-        FilledButton(
-          onPressed: _submit,
-          child: const Text('Invite'),
-        ),
+            ),
+          )
+        else if (_query.isNotEmpty && !_searching)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(24, 12, 24, 12),
+            child: Text(
+              'No matching users. Press Enter to invite by Matrix ID.',
+              style: TextStyle(fontSize: 12, color: cs.onSurfaceVariant),
+            ),
+          ),
       ],
     );
   }
 }
 
-// ── Suggestion tile ───────────────────────────────────────────
+// ── Suggestion option ─────────────────────────────────────────
 
-class _SuggestionTile extends StatelessWidget {
-  const _SuggestionTile({required this.profile, required this.onTap});
+class _SuggestionOption extends StatelessWidget {
+  const _SuggestionOption({required this.profile, required this.onTap});
 
   final Profile profile;
   final VoidCallback onTap;
@@ -244,30 +219,41 @@ class _SuggestionTile extends StatelessWidget {
     final firstChar = (name ?? profile.userId).isNotEmpty
         ? (name ?? profile.userId).characters.first.toUpperCase()
         : '?';
-    return ListTile(
-      dense: true,
-      contentPadding: const EdgeInsets.symmetric(horizontal: 4),
-      leading: CircleAvatar(
-        radius: 16,
-        backgroundColor: cs.primaryContainer,
-        child: Text(
-          firstChar,
-          style: TextStyle(color: cs.onPrimaryContainer, fontSize: 13),
-        ),
+    return SimpleDialogOption(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+      onPressed: onTap,
+      child: Row(
+        children: [
+          CircleAvatar(
+            radius: 18,
+            backgroundColor: cs.primaryContainer,
+            child: Text(
+              firstChar,
+              style: TextStyle(color: cs.onPrimaryContainer, fontSize: 14),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  name ?? profile.userId,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(fontSize: 14),
+                ),
+                if (name != null)
+                  Text(
+                    profile.userId,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(fontSize: 11, color: cs.onSurfaceVariant),
+                  ),
+              ],
+            ),
+          ),
+        ],
       ),
-      title: Text(
-        name ?? profile.userId,
-        overflow: TextOverflow.ellipsis,
-        style: const TextStyle(fontSize: 14),
-      ),
-      subtitle: name != null
-          ? Text(
-              profile.userId,
-              overflow: TextOverflow.ellipsis,
-              style: const TextStyle(fontSize: 11),
-            )
-          : null,
-      onTap: onTap,
     );
   }
 }

--- a/lib/features/rooms/widgets/room_details_panel.dart
+++ b/lib/features/rooms/widgets/room_details_panel.dart
@@ -7,6 +7,7 @@ import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/e2ee/widgets/key_verification_dialog.dart';
 import 'package:kohera/features/rooms/widgets/admin_settings_section.dart';
+import 'package:kohera/features/rooms/widgets/invite_user_dialog.dart';
 import 'package:kohera/features/rooms/widgets/room_members_section.dart';
 import 'package:kohera/features/rooms/widgets/shared_media_section.dart';
 import 'package:kohera/shared/widgets/avatar_edit_overlay.dart';
@@ -103,10 +104,7 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
   });
 
   Future<void> _showInviteDialog(Room room) async {
-    final result = await showDialog<String>(
-      context: context,
-      builder: (ctx) => _InviteUserDialog(room: room),
-    );
+    final result = await InviteUserDialog.show(context, room: room);
     if (result == null || !mounted) return;
 
     final scaffold = ScaffoldMessenger.of(context);
@@ -503,82 +501,5 @@ class _ActionButton extends StatelessWidget {
         ),
       ),
     );
-  }
-}
-
-// ── Invite dialog ──────────────────────────────────────────────
-
-class _InviteUserDialog extends StatefulWidget {
-  const _InviteUserDialog({required this.room});
-
-  final Room room;
-
-  @override
-  State<_InviteUserDialog> createState() => _InviteUserDialogState();
-}
-
-class _InviteUserDialogState extends State<_InviteUserDialog> {
-  static final _mxidRegex = RegExp(r'^@[^:]+:.+$');
-  final _controller = TextEditingController();
-  String? _error;
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    return AlertDialog(
-      title: const Text('Invite user'),
-      content: SizedBox(
-        width: 400,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            TextField(
-              controller: _controller,
-              autofocus: true,
-              decoration: const InputDecoration(
-                labelText: 'Matrix ID',
-                hintText: '@user:server.com',
-                border: OutlineInputBorder(),
-              ),
-              onSubmitted: (_) => _submit(),
-            ),
-            if (_error != null)
-              Padding(
-                padding: const EdgeInsets.only(top: 8),
-                child: Text(_error!, style: TextStyle(color: cs.error, fontSize: 13)),
-              ),
-          ],
-        ),
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(context),
-          child: const Text('Cancel'),
-        ),
-        FilledButton(
-          onPressed: _submit,
-          child: const Text('Invite'),
-        ),
-      ],
-    );
-  }
-
-  void _submit() {
-    final mxid = _controller.text.trim();
-    if (mxid.isEmpty) {
-      setState(() => _error = 'Please enter a Matrix ID');
-      return;
-    }
-    if (!_mxidRegex.hasMatch(mxid)) {
-      setState(() => _error = 'Invalid Matrix ID (use @user:server)');
-      return;
-    }
-    Navigator.pop(context, mxid);
   }
 }

--- a/test/e2e/room_management_test.dart
+++ b/test/e2e/room_management_test.dart
@@ -376,6 +376,11 @@ void main() {
   group('Room details — invite', () {
     testWidgets('invite user via room details panel', (tester) async {
       when(mockRoom.invite(any)).thenAnswer((_) async {});
+      when(mockClient.searchUserDirectory(any, limit: anyNamed('limit')))
+          .thenAnswer((_) async => SearchUserDirectoryResponse(
+                results: [],
+                limited: false,
+              ),);
       await tester.pumpWidget(buildDetailsApp());
       await tester.pumpAndSettle();
 
@@ -384,28 +389,27 @@ void main() {
 
       expect(find.text('Invite user'), findsOneWidget);
 
-      await tester.enterText(
-        find.widgetWithText(TextField, 'Matrix ID'),
-        '@bob:example.com',
-      );
-      await tester.tap(find.widgetWithText(FilledButton, 'Invite'));
+      await tester.enterText(find.byType(TextField), '@bob:example.com');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pumpAndSettle();
 
       verify(mockRoom.invite('@bob:example.com')).called(1);
     });
 
     testWidgets('invalid MXID shows error in invite dialog', (tester) async {
+      when(mockClient.searchUserDirectory(any, limit: anyNamed('limit')))
+          .thenAnswer((_) async => SearchUserDirectoryResponse(
+                results: [],
+                limited: false,
+              ),);
       await tester.pumpWidget(buildDetailsApp());
       await tester.pumpAndSettle();
 
       await tester.tap(find.text('Invite'));
       await tester.pumpAndSettle();
 
-      await tester.enterText(
-        find.widgetWithText(TextField, 'Matrix ID'),
-        'invalid-id',
-      );
-      await tester.tap(find.widgetWithText(FilledButton, 'Invite'));
+      await tester.enterText(find.byType(TextField), 'invalid-id');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pumpAndSettle();
 
       expect(
@@ -421,7 +425,7 @@ void main() {
       await tester.tap(find.text('Invite'));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.widgetWithText(FilledButton, 'Invite'));
+      await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pumpAndSettle();
 
       expect(find.text('Please enter a Matrix ID'), findsOneWidget);

--- a/test/widgets/invite_user_dialog_test.dart
+++ b/test/widgets/invite_user_dialog_test.dart
@@ -3,15 +3,26 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/features/rooms/widgets/invite_user_dialog.dart';
 import 'package:matrix/matrix.dart';
 import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 
-@GenerateNiceMocks([MockSpec<Room>()])
+@GenerateNiceMocks([MockSpec<Client>(), MockSpec<Room>()])
 import 'invite_user_dialog_test.mocks.dart';
 
 void main() {
   late MockRoom mockRoom;
+  late MockClient mockClient;
 
   setUp(() {
     mockRoom = MockRoom();
+    mockClient = MockClient();
+    when(mockRoom.client).thenReturn(mockClient);
+    when(mockRoom.getParticipants()).thenReturn([]);
+    when(mockClient.rooms).thenReturn([]);
+    when(mockClient.searchUserDirectory(any, limit: anyNamed('limit')))
+        .thenAnswer((_) async => SearchUserDirectoryResponse(
+              results: [],
+              limited: false,
+            ),);
   });
 
   Widget buildTestWidget({ValueChanged<String?>? onResult}) {
@@ -146,6 +157,86 @@ void main() {
       await tester.pump();
 
       expect(find.text('Please enter a Matrix ID'), findsOneWidget);
+    });
+
+    testWidgets('shows recent contacts from existing DMs', (tester) async {
+      final dmRoom = MockRoom();
+      when(dmRoom.isDirectChat).thenReturn(true);
+      when(dmRoom.directChatMatrixID).thenReturn('@bob:example.com');
+      when(dmRoom.getLocalizedDisplayname()).thenReturn('Bob');
+      when(dmRoom.avatar).thenReturn(null);
+      when(mockClient.rooms).thenReturn([dmRoom]);
+
+      await openDialog(tester);
+
+      expect(find.text('Recent contacts'), findsOneWidget);
+      expect(find.text('Bob'), findsOneWidget);
+    });
+
+    testWidgets('hides existing room members from recent contacts',
+        (tester) async {
+      final dmRoom = MockRoom();
+      when(dmRoom.isDirectChat).thenReturn(true);
+      when(dmRoom.directChatMatrixID).thenReturn('@bob:example.com');
+      when(dmRoom.getLocalizedDisplayname()).thenReturn('Bob');
+      when(dmRoom.avatar).thenReturn(null);
+      when(mockClient.rooms).thenReturn([dmRoom]);
+
+      // Bob is already in the room we're inviting to.
+      final bob = User('@bob:example.com', room: mockRoom);
+      when(mockRoom.getParticipants()).thenReturn([bob]);
+
+      await openDialog(tester);
+
+      expect(find.text('Recent contacts'), findsNothing);
+      expect(find.text('Bob'), findsNothing);
+    });
+
+    testWidgets('tapping a suggestion pops with that MXID', (tester) async {
+      String? result;
+
+      final original = FlutterError.onError;
+      FlutterError.onError = (d) {};
+      addTearDown(() => FlutterError.onError = original);
+
+      final dmRoom = MockRoom();
+      when(dmRoom.isDirectChat).thenReturn(true);
+      when(dmRoom.directChatMatrixID).thenReturn('@bob:example.com');
+      when(dmRoom.getLocalizedDisplayname()).thenReturn('Bob');
+      when(dmRoom.avatar).thenReturn(null);
+      when(mockClient.rooms).thenReturn([dmRoom]);
+
+      await openDialog(tester, onResult: (v) => result = v);
+
+      await tester.tap(find.text('Bob'));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(result, '@bob:example.com');
+    });
+
+    testWidgets('searches user directory after typing', (tester) async {
+      when(mockClient.searchUserDirectory(any, limit: anyNamed('limit')))
+          .thenAnswer((_) async => SearchUserDirectoryResponse(
+                results: [
+                  Profile(
+                    userId: '@carol:example.com',
+                    displayName: 'Carol',
+                  ),
+                ],
+                limited: false,
+              ),);
+
+      await openDialog(tester);
+
+      await tester.enterText(find.byType(TextField), 'car');
+      // debounce is 300ms
+      await tester.pump(const Duration(milliseconds: 350));
+      await tester.pumpAndSettle();
+
+      verify(mockClient.searchUserDirectory('car', limit: 20)).called(1);
+      expect(find.text('Carol'), findsOneWidget);
+      expect(find.text('@carol:example.com'), findsOneWidget);
     });
   });
 }

--- a/test/widgets/invite_user_dialog_test.dart
+++ b/test/widgets/invite_user_dialog_test.dart
@@ -53,21 +53,24 @@ void main() {
     await tester.pumpAndSettle();
   }
 
+  Future<void> submitField(WidgetTester tester) async {
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+  }
+
   group('InviteUserDialog', () {
     testWidgets('shows title and text field', (tester) async {
       await openDialog(tester);
 
       expect(find.text('Invite user'), findsOneWidget);
       expect(find.byType(TextField), findsOneWidget);
-      expect(find.text('Invite'), findsOneWidget);
-      expect(find.text('Cancel'), findsOneWidget);
     });
 
-    testWidgets('empty input shows validation error', (tester) async {
+    testWidgets('empty input on submit shows validation error',
+        (tester) async {
       await openDialog(tester);
 
-      await tester.tap(find.text('Invite'));
-      await tester.pumpAndSettle();
+      await submitField(tester);
 
       expect(find.text('Please enter a Matrix ID'), findsOneWidget);
     });
@@ -76,8 +79,7 @@ void main() {
       await openDialog(tester);
 
       await tester.enterText(find.byType(TextField), 'alice');
-      await tester.tap(find.text('Invite'));
-      await tester.pumpAndSettle();
+      await submitField(tester);
 
       expect(
         find.text('Invalid Matrix ID (use @user:server)'),
@@ -89,8 +91,7 @@ void main() {
       await openDialog(tester);
 
       await tester.enterText(find.byType(TextField), '@alice');
-      await tester.tap(find.text('Invite'));
-      await tester.pumpAndSettle();
+      await submitField(tester);
 
       expect(
         find.text('Invalid Matrix ID (use @user:server)'),
@@ -102,8 +103,7 @@ void main() {
       await openDialog(tester);
 
       await tester.enterText(find.byType(TextField), 'alice@server');
-      await tester.tap(find.text('Invite'));
-      await tester.pumpAndSettle();
+      await submitField(tester);
 
       expect(
         find.text('Invalid Matrix ID (use @user:server)'),
@@ -111,52 +111,26 @@ void main() {
       );
     });
 
-    testWidgets('valid MXID pops dialog with value', (tester) async {
+    testWidgets('valid MXID pops dialog with value on submit', (tester) async {
       String? result;
-
-      // Suppress controller-disposed errors from whenComplete in show()
-      final original = FlutterError.onError;
-      FlutterError.onError = (d) {};
-      addTearDown(() => FlutterError.onError = original);
 
       await openDialog(tester, onResult: (v) => result = v);
 
       await tester.enterText(find.byType(TextField), '@alice:matrix.org');
-      await tester.tap(find.text('Invite'));
-      await tester.pump();
-      await tester.pump(const Duration(seconds: 1));
+      await submitField(tester);
 
       expect(result, '@alice:matrix.org');
     });
 
-    testWidgets('cancel closes dialog', (tester) async {
+    testWidgets('barrier dismiss returns null', (tester) async {
       String? result = 'sentinel';
-
-      final original = FlutterError.onError;
-      FlutterError.onError = (d) {};
-      addTearDown(() => FlutterError.onError = original);
 
       await openDialog(tester, onResult: (v) => result = v);
 
-      await tester.tap(find.text('Cancel'));
-      await tester.pump();
-      await tester.pump(const Duration(seconds: 1));
+      await tester.tapAt(const Offset(10, 10));
+      await tester.pumpAndSettle();
 
       expect(result, isNull);
-    });
-
-    testWidgets('keyboard submit triggers validation', (tester) async {
-      final original = FlutterError.onError;
-      FlutterError.onError = (d) {};
-      addTearDown(() => FlutterError.onError = original);
-
-      await openDialog(tester);
-
-      await tester.enterText(find.byType(TextField), '');
-      await tester.testTextInput.receiveAction(TextInputAction.done);
-      await tester.pump();
-
-      expect(find.text('Please enter a Matrix ID'), findsOneWidget);
     });
 
     testWidgets('shows recent contacts from existing DMs', (tester) async {
@@ -195,10 +169,6 @@ void main() {
     testWidgets('tapping a suggestion pops with that MXID', (tester) async {
       String? result;
 
-      final original = FlutterError.onError;
-      FlutterError.onError = (d) {};
-      addTearDown(() => FlutterError.onError = original);
-
       final dmRoom = MockRoom();
       when(dmRoom.isDirectChat).thenReturn(true);
       when(dmRoom.directChatMatrixID).thenReturn('@bob:example.com');
@@ -209,8 +179,7 @@ void main() {
       await openDialog(tester, onResult: (v) => result = v);
 
       await tester.tap(find.text('Bob'));
-      await tester.pump();
-      await tester.pump(const Duration(seconds: 1));
+      await tester.pumpAndSettle();
 
       expect(result, '@bob:example.com');
     });
@@ -237,6 +206,20 @@ void main() {
       verify(mockClient.searchUserDirectory('car', limit: 20)).called(1);
       expect(find.text('Carol'), findsOneWidget);
       expect(find.text('@carol:example.com'), findsOneWidget);
+    });
+
+    testWidgets('shows empty-state hint when search returns no results',
+        (tester) async {
+      await openDialog(tester);
+
+      await tester.enterText(find.byType(TextField), 'nobody');
+      await tester.pump(const Duration(milliseconds: 350));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('No matching users. Press Enter to invite by Matrix ID.'),
+        findsOneWidget,
+      );
     });
   });
 }

--- a/test/widgets/invite_user_dialog_test.mocks.dart
+++ b/test/widgets/invite_user_dialog_test.mocks.dart
@@ -4,32 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i9;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
-import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
-    as _i10;
-import 'package:kohera/core/services/sub_services/selection_service.dart'
-    as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
-import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
-import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
-    as _i7;
-import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
-    as _i8;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:matrix/encryption.dart' as _i7;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i11;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/src/utils/space_child.dart' as _i10;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i8;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -737,9 +722,8 @@ class _FakeCreateContentResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakeCallPushRuleManager_65 extends _i1.SmartFake
-    implements _i7.CallPushRuleManager {
-  _FakeCallPushRuleManager_65(
+class _FakeRoomSummary_65 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -748,9 +732,8 @@ class _FakeCallPushRuleManager_65 extends _i1.SmartFake
         );
 }
 
-class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
-    implements _i8.MegolmKeyMirror {
-  _FakeMegolmKeyMirror_66(
+class _FakeClient_66 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -759,81 +742,9 @@ class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
         );
 }
 
-class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_67(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
-  _FakeUiaService_68(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeChatBackupService_69 extends _i1.SmartFake
-    implements _i10.ChatBackupService {
-  _FakeChatBackupService_69(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeSelectionService_70 extends _i1.SmartFake
-    implements _i11.SelectionService {
-  _FakeSelectionService_70(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_71(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_72(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_73(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeLatestReceiptState_74 extends _i1.SmartFake
+class _FakeLatestReceiptState_67 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_74(
+  _FakeLatestReceiptState_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,8 +753,8 @@ class _FakeLatestReceiptState_74 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_75(
+class _FakeTimeline_68 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,8 +763,8 @@ class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_76(
+class _FakeUser_69 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -880,12 +791,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
-      (super.noSuchMethod(
+  Set<_i7.KeyVerificationMethod> get verificationMethods => (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i7.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i7.KeyVerificationMethod>{},
+      ) as Set<_i7.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1005,11 +915,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i8.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i8.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1046,11 +956,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i8.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i8.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1080,11 +990,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i8.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i8.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1093,11 +1003,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i8.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i8.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1383,34 +1293,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i7.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i7.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i7.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i7.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i7.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i7.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i7.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i7.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1566,7 +1476,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i7.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1855,14 +1765,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i8.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i8.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2250,8 +2160,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i8.ifNotNull(
+              _i8.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2267,8 +2177,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i8.ifNotNull(
+              _i8.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2309,7 +2219,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2325,7 +2235,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2374,7 +2284,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2395,7 +2305,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2498,7 +2408,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2516,7 +2426,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3035,7 +2945,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i9.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3387,7 +3297,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3401,7 +3311,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3552,7 +3462,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i9.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4930,7 +4840,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4952,7 +4862,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5446,7 +5356,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5458,7 +5368,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6466,7 +6376,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6477,7 +6387,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6725,7 +6635,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6737,7 +6647,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6997,7 +6907,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7010,7 +6920,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7077,7 +6987,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7090,7 +7000,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7138,7 +7048,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7150,7 +7060,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7398,7 +7308,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7409,7 +7319,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7671,7 +7581,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i9.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7695,532 +7605,6 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i5.Future<Map<String, Object?>>);
 }
 
-/// A class which mocks [MatrixService].
-///
-/// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
-  @override
-  _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
-        Invocation.getter(#callPushRuleManager),
-        returnValue: _FakeCallPushRuleManager_65(
-          this,
-          Invocation.getter(#callPushRuleManager),
-        ),
-        returnValueForMissingStub: _FakeCallPushRuleManager_65(
-          this,
-          Invocation.getter(#callPushRuleManager),
-        ),
-      ) as _i7.CallPushRuleManager);
-
-  @override
-  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
-        Invocation.getter(#keyMirror),
-        returnValue: _FakeMegolmKeyMirror_66(
-          this,
-          Invocation.getter(#keyMirror),
-        ),
-        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
-          this,
-          Invocation.getter(#keyMirror),
-        ),
-      ) as _i8.MegolmKeyMirror);
-
-  @override
-  String get clientName => (super.noSuchMethod(
-        Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
-          this,
-          Invocation.getter(#clientName),
-        ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
-          this,
-          Invocation.getter(#clientName),
-        ),
-      ) as String);
-
-  @override
-  _i2.Client get client => (super.noSuchMethod(
-        Invocation.getter(#client),
-        returnValue: _FakeClient_67(
-          this,
-          Invocation.getter(#client),
-        ),
-        returnValueForMissingStub: _FakeClient_67(
-          this,
-          Invocation.getter(#client),
-        ),
-      ) as _i2.Client);
-
-  @override
-  bool get isLoggedIn => (super.noSuchMethod(
-        Invocation.getter(#isLoggedIn),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
-
-  @override
-  bool get disposed => (super.noSuchMethod(
-        Invocation.getter(#disposed),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
-
-  @override
-  _i9.UiaService get uia => (super.noSuchMethod(
-        Invocation.getter(#uia),
-        returnValue: _FakeUiaService_68(
-          this,
-          Invocation.getter(#uia),
-        ),
-        returnValueForMissingStub: _FakeUiaService_68(
-          this,
-          Invocation.getter(#uia),
-        ),
-      ) as _i9.UiaService);
-
-  @override
-  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
-        Invocation.getter(#chatBackup),
-        returnValue: _FakeChatBackupService_69(
-          this,
-          Invocation.getter(#chatBackup),
-        ),
-        returnValueForMissingStub: _FakeChatBackupService_69(
-          this,
-          Invocation.getter(#chatBackup),
-        ),
-      ) as _i10.ChatBackupService);
-
-  @override
-  _i11.SelectionService get selection => (super.noSuchMethod(
-        Invocation.getter(#selection),
-        returnValue: _FakeSelectionService_70(
-          this,
-          Invocation.getter(#selection),
-        ),
-        returnValueForMissingStub: _FakeSelectionService_70(
-          this,
-          Invocation.getter(#selection),
-        ),
-      ) as _i11.SelectionService);
-
-  @override
-  _i12.SyncService get sync => (super.noSuchMethod(
-        Invocation.getter(#sync),
-        returnValue: _FakeSyncService_71(
-          this,
-          Invocation.getter(#sync),
-        ),
-        returnValueForMissingStub: _FakeSyncService_71(
-          this,
-          Invocation.getter(#sync),
-        ),
-      ) as _i12.SyncService);
-
-  @override
-  _i13.AuthService get auth => (super.noSuchMethod(
-        Invocation.getter(#auth),
-        returnValue: _FakeAuthService_72(
-          this,
-          Invocation.getter(#auth),
-        ),
-        returnValueForMissingStub: _FakeAuthService_72(
-          this,
-          Invocation.getter(#auth),
-        ),
-      ) as _i13.AuthService);
-
-  @override
-  bool get hasSkippedSetup => (super.noSuchMethod(
-        Invocation.getter(#hasSkippedSetup),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
-
-  @override
-  set callPushRuleManager(_i7.CallPushRuleManager? value) => super.noSuchMethod(
-        Invocation.setter(
-          #callPushRuleManager,
-          value,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
-        Invocation.setter(
-          #keyMirror,
-          value,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  set isLoggedInForTest(bool? value) => super.noSuchMethod(
-        Invocation.setter(
-          #isLoggedInForTest,
-          value,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  set uia(_i9.UiaService? value) => super.noSuchMethod(
-        Invocation.setter(
-          #uia,
-          value,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
-        Invocation.setter(
-          #chatBackup,
-          value,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  set selection(_i11.SelectionService? value) => super.noSuchMethod(
-        Invocation.setter(
-          #selection,
-          value,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
-        Invocation.setter(
-          #sync,
-          value,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
-        Invocation.setter(
-          #auth,
-          value,
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  bool get hasListeners => (super.noSuchMethod(
-        Invocation.getter(#hasListeners),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
-
-  @override
-  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
-        Invocation.method(
-          #activateSessionForTest,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void notifyListeners() => super.noSuchMethod(
-        Invocation.method(
-          #notifyListeners,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void skipSetup() => super.noSuchMethod(
-        Invocation.method(
-          #skipSetup,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
-      super.noSuchMethod(
-        Invocation.method(
-          #didChangeAppLifecycleState,
-          [state],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
-        Invocation.method(
-          #init,
-          [],
-          {#restoreSession: restoreSession},
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<bool> login({
-    required String? homeserver,
-    required String? username,
-    required String? password,
-  }) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #login,
-          [],
-          {
-            #homeserver: homeserver,
-            #username: username,
-            #password: password,
-          },
-        ),
-        returnValue: _i5.Future<bool>.value(false),
-        returnValueForMissingStub: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
-
-  @override
-  _i5.Future<bool> completeSsoLogin({
-    required String? homeserver,
-    required String? loginToken,
-  }) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #completeSsoLogin,
-          [],
-          {
-            #homeserver: homeserver,
-            #loginToken: loginToken,
-          },
-        ),
-        returnValue: _i5.Future<bool>.value(false),
-        returnValueForMissingStub: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
-
-  @override
-  _i5.Future<void> completeRegistration(
-    _i2.RegisterResponse? response, {
-    String? password,
-  }) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #completeRegistration,
-          [response],
-          {#password: password},
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> logout() => (super.noSuchMethod(
-        Invocation.method(
-          #logout,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  _i5.Future<void> handleSoftLogout() => (super.noSuchMethod(
-        Invocation.method(
-          #handleSoftLogout,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-
-  @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #addListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(
-          #removeListener,
-          [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
-        Invocation.method(
-          #didPopRoute,
-          [],
-        ),
-        returnValue: _i5.Future<bool>.value(false),
-        returnValueForMissingStub: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
-
-  @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #handleStartBackGesture,
-          [backEvent],
-        ),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
-
-  @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
-      super.noSuchMethod(
-        Invocation.method(
-          #handleUpdateBackGestureProgress,
-          [backEvent],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void handleCommitBackGesture() => super.noSuchMethod(
-        Invocation.method(
-          #handleCommitBackGesture,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void handleCancelBackGesture() => super.noSuchMethod(
-        Invocation.method(
-          #handleCancelBackGesture,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void handleStatusBarTap() => super.noSuchMethod(
-        Invocation.method(
-          #handleStatusBarTap,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
-        Invocation.method(
-          #didPushRoute,
-          [route],
-        ),
-        returnValue: _i5.Future<bool>.value(false),
-        returnValueForMissingStub: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
-
-  @override
-  _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #didPushRouteInformation,
-          [routeInformation],
-        ),
-        returnValue: _i5.Future<bool>.value(false),
-        returnValueForMissingStub: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
-
-  @override
-  void didChangeMetrics() => super.noSuchMethod(
-        Invocation.method(
-          #didChangeMetrics,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void didChangeTextScaleFactor() => super.noSuchMethod(
-        Invocation.method(
-          #didChangeTextScaleFactor,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void didChangePlatformBrightness() => super.noSuchMethod(
-        Invocation.method(
-          #didChangePlatformBrightness,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
-        Invocation.method(
-          #didChangeLocales,
-          [locales],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
-        Invocation.method(
-          #didChangeViewFocus,
-          [event],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
-        Invocation.method(
-          #didRequestAppExit,
-          [],
-        ),
-        returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-        returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
-
-  @override
-  void didHaveMemoryPressure() => super.noSuchMethod(
-        Invocation.method(
-          #didHaveMemoryPressure,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void didChangeAccessibilityFeatures() => super.noSuchMethod(
-        Invocation.method(
-          #didChangeAccessibilityFeatures,
-          [],
-        ),
-        returnValueForMissingStub: null,
-      );
-}
-
 /// A class which mocks [Room].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -8228,11 +7612,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i8.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i8.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8262,11 +7646,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_73(
+        returnValue: _FakeRoomSummary_65(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_73(
+        returnValueForMissingStub: _FakeRoomSummary_65(
           this,
           Invocation.getter(#summary),
         ),
@@ -8319,11 +7703,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i8.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i8.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8359,11 +7743,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i8.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i8.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8379,11 +7763,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i8.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i8.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8392,11 +7776,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i8.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i8.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8419,11 +7803,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_67(
+        returnValue: _FakeClient_66(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_67(
+        returnValueForMissingStub: _FakeClient_66(
           this,
           Invocation.getter(#client),
         ),
@@ -8439,11 +7823,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i8.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i8.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8486,11 +7870,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_74(
+        returnValue: _FakeLatestReceiptState_67(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_74(
+        returnValueForMissingStub: _FakeLatestReceiptState_67(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8702,18 +8086,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i10.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i10.SpaceParent>[],
+        returnValueForMissingStub: <_i10.SpaceParent>[],
+      ) as List<_i10.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i10.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i10.SpaceChild>[],
+        returnValueForMissingStub: <_i10.SpaceChild>[],
+      ) as List<_i10.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8880,14 +8264,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i8.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i8.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8935,7 +8319,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8943,7 +8327,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8958,7 +8342,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8966,7 +8350,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9050,7 +8434,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9058,7 +8442,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9300,7 +8684,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9311,7 +8695,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9400,15 +8784,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i11.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i22.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i22.TimelineChunk?>.value(),
-      ) as _i5.Future<_i22.TimelineChunk?>);
+        returnValue: _i5.Future<_i11.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i11.TimelineChunk?>.value(),
+      ) as _i5.Future<_i11.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9449,7 +8833,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_68(
           this,
           Invocation.method(
             #getTimeline,
@@ -9466,7 +8850,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_68(
           this,
           Invocation.method(
             #getTimeline,
@@ -9530,14 +8914,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_69(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_69(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9553,14 +8937,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_69(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_69(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9616,7 +9000,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9624,7 +9008,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i8.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/invite_user_dialog_test.mocks.dart
+++ b/test/widgets/invite_user_dialog_test.mocks.dart
@@ -4,13 +4,32 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
+import 'dart:typed_data' as _i16;
+import 'dart:ui' as _i18;
 
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
+import 'package:http/http.dart' as _i4;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
+    as _i10;
+import 'package:kohera/core/services/sub_services/selection_service.dart'
+    as _i11;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
+import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
+    as _i7;
+import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
+    as _i8;
+import 'package:matrix/encryption.dart' as _i14;
 import 'package:matrix/matrix.dart' as _i2;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i7;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i6;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i4;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -27,8 +46,8 @@ import 'package:mockito/src/dummies.dart' as _i4;
 // ignore_for_file: subtype_of_sealed_class
 // ignore_for_file: invalid_use_of_internal_member
 
-class _FakeRoomSummary_0 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_0(
+class _FakeDatabaseApi_0 extends _i1.SmartFake implements _i2.DatabaseApi {
+  _FakeDatabaseApi_0(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -37,9 +56,61 @@ class _FakeRoomSummary_0 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_1<T> extends _i1.SmartFake
+class _FakeFilter_1 extends _i1.SmartFake implements _i2.Filter {
+  _FakeFilter_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeNativeImplementations_2 extends _i1.SmartFake
+    implements _i2.NativeImplementations {
+  _FakeNativeImplementations_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeDuration_3 extends _i1.SmartFake implements Duration {
+  _FakeDuration_3(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakePushruleEvaluator_4 extends _i1.SmartFake
+    implements _i2.PushruleEvaluator {
+  _FakePushruleEvaluator_4(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeProfile_5 extends _i1.SmartFake implements _i2.Profile {
+  _FakeProfile_5(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeCachedStreamController_6<T> extends _i1.SmartFake
     implements _i3.CachedStreamController<T> {
-  _FakeCachedStreamController_1(
+  _FakeCachedStreamController_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -48,8 +119,8 @@ class _FakeCachedStreamController_1<T> extends _i1.SmartFake
         );
 }
 
-class _FakeClient_2 extends _i1.SmartFake implements _i2.Client {
-  _FakeClient_2(
+class _FakeDateTime_7 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -58,8 +129,8 @@ class _FakeClient_2 extends _i1.SmartFake implements _i2.Client {
         );
 }
 
-class _FakeDateTime_3 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_3(
+class _FakeClient_8 extends _i1.SmartFake implements _i4.Client {
+  _FakeClient_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -68,9 +139,701 @@ class _FakeDateTime_3 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_4 extends _i1.SmartFake
+class _FakeDiscoveryInformation_9 extends _i1.SmartFake
+    implements _i2.DiscoveryInformation {
+  _FakeDiscoveryInformation_9(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetVersionsResponse_10 extends _i1.SmartFake
+    implements _i2.GetVersionsResponse {
+  _FakeGetVersionsResponse_10(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeRegisterResponse_11 extends _i1.SmartFake
+    implements _i2.RegisterResponse {
+  _FakeRegisterResponse_11(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLoginResponse_12 extends _i1.SmartFake implements _i2.LoginResponse {
+  _FakeLoginResponse_12(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetAuthMetadataResponse_13 extends _i1.SmartFake
+    implements _i2.GetAuthMetadataResponse {
+  _FakeGetAuthMetadataResponse_13(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeFuture_14<T1> extends _i1.SmartFake implements _i5.Future<T1> {
+  _FakeFuture_14(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeSyncUpdate_15 extends _i1.SmartFake implements _i2.SyncUpdate {
+  _FakeSyncUpdate_15(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeCachedProfileInformation_16 extends _i1.SmartFake
+    implements _i2.CachedProfileInformation {
+  _FakeCachedProfileInformation_16(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeMediaConfig_17 extends _i1.SmartFake implements _i2.MediaConfig {
+  _FakeMediaConfig_17(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeFileResponse_18 extends _i1.SmartFake implements _i6.FileResponse {
+  _FakeFileResponse_18(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakePreviewForUrl_19 extends _i1.SmartFake implements _i2.PreviewForUrl {
+  _FakePreviewForUrl_19(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeUri_20 extends _i1.SmartFake implements Uri {
+  _FakeUri_20(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeCachedPresence_21 extends _i1.SmartFake
+    implements _i2.CachedPresence {
+  _FakeCachedPresence_21(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeTurnServerCredentials_22 extends _i1.SmartFake
+    implements _i2.TurnServerCredentials {
+  _FakeTurnServerCredentials_22(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeRoomKeysUpdateResponse_23 extends _i1.SmartFake
+    implements _i2.RoomKeysUpdateResponse {
+  _FakeRoomKeysUpdateResponse_23(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeKeyBackupData_24 extends _i1.SmartFake implements _i2.KeyBackupData {
+  _FakeKeyBackupData_24(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetWellknownSupportResponse_25 extends _i1.SmartFake
+    implements _i2.GetWellknownSupportResponse {
+  _FakeGetWellknownSupportResponse_25(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGenerateLoginTokenResponse_26 extends _i1.SmartFake
+    implements _i2.GenerateLoginTokenResponse {
+  _FakeGenerateLoginTokenResponse_26(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetRoomSummaryResponse$3_27 extends _i1.SmartFake
+    implements _i2.GetRoomSummaryResponse$3 {
+  _FakeGetRoomSummaryResponse$3_27(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetSpaceHierarchyResponse_28 extends _i1.SmartFake
+    implements _i2.GetSpaceHierarchyResponse {
+  _FakeGetSpaceHierarchyResponse_28(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetRelatingEventsResponse_29 extends _i1.SmartFake
+    implements _i2.GetRelatingEventsResponse {
+  _FakeGetRelatingEventsResponse_29(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetRelatingEventsWithRelTypeResponse_30 extends _i1.SmartFake
+    implements _i2.GetRelatingEventsWithRelTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeResponse_30(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_31 extends _i1
+    .SmartFake implements _i2.GetRelatingEventsWithRelTypeAndEventTypeResponse {
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_31(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetThreadRootsResponse_32 extends _i1.SmartFake
+    implements _i2.GetThreadRootsResponse {
+  _FakeGetThreadRootsResponse_32(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetEventByTimestampResponse_33 extends _i1.SmartFake
+    implements _i2.GetEventByTimestampResponse {
+  _FakeGetEventByTimestampResponse_33(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeRequestTokenResponse_34 extends _i1.SmartFake
+    implements _i2.RequestTokenResponse {
+  _FakeRequestTokenResponse_34(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeTokenOwnerInfo_35 extends _i1.SmartFake
+    implements _i2.TokenOwnerInfo {
+  _FakeTokenOwnerInfo_35(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeWhoIsInfo_36 extends _i1.SmartFake implements _i2.WhoIsInfo {
+  _FakeWhoIsInfo_36(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeCapabilities_37 extends _i1.SmartFake implements _i2.Capabilities {
+  _FakeCapabilities_37(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeDevice_38 extends _i1.SmartFake implements _i2.Device {
+  _FakeDevice_38(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetRoomIdByAliasResponse_39 extends _i1.SmartFake
+    implements _i2.GetRoomIdByAliasResponse {
+  _FakeGetRoomIdByAliasResponse_39(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetEventsResponse_40 extends _i1.SmartFake
+    implements _i2.GetEventsResponse {
+  _FakeGetEventsResponse_40(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakePeekEventsResponse_41 extends _i1.SmartFake
+    implements _i2.PeekEventsResponse {
+  _FakePeekEventsResponse_41(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeMatrixEvent_42 extends _i1.SmartFake implements _i2.MatrixEvent {
+  _FakeMatrixEvent_42(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetKeysChangesResponse_43 extends _i1.SmartFake
+    implements _i2.GetKeysChangesResponse {
+  _FakeGetKeysChangesResponse_43(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeClaimKeysResponse_44 extends _i1.SmartFake
+    implements _i2.ClaimKeysResponse {
+  _FakeClaimKeysResponse_44(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeQueryKeysResponse_45 extends _i1.SmartFake
+    implements _i2.QueryKeysResponse {
+  _FakeQueryKeysResponse_45(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetNotificationsResponse_46 extends _i1.SmartFake
+    implements _i2.GetNotificationsResponse {
+  _FakeGetNotificationsResponse_46(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetPresenceResponse_47 extends _i1.SmartFake
+    implements _i2.GetPresenceResponse {
+  _FakeGetPresenceResponse_47(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetPublicRoomsResponse_48 extends _i1.SmartFake
+    implements _i2.GetPublicRoomsResponse {
+  _FakeGetPublicRoomsResponse_48(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeQueryPublicRoomsResponse_49 extends _i1.SmartFake
+    implements _i2.QueryPublicRoomsResponse {
+  _FakeQueryPublicRoomsResponse_49(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakePushRuleSet_50 extends _i1.SmartFake implements _i2.PushRuleSet {
+  _FakePushRuleSet_50(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetPushRulesGlobalResponse_51 extends _i1.SmartFake
+    implements _i2.GetPushRulesGlobalResponse {
+  _FakeGetPushRulesGlobalResponse_51(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakePushRule_52 extends _i1.SmartFake implements _i2.PushRule {
+  _FakePushRule_52(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeRefreshResponse_53 extends _i1.SmartFake
+    implements _i2.RefreshResponse {
+  _FakeRefreshResponse_53(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeRoomKeys_54 extends _i1.SmartFake implements _i2.RoomKeys {
+  _FakeRoomKeys_54(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeRoomKeyBackup_55 extends _i1.SmartFake implements _i2.RoomKeyBackup {
+  _FakeRoomKeyBackup_55(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetRoomKeysVersionCurrentResponse_56 extends _i1.SmartFake
+    implements _i2.GetRoomKeysVersionCurrentResponse {
+  _FakeGetRoomKeysVersionCurrentResponse_56(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetRoomKeysVersionResponse_57 extends _i1.SmartFake
+    implements _i2.GetRoomKeysVersionResponse {
+  _FakeGetRoomKeysVersionResponse_57(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeEventContext_58 extends _i1.SmartFake implements _i2.EventContext {
+  _FakeEventContext_58(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetRoomEventsResponse_59 extends _i1.SmartFake
+    implements _i2.GetRoomEventsResponse {
+  _FakeGetRoomEventsResponse_59(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeSearchResults_60 extends _i1.SmartFake implements _i2.SearchResults {
+  _FakeSearchResults_60(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGetProtocolMetadataResponse$2_61 extends _i1.SmartFake
+    implements _i2.GetProtocolMetadataResponse$2 {
+  _FakeGetProtocolMetadataResponse$2_61(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeOpenIdCredentials_62 extends _i1.SmartFake
+    implements _i2.OpenIdCredentials {
+  _FakeOpenIdCredentials_62(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeSearchUserDirectoryResponse_63 extends _i1.SmartFake
+    implements _i2.SearchUserDirectoryResponse {
+  _FakeSearchUserDirectoryResponse_63(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeCreateContentResponse_64 extends _i1.SmartFake
+    implements _i2.CreateContentResponse {
+  _FakeCreateContentResponse_64(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeCallPushRuleManager_65 extends _i1.SmartFake
+    implements _i7.CallPushRuleManager {
+  _FakeCallPushRuleManager_65(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeMegolmKeyMirror_66 extends _i1.SmartFake
+    implements _i8.MegolmKeyMirror {
+  _FakeMegolmKeyMirror_66(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeClient_67 extends _i1.SmartFake implements _i2.Client {
+  _FakeClient_67(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeUiaService_68 extends _i1.SmartFake implements _i9.UiaService {
+  _FakeUiaService_68(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeChatBackupService_69 extends _i1.SmartFake
+    implements _i10.ChatBackupService {
+  _FakeChatBackupService_69(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeSelectionService_70 extends _i1.SmartFake
+    implements _i11.SelectionService {
+  _FakeSelectionService_70(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
+  _FakeSyncService_71(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
+  _FakeAuthService_72(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_74 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_4(
+  _FakeLatestReceiptState_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -79,8 +842,8 @@ class _FakeLatestReceiptState_4 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_5 extends _i1.SmartFake implements _i2.SyncUpdate {
-  _FakeSyncUpdate_5(
+class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -89,8 +852,8 @@ class _FakeSyncUpdate_5 extends _i1.SmartFake implements _i2.SyncUpdate {
         );
 }
 
-class _FakeTimeline_6 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_6(
+class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -99,24 +862,7363 @@ class _FakeTimeline_6 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_7 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_7(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+/// A class which mocks [Client].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockClient extends _i1.Mock implements _i2.Client {
+  @override
+  _i2.DatabaseApi get database => (super.noSuchMethod(
+        Invocation.getter(#database),
+        returnValue: _FakeDatabaseApi_0(
+          this,
+          Invocation.getter(#database),
+        ),
+        returnValueForMissingStub: _FakeDatabaseApi_0(
+          this,
+          Invocation.getter(#database),
+        ),
+      ) as _i2.DatabaseApi);
+
+  @override
+  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+      (super.noSuchMethod(
+        Invocation.getter(#verificationMethods),
+        returnValue: <_i14.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
+      ) as Set<_i14.KeyVerificationMethod>);
+
+  @override
+  Set<String> get importantStateEvents => (super.noSuchMethod(
+        Invocation.getter(#importantStateEvents),
+        returnValue: <String>{},
+        returnValueForMissingStub: <String>{},
+      ) as Set<String>);
+
+  @override
+  Set<String> get roomPreviewLastEvents => (super.noSuchMethod(
+        Invocation.getter(#roomPreviewLastEvents),
+        returnValue: <String>{},
+        returnValueForMissingStub: <String>{},
+      ) as Set<String>);
+
+  @override
+  Set<String> get supportedLoginTypes => (super.noSuchMethod(
+        Invocation.getter(#supportedLoginTypes),
+        returnValue: <String>{},
+        returnValueForMissingStub: <String>{},
+      ) as Set<String>);
+
+  @override
+  bool get requestHistoryOnLimitedTimeline => (super.noSuchMethod(
+        Invocation.getter(#requestHistoryOnLimitedTimeline),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get formatLocalpart => (super.noSuchMethod(
+        Invocation.getter(#formatLocalpart),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get mxidLocalPartFallback => (super.noSuchMethod(
+        Invocation.getter(#mxidLocalPartFallback),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  _i2.ShareKeysWith get shareKeysWith => (super.noSuchMethod(
+        Invocation.getter(#shareKeysWith),
+        returnValue: _i2.ShareKeysWith.all,
+        returnValueForMissingStub: _i2.ShareKeysWith.all,
+      ) as _i2.ShareKeysWith);
+
+  @override
+  Map<String, _i2.CommandExecutionCallback> get commands => (super.noSuchMethod(
+        Invocation.getter(#commands),
+        returnValue: <String, _i2.CommandExecutionCallback>{},
+        returnValueForMissingStub: <String, _i2.CommandExecutionCallback>{},
+      ) as Map<String, _i2.CommandExecutionCallback>);
+
+  @override
+  _i2.Filter get syncFilter => (super.noSuchMethod(
+        Invocation.getter(#syncFilter),
+        returnValue: _FakeFilter_1(
+          this,
+          Invocation.getter(#syncFilter),
+        ),
+        returnValueForMissingStub: _FakeFilter_1(
+          this,
+          Invocation.getter(#syncFilter),
+        ),
+      ) as _i2.Filter);
+
+  @override
+  _i2.NativeImplementations get nativeImplementations => (super.noSuchMethod(
+        Invocation.getter(#nativeImplementations),
+        returnValue: _FakeNativeImplementations_2(
+          this,
+          Invocation.getter(#nativeImplementations),
+        ),
+        returnValueForMissingStub: _FakeNativeImplementations_2(
+          this,
+          Invocation.getter(#nativeImplementations),
+        ),
+      ) as _i2.NativeImplementations);
+
+  @override
+  bool get convertLinebreaksInFormatting => (super.noSuchMethod(
+        Invocation.getter(#convertLinebreaksInFormatting),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  Duration get sendTimelineEventTimeout => (super.noSuchMethod(
+        Invocation.getter(#sendTimelineEventTimeout),
+        returnValue: _FakeDuration_3(
+          this,
+          Invocation.getter(#sendTimelineEventTimeout),
+        ),
+        returnValueForMissingStub: _FakeDuration_3(
+          this,
+          Invocation.getter(#sendTimelineEventTimeout),
+        ),
+      ) as Duration);
+
+  @override
+  Duration get typingIndicatorTimeout => (super.noSuchMethod(
+        Invocation.getter(#typingIndicatorTimeout),
+        returnValue: _FakeDuration_3(
+          this,
+          Invocation.getter(#typingIndicatorTimeout),
+        ),
+        returnValueForMissingStub: _FakeDuration_3(
+          this,
+          Invocation.getter(#typingIndicatorTimeout),
+        ),
+      ) as Duration);
+
+  @override
+  String get clientName => (super.noSuchMethod(
+        Invocation.getter(#clientName),
+        returnValue: _i15.dummyValue<String>(
+          this,
+          Invocation.getter(#clientName),
+        ),
+        returnValueForMissingStub: _i15.dummyValue<String>(
+          this,
+          Invocation.getter(#clientName),
+        ),
+      ) as String);
+
+  @override
+  _i2.LoginState get loginState => (super.noSuchMethod(
+        Invocation.getter(#loginState),
+        returnValue: _i2.LoginState.loggedIn,
+        returnValueForMissingStub: _i2.LoginState.loggedIn,
+      ) as _i2.LoginState);
+
+  @override
+  List<_i2.Room> get rooms => (super.noSuchMethod(
+        Invocation.getter(#rooms),
+        returnValue: <_i2.Room>[],
+        returnValueForMissingStub: <_i2.Room>[],
+      ) as List<_i2.Room>);
+
+  @override
+  List<_i2.ArchivedRoom> get archivedRooms => (super.noSuchMethod(
+        Invocation.getter(#archivedRooms),
+        returnValue: <_i2.ArchivedRoom>[],
+        returnValueForMissingStub: <_i2.ArchivedRoom>[],
+      ) as List<_i2.ArchivedRoom>);
+
+  @override
+  bool get enableDehydratedDevices => (super.noSuchMethod(
+        Invocation.getter(#enableDehydratedDevices),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  String get dehydratedDeviceDisplayName => (super.noSuchMethod(
+        Invocation.getter(#dehydratedDeviceDisplayName),
+        returnValue: _i15.dummyValue<String>(
+          this,
+          Invocation.getter(#dehydratedDeviceDisplayName),
+        ),
+        returnValueForMissingStub: _i15.dummyValue<String>(
+          this,
+          Invocation.getter(#dehydratedDeviceDisplayName),
+        ),
+      ) as String);
+
+  @override
+  bool get receiptsPublicByDefault => (super.noSuchMethod(
+        Invocation.getter(#receiptsPublicByDefault),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get encryptionEnabled => (super.noSuchMethod(
+        Invocation.getter(#encryptionEnabled),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get fileEncryptionEnabled => (super.noSuchMethod(
+        Invocation.getter(#fileEncryptionEnabled),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  String get identityKey => (super.noSuchMethod(
+        Invocation.getter(#identityKey),
+        returnValue: _i15.dummyValue<String>(
+          this,
+          Invocation.getter(#identityKey),
+        ),
+        returnValueForMissingStub: _i15.dummyValue<String>(
+          this,
+          Invocation.getter(#identityKey),
+        ),
+      ) as String);
+
+  @override
+  String get fingerprintKey => (super.noSuchMethod(
+        Invocation.getter(#fingerprintKey),
+        returnValue: _i15.dummyValue<String>(
+          this,
+          Invocation.getter(#fingerprintKey),
+        ),
+        returnValueForMissingStub: _i15.dummyValue<String>(
+          this,
+          Invocation.getter(#fingerprintKey),
+        ),
+      ) as String);
+
+  @override
+  bool get isUnknownSession => (super.noSuchMethod(
+        Invocation.getter(#isUnknownSession),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  Map<String, _i2.BasicEvent> get accountData => (super.noSuchMethod(
+        Invocation.getter(#accountData),
+        returnValue: <String, _i2.BasicEvent>{},
+        returnValueForMissingStub: <String, _i2.BasicEvent>{},
+      ) as Map<String, _i2.BasicEvent>);
+
+  @override
+  _i2.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
+        Invocation.getter(#pushruleEvaluator),
+        returnValue: _FakePushruleEvaluator_4(
+          this,
+          Invocation.getter(#pushruleEvaluator),
+        ),
+        returnValueForMissingStub: _FakePushruleEvaluator_4(
+          this,
+          Invocation.getter(#pushruleEvaluator),
+        ),
+      ) as _i2.PushruleEvaluator);
+
+  @override
+  Map<String, _i2.CachedPresence> get presences => (super.noSuchMethod(
+        Invocation.getter(#presences),
+        returnValue: <String, _i2.CachedPresence>{},
+        returnValueForMissingStub: <String, _i2.CachedPresence>{},
+      ) as Map<String, _i2.CachedPresence>);
+
+  @override
+  Map<String, List<String>> get directChats => (super.noSuchMethod(
+        Invocation.getter(#directChats),
+        returnValue: <String, List<String>>{},
+        returnValueForMissingStub: <String, List<String>>{},
+      ) as Map<String, List<String>>);
+
+  @override
+  _i5.Future<_i2.Profile> get ownProfile => (super.noSuchMethod(
+        Invocation.getter(#ownProfile),
+        returnValue: _i5.Future<_i2.Profile>.value(_FakeProfile_5(
+          this,
+          Invocation.getter(#ownProfile),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.Profile>.value(_FakeProfile_5(
+          this,
+          Invocation.getter(#ownProfile),
+        )),
+      ) as _i5.Future<_i2.Profile>);
+
+  @override
+  _i3.CachedStreamController<String> get onUserProfileUpdate =>
+      (super.noSuchMethod(
+        Invocation.getter(#onUserProfileUpdate),
+        returnValue: _FakeCachedStreamController_6<String>(
+          this,
+          Invocation.getter(#onUserProfileUpdate),
+        ),
+        returnValueForMissingStub: _FakeCachedStreamController_6<String>(
+          this,
+          Invocation.getter(#onUserProfileUpdate),
+        ),
+      ) as _i3.CachedStreamController<String>);
+
+  @override
+  _i5.Future<List<_i2.Room>> get archive => (super.noSuchMethod(
+        Invocation.getter(#archive),
+        returnValue: _i5.Future<List<_i2.Room>>.value(<_i2.Room>[]),
+        returnValueForMissingStub:
+            _i5.Future<List<_i2.Room>>.value(<_i2.Room>[]),
+      ) as _i5.Future<List<_i2.Room>>);
+
+  @override
+  _i3.CachedStreamController<_i2.EventUpdate> get onEvent =>
+      (super.noSuchMethod(
+        Invocation.getter(#onEvent),
+        returnValue: _FakeCachedStreamController_6<_i2.EventUpdate>(
+          this,
+          Invocation.getter(#onEvent),
+        ),
+        returnValueForMissingStub:
+            _FakeCachedStreamController_6<_i2.EventUpdate>(
+          this,
+          Invocation.getter(#onEvent),
+        ),
+      ) as _i3.CachedStreamController<_i2.EventUpdate>);
+
+  @override
+  _i3.CachedStreamController<_i2.Event> get onTimelineEvent =>
+      (super.noSuchMethod(
+        Invocation.getter(#onTimelineEvent),
+        returnValue: _FakeCachedStreamController_6<_i2.Event>(
+          this,
+          Invocation.getter(#onTimelineEvent),
+        ),
+        returnValueForMissingStub: _FakeCachedStreamController_6<_i2.Event>(
+          this,
+          Invocation.getter(#onTimelineEvent),
+        ),
+      ) as _i3.CachedStreamController<_i2.Event>);
+
+  @override
+  _i3.CachedStreamController<_i2.Event> get onHistoryEvent =>
+      (super.noSuchMethod(
+        Invocation.getter(#onHistoryEvent),
+        returnValue: _FakeCachedStreamController_6<_i2.Event>(
+          this,
+          Invocation.getter(#onHistoryEvent),
+        ),
+        returnValueForMissingStub: _FakeCachedStreamController_6<_i2.Event>(
+          this,
+          Invocation.getter(#onHistoryEvent),
+        ),
+      ) as _i3.CachedStreamController<_i2.Event>);
+
+  @override
+  _i3.CachedStreamController<_i2.Event> get onNotification =>
+      (super.noSuchMethod(
+        Invocation.getter(#onNotification),
+        returnValue: _FakeCachedStreamController_6<_i2.Event>(
+          this,
+          Invocation.getter(#onNotification),
+        ),
+        returnValueForMissingStub: _FakeCachedStreamController_6<_i2.Event>(
+          this,
+          Invocation.getter(#onNotification),
+        ),
+      ) as _i3.CachedStreamController<_i2.Event>);
+
+  @override
+  _i3.CachedStreamController<_i2.ToDeviceEvent> get onToDeviceEvent =>
+      (super.noSuchMethod(
+        Invocation.getter(#onToDeviceEvent),
+        returnValue: _FakeCachedStreamController_6<_i2.ToDeviceEvent>(
+          this,
+          Invocation.getter(#onToDeviceEvent),
+        ),
+        returnValueForMissingStub:
+            _FakeCachedStreamController_6<_i2.ToDeviceEvent>(
+          this,
+          Invocation.getter(#onToDeviceEvent),
+        ),
+      ) as _i3.CachedStreamController<_i2.ToDeviceEvent>);
+
+  @override
+  _i3.CachedStreamController<List<_i2.BasicEventWithSender>> get onCallEvents =>
+      (super.noSuchMethod(
+        Invocation.getter(#onCallEvents),
+        returnValue:
+            _FakeCachedStreamController_6<List<_i2.BasicEventWithSender>>(
+          this,
+          Invocation.getter(#onCallEvents),
+        ),
+        returnValueForMissingStub:
+            _FakeCachedStreamController_6<List<_i2.BasicEventWithSender>>(
+          this,
+          Invocation.getter(#onCallEvents),
+        ),
+      ) as _i3.CachedStreamController<List<_i2.BasicEventWithSender>>);
+
+  @override
+  _i3.CachedStreamController<_i2.LoginState> get onLoginStateChanged =>
+      (super.noSuchMethod(
+        Invocation.getter(#onLoginStateChanged),
+        returnValue: _FakeCachedStreamController_6<_i2.LoginState>(
+          this,
+          Invocation.getter(#onLoginStateChanged),
+        ),
+        returnValueForMissingStub:
+            _FakeCachedStreamController_6<_i2.LoginState>(
+          this,
+          Invocation.getter(#onLoginStateChanged),
+        ),
+      ) as _i3.CachedStreamController<_i2.LoginState>);
+
+  @override
+  _i3.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+        Invocation.getter(#onCacheCleared),
+        returnValue: _FakeCachedStreamController_6<bool>(
+          this,
+          Invocation.getter(#onCacheCleared),
+        ),
+        returnValueForMissingStub: _FakeCachedStreamController_6<bool>(
+          this,
+          Invocation.getter(#onCacheCleared),
+        ),
+      ) as _i3.CachedStreamController<bool>);
+
+  @override
+  _i3.CachedStreamController<_i2.SdkError> get onEncryptionError =>
+      (super.noSuchMethod(
+        Invocation.getter(#onEncryptionError),
+        returnValue: _FakeCachedStreamController_6<_i2.SdkError>(
+          this,
+          Invocation.getter(#onEncryptionError),
+        ),
+        returnValueForMissingStub: _FakeCachedStreamController_6<_i2.SdkError>(
+          this,
+          Invocation.getter(#onEncryptionError),
+        ),
+      ) as _i3.CachedStreamController<_i2.SdkError>);
+
+  @override
+  _i3.CachedStreamController<_i2.SyncUpdate> get onSync => (super.noSuchMethod(
+        Invocation.getter(#onSync),
+        returnValue: _FakeCachedStreamController_6<_i2.SyncUpdate>(
+          this,
+          Invocation.getter(#onSync),
+        ),
+        returnValueForMissingStub:
+            _FakeCachedStreamController_6<_i2.SyncUpdate>(
+          this,
+          Invocation.getter(#onSync),
+        ),
+      ) as _i3.CachedStreamController<_i2.SyncUpdate>);
+
+  @override
+  _i3.CachedStreamController<_i2.SyncStatusUpdate> get onSyncStatus =>
+      (super.noSuchMethod(
+        Invocation.getter(#onSyncStatus),
+        returnValue: _FakeCachedStreamController_6<_i2.SyncStatusUpdate>(
+          this,
+          Invocation.getter(#onSyncStatus),
+        ),
+        returnValueForMissingStub:
+            _FakeCachedStreamController_6<_i2.SyncStatusUpdate>(
+          this,
+          Invocation.getter(#onSyncStatus),
+        ),
+      ) as _i3.CachedStreamController<_i2.SyncStatusUpdate>);
+
+  @override
+  _i3.CachedStreamController<_i2.Presence> get onPresence =>
+      (super.noSuchMethod(
+        Invocation.getter(#onPresence),
+        returnValue: _FakeCachedStreamController_6<_i2.Presence>(
+          this,
+          Invocation.getter(#onPresence),
+        ),
+        returnValueForMissingStub: _FakeCachedStreamController_6<_i2.Presence>(
+          this,
+          Invocation.getter(#onPresence),
+        ),
+      ) as _i3.CachedStreamController<_i2.Presence>);
+
+  @override
+  _i3.CachedStreamController<_i2.CachedPresence> get onPresenceChanged =>
+      (super.noSuchMethod(
+        Invocation.getter(#onPresenceChanged),
+        returnValue: _FakeCachedStreamController_6<_i2.CachedPresence>(
+          this,
+          Invocation.getter(#onPresenceChanged),
+        ),
+        returnValueForMissingStub:
+            _FakeCachedStreamController_6<_i2.CachedPresence>(
+          this,
+          Invocation.getter(#onPresenceChanged),
+        ),
+      ) as _i3.CachedStreamController<_i2.CachedPresence>);
+
+  @override
+  _i3.CachedStreamController<_i2.BasicEvent> get onAccountData =>
+      (super.noSuchMethod(
+        Invocation.getter(#onAccountData),
+        returnValue: _FakeCachedStreamController_6<_i2.BasicEvent>(
+          this,
+          Invocation.getter(#onAccountData),
+        ),
+        returnValueForMissingStub:
+            _FakeCachedStreamController_6<_i2.BasicEvent>(
+          this,
+          Invocation.getter(#onAccountData),
+        ),
+      ) as _i3.CachedStreamController<_i2.BasicEvent>);
+
+  @override
+  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+      (super.noSuchMethod(
+        Invocation.getter(#onRoomKeyRequest),
+        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+          this,
+          Invocation.getter(#onRoomKeyRequest),
+        ),
+        returnValueForMissingStub:
+            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+          this,
+          Invocation.getter(#onRoomKeyRequest),
+        ),
+      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+
+  @override
+  _i3.CachedStreamController<_i14.KeyVerification>
+      get onKeyVerificationRequest => (super.noSuchMethod(
+            Invocation.getter(#onKeyVerificationRequest),
+            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+              this,
+              Invocation.getter(#onKeyVerificationRequest),
+            ),
+            returnValueForMissingStub:
+                _FakeCachedStreamController_6<_i14.KeyVerification>(
+              this,
+              Invocation.getter(#onKeyVerificationRequest),
+            ),
+          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+
+  @override
+  _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
+      (super.noSuchMethod(
+        Invocation.getter(#onUiaRequest),
+        returnValue: _FakeCachedStreamController_6<_i2.UiaRequest<dynamic>>(
+          this,
+          Invocation.getter(#onUiaRequest),
+        ),
+        returnValueForMissingStub:
+            _FakeCachedStreamController_6<_i2.UiaRequest<dynamic>>(
+          this,
+          Invocation.getter(#onUiaRequest),
+        ),
+      ) as _i3.CachedStreamController<_i2.UiaRequest<dynamic>>);
+
+  @override
+  _i3.CachedStreamController<_i2.Event> get onGroupMember =>
+      (super.noSuchMethod(
+        Invocation.getter(#onGroupMember),
+        returnValue: _FakeCachedStreamController_6<_i2.Event>(
+          this,
+          Invocation.getter(#onGroupMember),
+        ),
+        returnValueForMissingStub: _FakeCachedStreamController_6<_i2.Event>(
+          this,
+          Invocation.getter(#onGroupMember),
+        ),
+      ) as _i3.CachedStreamController<_i2.Event>);
+
+  @override
+  _i3.CachedStreamController<String> get onCancelSendEvent =>
+      (super.noSuchMethod(
+        Invocation.getter(#onCancelSendEvent),
+        returnValue: _FakeCachedStreamController_6<String>(
+          this,
+          Invocation.getter(#onCancelSendEvent),
+        ),
+        returnValueForMissingStub: _FakeCachedStreamController_6<String>(
+          this,
+          Invocation.getter(#onCancelSendEvent),
+        ),
+      ) as _i3.CachedStreamController<String>);
+
+  @override
+  _i3.CachedStreamController<({String roomId, _i2.StrippedStateEvent state})>
+      get onRoomState => (super.noSuchMethod(
+            Invocation.getter(#onRoomState),
+            returnValue: _FakeCachedStreamController_6<
+                ({String roomId, _i2.StrippedStateEvent state})>(
+              this,
+              Invocation.getter(#onRoomState),
+            ),
+            returnValueForMissingStub: _FakeCachedStreamController_6<
+                ({String roomId, _i2.StrippedStateEvent state})>(
+              this,
+              Invocation.getter(#onRoomState),
+            ),
+          ) as _i3.CachedStreamController<
+              ({String roomId, _i2.StrippedStateEvent state})>);
+
+  @override
+  int get syncErrorTimeoutSec => (super.noSuchMethod(
+        Invocation.getter(#syncErrorTimeoutSec),
+        returnValue: 0,
+        returnValueForMissingStub: 0,
+      ) as int);
+
+  @override
+  bool get syncPending => (super.noSuchMethod(
+        Invocation.getter(#syncPending),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  DateTime get lastStaleCallRun => (super.noSuchMethod(
+        Invocation.getter(#lastStaleCallRun),
+        returnValue: _FakeDateTime_7(
+          this,
+          Invocation.getter(#lastStaleCallRun),
+        ),
+        returnValueForMissingStub: _FakeDateTime_7(
+          this,
+          Invocation.getter(#lastStaleCallRun),
+        ),
+      ) as DateTime);
+
+  @override
+  bool get pinUnreadRooms => (super.noSuchMethod(
+        Invocation.getter(#pinUnreadRooms),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get pinInvitedRooms => (super.noSuchMethod(
+        Invocation.getter(#pinInvitedRooms),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  _i2.RoomSorter get sortRoomsBy => (super.noSuchMethod(
+        Invocation.getter(#sortRoomsBy),
+        returnValue: (
+          _i2.Room a,
+          _i2.Room b,
+        ) =>
+            0,
+        returnValueForMissingStub: (
+          _i2.Room a,
+          _i2.Room b,
+        ) =>
+            0,
+      ) as _i2.RoomSorter);
+
+  @override
+  Map<String, _i2.DeviceKeysList> get userDeviceKeys => (super.noSuchMethod(
+        Invocation.getter(#userDeviceKeys),
+        returnValue: <String, _i2.DeviceKeysList>{},
+        returnValueForMissingStub: <String, _i2.DeviceKeysList>{},
+      ) as Map<String, _i2.DeviceKeysList>);
+
+  @override
+  List<_i2.DeviceKeys> get unverifiedDevices => (super.noSuchMethod(
+        Invocation.getter(#unverifiedDevices),
+        returnValue: <_i2.DeviceKeys>[],
+        returnValueForMissingStub: <_i2.DeviceKeys>[],
+      ) as List<_i2.DeviceKeys>);
+
+  @override
+  bool get allPushNotificationsMuted => (super.noSuchMethod(
+        Invocation.getter(#allPushNotificationsMuted),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  List<String> get ignoredUsers => (super.noSuchMethod(
+        Invocation.getter(#ignoredUsers),
+        returnValue: <String>[],
+        returnValueForMissingStub: <String>[],
+      ) as List<String>);
+
+  @override
+  set database(_i2.DatabaseApi? db) => super.noSuchMethod(
+        Invocation.setter(
+          #database,
+          db,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #verificationMethods,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set importantStateEvents(Set<String>? value) => super.noSuchMethod(
+        Invocation.setter(
+          #importantStateEvents,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set roomPreviewLastEvents(Set<String>? value) => super.noSuchMethod(
+        Invocation.setter(
+          #roomPreviewLastEvents,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set supportedLoginTypes(Set<String>? value) => super.noSuchMethod(
+        Invocation.setter(
+          #supportedLoginTypes,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set requestHistoryOnLimitedTimeline(bool? value) => super.noSuchMethod(
+        Invocation.setter(
+          #requestHistoryOnLimitedTimeline,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set shareKeysWith(_i2.ShareKeysWith? value) => super.noSuchMethod(
+        Invocation.setter(
+          #shareKeysWith,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set onSoftLogout(_i5.Future<void> Function(_i2.Client)? value) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #onSoftLogout,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set customImageResizer(
+          _i5.Future<_i2.MatrixImageFileResizedResponse?> Function(
+                  _i2.MatrixImageFileResizeArguments)?
+              value) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #customImageResizer,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set customRefreshTokenLifetime(Duration? value) => super.noSuchMethod(
+        Invocation.setter(
+          #customRefreshTokenLifetime,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set enableDehydratedDevices(bool? value) => super.noSuchMethod(
+        Invocation.setter(
+          #enableDehydratedDevices,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set receiptsPublicByDefault(bool? value) => super.noSuchMethod(
+        Invocation.setter(
+          #receiptsPublicByDefault,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set rooms(List<_i2.Room>? newList) => super.noSuchMethod(
+        Invocation.setter(
+          #rooms,
+          newList,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set presences(Map<String, _i2.CachedPresence>? value) => super.noSuchMethod(
+        Invocation.setter(
+          #presences,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set syncErrorTimeoutSec(int? value) => super.noSuchMethod(
+        Invocation.setter(
+          #syncErrorTimeoutSec,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set backgroundSync(bool? enabled) => super.noSuchMethod(
+        Invocation.setter(
+          #backgroundSync,
+          enabled,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set syncPresence(_i2.PresenceType? value) => super.noSuchMethod(
+        Invocation.setter(
+          #syncPresence,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set lastStaleCallRun(DateTime? value) => super.noSuchMethod(
+        Invocation.setter(
+          #lastStaleCallRun,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set pinUnreadRooms(bool? value) => super.noSuchMethod(
+        Invocation.setter(
+          #pinUnreadRooms,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set pinInvitedRooms(bool? value) => super.noSuchMethod(
+        Invocation.setter(
+          #pinInvitedRooms,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set userDeviceKeysLoading(_i5.Future<dynamic>? value) => super.noSuchMethod(
+        Invocation.setter(
+          #userDeviceKeysLoading,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set roomsLoading(_i5.Future<dynamic>? value) => super.noSuchMethod(
+        Invocation.setter(
+          #roomsLoading,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set firstSyncReceived(_i5.Future<dynamic>? value) => super.noSuchMethod(
+        Invocation.setter(
+          #firstSyncReceived,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set homeserver(Uri? uri) => super.noSuchMethod(
+        Invocation.setter(
+          #homeserver,
+          uri,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set accessToken(String? token) => super.noSuchMethod(
+        Invocation.setter(
+          #accessToken,
+          token,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i4.Client get httpClient => (super.noSuchMethod(
+        Invocation.getter(#httpClient),
+        returnValue: _FakeClient_8(
+          this,
+          Invocation.getter(#httpClient),
+        ),
+        returnValueForMissingStub: _FakeClient_8(
+          this,
+          Invocation.getter(#httpClient),
+        ),
+      ) as _i4.Client);
+
+  @override
+  set httpClient(_i4.Client? value) => super.noSuchMethod(
+        Invocation.setter(
+          #httpClient,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set baseUri(Uri? value) => super.noSuchMethod(
+        Invocation.setter(
+          #baseUri,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set bearerToken(String? value) => super.noSuchMethod(
+        Invocation.setter(
+          #bearerToken,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<void> refreshAccessToken({Duration? customRefreshTokenLifetime}) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #refreshAccessToken,
+          [],
+          {#customRefreshTokenLifetime: customRefreshTokenLifetime},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  bool isLogged() => (super.noSuchMethod(
+        Invocation.method(
+          #isLogged,
+          [],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  String generateUniqueTransactionId() => (super.noSuchMethod(
+        Invocation.method(
+          #generateUniqueTransactionId,
+          [],
+        ),
+        returnValue: _i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #generateUniqueTransactionId,
+            [],
+          ),
+        ),
+        returnValueForMissingStub: _i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #generateUniqueTransactionId,
+            [],
+          ),
+        ),
+      ) as String);
+
+  @override
+  _i2.Room? getRoomByAlias(String? alias) => (super.noSuchMethod(
+        Invocation.method(
+          #getRoomByAlias,
+          [alias],
+        ),
+        returnValueForMissingStub: null,
+      ) as _i2.Room?);
+
+  @override
+  _i2.Room? getRoomById(String? id) => (super.noSuchMethod(
+        Invocation.method(
+          #getRoomById,
+          [id],
+        ),
+        returnValueForMissingStub: null,
+      ) as _i2.Room?);
+
+  @override
+  String? getDirectChatFromUserId(String? userId) => (super.noSuchMethod(
+        Invocation.method(
+          #getDirectChatFromUserId,
+          [userId],
+        ),
+        returnValueForMissingStub: null,
+      ) as String?);
+
+  @override
+  _i5.Future<_i2.DiscoveryInformation> getDiscoveryInformationsByUserId(
+          String? MatrixIdOrDomain) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getDiscoveryInformationsByUserId,
+          [MatrixIdOrDomain],
+        ),
+        returnValue: _i5.Future<_i2.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_9(
+          this,
+          Invocation.method(
+            #getDiscoveryInformationsByUserId,
+            [MatrixIdOrDomain],
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_9(
+          this,
+          Invocation.method(
+            #getDiscoveryInformationsByUserId,
+            [MatrixIdOrDomain],
+          ),
+        )),
+      ) as _i5.Future<_i2.DiscoveryInformation>);
+
+  @override
+  _i5.Future<
+      (
+        _i2.DiscoveryInformation?,
+        _i2.GetVersionsResponse,
+        List<_i2.LoginFlow>,
+        _i2.GetAuthMetadataResponse?
+      )> checkHomeserver(
+    Uri? homeserverUrl, {
+    bool? checkWellKnown = true,
+    bool? fetchAuthMetadata,
+    Set<String>? overrideSupportedVersions,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #checkHomeserver,
+          [homeserverUrl],
+          {
+            #checkWellKnown: checkWellKnown,
+            #fetchAuthMetadata: fetchAuthMetadata,
+            #overrideSupportedVersions: overrideSupportedVersions,
+          },
+        ),
+        returnValue: _i5.Future<
+            (
+              _i2.DiscoveryInformation?,
+              _i2.GetVersionsResponse,
+              List<_i2.LoginFlow>,
+              _i2.GetAuthMetadataResponse?
+            )>.value((
+          null,
+          _FakeGetVersionsResponse_10(
+            this,
+            Invocation.method(
+              #checkHomeserver,
+              [homeserverUrl],
+              {
+                #checkWellKnown: checkWellKnown,
+                #fetchAuthMetadata: fetchAuthMetadata,
+                #overrideSupportedVersions: overrideSupportedVersions,
+              },
+            ),
+          ),
+          <_i2.LoginFlow>[],
+          null
+        )),
+        returnValueForMissingStub: _i5.Future<
+            (
+              _i2.DiscoveryInformation?,
+              _i2.GetVersionsResponse,
+              List<_i2.LoginFlow>,
+              _i2.GetAuthMetadataResponse?
+            )>.value((
+          null,
+          _FakeGetVersionsResponse_10(
+            this,
+            Invocation.method(
+              #checkHomeserver,
+              [homeserverUrl],
+              {
+                #checkWellKnown: checkWellKnown,
+                #fetchAuthMetadata: fetchAuthMetadata,
+                #overrideSupportedVersions: overrideSupportedVersions,
+              },
+            ),
+          ),
+          <_i2.LoginFlow>[],
+          null
+        )),
+      ) as _i5.Future<
+          (
+            _i2.DiscoveryInformation?,
+            _i2.GetVersionsResponse,
+            List<_i2.LoginFlow>,
+            _i2.GetAuthMetadataResponse?
+          )>);
+
+  @override
+  _i5.Future<_i2.DiscoveryInformation> getWellknown({
+    Duration? cacheLifetime = const Duration(days: 3),
+    bool? throwOnUpdateFailure = false,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getWellknown,
+          [],
+          {
+            #cacheLifetime: cacheLifetime,
+            #throwOnUpdateFailure: throwOnUpdateFailure,
+          },
+        ),
+        returnValue: _i5.Future<_i2.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_9(
+          this,
+          Invocation.method(
+            #getWellknown,
+            [],
+            {
+              #cacheLifetime: cacheLifetime,
+              #throwOnUpdateFailure: throwOnUpdateFailure,
+            },
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_9(
+          this,
+          Invocation.method(
+            #getWellknown,
+            [],
+            {
+              #cacheLifetime: cacheLifetime,
+              #throwOnUpdateFailure: throwOnUpdateFailure,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.DiscoveryInformation>);
+
+  @override
+  _i5.Future<_i2.RegisterResponse> register({
+    String? username,
+    String? password,
+    String? deviceId,
+    String? initialDeviceDisplayName,
+    bool? inhibitLogin,
+    bool? refreshToken,
+    _i2.AuthenticationData? auth,
+    _i2.AccountKind? kind,
+    void Function(_i2.InitState)? onInitStateChanged,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #register,
+          [],
+          {
+            #username: username,
+            #password: password,
+            #deviceId: deviceId,
+            #initialDeviceDisplayName: initialDeviceDisplayName,
+            #inhibitLogin: inhibitLogin,
+            #refreshToken: refreshToken,
+            #auth: auth,
+            #kind: kind,
+            #onInitStateChanged: onInitStateChanged,
+          },
+        ),
+        returnValue:
+            _i5.Future<_i2.RegisterResponse>.value(_FakeRegisterResponse_11(
+          this,
+          Invocation.method(
+            #register,
+            [],
+            {
+              #username: username,
+              #password: password,
+              #deviceId: deviceId,
+              #initialDeviceDisplayName: initialDeviceDisplayName,
+              #inhibitLogin: inhibitLogin,
+              #refreshToken: refreshToken,
+              #auth: auth,
+              #kind: kind,
+              #onInitStateChanged: onInitStateChanged,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.RegisterResponse>.value(_FakeRegisterResponse_11(
+          this,
+          Invocation.method(
+            #register,
+            [],
+            {
+              #username: username,
+              #password: password,
+              #deviceId: deviceId,
+              #initialDeviceDisplayName: initialDeviceDisplayName,
+              #inhibitLogin: inhibitLogin,
+              #refreshToken: refreshToken,
+              #auth: auth,
+              #kind: kind,
+              #onInitStateChanged: onInitStateChanged,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.RegisterResponse>);
+
+  @override
+  _i5.Future<_i2.LoginResponse> login(
+    String? type, {
+    _i2.AuthenticationIdentifier? identifier,
+    String? password,
+    String? token,
+    String? deviceId,
+    String? initialDeviceDisplayName,
+    bool? refreshToken,
+    String? user,
+    String? medium,
+    String? address,
+    void Function(_i2.InitState)? onInitStateChanged,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #login,
+          [type],
+          {
+            #identifier: identifier,
+            #password: password,
+            #token: token,
+            #deviceId: deviceId,
+            #initialDeviceDisplayName: initialDeviceDisplayName,
+            #refreshToken: refreshToken,
+            #user: user,
+            #medium: medium,
+            #address: address,
+            #onInitStateChanged: onInitStateChanged,
+          },
+        ),
+        returnValue: _i5.Future<_i2.LoginResponse>.value(_FakeLoginResponse_12(
+          this,
+          Invocation.method(
+            #login,
+            [type],
+            {
+              #identifier: identifier,
+              #password: password,
+              #token: token,
+              #deviceId: deviceId,
+              #initialDeviceDisplayName: initialDeviceDisplayName,
+              #refreshToken: refreshToken,
+              #user: user,
+              #medium: medium,
+              #address: address,
+              #onInitStateChanged: onInitStateChanged,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.LoginResponse>.value(_FakeLoginResponse_12(
+          this,
+          Invocation.method(
+            #login,
+            [type],
+            {
+              #identifier: identifier,
+              #password: password,
+              #token: token,
+              #deviceId: deviceId,
+              #initialDeviceDisplayName: initialDeviceDisplayName,
+              #refreshToken: refreshToken,
+              #user: user,
+              #medium: medium,
+              #address: address,
+              #onInitStateChanged: onInitStateChanged,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.LoginResponse>);
+
+  @override
+  _i5.Future<_i2.GetAuthMetadataResponse> getAuthMetadata({
+    Duration? cacheLifetime = const Duration(days: 3),
+    bool? throwOnUpdateFailure = false,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getAuthMetadata,
+          [],
+          {
+            #cacheLifetime: cacheLifetime,
+            #throwOnUpdateFailure: throwOnUpdateFailure,
+          },
+        ),
+        returnValue: _i5.Future<_i2.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_13(
+          this,
+          Invocation.method(
+            #getAuthMetadata,
+            [],
+            {
+              #cacheLifetime: cacheLifetime,
+              #throwOnUpdateFailure: throwOnUpdateFailure,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_13(
+          this,
+          Invocation.method(
+            #getAuthMetadata,
+            [],
+            {
+              #cacheLifetime: cacheLifetime,
+              #throwOnUpdateFailure: throwOnUpdateFailure,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.GetAuthMetadataResponse>);
+
+  @override
+  _i5.Future<void> logout() => (super.noSuchMethod(
+        Invocation.method(
+          #logout,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logoutAll() => (super.noSuchMethod(
+        Invocation.method(
+          #logoutAll,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<T> uiaRequestBackground<T>(
+          _i5.Future<T> Function(_i2.AuthenticationData?)? request) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #uiaRequestBackground,
+          [request],
+        ),
+        returnValue: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
+                this,
+                Invocation.method(
+                  #uiaRequestBackground,
+                  [request],
+                ),
+              ),
+              (T v) => _i5.Future<T>.value(v),
+            ) ??
+            _FakeFuture_14<T>(
+              this,
+              Invocation.method(
+                #uiaRequestBackground,
+                [request],
+              ),
+            ),
+        returnValueForMissingStub: _i15.ifNotNull(
+              _i15.dummyValueOrNull<T>(
+                this,
+                Invocation.method(
+                  #uiaRequestBackground,
+                  [request],
+                ),
+              ),
+              (T v) => _i5.Future<T>.value(v),
+            ) ??
+            _FakeFuture_14<T>(
+              this,
+              Invocation.method(
+                #uiaRequestBackground,
+                [request],
+              ),
+            ),
+      ) as _i5.Future<T>);
+
+  @override
+  _i5.Future<String> startDirectChat(
+    String? mxid, {
+    bool? enableEncryption,
+    List<_i2.StateEvent>? initialState,
+    bool? waitForSync = true,
+    Map<String, dynamic>? powerLevelContentOverride,
+    _i2.CreateRoomPreset? preset = _i2.CreateRoomPreset.trustedPrivateChat,
+    bool? skipExistingChat = false,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #startDirectChat,
+          [mxid],
+          {
+            #enableEncryption: enableEncryption,
+            #initialState: initialState,
+            #waitForSync: waitForSync,
+            #powerLevelContentOverride: powerLevelContentOverride,
+            #preset: preset,
+            #skipExistingChat: skipExistingChat,
+          },
+        ),
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #startDirectChat,
+            [mxid],
+            {
+              #enableEncryption: enableEncryption,
+              #initialState: initialState,
+              #waitForSync: waitForSync,
+              #powerLevelContentOverride: powerLevelContentOverride,
+              #preset: preset,
+              #skipExistingChat: skipExistingChat,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #startDirectChat,
+            [mxid],
+            {
+              #enableEncryption: enableEncryption,
+              #initialState: initialState,
+              #waitForSync: waitForSync,
+              #powerLevelContentOverride: powerLevelContentOverride,
+              #preset: preset,
+              #skipExistingChat: skipExistingChat,
+            },
+          ),
+        )),
+      ) as _i5.Future<String>);
+
+  @override
+  _i5.Future<String> createGroupChat({
+    String? groupName,
+    bool? enableEncryption,
+    List<String>? invite,
+    _i2.CreateRoomPreset? preset = _i2.CreateRoomPreset.privateChat,
+    List<_i2.StateEvent>? initialState,
+    _i2.Visibility? visibility,
+    _i2.HistoryVisibility? historyVisibility,
+    bool? waitForSync = true,
+    bool? groupCall = false,
+    bool? federated = true,
+    Map<String, dynamic>? powerLevelContentOverride,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #createGroupChat,
+          [],
+          {
+            #groupName: groupName,
+            #enableEncryption: enableEncryption,
+            #invite: invite,
+            #preset: preset,
+            #initialState: initialState,
+            #visibility: visibility,
+            #historyVisibility: historyVisibility,
+            #waitForSync: waitForSync,
+            #groupCall: groupCall,
+            #federated: federated,
+            #powerLevelContentOverride: powerLevelContentOverride,
+          },
+        ),
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #createGroupChat,
+            [],
+            {
+              #groupName: groupName,
+              #enableEncryption: enableEncryption,
+              #invite: invite,
+              #preset: preset,
+              #initialState: initialState,
+              #visibility: visibility,
+              #historyVisibility: historyVisibility,
+              #waitForSync: waitForSync,
+              #groupCall: groupCall,
+              #federated: federated,
+              #powerLevelContentOverride: powerLevelContentOverride,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #createGroupChat,
+            [],
+            {
+              #groupName: groupName,
+              #enableEncryption: enableEncryption,
+              #invite: invite,
+              #preset: preset,
+              #initialState: initialState,
+              #visibility: visibility,
+              #historyVisibility: historyVisibility,
+              #waitForSync: waitForSync,
+              #groupCall: groupCall,
+              #federated: federated,
+              #powerLevelContentOverride: powerLevelContentOverride,
+            },
+          ),
+        )),
+      ) as _i5.Future<String>);
+
+  @override
+  _i5.Future<_i2.SyncUpdate> waitForRoomInSync(
+    String? roomId, {
+    bool? join = false,
+    bool? invite = false,
+    bool? leave = false,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #waitForRoomInSync,
+          [roomId],
+          {
+            #join: join,
+            #invite: invite,
+            #leave: leave,
+          },
+        ),
+        returnValue: _i5.Future<_i2.SyncUpdate>.value(_FakeSyncUpdate_15(
+          this,
+          Invocation.method(
+            #waitForRoomInSync,
+            [roomId],
+            {
+              #join: join,
+              #invite: invite,
+              #leave: leave,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.SyncUpdate>.value(_FakeSyncUpdate_15(
+          this,
+          Invocation.method(
+            #waitForRoomInSync,
+            [roomId],
+            {
+              #join: join,
+              #invite: invite,
+              #leave: leave,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.SyncUpdate>);
+
+  @override
+  _i5.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #userOwnsEncryptionKeys,
+          [userId],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<String> createSpace({
+    String? name,
+    String? topic,
+    _i2.Visibility? visibility = _i2.Visibility.public,
+    String? spaceAliasName,
+    List<String>? invite,
+    List<_i2.Invite3pid>? invite3pid,
+    String? roomVersion,
+    bool? waitForSync = false,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #createSpace,
+          [],
+          {
+            #name: name,
+            #topic: topic,
+            #visibility: visibility,
+            #spaceAliasName: spaceAliasName,
+            #invite: invite,
+            #invite3pid: invite3pid,
+            #roomVersion: roomVersion,
+            #waitForSync: waitForSync,
+          },
+        ),
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #createSpace,
+            [],
+            {
+              #name: name,
+              #topic: topic,
+              #visibility: visibility,
+              #spaceAliasName: spaceAliasName,
+              #invite: invite,
+              #invite3pid: invite3pid,
+              #roomVersion: roomVersion,
+              #waitForSync: waitForSync,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #createSpace,
+            [],
+            {
+              #name: name,
+              #topic: topic,
+              #visibility: visibility,
+              #spaceAliasName: spaceAliasName,
+              #invite: invite,
+              #invite3pid: invite3pid,
+              #roomVersion: roomVersion,
+              #waitForSync: waitForSync,
+            },
+          ),
+        )),
+      ) as _i5.Future<String>);
+
+  @override
+  _i5.Future<_i2.Profile> fetchOwnProfileFromServer(
+          {bool? useServerCache = false}) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #fetchOwnProfileFromServer,
+          [],
+          {#useServerCache: useServerCache},
+        ),
+        returnValue: _i5.Future<_i2.Profile>.value(_FakeProfile_5(
+          this,
+          Invocation.method(
+            #fetchOwnProfileFromServer,
+            [],
+            {#useServerCache: useServerCache},
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.Profile>.value(_FakeProfile_5(
+          this,
+          Invocation.method(
+            #fetchOwnProfileFromServer,
+            [],
+            {#useServerCache: useServerCache},
+          ),
+        )),
+      ) as _i5.Future<_i2.Profile>);
+
+  @override
+  _i5.Future<_i2.Profile> fetchOwnProfile({
+    bool? getFromRooms = true,
+    bool? cache = true,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #fetchOwnProfile,
+          [],
+          {
+            #getFromRooms: getFromRooms,
+            #cache: cache,
+          },
+        ),
+        returnValue: _i5.Future<_i2.Profile>.value(_FakeProfile_5(
+          this,
+          Invocation.method(
+            #fetchOwnProfile,
+            [],
+            {
+              #getFromRooms: getFromRooms,
+              #cache: cache,
+            },
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.Profile>.value(_FakeProfile_5(
+          this,
+          Invocation.method(
+            #fetchOwnProfile,
+            [],
+            {
+              #getFromRooms: getFromRooms,
+              #cache: cache,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.Profile>);
+
+  @override
+  _i5.Future<_i2.CachedProfileInformation> getUserProfile(
+    String? userId, {
+    Duration? timeout = const Duration(seconds: 30),
+    Duration? maxCacheAge = const Duration(days: 1),
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getUserProfile,
+          [userId],
+          {
+            #timeout: timeout,
+            #maxCacheAge: maxCacheAge,
+          },
+        ),
+        returnValue: _i5.Future<_i2.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_16(
+          this,
+          Invocation.method(
+            #getUserProfile,
+            [userId],
+            {
+              #timeout: timeout,
+              #maxCacheAge: maxCacheAge,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_16(
+          this,
+          Invocation.method(
+            #getUserProfile,
+            [userId],
+            {
+              #timeout: timeout,
+              #maxCacheAge: maxCacheAge,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.CachedProfileInformation>);
+
+  @override
+  _i5.Future<_i2.Profile> getProfileFromUserId(
+    String? userId, {
+    bool? getFromRooms,
+    bool? cache,
+    Duration? timeout = const Duration(seconds: 30),
+    Duration? maxCacheAge = const Duration(days: 1),
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getProfileFromUserId,
+          [userId],
+          {
+            #getFromRooms: getFromRooms,
+            #cache: cache,
+            #timeout: timeout,
+            #maxCacheAge: maxCacheAge,
+          },
+        ),
+        returnValue: _i5.Future<_i2.Profile>.value(_FakeProfile_5(
+          this,
+          Invocation.method(
+            #getProfileFromUserId,
+            [userId],
+            {
+              #getFromRooms: getFromRooms,
+              #cache: cache,
+              #timeout: timeout,
+              #maxCacheAge: maxCacheAge,
+            },
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.Profile>.value(_FakeProfile_5(
+          this,
+          Invocation.method(
+            #getProfileFromUserId,
+            [userId],
+            {
+              #getFromRooms: getFromRooms,
+              #cache: cache,
+              #timeout: timeout,
+              #maxCacheAge: maxCacheAge,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.Profile>);
+
+  @override
+  _i2.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getArchiveRoomFromCache,
+          [roomId],
+        ),
+        returnValueForMissingStub: null,
+      ) as _i2.ArchivedRoom?);
+
+  @override
+  void clearArchivesFromCache() => super.noSuchMethod(
+        Invocation.method(
+          #clearArchivesFromCache,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<List<_i2.Room>> loadArchive() => (super.noSuchMethod(
+        Invocation.method(
+          #loadArchive,
+          [],
+        ),
+        returnValue: _i5.Future<List<_i2.Room>>.value(<_i2.Room>[]),
+        returnValueForMissingStub:
+            _i5.Future<List<_i2.Room>>.value(<_i2.Room>[]),
+      ) as _i5.Future<List<_i2.Room>>);
+
+  @override
+  _i5.Future<List<_i2.ArchivedRoom>> loadArchiveWithTimeline() =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #loadArchiveWithTimeline,
+          [],
+        ),
+        returnValue:
+            _i5.Future<List<_i2.ArchivedRoom>>.value(<_i2.ArchivedRoom>[]),
+        returnValueForMissingStub:
+            _i5.Future<List<_i2.ArchivedRoom>>.value(<_i2.ArchivedRoom>[]),
+      ) as _i5.Future<List<_i2.ArchivedRoom>>);
+
+  @override
+  _i5.Future<_i2.GetVersionsResponse> getVersions({
+    Duration? cacheLifetime = const Duration(days: 3),
+    bool? throwOnUpdateFailure = false,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getVersions,
+          [],
+          {
+            #cacheLifetime: cacheLifetime,
+            #throwOnUpdateFailure: throwOnUpdateFailure,
+          },
+        ),
+        returnValue: _i5.Future<_i2.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_10(
+          this,
+          Invocation.method(
+            #getVersions,
+            [],
+            {
+              #cacheLifetime: cacheLifetime,
+              #throwOnUpdateFailure: throwOnUpdateFailure,
+            },
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_10(
+          this,
+          Invocation.method(
+            #getVersions,
+            [],
+            {
+              #cacheLifetime: cacheLifetime,
+              #throwOnUpdateFailure: throwOnUpdateFailure,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.GetVersionsResponse>);
+
+  @override
+  _i5.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+        Invocation.method(
+          #authenticatedMediaSupported,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<_i2.MediaConfig> getConfig({
+    Duration? cacheLifetime = const Duration(days: 3),
+    bool? throwOnUpdateFailure = false,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getConfig,
+          [],
+          {
+            #cacheLifetime: cacheLifetime,
+            #throwOnUpdateFailure: throwOnUpdateFailure,
+          },
+        ),
+        returnValue: _i5.Future<_i2.MediaConfig>.value(_FakeMediaConfig_17(
+          this,
+          Invocation.method(
+            #getConfig,
+            [],
+            {
+              #cacheLifetime: cacheLifetime,
+              #throwOnUpdateFailure: throwOnUpdateFailure,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.MediaConfig>.value(_FakeMediaConfig_17(
+          this,
+          Invocation.method(
+            #getConfig,
+            [],
+            {
+              #cacheLifetime: cacheLifetime,
+              #throwOnUpdateFailure: throwOnUpdateFailure,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.MediaConfig>);
+
+  @override
+  _i5.Future<_i6.FileResponse> getContent(
+    String? serverName,
+    String? mediaId, {
+    bool? allowRemote,
+    int? timeoutMs,
+    bool? allowRedirect,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getContent,
+          [
+            serverName,
+            mediaId,
+          ],
+          {
+            #allowRemote: allowRemote,
+            #timeoutMs: timeoutMs,
+            #allowRedirect: allowRedirect,
+          },
+        ),
+        returnValue: _i5.Future<_i6.FileResponse>.value(_FakeFileResponse_18(
+          this,
+          Invocation.method(
+            #getContent,
+            [
+              serverName,
+              mediaId,
+            ],
+            {
+              #allowRemote: allowRemote,
+              #timeoutMs: timeoutMs,
+              #allowRedirect: allowRedirect,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i6.FileResponse>.value(_FakeFileResponse_18(
+          this,
+          Invocation.method(
+            #getContent,
+            [
+              serverName,
+              mediaId,
+            ],
+            {
+              #allowRemote: allowRemote,
+              #timeoutMs: timeoutMs,
+              #allowRedirect: allowRedirect,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i6.FileResponse>);
+
+  @override
+  _i5.Future<_i6.FileResponse> getContentOverrideName(
+    String? serverName,
+    String? mediaId,
+    String? fileName, {
+    bool? allowRemote,
+    int? timeoutMs,
+    bool? allowRedirect,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getContentOverrideName,
+          [
+            serverName,
+            mediaId,
+            fileName,
+          ],
+          {
+            #allowRemote: allowRemote,
+            #timeoutMs: timeoutMs,
+            #allowRedirect: allowRedirect,
+          },
+        ),
+        returnValue: _i5.Future<_i6.FileResponse>.value(_FakeFileResponse_18(
+          this,
+          Invocation.method(
+            #getContentOverrideName,
+            [
+              serverName,
+              mediaId,
+              fileName,
+            ],
+            {
+              #allowRemote: allowRemote,
+              #timeoutMs: timeoutMs,
+              #allowRedirect: allowRedirect,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i6.FileResponse>.value(_FakeFileResponse_18(
+          this,
+          Invocation.method(
+            #getContentOverrideName,
+            [
+              serverName,
+              mediaId,
+              fileName,
+            ],
+            {
+              #allowRemote: allowRemote,
+              #timeoutMs: timeoutMs,
+              #allowRedirect: allowRedirect,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i6.FileResponse>);
+
+  @override
+  _i5.Future<_i6.FileResponse> getContentThumbnail(
+    String? serverName,
+    String? mediaId,
+    int? width,
+    int? height, {
+    _i2.Method? method,
+    bool? allowRemote,
+    int? timeoutMs,
+    bool? allowRedirect,
+    bool? animated,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getContentThumbnail,
+          [
+            serverName,
+            mediaId,
+            width,
+            height,
+          ],
+          {
+            #method: method,
+            #allowRemote: allowRemote,
+            #timeoutMs: timeoutMs,
+            #allowRedirect: allowRedirect,
+            #animated: animated,
+          },
+        ),
+        returnValue: _i5.Future<_i6.FileResponse>.value(_FakeFileResponse_18(
+          this,
+          Invocation.method(
+            #getContentThumbnail,
+            [
+              serverName,
+              mediaId,
+              width,
+              height,
+            ],
+            {
+              #method: method,
+              #allowRemote: allowRemote,
+              #timeoutMs: timeoutMs,
+              #allowRedirect: allowRedirect,
+              #animated: animated,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i6.FileResponse>.value(_FakeFileResponse_18(
+          this,
+          Invocation.method(
+            #getContentThumbnail,
+            [
+              serverName,
+              mediaId,
+              width,
+              height,
+            ],
+            {
+              #method: method,
+              #allowRemote: allowRemote,
+              #timeoutMs: timeoutMs,
+              #allowRedirect: allowRedirect,
+              #animated: animated,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i6.FileResponse>);
+
+  @override
+  _i5.Future<_i2.PreviewForUrl> getUrlPreview(
+    Uri? url, {
+    int? ts,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getUrlPreview,
+          [url],
+          {#ts: ts},
+        ),
+        returnValue: _i5.Future<_i2.PreviewForUrl>.value(_FakePreviewForUrl_19(
+          this,
+          Invocation.method(
+            #getUrlPreview,
+            [url],
+            {#ts: ts},
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.PreviewForUrl>.value(_FakePreviewForUrl_19(
+          this,
+          Invocation.method(
+            #getUrlPreview,
+            [url],
+            {#ts: ts},
+          ),
+        )),
+      ) as _i5.Future<_i2.PreviewForUrl>);
+
+  @override
+  _i5.Future<Uri> uploadContent(
+    _i16.Uint8List? file, {
+    String? filename,
+    String? contentType,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #uploadContent,
+          [file],
+          {
+            #filename: filename,
+            #contentType: contentType,
+          },
+        ),
+        returnValue: _i5.Future<Uri>.value(_FakeUri_20(
+          this,
+          Invocation.method(
+            #uploadContent,
+            [file],
+            {
+              #filename: filename,
+              #contentType: contentType,
+            },
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<Uri>.value(_FakeUri_20(
+          this,
+          Invocation.method(
+            #uploadContent,
+            [file],
+            {
+              #filename: filename,
+              #contentType: contentType,
+            },
+          ),
+        )),
+      ) as _i5.Future<Uri>);
+
+  @override
+  _i5.Future<void> setTyping(
+    String? userId,
+    String? roomId,
+    bool? typing, {
+    int? timeout,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setTyping,
+          [
+            userId,
+            roomId,
+            typing,
+          ],
+          {#timeout: timeout},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<String?> exportDump() => (super.noSuchMethod(
+        Invocation.method(
+          #exportDump,
+          [],
+        ),
+        returnValue: _i5.Future<String?>.value(),
+        returnValueForMissingStub: _i5.Future<String?>.value(),
+      ) as _i5.Future<String?>);
+
+  @override
+  _i5.Future<bool> importDump(String? export) => (super.noSuchMethod(
+        Invocation.method(
+          #importDump,
+          [export],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<void> setAvatar(_i2.MatrixFile? file) => (super.noSuchMethod(
+        Invocation.method(
+          #setAvatar,
+          [file],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<_i2.Event?> getEventByPushNotification(
+    _i2.PushNotification? notification, {
+    bool? storeInDatabase = true,
+    Duration? timeoutForServerRequests = const Duration(seconds: 8),
+    bool? returnNullIfSeen = true,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getEventByPushNotification,
+          [notification],
+          {
+            #storeInDatabase: storeInDatabase,
+            #timeoutForServerRequests: timeoutForServerRequests,
+            #returnNullIfSeen: returnNullIfSeen,
+          },
+        ),
+        returnValue: _i5.Future<_i2.Event?>.value(),
+        returnValueForMissingStub: _i5.Future<_i2.Event?>.value(),
+      ) as _i5.Future<_i2.Event?>);
+
+  @override
+  _i5.Future<void> init({
+    String? newToken,
+    DateTime? newTokenExpiresAt,
+    String? newRefreshToken,
+    Uri? newHomeserver,
+    String? newUserID,
+    String? newDeviceName,
+    String? newDeviceID,
+    String? newOlmAccount,
+    String? newOidcClientId,
+    bool? waitForFirstSync = true,
+    bool? waitUntilLoadCompletedLoaded = true,
+    void Function()? onMigration,
+    void Function(_i2.InitState)? onInitStateChanged,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+          {
+            #newToken: newToken,
+            #newTokenExpiresAt: newTokenExpiresAt,
+            #newRefreshToken: newRefreshToken,
+            #newHomeserver: newHomeserver,
+            #newUserID: newUserID,
+            #newDeviceName: newDeviceName,
+            #newDeviceID: newDeviceID,
+            #newOlmAccount: newOlmAccount,
+            #newOidcClientId: newOidcClientId,
+            #waitForFirstSync: waitForFirstSync,
+            #waitUntilLoadCompletedLoaded: waitUntilLoadCompletedLoaded,
+            #onMigration: onMigration,
+            #onInitStateChanged: onInitStateChanged,
+          },
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  void setUserId(String? s) => super.noSuchMethod(
+        Invocation.method(
+          #setUserId,
+          [s],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<void> clear() => (super.noSuchMethod(
+        Invocation.method(
+          #clear,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+        Invocation.method(
+          #oneShotSync,
+          [],
+          {#timeout: timeout},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> ensureNotSoftLoggedOut(
+          [Duration? expiresIn = const Duration(minutes: 1)]) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #ensureNotSoftLoggedOut,
+          [expiresIn],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> handleSync(
+    _i2.SyncUpdate? sync, {
+    _i2.Direction? direction,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleSync,
+          [sync],
+          {#direction: direction},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i2.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getUserDeviceKeysByCurve25519Key,
+          [senderKey],
+        ),
+        returnValueForMissingStub: null,
+      ) as _i2.DeviceKeys?);
+
+  @override
+  _i5.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateUserDeviceKeys,
+          [],
+          {#additionalUsers: additionalUsers},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+        Invocation.method(
+          #processToDeviceQueue,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> sendToDevice(
+    String? eventType,
+    String? txnId,
+    Map<String, Map<String, Map<String, dynamic>>>? messages,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #sendToDevice,
+          [
+            eventType,
+            txnId,
+            messages,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> sendToDevicesOfUserIds(
+    Set<String>? users,
+    String? eventType,
+    Map<String, dynamic>? message, {
+    String? messageId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #sendToDevicesOfUserIds,
+          [
+            users,
+            eventType,
+            message,
+          ],
+          {#messageId: messageId},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> sendToDeviceEncrypted(
+    List<_i2.DeviceKeys>? deviceKeys,
+    String? eventType,
+    Map<String, dynamic>? message, {
+    String? messageId,
+    bool? onlyVerified = false,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #sendToDeviceEncrypted,
+          [
+            deviceKeys,
+            eventType,
+            message,
+          ],
+          {
+            #messageId: messageId,
+            #onlyVerified: onlyVerified,
+          },
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> sendToDeviceEncryptedChunked(
+    List<_i2.DeviceKeys>? deviceKeys,
+    String? eventType,
+    Map<String, dynamic>? message,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #sendToDeviceEncryptedChunked,
+          [
+            deviceKeys,
+            eventType,
+            message,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setMuteAllPushNotifications(bool? muted) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setMuteAllPushNotifications,
+          [muted],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<String> joinRoom(
+    String? roomIdOrAlias, {
+    List<String>? serverName,
+    List<String>? via,
+    String? reason,
+    _i2.ThirdPartySigned? thirdPartySigned,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #joinRoom,
+          [roomIdOrAlias],
+          {
+            #serverName: serverName,
+            #via: via,
+            #reason: reason,
+            #thirdPartySigned: thirdPartySigned,
+          },
+        ),
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #joinRoom,
+            [roomIdOrAlias],
+            {
+              #serverName: serverName,
+              #via: via,
+              #reason: reason,
+              #thirdPartySigned: thirdPartySigned,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #joinRoom,
+            [roomIdOrAlias],
+            {
+              #serverName: serverName,
+              #via: via,
+              #reason: reason,
+              #thirdPartySigned: thirdPartySigned,
+            },
+          ),
+        )),
+      ) as _i5.Future<String>);
+
+  @override
+  _i5.Future<void> changePassword(
+    String? newPassword, {
+    String? oldPassword,
+    _i2.AuthenticationData? auth,
+    bool? logoutDevices,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #changePassword,
+          [newPassword],
+          {
+            #oldPassword: oldPassword,
+            #auth: auth,
+            #logoutDevices: logoutDevices,
+          },
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> clearCache() => (super.noSuchMethod(
+        Invocation.method(
+          #clearCache,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> ignoreUser(
+    String? userId, {
+    bool? leaveRooms = true,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #ignoreUser,
+          [userId],
+          {#leaveRooms: leaveRooms},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+        Invocation.method(
+          #unignoreUser,
+          [userId],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<_i2.CachedPresence> fetchCurrentPresence(
+    String? userId, {
+    bool? fetchOnlyFromCached = false,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #fetchCurrentPresence,
+          [userId],
+          {#fetchOnlyFromCached: fetchOnlyFromCached},
+        ),
+        returnValue:
+            _i5.Future<_i2.CachedPresence>.value(_FakeCachedPresence_21(
+          this,
+          Invocation.method(
+            #fetchCurrentPresence,
+            [userId],
+            {#fetchOnlyFromCached: fetchOnlyFromCached},
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.CachedPresence>.value(_FakeCachedPresence_21(
+          this,
+          Invocation.method(
+            #fetchCurrentPresence,
+            [userId],
+            {#fetchOnlyFromCached: fetchOnlyFromCached},
+          ),
+        )),
+      ) as _i5.Future<_i2.CachedPresence>);
+
+  @override
+  _i5.Future<void> abortSync() => (super.noSuchMethod(
+        Invocation.method(
+          #abortSync,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> dispose({bool? closeDatabase = true}) => (super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+          {#closeDatabase: closeDatabase},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<String?> redactEventWithMetadata(
+    String? roomId,
+    String? eventId,
+    String? txnId, {
+    String? reason,
+    Map<String, Object?>? metadata,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #redactEventWithMetadata,
+          [
+            roomId,
+            eventId,
+            txnId,
+          ],
+          {
+            #reason: reason,
+            #metadata: metadata,
+          },
+        ),
+        returnValue: _i5.Future<String?>.value(),
+        returnValueForMissingStub: _i5.Future<String?>.value(),
+      ) as _i5.Future<String?>);
+
+  @override
+  Never unexpectedResponse(
+    _i4.BaseResponse? response,
+    _i16.Uint8List? body,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #unexpectedResponse,
+          [
+            response,
+            body,
+          ],
+        ),
+        returnValue: null,
+        returnValueForMissingStub: null,
+      ) as Never);
+
+  @override
+  Never bodySizeExceeded(
+    int? expected,
+    int? actual,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #bodySizeExceeded,
+          [
+            expected,
+            actual,
+          ],
+        ),
+        returnValue: null,
+        returnValueForMissingStub: null,
+      ) as Never);
+
+  @override
+  _i5.Future<Map<String, Object?>> request(
+    _i2.RequestType? type,
+    String? action, {
+    dynamic data = '',
+    String? contentType = 'application/json',
+    Map<String, Object?>? query,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #request,
+          [
+            type,
+            action,
+          ],
+          {
+            #data: data,
+            #contentType: contentType,
+            #query: query,
+          },
+        ),
+        returnValue:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+        returnValueForMissingStub:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i5.Future<Map<String, Object?>>);
+
+  @override
+  _i5.Future<void> postPusher(
+    _i2.Pusher? pusher, {
+    bool? append,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #postPusher,
+          [pusher],
+          {#append: append},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> deletePusher(_i2.PusherId? pusher) => (super.noSuchMethod(
+        Invocation.method(
+          #deletePusher,
+          [pusher],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteDeviceDisplayName,
+          [deviceId],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<_i2.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+        Invocation.method(
+          #getTurnServer,
+          [],
+        ),
+        returnValue: _i5.Future<_i2.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_22(
+          this,
+          Invocation.method(
+            #getTurnServer,
+            [],
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_22(
+          this,
+          Invocation.method(
+            #getTurnServer,
+            [],
+          ),
+        )),
+      ) as _i5.Future<_i2.TurnServerCredentials>);
+
+  @override
+  _i5.Future<_i2.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+    String? roomId,
+    String? sessionId,
+    String? version,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRoomKeysBySessionId,
+          [
+            roomId,
+            sessionId,
+            version,
+          ],
+        ),
+        returnValue: _i5.Future<_i2.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_23(
+          this,
+          Invocation.method(
+            #deleteRoomKeysBySessionId,
+            [
+              roomId,
+              sessionId,
+              version,
+            ],
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_23(
+          this,
+          Invocation.method(
+            #deleteRoomKeysBySessionId,
+            [
+              roomId,
+              sessionId,
+              version,
+            ],
+          ),
+        )),
+      ) as _i5.Future<_i2.RoomKeysUpdateResponse>);
+
+  @override
+  _i5.Future<_i2.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+    String? roomId,
+    String? sessionId,
+    String? version,
+    _i2.KeyBackupData? data,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #putRoomKeysBySessionId,
+          [
+            roomId,
+            sessionId,
+            version,
+            data,
+          ],
+        ),
+        returnValue: _i5.Future<_i2.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_23(
+          this,
+          Invocation.method(
+            #putRoomKeysBySessionId,
+            [
+              roomId,
+              sessionId,
+              version,
+              data,
+            ],
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_23(
+          this,
+          Invocation.method(
+            #putRoomKeysBySessionId,
+            [
+              roomId,
+              sessionId,
+              version,
+              data,
+            ],
+          ),
+        )),
+      ) as _i5.Future<_i2.RoomKeysUpdateResponse>);
+
+  @override
+  _i5.Future<_i2.KeyBackupData> getRoomKeysBySessionId(
+    String? roomId,
+    String? sessionId,
+    String? version,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getRoomKeysBySessionId,
+          [
+            roomId,
+            sessionId,
+            version,
+          ],
+        ),
+        returnValue: _i5.Future<_i2.KeyBackupData>.value(_FakeKeyBackupData_24(
+          this,
+          Invocation.method(
+            #getRoomKeysBySessionId,
+            [
+              roomId,
+              sessionId,
+              version,
+            ],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.KeyBackupData>.value(_FakeKeyBackupData_24(
+          this,
+          Invocation.method(
+            #getRoomKeysBySessionId,
+            [
+              roomId,
+              sessionId,
+              version,
+            ],
+          ),
+        )),
+      ) as _i5.Future<_i2.KeyBackupData>);
+
+  @override
+  _i5.Future<_i2.GetWellknownSupportResponse> getWellknownSupport() =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getWellknownSupport,
+          [],
+        ),
+        returnValue: _i5.Future<_i2.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_25(
+          this,
+          Invocation.method(
+            #getWellknownSupport,
+            [],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_25(
+          this,
+          Invocation.method(
+            #getWellknownSupport,
+            [],
+          ),
+        )),
+      ) as _i5.Future<_i2.GetWellknownSupportResponse>);
+
+  @override
+  _i5.Future<int> pingAppservice(
+    String? appserviceId, {
+    String? transactionId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #pingAppservice,
+          [appserviceId],
+          {#transactionId: transactionId},
+        ),
+        returnValue: _i5.Future<int>.value(0),
+        returnValueForMissingStub: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
+
+  @override
+  _i5.Future<_i2.GenerateLoginTokenResponse> generateLoginToken(
+          {_i2.AuthenticationData? auth}) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #generateLoginToken,
+          [],
+          {#auth: auth},
+        ),
+        returnValue: _i5.Future<_i2.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_26(
+          this,
+          Invocation.method(
+            #generateLoginToken,
+            [],
+            {#auth: auth},
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_26(
+          this,
+          Invocation.method(
+            #generateLoginToken,
+            [],
+            {#auth: auth},
+          ),
+        )),
+      ) as _i5.Future<_i2.GenerateLoginTokenResponse>);
+
+  @override
+  _i5.Future<_i2.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+        Invocation.method(
+          #getConfigAuthed,
+          [],
+        ),
+        returnValue: _i5.Future<_i2.MediaConfig>.value(_FakeMediaConfig_17(
+          this,
+          Invocation.method(
+            #getConfigAuthed,
+            [],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.MediaConfig>.value(_FakeMediaConfig_17(
+          this,
+          Invocation.method(
+            #getConfigAuthed,
+            [],
+          ),
+        )),
+      ) as _i5.Future<_i2.MediaConfig>);
+
+  @override
+  _i5.Future<_i6.FileResponse> getContentAuthed(
+    String? serverName,
+    String? mediaId, {
+    int? timeoutMs,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getContentAuthed,
+          [
+            serverName,
+            mediaId,
+          ],
+          {#timeoutMs: timeoutMs},
+        ),
+        returnValue: _i5.Future<_i6.FileResponse>.value(_FakeFileResponse_18(
+          this,
+          Invocation.method(
+            #getContentAuthed,
+            [
+              serverName,
+              mediaId,
+            ],
+            {#timeoutMs: timeoutMs},
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i6.FileResponse>.value(_FakeFileResponse_18(
+          this,
+          Invocation.method(
+            #getContentAuthed,
+            [
+              serverName,
+              mediaId,
+            ],
+            {#timeoutMs: timeoutMs},
+          ),
+        )),
+      ) as _i5.Future<_i6.FileResponse>);
+
+  @override
+  _i5.Future<_i6.FileResponse> getContentOverrideNameAuthed(
+    String? serverName,
+    String? mediaId,
+    String? fileName, {
+    int? timeoutMs,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getContentOverrideNameAuthed,
+          [
+            serverName,
+            mediaId,
+            fileName,
+          ],
+          {#timeoutMs: timeoutMs},
+        ),
+        returnValue: _i5.Future<_i6.FileResponse>.value(_FakeFileResponse_18(
+          this,
+          Invocation.method(
+            #getContentOverrideNameAuthed,
+            [
+              serverName,
+              mediaId,
+              fileName,
+            ],
+            {#timeoutMs: timeoutMs},
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i6.FileResponse>.value(_FakeFileResponse_18(
+          this,
+          Invocation.method(
+            #getContentOverrideNameAuthed,
+            [
+              serverName,
+              mediaId,
+              fileName,
+            ],
+            {#timeoutMs: timeoutMs},
+          ),
+        )),
+      ) as _i5.Future<_i6.FileResponse>);
+
+  @override
+  _i5.Future<_i2.PreviewForUrl> getUrlPreviewAuthed(
+    Uri? url, {
+    int? ts,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getUrlPreviewAuthed,
+          [url],
+          {#ts: ts},
+        ),
+        returnValue: _i5.Future<_i2.PreviewForUrl>.value(_FakePreviewForUrl_19(
+          this,
+          Invocation.method(
+            #getUrlPreviewAuthed,
+            [url],
+            {#ts: ts},
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.PreviewForUrl>.value(_FakePreviewForUrl_19(
+          this,
+          Invocation.method(
+            #getUrlPreviewAuthed,
+            [url],
+            {#ts: ts},
+          ),
+        )),
+      ) as _i5.Future<_i2.PreviewForUrl>);
+
+  @override
+  _i5.Future<_i6.FileResponse> getContentThumbnailAuthed(
+    String? serverName,
+    String? mediaId,
+    int? width,
+    int? height, {
+    _i2.Method? method,
+    int? timeoutMs,
+    bool? animated,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getContentThumbnailAuthed,
+          [
+            serverName,
+            mediaId,
+            width,
+            height,
+          ],
+          {
+            #method: method,
+            #timeoutMs: timeoutMs,
+            #animated: animated,
+          },
+        ),
+        returnValue: _i5.Future<_i6.FileResponse>.value(_FakeFileResponse_18(
+          this,
+          Invocation.method(
+            #getContentThumbnailAuthed,
+            [
+              serverName,
+              mediaId,
+              width,
+              height,
+            ],
+            {
+              #method: method,
+              #timeoutMs: timeoutMs,
+              #animated: animated,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i6.FileResponse>.value(_FakeFileResponse_18(
+          this,
+          Invocation.method(
+            #getContentThumbnailAuthed,
+            [
+              serverName,
+              mediaId,
+              width,
+              height,
+            ],
+            {
+              #method: method,
+              #timeoutMs: timeoutMs,
+              #animated: animated,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i6.FileResponse>);
+
+  @override
+  _i5.Future<bool> registrationTokenValidity(String? token) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #registrationTokenValidity,
+          [token],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<_i2.GetRoomSummaryResponse$3> getRoomSummary(
+    String? roomIdOrAlias, {
+    List<String>? via,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getRoomSummary,
+          [roomIdOrAlias],
+          {#via: via},
+        ),
+        returnValue: _i5.Future<_i2.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_27(
+          this,
+          Invocation.method(
+            #getRoomSummary,
+            [roomIdOrAlias],
+            {#via: via},
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_27(
+          this,
+          Invocation.method(
+            #getRoomSummary,
+            [roomIdOrAlias],
+            {#via: via},
+          ),
+        )),
+      ) as _i5.Future<_i2.GetRoomSummaryResponse$3>);
+
+  @override
+  _i5.Future<_i2.GetSpaceHierarchyResponse> getSpaceHierarchy(
+    String? roomId, {
+    bool? suggestedOnly,
+    int? limit,
+    int? maxDepth,
+    String? from,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getSpaceHierarchy,
+          [roomId],
+          {
+            #suggestedOnly: suggestedOnly,
+            #limit: limit,
+            #maxDepth: maxDepth,
+            #from: from,
+          },
+        ),
+        returnValue: _i5.Future<_i2.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_28(
+          this,
+          Invocation.method(
+            #getSpaceHierarchy,
+            [roomId],
+            {
+              #suggestedOnly: suggestedOnly,
+              #limit: limit,
+              #maxDepth: maxDepth,
+              #from: from,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_28(
+          this,
+          Invocation.method(
+            #getSpaceHierarchy,
+            [roomId],
+            {
+              #suggestedOnly: suggestedOnly,
+              #limit: limit,
+              #maxDepth: maxDepth,
+              #from: from,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.GetSpaceHierarchyResponse>);
+
+  @override
+  _i5.Future<_i2.GetRelatingEventsResponse> getRelatingEvents(
+    String? roomId,
+    String? eventId, {
+    String? from,
+    String? to,
+    int? limit,
+    _i2.Direction? dir,
+    bool? recurse,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getRelatingEvents,
+          [
+            roomId,
+            eventId,
+          ],
+          {
+            #from: from,
+            #to: to,
+            #limit: limit,
+            #dir: dir,
+            #recurse: recurse,
+          },
+        ),
+        returnValue: _i5.Future<_i2.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_29(
+          this,
+          Invocation.method(
+            #getRelatingEvents,
+            [
+              roomId,
+              eventId,
+            ],
+            {
+              #from: from,
+              #to: to,
+              #limit: limit,
+              #dir: dir,
+              #recurse: recurse,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_29(
+          this,
+          Invocation.method(
+            #getRelatingEvents,
+            [
+              roomId,
+              eventId,
+            ],
+            {
+              #from: from,
+              #to: to,
+              #limit: limit,
+              #dir: dir,
+              #recurse: recurse,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.GetRelatingEventsResponse>);
+
+  @override
+  _i5.Future<_i2.GetRelatingEventsWithRelTypeResponse>
+      getRelatingEventsWithRelType(
+    String? roomId,
+    String? eventId,
+    String? relType, {
+    String? from,
+    String? to,
+    int? limit,
+    _i2.Direction? dir,
+    bool? recurse,
+  }) =>
+          (super.noSuchMethod(
+            Invocation.method(
+              #getRelatingEventsWithRelType,
+              [
+                roomId,
+                eventId,
+                relType,
+              ],
+              {
+                #from: from,
+                #to: to,
+                #limit: limit,
+                #dir: dir,
+                #recurse: recurse,
+              },
+            ),
+            returnValue:
+                _i5.Future<_i2.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_30(
+              this,
+              Invocation.method(
+                #getRelatingEventsWithRelType,
+                [
+                  roomId,
+                  eventId,
+                  relType,
+                ],
+                {
+                  #from: from,
+                  #to: to,
+                  #limit: limit,
+                  #dir: dir,
+                  #recurse: recurse,
+                },
+              ),
+            )),
+            returnValueForMissingStub:
+                _i5.Future<_i2.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_30(
+              this,
+              Invocation.method(
+                #getRelatingEventsWithRelType,
+                [
+                  roomId,
+                  eventId,
+                  relType,
+                ],
+                {
+                  #from: from,
+                  #to: to,
+                  #limit: limit,
+                  #dir: dir,
+                  #recurse: recurse,
+                },
+              ),
+            )),
+          ) as _i5.Future<_i2.GetRelatingEventsWithRelTypeResponse>);
+
+  @override
+  _i5.Future<_i2.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+      getRelatingEventsWithRelTypeAndEventType(
+    String? roomId,
+    String? eventId,
+    String? relType,
+    String? eventType, {
+    String? from,
+    String? to,
+    int? limit,
+    _i2.Direction? dir,
+    bool? recurse,
+  }) =>
+          (super.noSuchMethod(
+            Invocation.method(
+              #getRelatingEventsWithRelTypeAndEventType,
+              [
+                roomId,
+                eventId,
+                relType,
+                eventType,
+              ],
+              {
+                #from: from,
+                #to: to,
+                #limit: limit,
+                #dir: dir,
+                #recurse: recurse,
+              },
+            ),
+            returnValue: _i5.Future<
+                    _i2.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_31(
+              this,
+              Invocation.method(
+                #getRelatingEventsWithRelTypeAndEventType,
+                [
+                  roomId,
+                  eventId,
+                  relType,
+                  eventType,
+                ],
+                {
+                  #from: from,
+                  #to: to,
+                  #limit: limit,
+                  #dir: dir,
+                  #recurse: recurse,
+                },
+              ),
+            )),
+            returnValueForMissingStub: _i5.Future<
+                    _i2.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_31(
+              this,
+              Invocation.method(
+                #getRelatingEventsWithRelTypeAndEventType,
+                [
+                  roomId,
+                  eventId,
+                  relType,
+                  eventType,
+                ],
+                {
+                  #from: from,
+                  #to: to,
+                  #limit: limit,
+                  #dir: dir,
+                  #recurse: recurse,
+                },
+              ),
+            )),
+          ) as _i5
+              .Future<_i2.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
+
+  @override
+  _i5.Future<_i2.GetThreadRootsResponse> getThreadRoots(
+    String? roomId, {
+    _i2.Include? include,
+    int? limit,
+    String? from,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getThreadRoots,
+          [roomId],
+          {
+            #include: include,
+            #limit: limit,
+            #from: from,
+          },
+        ),
+        returnValue: _i5.Future<_i2.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_32(
+          this,
+          Invocation.method(
+            #getThreadRoots,
+            [roomId],
+            {
+              #include: include,
+              #limit: limit,
+              #from: from,
+            },
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_32(
+          this,
+          Invocation.method(
+            #getThreadRoots,
+            [roomId],
+            {
+              #include: include,
+              #limit: limit,
+              #from: from,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.GetThreadRootsResponse>);
+
+  @override
+  _i5.Future<_i2.GetEventByTimestampResponse> getEventByTimestamp(
+    String? roomId,
+    int? ts,
+    _i2.Direction? dir,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getEventByTimestamp,
+          [
+            roomId,
+            ts,
+            dir,
+          ],
+        ),
+        returnValue: _i5.Future<_i2.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_33(
+          this,
+          Invocation.method(
+            #getEventByTimestamp,
+            [
+              roomId,
+              ts,
+              dir,
+            ],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_33(
+          this,
+          Invocation.method(
+            #getEventByTimestamp,
+            [
+              roomId,
+              ts,
+              dir,
+            ],
+          ),
+        )),
+      ) as _i5.Future<_i2.GetEventByTimestampResponse>);
+
+  @override
+  _i5.Future<List<_i2.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getAccount3PIDs,
+          [],
+        ),
+        returnValue: _i5.Future<List<_i2.ThirdPartyIdentifier>?>.value(),
+        returnValueForMissingStub:
+            _i5.Future<List<_i2.ThirdPartyIdentifier>?>.value(),
+      ) as _i5.Future<List<_i2.ThirdPartyIdentifier>?>);
+
+  @override
+  _i5.Future<Uri?> post3PIDs(_i2.ThreePidCredentials? threePidCreds) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #post3PIDs,
+          [threePidCreds],
+        ),
+        returnValue: _i5.Future<Uri?>.value(),
+        returnValueForMissingStub: _i5.Future<Uri?>.value(),
+      ) as _i5.Future<Uri?>);
+
+  @override
+  _i5.Future<void> add3PID(
+    String? clientSecret,
+    String? sid, {
+    _i2.AuthenticationData? auth,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #add3PID,
+          [
+            clientSecret,
+            sid,
+          ],
+          {#auth: auth},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> bind3PID(
+    String? clientSecret,
+    String? idAccessToken,
+    String? idServer,
+    String? sid,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #bind3PID,
+          [
+            clientSecret,
+            idAccessToken,
+            idServer,
+            sid,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<_i2.IdServerUnbindResult> delete3pidFromAccount(
+    String? address,
+    _i2.ThirdPartyIdentifierMedium? medium, {
+    String? idServer,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #delete3pidFromAccount,
+          [
+            address,
+            medium,
+          ],
+          {#idServer: idServer},
+        ),
+        returnValue: _i5.Future<_i2.IdServerUnbindResult>.value(
+            _i2.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i5.Future<_i2.IdServerUnbindResult>.value(
+            _i2.IdServerUnbindResult.noSupport),
+      ) as _i5.Future<_i2.IdServerUnbindResult>);
+
+  @override
+  _i5.Future<_i2.RequestTokenResponse> requestTokenTo3PIDEmail(
+    String? clientSecret,
+    String? email,
+    int? sendAttempt, {
+    Uri? nextLink,
+    String? idAccessToken,
+    String? idServer,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #requestTokenTo3PIDEmail,
+          [
+            clientSecret,
+            email,
+            sendAttempt,
+          ],
+          {
+            #nextLink: nextLink,
+            #idAccessToken: idAccessToken,
+            #idServer: idServer,
+          },
+        ),
+        returnValue: _i5.Future<_i2.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_34(
+          this,
+          Invocation.method(
+            #requestTokenTo3PIDEmail,
+            [
+              clientSecret,
+              email,
+              sendAttempt,
+            ],
+            {
+              #nextLink: nextLink,
+              #idAccessToken: idAccessToken,
+              #idServer: idServer,
+            },
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_34(
+          this,
+          Invocation.method(
+            #requestTokenTo3PIDEmail,
+            [
+              clientSecret,
+              email,
+              sendAttempt,
+            ],
+            {
+              #nextLink: nextLink,
+              #idAccessToken: idAccessToken,
+              #idServer: idServer,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.RequestTokenResponse>);
+
+  @override
+  _i5.Future<_i2.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+    String? clientSecret,
+    String? country,
+    String? phoneNumber,
+    int? sendAttempt, {
+    Uri? nextLink,
+    String? idAccessToken,
+    String? idServer,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #requestTokenTo3PIDMSISDN,
+          [
+            clientSecret,
+            country,
+            phoneNumber,
+            sendAttempt,
+          ],
+          {
+            #nextLink: nextLink,
+            #idAccessToken: idAccessToken,
+            #idServer: idServer,
+          },
+        ),
+        returnValue: _i5.Future<_i2.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_34(
+          this,
+          Invocation.method(
+            #requestTokenTo3PIDMSISDN,
+            [
+              clientSecret,
+              country,
+              phoneNumber,
+              sendAttempt,
+            ],
+            {
+              #nextLink: nextLink,
+              #idAccessToken: idAccessToken,
+              #idServer: idServer,
+            },
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_34(
+          this,
+          Invocation.method(
+            #requestTokenTo3PIDMSISDN,
+            [
+              clientSecret,
+              country,
+              phoneNumber,
+              sendAttempt,
+            ],
+            {
+              #nextLink: nextLink,
+              #idAccessToken: idAccessToken,
+              #idServer: idServer,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.RequestTokenResponse>);
+
+  @override
+  _i5.Future<_i2.IdServerUnbindResult> unbind3pidFromAccount(
+    String? address,
+    _i2.ThirdPartyIdentifierMedium? medium, {
+    String? idServer,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #unbind3pidFromAccount,
+          [
+            address,
+            medium,
+          ],
+          {#idServer: idServer},
+        ),
+        returnValue: _i5.Future<_i2.IdServerUnbindResult>.value(
+            _i2.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i5.Future<_i2.IdServerUnbindResult>.value(
+            _i2.IdServerUnbindResult.noSupport),
+      ) as _i5.Future<_i2.IdServerUnbindResult>);
+
+  @override
+  _i5.Future<_i2.IdServerUnbindResult> deactivateAccount({
+    _i2.AuthenticationData? auth,
+    bool? erase,
+    String? idServer,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deactivateAccount,
+          [],
+          {
+            #auth: auth,
+            #erase: erase,
+            #idServer: idServer,
+          },
+        ),
+        returnValue: _i5.Future<_i2.IdServerUnbindResult>.value(
+            _i2.IdServerUnbindResult.noSupport),
+        returnValueForMissingStub: _i5.Future<_i2.IdServerUnbindResult>.value(
+            _i2.IdServerUnbindResult.noSupport),
+      ) as _i5.Future<_i2.IdServerUnbindResult>);
+
+  @override
+  _i5.Future<_i2.RequestTokenResponse> requestTokenToResetPasswordEmail(
+    String? clientSecret,
+    String? email,
+    int? sendAttempt, {
+    Uri? nextLink,
+    String? idAccessToken,
+    String? idServer,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #requestTokenToResetPasswordEmail,
+          [
+            clientSecret,
+            email,
+            sendAttempt,
+          ],
+          {
+            #nextLink: nextLink,
+            #idAccessToken: idAccessToken,
+            #idServer: idServer,
+          },
+        ),
+        returnValue: _i5.Future<_i2.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_34(
+          this,
+          Invocation.method(
+            #requestTokenToResetPasswordEmail,
+            [
+              clientSecret,
+              email,
+              sendAttempt,
+            ],
+            {
+              #nextLink: nextLink,
+              #idAccessToken: idAccessToken,
+              #idServer: idServer,
+            },
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_34(
+          this,
+          Invocation.method(
+            #requestTokenToResetPasswordEmail,
+            [
+              clientSecret,
+              email,
+              sendAttempt,
+            ],
+            {
+              #nextLink: nextLink,
+              #idAccessToken: idAccessToken,
+              #idServer: idServer,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.RequestTokenResponse>);
+
+  @override
+  _i5.Future<_i2.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+    String? clientSecret,
+    String? country,
+    String? phoneNumber,
+    int? sendAttempt, {
+    Uri? nextLink,
+    String? idAccessToken,
+    String? idServer,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #requestTokenToResetPasswordMSISDN,
+          [
+            clientSecret,
+            country,
+            phoneNumber,
+            sendAttempt,
+          ],
+          {
+            #nextLink: nextLink,
+            #idAccessToken: idAccessToken,
+            #idServer: idServer,
+          },
+        ),
+        returnValue: _i5.Future<_i2.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_34(
+          this,
+          Invocation.method(
+            #requestTokenToResetPasswordMSISDN,
+            [
+              clientSecret,
+              country,
+              phoneNumber,
+              sendAttempt,
+            ],
+            {
+              #nextLink: nextLink,
+              #idAccessToken: idAccessToken,
+              #idServer: idServer,
+            },
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_34(
+          this,
+          Invocation.method(
+            #requestTokenToResetPasswordMSISDN,
+            [
+              clientSecret,
+              country,
+              phoneNumber,
+              sendAttempt,
+            ],
+            {
+              #nextLink: nextLink,
+              #idAccessToken: idAccessToken,
+              #idServer: idServer,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.RequestTokenResponse>);
+
+  @override
+  _i5.Future<_i2.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+        Invocation.method(
+          #getTokenOwner,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i2.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_35(
+          this,
+          Invocation.method(
+            #getTokenOwner,
+            [],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_35(
+          this,
+          Invocation.method(
+            #getTokenOwner,
+            [],
+          ),
+        )),
+      ) as _i5.Future<_i2.TokenOwnerInfo>);
+
+  @override
+  _i5.Future<_i2.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+        Invocation.method(
+          #getWhoIs,
+          [userId],
+        ),
+        returnValue: _i5.Future<_i2.WhoIsInfo>.value(_FakeWhoIsInfo_36(
+          this,
+          Invocation.method(
+            #getWhoIs,
+            [userId],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.WhoIsInfo>.value(_FakeWhoIsInfo_36(
+          this,
+          Invocation.method(
+            #getWhoIs,
+            [userId],
+          ),
+        )),
+      ) as _i5.Future<_i2.WhoIsInfo>);
+
+  @override
+  _i5.Future<_i2.Capabilities> getCapabilities() => (super.noSuchMethod(
+        Invocation.method(
+          #getCapabilities,
+          [],
+        ),
+        returnValue: _i5.Future<_i2.Capabilities>.value(_FakeCapabilities_37(
+          this,
+          Invocation.method(
+            #getCapabilities,
+            [],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.Capabilities>.value(_FakeCapabilities_37(
+          this,
+          Invocation.method(
+            #getCapabilities,
+            [],
+          ),
+        )),
+      ) as _i5.Future<_i2.Capabilities>);
+
+  @override
+  _i5.Future<String> createRoom({
+    Map<String, Object?>? creationContent,
+    List<_i2.StateEvent>? initialState,
+    List<String>? invite,
+    List<_i2.Invite3pid>? invite3pid,
+    bool? isDirect,
+    String? name,
+    Map<String, Object?>? powerLevelContentOverride,
+    _i2.CreateRoomPreset? preset,
+    String? roomAliasName,
+    String? roomVersion,
+    String? topic,
+    _i2.Visibility? visibility,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #createRoom,
+          [],
+          {
+            #creationContent: creationContent,
+            #initialState: initialState,
+            #invite: invite,
+            #invite3pid: invite3pid,
+            #isDirect: isDirect,
+            #name: name,
+            #powerLevelContentOverride: powerLevelContentOverride,
+            #preset: preset,
+            #roomAliasName: roomAliasName,
+            #roomVersion: roomVersion,
+            #topic: topic,
+            #visibility: visibility,
+          },
+        ),
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #createRoom,
+            [],
+            {
+              #creationContent: creationContent,
+              #initialState: initialState,
+              #invite: invite,
+              #invite3pid: invite3pid,
+              #isDirect: isDirect,
+              #name: name,
+              #powerLevelContentOverride: powerLevelContentOverride,
+              #preset: preset,
+              #roomAliasName: roomAliasName,
+              #roomVersion: roomVersion,
+              #topic: topic,
+              #visibility: visibility,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #createRoom,
+            [],
+            {
+              #creationContent: creationContent,
+              #initialState: initialState,
+              #invite: invite,
+              #invite3pid: invite3pid,
+              #isDirect: isDirect,
+              #name: name,
+              #powerLevelContentOverride: powerLevelContentOverride,
+              #preset: preset,
+              #roomAliasName: roomAliasName,
+              #roomVersion: roomVersion,
+              #topic: topic,
+              #visibility: visibility,
+            },
+          ),
+        )),
+      ) as _i5.Future<String>);
+
+  @override
+  _i5.Future<void> deleteDevices(
+    List<String>? devices, {
+    _i2.AuthenticationData? auth,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteDevices,
+          [devices],
+          {#auth: auth},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<List<_i2.Device>?> getDevices() => (super.noSuchMethod(
+        Invocation.method(
+          #getDevices,
+          [],
+        ),
+        returnValue: _i5.Future<List<_i2.Device>?>.value(),
+        returnValueForMissingStub: _i5.Future<List<_i2.Device>?>.value(),
+      ) as _i5.Future<List<_i2.Device>?>);
+
+  @override
+  _i5.Future<void> deleteDevice(
+    String? deviceId, {
+    _i2.AuthenticationData? auth,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteDevice,
+          [deviceId],
+          {#auth: auth},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<_i2.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+        Invocation.method(
+          #getDevice,
+          [deviceId],
+        ),
+        returnValue: _i5.Future<_i2.Device>.value(_FakeDevice_38(
+          this,
+          Invocation.method(
+            #getDevice,
+            [deviceId],
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.Device>.value(_FakeDevice_38(
+          this,
+          Invocation.method(
+            #getDevice,
+            [deviceId],
+          ),
+        )),
+      ) as _i5.Future<_i2.Device>);
+
+  @override
+  _i5.Future<void> updateDevice(
+    String? deviceId, {
+    String? displayName,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateDevice,
+          [deviceId],
+          {#displayName: displayName},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+    String? networkId,
+    String? roomId,
+    _i2.Visibility? visibility,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateAppserviceRoomDirectoryVisibility,
+          [
+            networkId,
+            roomId,
+            visibility,
+          ],
+        ),
+        returnValue:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+        returnValueForMissingStub:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i5.Future<Map<String, Object?>>);
+
+  @override
+  _i5.Future<_i2.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getRoomVisibilityOnDirectory,
+          [roomId],
+        ),
+        returnValue: _i5.Future<_i2.Visibility?>.value(),
+        returnValueForMissingStub: _i5.Future<_i2.Visibility?>.value(),
+      ) as _i5.Future<_i2.Visibility?>);
+
+  @override
+  _i5.Future<void> setRoomVisibilityOnDirectory(
+    String? roomId, {
+    _i2.Visibility? visibility,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setRoomVisibilityOnDirectory,
+          [roomId],
+          {#visibility: visibility},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+        Invocation.method(
+          #deleteRoomAlias,
+          [roomAlias],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<_i2.GetRoomIdByAliasResponse> getRoomIdByAlias(
+          String? roomAlias) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getRoomIdByAlias,
+          [roomAlias],
+        ),
+        returnValue: _i5.Future<_i2.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_39(
+          this,
+          Invocation.method(
+            #getRoomIdByAlias,
+            [roomAlias],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_39(
+          this,
+          Invocation.method(
+            #getRoomIdByAlias,
+            [roomAlias],
+          ),
+        )),
+      ) as _i5.Future<_i2.GetRoomIdByAliasResponse>);
+
+  @override
+  _i5.Future<void> setRoomAlias(
+    String? roomAlias,
+    String? roomId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setRoomAlias,
+          [
+            roomAlias,
+            roomId,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<_i2.GetEventsResponse> getEvents({
+    String? from,
+    int? timeout,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getEvents,
+          [],
+          {
+            #from: from,
+            #timeout: timeout,
+          },
+        ),
+        returnValue:
+            _i5.Future<_i2.GetEventsResponse>.value(_FakeGetEventsResponse_40(
+          this,
+          Invocation.method(
+            #getEvents,
+            [],
+            {
+              #from: from,
+              #timeout: timeout,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.GetEventsResponse>.value(_FakeGetEventsResponse_40(
+          this,
+          Invocation.method(
+            #getEvents,
+            [],
+            {
+              #from: from,
+              #timeout: timeout,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.GetEventsResponse>);
+
+  @override
+  _i5.Future<_i2.PeekEventsResponse> peekEvents({
+    String? from,
+    int? timeout,
+    String? roomId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #peekEvents,
+          [],
+          {
+            #from: from,
+            #timeout: timeout,
+            #roomId: roomId,
+          },
+        ),
+        returnValue:
+            _i5.Future<_i2.PeekEventsResponse>.value(_FakePeekEventsResponse_41(
+          this,
+          Invocation.method(
+            #peekEvents,
+            [],
+            {
+              #from: from,
+              #timeout: timeout,
+              #roomId: roomId,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.PeekEventsResponse>.value(_FakePeekEventsResponse_41(
+          this,
+          Invocation.method(
+            #peekEvents,
+            [],
+            {
+              #from: from,
+              #timeout: timeout,
+              #roomId: roomId,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.PeekEventsResponse>);
+
+  @override
+  _i5.Future<_i2.MatrixEvent> getOneEvent(String? eventId) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getOneEvent,
+          [eventId],
+        ),
+        returnValue: _i5.Future<_i2.MatrixEvent>.value(_FakeMatrixEvent_42(
+          this,
+          Invocation.method(
+            #getOneEvent,
+            [eventId],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.MatrixEvent>.value(_FakeMatrixEvent_42(
+          this,
+          Invocation.method(
+            #getOneEvent,
+            [eventId],
+          ),
+        )),
+      ) as _i5.Future<_i2.MatrixEvent>);
+
+  @override
+  _i5.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+        Invocation.method(
+          #getJoinedRooms,
+          [],
+        ),
+        returnValue: _i5.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i5.Future<List<String>>.value(<String>[]),
+      ) as _i5.Future<List<String>>);
+
+  @override
+  _i5.Future<_i2.GetKeysChangesResponse> getKeysChanges(
+    String? from,
+    String? to,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getKeysChanges,
+          [
+            from,
+            to,
+          ],
+        ),
+        returnValue: _i5.Future<_i2.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_43(
+          this,
+          Invocation.method(
+            #getKeysChanges,
+            [
+              from,
+              to,
+            ],
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_43(
+          this,
+          Invocation.method(
+            #getKeysChanges,
+            [
+              from,
+              to,
+            ],
+          ),
+        )),
+      ) as _i5.Future<_i2.GetKeysChangesResponse>);
+
+  @override
+  _i5.Future<_i2.ClaimKeysResponse> claimKeys(
+    Map<String, Map<String, String>>? oneTimeKeys, {
+    int? timeout,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #claimKeys,
+          [oneTimeKeys],
+          {#timeout: timeout},
+        ),
+        returnValue:
+            _i5.Future<_i2.ClaimKeysResponse>.value(_FakeClaimKeysResponse_44(
+          this,
+          Invocation.method(
+            #claimKeys,
+            [oneTimeKeys],
+            {#timeout: timeout},
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.ClaimKeysResponse>.value(_FakeClaimKeysResponse_44(
+          this,
+          Invocation.method(
+            #claimKeys,
+            [oneTimeKeys],
+            {#timeout: timeout},
+          ),
+        )),
+      ) as _i5.Future<_i2.ClaimKeysResponse>);
+
+  @override
+  _i5.Future<void> uploadCrossSigningKeys({
+    _i2.AuthenticationData? auth,
+    _i2.MatrixCrossSigningKey? masterKey,
+    _i2.MatrixCrossSigningKey? selfSigningKey,
+    _i2.MatrixCrossSigningKey? userSigningKey,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #uploadCrossSigningKeys,
+          [],
+          {
+            #auth: auth,
+            #masterKey: masterKey,
+            #selfSigningKey: selfSigningKey,
+            #userSigningKey: userSigningKey,
+          },
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<_i2.QueryKeysResponse> queryKeys(
+    Map<String, List<String>>? deviceKeys, {
+    int? timeout,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #queryKeys,
+          [deviceKeys],
+          {#timeout: timeout},
+        ),
+        returnValue:
+            _i5.Future<_i2.QueryKeysResponse>.value(_FakeQueryKeysResponse_45(
+          this,
+          Invocation.method(
+            #queryKeys,
+            [deviceKeys],
+            {#timeout: timeout},
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.QueryKeysResponse>.value(_FakeQueryKeysResponse_45(
+          this,
+          Invocation.method(
+            #queryKeys,
+            [deviceKeys],
+            {#timeout: timeout},
+          ),
+        )),
+      ) as _i5.Future<_i2.QueryKeysResponse>);
+
+  @override
+  _i5.Future<
+      Map<
+          String,
+          Map<String,
+              Map<String, Object?>>>?> uploadCrossSigningSignatures(
+          Map<String, Map<String, Map<String, Object?>>>? body) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #uploadCrossSigningSignatures,
+          [body],
+        ),
+        returnValue:
+            _i5.Future<Map<String, Map<String, Map<String, Object?>>>?>.value(),
+        returnValueForMissingStub:
+            _i5.Future<Map<String, Map<String, Map<String, Object?>>>?>.value(),
+      ) as _i5.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+
+  @override
+  _i5.Future<Map<String, int>> uploadKeys({
+    _i2.MatrixDeviceKeys? deviceKeys,
+    Map<String, Object?>? fallbackKeys,
+    Map<String, Object?>? oneTimeKeys,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #uploadKeys,
+          [],
+          {
+            #deviceKeys: deviceKeys,
+            #fallbackKeys: fallbackKeys,
+            #oneTimeKeys: oneTimeKeys,
+          },
+        ),
+        returnValue: _i5.Future<Map<String, int>>.value(<String, int>{}),
+        returnValueForMissingStub:
+            _i5.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i5.Future<Map<String, int>>);
+
+  @override
+  _i5.Future<String> knockRoom(
+    String? roomIdOrAlias, {
+    List<String>? via,
+    String? reason,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #knockRoom,
+          [roomIdOrAlias],
+          {
+            #via: via,
+            #reason: reason,
+          },
+        ),
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #knockRoom,
+            [roomIdOrAlias],
+            {
+              #via: via,
+              #reason: reason,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #knockRoom,
+            [roomIdOrAlias],
+            {
+              #via: via,
+              #reason: reason,
+            },
+          ),
+        )),
+      ) as _i5.Future<String>);
+
+  @override
+  _i5.Future<List<_i2.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+        Invocation.method(
+          #getLoginFlows,
+          [],
+        ),
+        returnValue: _i5.Future<List<_i2.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i5.Future<List<_i2.LoginFlow>?>.value(),
+      ) as _i5.Future<List<_i2.LoginFlow>?>);
+
+  @override
+  _i5.Future<_i2.GetNotificationsResponse> getNotifications({
+    String? from,
+    int? limit,
+    String? only,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getNotifications,
+          [],
+          {
+            #from: from,
+            #limit: limit,
+            #only: only,
+          },
+        ),
+        returnValue: _i5.Future<_i2.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_46(
+          this,
+          Invocation.method(
+            #getNotifications,
+            [],
+            {
+              #from: from,
+              #limit: limit,
+              #only: only,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_46(
+          this,
+          Invocation.method(
+            #getNotifications,
+            [],
+            {
+              #from: from,
+              #limit: limit,
+              #only: only,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.GetNotificationsResponse>);
+
+  @override
+  _i5.Future<_i2.GetPresenceResponse> getPresence(String? userId) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getPresence,
+          [userId],
+        ),
+        returnValue: _i5.Future<_i2.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_47(
+          this,
+          Invocation.method(
+            #getPresence,
+            [userId],
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_47(
+          this,
+          Invocation.method(
+            #getPresence,
+            [userId],
+          ),
+        )),
+      ) as _i5.Future<_i2.GetPresenceResponse>);
+
+  @override
+  _i5.Future<void> setPresence(
+    String? userId,
+    _i2.PresenceType? presence, {
+    String? statusMsg,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setPresence,
+          [
+            userId,
+            presence,
+          ],
+          {#statusMsg: statusMsg},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<Map<String, Object?>> deleteProfileField(
+    String? userId,
+    String? keyName,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteProfileField,
+          [
+            userId,
+            keyName,
+          ],
+        ),
+        returnValue:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+        returnValueForMissingStub:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i5.Future<Map<String, Object?>>);
+
+  @override
+  _i5.Future<Map<String, Object?>> getProfileField(
+    String? userId,
+    String? keyName,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getProfileField,
+          [
+            userId,
+            keyName,
+          ],
+        ),
+        returnValue:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+        returnValueForMissingStub:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i5.Future<Map<String, Object?>>);
+
+  @override
+  _i5.Future<Map<String, Object?>> setProfileField(
+    String? userId,
+    String? keyName,
+    Map<String, Object?>? body,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setProfileField,
+          [
+            userId,
+            keyName,
+            body,
+          ],
+        ),
+        returnValue:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+        returnValueForMissingStub:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i5.Future<Map<String, Object?>>);
+
+  @override
+  _i5.Future<_i2.GetPublicRoomsResponse> getPublicRooms({
+    int? limit,
+    String? since,
+    String? server,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getPublicRooms,
+          [],
+          {
+            #limit: limit,
+            #since: since,
+            #server: server,
+          },
+        ),
+        returnValue: _i5.Future<_i2.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_48(
+          this,
+          Invocation.method(
+            #getPublicRooms,
+            [],
+            {
+              #limit: limit,
+              #since: since,
+              #server: server,
+            },
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_48(
+          this,
+          Invocation.method(
+            #getPublicRooms,
+            [],
+            {
+              #limit: limit,
+              #since: since,
+              #server: server,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.GetPublicRoomsResponse>);
+
+  @override
+  _i5.Future<_i2.QueryPublicRoomsResponse> queryPublicRooms({
+    String? server,
+    _i2.PublicRoomQueryFilter? filter,
+    bool? includeAllNetworks,
+    int? limit,
+    String? since,
+    String? thirdPartyInstanceId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #queryPublicRooms,
+          [],
+          {
+            #server: server,
+            #filter: filter,
+            #includeAllNetworks: includeAllNetworks,
+            #limit: limit,
+            #since: since,
+            #thirdPartyInstanceId: thirdPartyInstanceId,
+          },
+        ),
+        returnValue: _i5.Future<_i2.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_49(
+          this,
+          Invocation.method(
+            #queryPublicRooms,
+            [],
+            {
+              #server: server,
+              #filter: filter,
+              #includeAllNetworks: includeAllNetworks,
+              #limit: limit,
+              #since: since,
+              #thirdPartyInstanceId: thirdPartyInstanceId,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_49(
+          this,
+          Invocation.method(
+            #queryPublicRooms,
+            [],
+            {
+              #server: server,
+              #filter: filter,
+              #includeAllNetworks: includeAllNetworks,
+              #limit: limit,
+              #since: since,
+              #thirdPartyInstanceId: thirdPartyInstanceId,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.QueryPublicRoomsResponse>);
+
+  @override
+  _i5.Future<List<_i2.Pusher>?> getPushers() => (super.noSuchMethod(
+        Invocation.method(
+          #getPushers,
+          [],
+        ),
+        returnValue: _i5.Future<List<_i2.Pusher>?>.value(),
+        returnValueForMissingStub: _i5.Future<List<_i2.Pusher>?>.value(),
+      ) as _i5.Future<List<_i2.Pusher>?>);
+
+  @override
+  _i5.Future<_i2.PushRuleSet> getPushRules() => (super.noSuchMethod(
+        Invocation.method(
+          #getPushRules,
+          [],
+        ),
+        returnValue: _i5.Future<_i2.PushRuleSet>.value(_FakePushRuleSet_50(
+          this,
+          Invocation.method(
+            #getPushRules,
+            [],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.PushRuleSet>.value(_FakePushRuleSet_50(
+          this,
+          Invocation.method(
+            #getPushRules,
+            [],
+          ),
+        )),
+      ) as _i5.Future<_i2.PushRuleSet>);
+
+  @override
+  _i5.Future<_i2.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getPushRulesGlobal,
+          [],
+        ),
+        returnValue: _i5.Future<_i2.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_51(
+          this,
+          Invocation.method(
+            #getPushRulesGlobal,
+            [],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_51(
+          this,
+          Invocation.method(
+            #getPushRulesGlobal,
+            [],
+          ),
+        )),
+      ) as _i5.Future<_i2.GetPushRulesGlobalResponse>);
+
+  @override
+  _i5.Future<void> deletePushRule(
+    _i2.PushRuleKind? kind,
+    String? ruleId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deletePushRule,
+          [
+            kind,
+            ruleId,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<_i2.PushRule> getPushRule(
+    _i2.PushRuleKind? kind,
+    String? ruleId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getPushRule,
+          [
+            kind,
+            ruleId,
+          ],
+        ),
+        returnValue: _i5.Future<_i2.PushRule>.value(_FakePushRule_52(
+          this,
+          Invocation.method(
+            #getPushRule,
+            [
+              kind,
+              ruleId,
+            ],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.PushRule>.value(_FakePushRule_52(
+          this,
+          Invocation.method(
+            #getPushRule,
+            [
+              kind,
+              ruleId,
+            ],
+          ),
+        )),
+      ) as _i5.Future<_i2.PushRule>);
+
+  @override
+  _i5.Future<void> setPushRule(
+    _i2.PushRuleKind? kind,
+    String? ruleId,
+    List<Object?>? actions, {
+    String? before,
+    String? after,
+    List<_i2.PushCondition>? conditions,
+    String? pattern,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setPushRule,
+          [
+            kind,
+            ruleId,
+            actions,
+          ],
+          {
+            #before: before,
+            #after: after,
+            #conditions: conditions,
+            #pattern: pattern,
+          },
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<List<Object?>> getPushRuleActions(
+    _i2.PushRuleKind? kind,
+    String? ruleId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getPushRuleActions,
+          [
+            kind,
+            ruleId,
+          ],
+        ),
+        returnValue: _i5.Future<List<Object?>>.value(<Object?>[]),
+        returnValueForMissingStub: _i5.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i5.Future<List<Object?>>);
+
+  @override
+  _i5.Future<void> setPushRuleActions(
+    _i2.PushRuleKind? kind,
+    String? ruleId,
+    List<Object?>? actions,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setPushRuleActions,
+          [
+            kind,
+            ruleId,
+            actions,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<bool> isPushRuleEnabled(
+    _i2.PushRuleKind? kind,
+    String? ruleId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #isPushRuleEnabled,
+          [
+            kind,
+            ruleId,
+          ],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<void> setPushRuleEnabled(
+    _i2.PushRuleKind? kind,
+    String? ruleId,
+    bool? enabled,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setPushRuleEnabled,
+          [
+            kind,
+            ruleId,
+            enabled,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<_i2.RefreshResponse> refresh(String? refreshToken) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #refresh,
+          [refreshToken],
+        ),
+        returnValue:
+            _i5.Future<_i2.RefreshResponse>.value(_FakeRefreshResponse_53(
+          this,
+          Invocation.method(
+            #refresh,
+            [refreshToken],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.RefreshResponse>.value(_FakeRefreshResponse_53(
+          this,
+          Invocation.method(
+            #refresh,
+            [refreshToken],
+          ),
+        )),
+      ) as _i5.Future<_i2.RefreshResponse>);
+
+  @override
+  _i5.Future<bool?> checkUsernameAvailability(String? username) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #checkUsernameAvailability,
+          [username],
+        ),
+        returnValue: _i5.Future<bool?>.value(),
+        returnValueForMissingStub: _i5.Future<bool?>.value(),
+      ) as _i5.Future<bool?>);
+
+  @override
+  _i5.Future<_i2.RequestTokenResponse> requestTokenToRegisterEmail(
+    String? clientSecret,
+    String? email,
+    int? sendAttempt, {
+    Uri? nextLink,
+    String? idAccessToken,
+    String? idServer,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #requestTokenToRegisterEmail,
+          [
+            clientSecret,
+            email,
+            sendAttempt,
+          ],
+          {
+            #nextLink: nextLink,
+            #idAccessToken: idAccessToken,
+            #idServer: idServer,
+          },
+        ),
+        returnValue: _i5.Future<_i2.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_34(
+          this,
+          Invocation.method(
+            #requestTokenToRegisterEmail,
+            [
+              clientSecret,
+              email,
+              sendAttempt,
+            ],
+            {
+              #nextLink: nextLink,
+              #idAccessToken: idAccessToken,
+              #idServer: idServer,
+            },
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_34(
+          this,
+          Invocation.method(
+            #requestTokenToRegisterEmail,
+            [
+              clientSecret,
+              email,
+              sendAttempt,
+            ],
+            {
+              #nextLink: nextLink,
+              #idAccessToken: idAccessToken,
+              #idServer: idServer,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.RequestTokenResponse>);
+
+  @override
+  _i5.Future<_i2.RequestTokenResponse> requestTokenToRegisterMSISDN(
+    String? clientSecret,
+    String? country,
+    String? phoneNumber,
+    int? sendAttempt, {
+    Uri? nextLink,
+    String? idAccessToken,
+    String? idServer,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #requestTokenToRegisterMSISDN,
+          [
+            clientSecret,
+            country,
+            phoneNumber,
+            sendAttempt,
+          ],
+          {
+            #nextLink: nextLink,
+            #idAccessToken: idAccessToken,
+            #idServer: idServer,
+          },
+        ),
+        returnValue: _i5.Future<_i2.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_34(
+          this,
+          Invocation.method(
+            #requestTokenToRegisterMSISDN,
+            [
+              clientSecret,
+              country,
+              phoneNumber,
+              sendAttempt,
+            ],
+            {
+              #nextLink: nextLink,
+              #idAccessToken: idAccessToken,
+              #idServer: idServer,
+            },
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_34(
+          this,
+          Invocation.method(
+            #requestTokenToRegisterMSISDN,
+            [
+              clientSecret,
+              country,
+              phoneNumber,
+              sendAttempt,
+            ],
+            {
+              #nextLink: nextLink,
+              #idAccessToken: idAccessToken,
+              #idServer: idServer,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.RequestTokenResponse>);
+
+  @override
+  _i5.Future<_i2.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRoomKeys,
+          [version],
+        ),
+        returnValue: _i5.Future<_i2.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_23(
+          this,
+          Invocation.method(
+            #deleteRoomKeys,
+            [version],
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_23(
+          this,
+          Invocation.method(
+            #deleteRoomKeys,
+            [version],
+          ),
+        )),
+      ) as _i5.Future<_i2.RoomKeysUpdateResponse>);
+
+  @override
+  _i5.Future<_i2.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+        Invocation.method(
+          #getRoomKeys,
+          [version],
+        ),
+        returnValue: _i5.Future<_i2.RoomKeys>.value(_FakeRoomKeys_54(
+          this,
+          Invocation.method(
+            #getRoomKeys,
+            [version],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.RoomKeys>.value(_FakeRoomKeys_54(
+          this,
+          Invocation.method(
+            #getRoomKeys,
+            [version],
+          ),
+        )),
+      ) as _i5.Future<_i2.RoomKeys>);
+
+  @override
+  _i5.Future<_i2.RoomKeysUpdateResponse> putRoomKeys(
+    String? version,
+    _i2.RoomKeys? body,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #putRoomKeys,
+          [
+            version,
+            body,
+          ],
+        ),
+        returnValue: _i5.Future<_i2.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_23(
+          this,
+          Invocation.method(
+            #putRoomKeys,
+            [
+              version,
+              body,
+            ],
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_23(
+          this,
+          Invocation.method(
+            #putRoomKeys,
+            [
+              version,
+              body,
+            ],
+          ),
+        )),
+      ) as _i5.Future<_i2.RoomKeysUpdateResponse>);
+
+  @override
+  _i5.Future<_i2.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+    String? roomId,
+    String? version,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRoomKeysByRoomId,
+          [
+            roomId,
+            version,
+          ],
+        ),
+        returnValue: _i5.Future<_i2.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_23(
+          this,
+          Invocation.method(
+            #deleteRoomKeysByRoomId,
+            [
+              roomId,
+              version,
+            ],
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_23(
+          this,
+          Invocation.method(
+            #deleteRoomKeysByRoomId,
+            [
+              roomId,
+              version,
+            ],
+          ),
+        )),
+      ) as _i5.Future<_i2.RoomKeysUpdateResponse>);
+
+  @override
+  _i5.Future<_i2.RoomKeyBackup> getRoomKeysByRoomId(
+    String? roomId,
+    String? version,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getRoomKeysByRoomId,
+          [
+            roomId,
+            version,
+          ],
+        ),
+        returnValue: _i5.Future<_i2.RoomKeyBackup>.value(_FakeRoomKeyBackup_55(
+          this,
+          Invocation.method(
+            #getRoomKeysByRoomId,
+            [
+              roomId,
+              version,
+            ],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.RoomKeyBackup>.value(_FakeRoomKeyBackup_55(
+          this,
+          Invocation.method(
+            #getRoomKeysByRoomId,
+            [
+              roomId,
+              version,
+            ],
+          ),
+        )),
+      ) as _i5.Future<_i2.RoomKeyBackup>);
+
+  @override
+  _i5.Future<_i2.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+    String? roomId,
+    String? version,
+    _i2.RoomKeyBackup? body,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #putRoomKeysByRoomId,
+          [
+            roomId,
+            version,
+            body,
+          ],
+        ),
+        returnValue: _i5.Future<_i2.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_23(
+          this,
+          Invocation.method(
+            #putRoomKeysByRoomId,
+            [
+              roomId,
+              version,
+              body,
+            ],
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_23(
+          this,
+          Invocation.method(
+            #putRoomKeysByRoomId,
+            [
+              roomId,
+              version,
+              body,
+            ],
+          ),
+        )),
+      ) as _i5.Future<_i2.RoomKeysUpdateResponse>);
+
+  @override
+  _i5.Future<_i2.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+    String? roomId,
+    String? sessionId,
+    String? version,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRoomKeyBySessionId,
+          [
+            roomId,
+            sessionId,
+            version,
+          ],
+        ),
+        returnValue: _i5.Future<_i2.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_23(
+          this,
+          Invocation.method(
+            #deleteRoomKeyBySessionId,
+            [
+              roomId,
+              sessionId,
+              version,
+            ],
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_23(
+          this,
+          Invocation.method(
+            #deleteRoomKeyBySessionId,
+            [
+              roomId,
+              sessionId,
+              version,
+            ],
+          ),
+        )),
+      ) as _i5.Future<_i2.RoomKeysUpdateResponse>);
+
+  @override
+  _i5.Future<_i2.KeyBackupData> getRoomKeyBySessionId(
+    String? roomId,
+    String? sessionId,
+    String? version,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getRoomKeyBySessionId,
+          [
+            roomId,
+            sessionId,
+            version,
+          ],
+        ),
+        returnValue: _i5.Future<_i2.KeyBackupData>.value(_FakeKeyBackupData_24(
+          this,
+          Invocation.method(
+            #getRoomKeyBySessionId,
+            [
+              roomId,
+              sessionId,
+              version,
+            ],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.KeyBackupData>.value(_FakeKeyBackupData_24(
+          this,
+          Invocation.method(
+            #getRoomKeyBySessionId,
+            [
+              roomId,
+              sessionId,
+              version,
+            ],
+          ),
+        )),
+      ) as _i5.Future<_i2.KeyBackupData>);
+
+  @override
+  _i5.Future<_i2.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+    String? roomId,
+    String? sessionId,
+    String? version,
+    _i2.KeyBackupData? body,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #putRoomKeyBySessionId,
+          [
+            roomId,
+            sessionId,
+            version,
+            body,
+          ],
+        ),
+        returnValue: _i5.Future<_i2.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_23(
+          this,
+          Invocation.method(
+            #putRoomKeyBySessionId,
+            [
+              roomId,
+              sessionId,
+              version,
+              body,
+            ],
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_23(
+          this,
+          Invocation.method(
+            #putRoomKeyBySessionId,
+            [
+              roomId,
+              sessionId,
+              version,
+              body,
+            ],
+          ),
+        )),
+      ) as _i5.Future<_i2.RoomKeysUpdateResponse>);
+
+  @override
+  _i5.Future<_i2.GetRoomKeysVersionCurrentResponse>
+      getRoomKeysVersionCurrent() => (super.noSuchMethod(
+            Invocation.method(
+              #getRoomKeysVersionCurrent,
+              [],
+            ),
+            returnValue:
+                _i5.Future<_i2.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_56(
+              this,
+              Invocation.method(
+                #getRoomKeysVersionCurrent,
+                [],
+              ),
+            )),
+            returnValueForMissingStub:
+                _i5.Future<_i2.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_56(
+              this,
+              Invocation.method(
+                #getRoomKeysVersionCurrent,
+                [],
+              ),
+            )),
+          ) as _i5.Future<_i2.GetRoomKeysVersionCurrentResponse>);
+
+  @override
+  _i5.Future<String> postRoomKeysVersion(
+    _i2.BackupAlgorithm? algorithm,
+    Map<String, Object?>? authData,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #postRoomKeysVersion,
+          [
+            algorithm,
+            authData,
+          ],
+        ),
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #postRoomKeysVersion,
+            [
+              algorithm,
+              authData,
+            ],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #postRoomKeysVersion,
+            [
+              algorithm,
+              authData,
+            ],
+          ),
+        )),
+      ) as _i5.Future<String>);
+
+  @override
+  _i5.Future<void> deleteRoomKeysVersion(String? version) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRoomKeysVersion,
+          [version],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<_i2.GetRoomKeysVersionResponse> getRoomKeysVersion(
+          String? version) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getRoomKeysVersion,
+          [version],
+        ),
+        returnValue: _i5.Future<_i2.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_57(
+          this,
+          Invocation.method(
+            #getRoomKeysVersion,
+            [version],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_57(
+          this,
+          Invocation.method(
+            #getRoomKeysVersion,
+            [version],
+          ),
+        )),
+      ) as _i5.Future<_i2.GetRoomKeysVersionResponse>);
+
+  @override
+  _i5.Future<Map<String, Object?>> putRoomKeysVersion(
+    String? version,
+    _i2.BackupAlgorithm? algorithm,
+    Map<String, Object?>? authData,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #putRoomKeysVersion,
+          [
+            version,
+            algorithm,
+            authData,
+          ],
+        ),
+        returnValue:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+        returnValueForMissingStub:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i5.Future<Map<String, Object?>>);
+
+  @override
+  _i5.Future<List<String>> getLocalAliases(String? roomId) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getLocalAliases,
+          [roomId],
+        ),
+        returnValue: _i5.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i5.Future<List<String>>.value(<String>[]),
+      ) as _i5.Future<List<String>>);
+
+  @override
+  _i5.Future<void> ban(
+    String? roomId,
+    String? userId, {
+    String? reason,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #ban,
+          [
+            roomId,
+            userId,
+          ],
+          {#reason: reason},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<_i2.EventContext> getEventContext(
+    String? roomId,
+    String? eventId, {
+    int? limit,
+    String? filter,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getEventContext,
+          [
+            roomId,
+            eventId,
+          ],
+          {
+            #limit: limit,
+            #filter: filter,
+          },
+        ),
+        returnValue: _i5.Future<_i2.EventContext>.value(_FakeEventContext_58(
+          this,
+          Invocation.method(
+            #getEventContext,
+            [
+              roomId,
+              eventId,
+            ],
+            {
+              #limit: limit,
+              #filter: filter,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.EventContext>.value(_FakeEventContext_58(
+          this,
+          Invocation.method(
+            #getEventContext,
+            [
+              roomId,
+              eventId,
+            ],
+            {
+              #limit: limit,
+              #filter: filter,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.EventContext>);
+
+  @override
+  _i5.Future<_i2.MatrixEvent> getOneRoomEvent(
+    String? roomId,
+    String? eventId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getOneRoomEvent,
+          [
+            roomId,
+            eventId,
+          ],
+        ),
+        returnValue: _i5.Future<_i2.MatrixEvent>.value(_FakeMatrixEvent_42(
+          this,
+          Invocation.method(
+            #getOneRoomEvent,
+            [
+              roomId,
+              eventId,
+            ],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.MatrixEvent>.value(_FakeMatrixEvent_42(
+          this,
+          Invocation.method(
+            #getOneRoomEvent,
+            [
+              roomId,
+              eventId,
+            ],
+          ),
+        )),
+      ) as _i5.Future<_i2.MatrixEvent>);
+
+  @override
+  _i5.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+        Invocation.method(
+          #forgetRoom,
+          [roomId],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> inviteBy3PID(
+    String? roomId,
+    _i2.Invite3pid? body,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #inviteBy3PID,
+          [
+            roomId,
+            body,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> inviteUser(
+    String? roomId,
+    String? userId, {
+    String? reason,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #inviteUser,
+          [
+            roomId,
+            userId,
+          ],
+          {#reason: reason},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<String> joinRoomById(
+    String? roomId, {
+    String? reason,
+    _i2.ThirdPartySigned? thirdPartySigned,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #joinRoomById,
+          [roomId],
+          {
+            #reason: reason,
+            #thirdPartySigned: thirdPartySigned,
+          },
+        ),
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #joinRoomById,
+            [roomId],
+            {
+              #reason: reason,
+              #thirdPartySigned: thirdPartySigned,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #joinRoomById,
+            [roomId],
+            {
+              #reason: reason,
+              #thirdPartySigned: thirdPartySigned,
+            },
+          ),
+        )),
+      ) as _i5.Future<String>);
+
+  @override
+  _i5.Future<Map<String, _i2.RoomMember>?> getJoinedMembersByRoom(
+          String? roomId) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getJoinedMembersByRoom,
+          [roomId],
+        ),
+        returnValue: _i5.Future<Map<String, _i2.RoomMember>?>.value(),
+        returnValueForMissingStub:
+            _i5.Future<Map<String, _i2.RoomMember>?>.value(),
+      ) as _i5.Future<Map<String, _i2.RoomMember>?>);
+
+  @override
+  _i5.Future<void> kick(
+    String? roomId,
+    String? userId, {
+    String? reason,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #kick,
+          [
+            roomId,
+            userId,
+          ],
+          {#reason: reason},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> leaveRoom(
+    String? roomId, {
+    String? reason,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #leaveRoom,
+          [roomId],
+          {#reason: reason},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<List<_i2.MatrixEvent>?> getMembersByRoom(
+    String? roomId, {
+    String? at,
+    _i2.Membership? membership,
+    _i2.Membership? notMembership,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getMembersByRoom,
+          [roomId],
+          {
+            #at: at,
+            #membership: membership,
+            #notMembership: notMembership,
+          },
+        ),
+        returnValue: _i5.Future<List<_i2.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i5.Future<List<_i2.MatrixEvent>?>.value(),
+      ) as _i5.Future<List<_i2.MatrixEvent>?>);
+
+  @override
+  _i5.Future<_i2.GetRoomEventsResponse> getRoomEvents(
+    String? roomId,
+    _i2.Direction? dir, {
+    String? from,
+    String? to,
+    int? limit,
+    String? filter,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getRoomEvents,
+          [
+            roomId,
+            dir,
+          ],
+          {
+            #from: from,
+            #to: to,
+            #limit: limit,
+            #filter: filter,
+          },
+        ),
+        returnValue: _i5.Future<_i2.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_59(
+          this,
+          Invocation.method(
+            #getRoomEvents,
+            [
+              roomId,
+              dir,
+            ],
+            {
+              #from: from,
+              #to: to,
+              #limit: limit,
+              #filter: filter,
+            },
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_59(
+          this,
+          Invocation.method(
+            #getRoomEvents,
+            [
+              roomId,
+              dir,
+            ],
+            {
+              #from: from,
+              #to: to,
+              #limit: limit,
+              #filter: filter,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.GetRoomEventsResponse>);
+
+  @override
+  _i5.Future<void> setReadMarker(
+    String? roomId, {
+    String? mFullyRead,
+    String? mRead,
+    String? mReadPrivate,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setReadMarker,
+          [roomId],
+          {
+            #mFullyRead: mFullyRead,
+            #mRead: mRead,
+            #mReadPrivate: mReadPrivate,
+          },
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> postReceipt(
+    String? roomId,
+    _i2.ReceiptType? receiptType,
+    String? eventId, {
+    String? threadId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #postReceipt,
+          [
+            roomId,
+            receiptType,
+            eventId,
+          ],
+          {#threadId: threadId},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<String?> redactEvent(
+    String? roomId,
+    String? eventId,
+    String? txnId, {
+    String? reason,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #redactEvent,
+          [
+            roomId,
+            eventId,
+            txnId,
+          ],
+          {#reason: reason},
+        ),
+        returnValue: _i5.Future<String?>.value(),
+        returnValueForMissingStub: _i5.Future<String?>.value(),
+      ) as _i5.Future<String?>);
+
+  @override
+  _i5.Future<void> reportRoom(
+    String? roomId,
+    String? reason,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #reportRoom,
+          [
+            roomId,
+            reason,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> reportEvent(
+    String? roomId,
+    String? eventId, {
+    String? reason,
+    int? score,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #reportEvent,
+          [
+            roomId,
+            eventId,
+          ],
+          {
+            #reason: reason,
+            #score: score,
+          },
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<String> sendMessage(
+    String? roomId,
+    String? eventType,
+    String? txnId,
+    Map<String, Object?>? body,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #sendMessage,
+          [
+            roomId,
+            eventType,
+            txnId,
+            body,
+          ],
+        ),
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #sendMessage,
+            [
+              roomId,
+              eventType,
+              txnId,
+              body,
+            ],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #sendMessage,
+            [
+              roomId,
+              eventType,
+              txnId,
+              body,
+            ],
+          ),
+        )),
+      ) as _i5.Future<String>);
+
+  @override
+  _i5.Future<List<_i2.MatrixEvent>> getRoomState(String? roomId) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getRoomState,
+          [roomId],
+        ),
+        returnValue:
+            _i5.Future<List<_i2.MatrixEvent>>.value(<_i2.MatrixEvent>[]),
+        returnValueForMissingStub:
+            _i5.Future<List<_i2.MatrixEvent>>.value(<_i2.MatrixEvent>[]),
+      ) as _i5.Future<List<_i2.MatrixEvent>>);
+
+  @override
+  _i5.Future<Map<String, Object?>> getRoomStateWithKey(
+    String? roomId,
+    String? eventType,
+    String? stateKey, {
+    _i2.Format? format,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getRoomStateWithKey,
+          [
+            roomId,
+            eventType,
+            stateKey,
+          ],
+          {#format: format},
+        ),
+        returnValue:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+        returnValueForMissingStub:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i5.Future<Map<String, Object?>>);
+
+  @override
+  _i5.Future<String> setRoomStateWithKey(
+    String? roomId,
+    String? eventType,
+    String? stateKey,
+    Map<String, Object?>? body,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setRoomStateWithKey,
+          [
+            roomId,
+            eventType,
+            stateKey,
+            body,
+          ],
+        ),
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #setRoomStateWithKey,
+            [
+              roomId,
+              eventType,
+              stateKey,
+              body,
+            ],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #setRoomStateWithKey,
+            [
+              roomId,
+              eventType,
+              stateKey,
+              body,
+            ],
+          ),
+        )),
+      ) as _i5.Future<String>);
+
+  @override
+  _i5.Future<void> unban(
+    String? roomId,
+    String? userId, {
+    String? reason,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #unban,
+          [
+            roomId,
+            userId,
+          ],
+          {#reason: reason},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<String> upgradeRoom(
+    String? roomId,
+    String? newVersion, {
+    List<String>? additionalCreators,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #upgradeRoom,
+          [
+            roomId,
+            newVersion,
+          ],
+          {#additionalCreators: additionalCreators},
+        ),
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #upgradeRoom,
+            [
+              roomId,
+              newVersion,
+            ],
+            {#additionalCreators: additionalCreators},
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #upgradeRoom,
+            [
+              roomId,
+              newVersion,
+            ],
+            {#additionalCreators: additionalCreators},
+          ),
+        )),
+      ) as _i5.Future<String>);
+
+  @override
+  _i5.Future<_i2.SearchResults> search(
+    _i2.Categories? searchCategories, {
+    String? nextBatch,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #search,
+          [searchCategories],
+          {#nextBatch: nextBatch},
+        ),
+        returnValue: _i5.Future<_i2.SearchResults>.value(_FakeSearchResults_60(
+          this,
+          Invocation.method(
+            #search,
+            [searchCategories],
+            {#nextBatch: nextBatch},
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.SearchResults>.value(_FakeSearchResults_60(
+          this,
+          Invocation.method(
+            #search,
+            [searchCategories],
+            {#nextBatch: nextBatch},
+          ),
+        )),
+      ) as _i5.Future<_i2.SearchResults>);
+
+  @override
+  _i5.Future<_i2.SyncUpdate> sync({
+    String? filter,
+    String? since,
+    bool? fullState,
+    _i2.PresenceType? setPresence,
+    int? timeout,
+    bool? useStateAfter,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #sync,
+          [],
+          {
+            #filter: filter,
+            #since: since,
+            #fullState: fullState,
+            #setPresence: setPresence,
+            #timeout: timeout,
+            #useStateAfter: useStateAfter,
+          },
+        ),
+        returnValue: _i5.Future<_i2.SyncUpdate>.value(_FakeSyncUpdate_15(
+          this,
+          Invocation.method(
+            #sync,
+            [],
+            {
+              #filter: filter,
+              #since: since,
+              #fullState: fullState,
+              #setPresence: setPresence,
+              #timeout: timeout,
+              #useStateAfter: useStateAfter,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.SyncUpdate>.value(_FakeSyncUpdate_15(
+          this,
+          Invocation.method(
+            #sync,
+            [],
+            {
+              #filter: filter,
+              #since: since,
+              #fullState: fullState,
+              #setPresence: setPresence,
+              #timeout: timeout,
+              #useStateAfter: useStateAfter,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i2.SyncUpdate>);
+
+  @override
+  _i5.Future<List<_i2.Location>> queryLocationByAlias(String? alias) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #queryLocationByAlias,
+          [alias],
+        ),
+        returnValue: _i5.Future<List<_i2.Location>>.value(<_i2.Location>[]),
+        returnValueForMissingStub:
+            _i5.Future<List<_i2.Location>>.value(<_i2.Location>[]),
+      ) as _i5.Future<List<_i2.Location>>);
+
+  @override
+  _i5.Future<List<_i2.Location>> queryLocationByProtocol(
+    String? protocol, {
+    Map<String, String>? fields,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #queryLocationByProtocol,
+          [protocol],
+          {#fields: fields},
+        ),
+        returnValue: _i5.Future<List<_i2.Location>>.value(<_i2.Location>[]),
+        returnValueForMissingStub:
+            _i5.Future<List<_i2.Location>>.value(<_i2.Location>[]),
+      ) as _i5.Future<List<_i2.Location>>);
+
+  @override
+  _i5.Future<_i2.GetProtocolMetadataResponse$2> getProtocolMetadata(
+          String? protocol) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getProtocolMetadata,
+          [protocol],
+        ),
+        returnValue: _i5.Future<_i2.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_61(
+          this,
+          Invocation.method(
+            #getProtocolMetadata,
+            [protocol],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_61(
+          this,
+          Invocation.method(
+            #getProtocolMetadata,
+            [protocol],
+          ),
+        )),
+      ) as _i5.Future<_i2.GetProtocolMetadataResponse$2>);
+
+  @override
+  _i5.Future<Map<String, _i2.GetProtocolsResponse$2>> getProtocols() =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getProtocols,
+          [],
+        ),
+        returnValue: _i5.Future<Map<String, _i2.GetProtocolsResponse$2>>.value(
+            <String, _i2.GetProtocolsResponse$2>{}),
+        returnValueForMissingStub:
+            _i5.Future<Map<String, _i2.GetProtocolsResponse$2>>.value(
+                <String, _i2.GetProtocolsResponse$2>{}),
+      ) as _i5.Future<Map<String, _i2.GetProtocolsResponse$2>>);
+
+  @override
+  _i5.Future<List<_i2.ThirdPartyUser>> queryUserByID(String? userid) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #queryUserByID,
+          [userid],
+        ),
+        returnValue:
+            _i5.Future<List<_i2.ThirdPartyUser>>.value(<_i2.ThirdPartyUser>[]),
+        returnValueForMissingStub:
+            _i5.Future<List<_i2.ThirdPartyUser>>.value(<_i2.ThirdPartyUser>[]),
+      ) as _i5.Future<List<_i2.ThirdPartyUser>>);
+
+  @override
+  _i5.Future<List<_i2.ThirdPartyUser>> queryUserByProtocol(
+    String? protocol, {
+    Map<String, String>? fields,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #queryUserByProtocol,
+          [protocol],
+          {#fields: fields},
+        ),
+        returnValue:
+            _i5.Future<List<_i2.ThirdPartyUser>>.value(<_i2.ThirdPartyUser>[]),
+        returnValueForMissingStub:
+            _i5.Future<List<_i2.ThirdPartyUser>>.value(<_i2.ThirdPartyUser>[]),
+      ) as _i5.Future<List<_i2.ThirdPartyUser>>);
+
+  @override
+  _i5.Future<Map<String, Object?>> getAccountData(
+    String? userId,
+    String? type,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getAccountData,
+          [
+            userId,
+            type,
+          ],
+        ),
+        returnValue:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+        returnValueForMissingStub:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i5.Future<Map<String, Object?>>);
+
+  @override
+  _i5.Future<void> setAccountData(
+    String? userId,
+    String? type,
+    Map<String, Object?>? body,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setAccountData,
+          [
+            userId,
+            type,
+            body,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<String> defineFilter(
+    String? userId,
+    _i2.Filter? body,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #defineFilter,
+          [
+            userId,
+            body,
+          ],
+        ),
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #defineFilter,
+            [
+              userId,
+              body,
+            ],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #defineFilter,
+            [
+              userId,
+              body,
+            ],
+          ),
+        )),
+      ) as _i5.Future<String>);
+
+  @override
+  _i5.Future<_i2.Filter> getFilter(
+    String? userId,
+    String? filterId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getFilter,
+          [
+            userId,
+            filterId,
+          ],
+        ),
+        returnValue: _i5.Future<_i2.Filter>.value(_FakeFilter_1(
+          this,
+          Invocation.method(
+            #getFilter,
+            [
+              userId,
+              filterId,
+            ],
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.Filter>.value(_FakeFilter_1(
+          this,
+          Invocation.method(
+            #getFilter,
+            [
+              userId,
+              filterId,
+            ],
+          ),
+        )),
+      ) as _i5.Future<_i2.Filter>);
+
+  @override
+  _i5.Future<_i2.OpenIdCredentials> requestOpenIdToken(
+    String? userId,
+    Map<String, Object?>? body,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #requestOpenIdToken,
+          [
+            userId,
+            body,
+          ],
+        ),
+        returnValue:
+            _i5.Future<_i2.OpenIdCredentials>.value(_FakeOpenIdCredentials_62(
+          this,
+          Invocation.method(
+            #requestOpenIdToken,
+            [
+              userId,
+              body,
+            ],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.OpenIdCredentials>.value(_FakeOpenIdCredentials_62(
+          this,
+          Invocation.method(
+            #requestOpenIdToken,
+            [
+              userId,
+              body,
+            ],
+          ),
+        )),
+      ) as _i5.Future<_i2.OpenIdCredentials>);
+
+  @override
+  _i5.Future<Map<String, Object?>> getAccountDataPerRoom(
+    String? userId,
+    String? roomId,
+    String? type,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getAccountDataPerRoom,
+          [
+            userId,
+            roomId,
+            type,
+          ],
+        ),
+        returnValue:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+        returnValueForMissingStub:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i5.Future<Map<String, Object?>>);
+
+  @override
+  _i5.Future<void> setAccountDataPerRoom(
+    String? userId,
+    String? roomId,
+    String? type,
+    Map<String, Object?>? body,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setAccountDataPerRoom,
+          [
+            userId,
+            roomId,
+            type,
+            body,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<Map<String, _i2.Tag>?> getRoomTags(
+    String? userId,
+    String? roomId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getRoomTags,
+          [
+            userId,
+            roomId,
+          ],
+        ),
+        returnValue: _i5.Future<Map<String, _i2.Tag>?>.value(),
+        returnValueForMissingStub: _i5.Future<Map<String, _i2.Tag>?>.value(),
+      ) as _i5.Future<Map<String, _i2.Tag>?>);
+
+  @override
+  _i5.Future<void> deleteRoomTag(
+    String? userId,
+    String? roomId,
+    String? tag,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteRoomTag,
+          [
+            userId,
+            roomId,
+            tag,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setRoomTag(
+    String? userId,
+    String? roomId,
+    String? tag,
+    _i2.Tag? body,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setRoomTag,
+          [
+            userId,
+            roomId,
+            tag,
+            body,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<_i2.SearchUserDirectoryResponse> searchUserDirectory(
+    String? searchTerm, {
+    int? limit,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #searchUserDirectory,
+          [searchTerm],
+          {#limit: limit},
+        ),
+        returnValue: _i5.Future<_i2.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_63(
+          this,
+          Invocation.method(
+            #searchUserDirectory,
+            [searchTerm],
+            {#limit: limit},
+          ),
+        )),
+        returnValueForMissingStub:
+            _i5.Future<_i2.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_63(
+          this,
+          Invocation.method(
+            #searchUserDirectory,
+            [searchTerm],
+            {#limit: limit},
+          ),
+        )),
+      ) as _i5.Future<_i2.SearchUserDirectoryResponse>);
+
+  @override
+  _i5.Future<Map<String, Object?>> reportUser(
+    String? userId,
+    String? reason,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #reportUser,
+          [
+            userId,
+            reason,
+          ],
+        ),
+        returnValue:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+        returnValueForMissingStub:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i5.Future<Map<String, Object?>>);
+
+  @override
+  _i5.Future<_i2.CreateContentResponse> createContent() => (super.noSuchMethod(
+        Invocation.method(
+          #createContent,
+          [],
+        ),
+        returnValue: _i5.Future<_i2.CreateContentResponse>.value(
+            _FakeCreateContentResponse_64(
+          this,
+          Invocation.method(
+            #createContent,
+            [],
+          ),
+        )),
+        returnValueForMissingStub: _i5.Future<_i2.CreateContentResponse>.value(
+            _FakeCreateContentResponse_64(
+          this,
+          Invocation.method(
+            #createContent,
+            [],
+          ),
+        )),
+      ) as _i5.Future<_i2.CreateContentResponse>);
+
+  @override
+  _i5.Future<Map<String, Object?>> uploadContentToMXC(
+    String? serverName,
+    String? mediaId,
+    _i16.Uint8List? body, {
+    String? filename,
+    String? contentType,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #uploadContentToMXC,
+          [
+            serverName,
+            mediaId,
+            body,
+          ],
+          {
+            #filename: filename,
+            #contentType: contentType,
+          },
+        ),
+        returnValue:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+        returnValueForMissingStub:
+            _i5.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i5.Future<Map<String, Object?>>);
 }
 
-class _FakeUri_8 extends _i1.SmartFake implements Uri {
-  _FakeUri_8(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
+/// A class which mocks [MatrixService].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+  @override
+  _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
+        Invocation.getter(#callPushRuleManager),
+        returnValue: _FakeCallPushRuleManager_65(
+          this,
+          Invocation.getter(#callPushRuleManager),
+        ),
+        returnValueForMissingStub: _FakeCallPushRuleManager_65(
+          this,
+          Invocation.getter(#callPushRuleManager),
+        ),
+      ) as _i7.CallPushRuleManager);
+
+  @override
+  _i8.MegolmKeyMirror get keyMirror => (super.noSuchMethod(
+        Invocation.getter(#keyMirror),
+        returnValue: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+        returnValueForMissingStub: _FakeMegolmKeyMirror_66(
+          this,
+          Invocation.getter(#keyMirror),
+        ),
+      ) as _i8.MegolmKeyMirror);
+
+  @override
+  String get clientName => (super.noSuchMethod(
+        Invocation.getter(#clientName),
+        returnValue: _i15.dummyValue<String>(
+          this,
+          Invocation.getter(#clientName),
+        ),
+        returnValueForMissingStub: _i15.dummyValue<String>(
+          this,
+          Invocation.getter(#clientName),
+        ),
+      ) as String);
+
+  @override
+  _i2.Client get client => (super.noSuchMethod(
+        Invocation.getter(#client),
+        returnValue: _FakeClient_67(
+          this,
+          Invocation.getter(#client),
+        ),
+        returnValueForMissingStub: _FakeClient_67(
+          this,
+          Invocation.getter(#client),
+        ),
+      ) as _i2.Client);
+
+  @override
+  bool get isLoggedIn => (super.noSuchMethod(
+        Invocation.getter(#isLoggedIn),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get disposed => (super.noSuchMethod(
+        Invocation.getter(#disposed),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  _i9.UiaService get uia => (super.noSuchMethod(
+        Invocation.getter(#uia),
+        returnValue: _FakeUiaService_68(
+          this,
+          Invocation.getter(#uia),
+        ),
+        returnValueForMissingStub: _FakeUiaService_68(
+          this,
+          Invocation.getter(#uia),
+        ),
+      ) as _i9.UiaService);
+
+  @override
+  _i10.ChatBackupService get chatBackup => (super.noSuchMethod(
+        Invocation.getter(#chatBackup),
+        returnValue: _FakeChatBackupService_69(
+          this,
+          Invocation.getter(#chatBackup),
+        ),
+        returnValueForMissingStub: _FakeChatBackupService_69(
+          this,
+          Invocation.getter(#chatBackup),
+        ),
+      ) as _i10.ChatBackupService);
+
+  @override
+  _i11.SelectionService get selection => (super.noSuchMethod(
+        Invocation.getter(#selection),
+        returnValue: _FakeSelectionService_70(
+          this,
+          Invocation.getter(#selection),
+        ),
+        returnValueForMissingStub: _FakeSelectionService_70(
+          this,
+          Invocation.getter(#selection),
+        ),
+      ) as _i11.SelectionService);
+
+  @override
+  _i12.SyncService get sync => (super.noSuchMethod(
+        Invocation.getter(#sync),
+        returnValue: _FakeSyncService_71(
+          this,
+          Invocation.getter(#sync),
+        ),
+        returnValueForMissingStub: _FakeSyncService_71(
+          this,
+          Invocation.getter(#sync),
+        ),
+      ) as _i12.SyncService);
+
+  @override
+  _i13.AuthService get auth => (super.noSuchMethod(
+        Invocation.getter(#auth),
+        returnValue: _FakeAuthService_72(
+          this,
+          Invocation.getter(#auth),
+        ),
+        returnValueForMissingStub: _FakeAuthService_72(
+          this,
+          Invocation.getter(#auth),
+        ),
+      ) as _i13.AuthService);
+
+  @override
+  bool get hasSkippedSetup => (super.noSuchMethod(
+        Invocation.getter(#hasSkippedSetup),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  set callPushRuleManager(_i7.CallPushRuleManager? value) => super.noSuchMethod(
+        Invocation.setter(
+          #callPushRuleManager,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set keyMirror(_i8.MegolmKeyMirror? value) => super.noSuchMethod(
+        Invocation.setter(
+          #keyMirror,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set isLoggedInForTest(bool? value) => super.noSuchMethod(
+        Invocation.setter(
+          #isLoggedInForTest,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set uia(_i9.UiaService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #uia,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set chatBackup(_i10.ChatBackupService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #chatBackup,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set selection(_i11.SelectionService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #selection,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i12.SyncService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #sync,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set auth(_i13.AuthService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #auth,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  _i5.Future<void> activateSessionForTest() => (super.noSuchMethod(
+        Invocation.method(
+          #activateSessionForTest,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  void notifyListeners() => super.noSuchMethod(
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void skipSetup() => super.noSuchMethod(
+        Invocation.method(
+          #skipSetup,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #didChangeAppLifecycleState,
+          [state],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+        Invocation.method(
+          #init,
+          [],
+          {#restoreSession: restoreSession},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<bool> login({
+    required String? homeserver,
+    required String? username,
+    required String? password,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #login,
+          [],
+          {
+            #homeserver: homeserver,
+            #username: username,
+            #password: password,
+          },
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> completeSsoLogin({
+    required String? homeserver,
+    required String? loginToken,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #completeSsoLogin,
+          [],
+          {
+            #homeserver: homeserver,
+            #loginToken: loginToken,
+          },
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<void> completeRegistration(
+    _i2.RegisterResponse? response, {
+    String? password,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #completeRegistration,
+          [response],
+          {#password: password},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> logout() => (super.noSuchMethod(
+        Invocation.method(
+          #logout,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> handleSoftLogout() => (super.noSuchMethod(
+        Invocation.method(
+          #handleSoftLogout,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPopRoute() => (super.noSuchMethod(
+        Invocation.method(
+          #didPopRoute,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #handleStartBackGesture,
+          [backEvent],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #handleUpdateBackGestureProgress,
+          [backEvent],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCommitBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCommitBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleCancelBackGesture() => super.noSuchMethod(
+        Invocation.method(
+          #handleCancelBackGesture,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void handleStatusBarTap() => super.noSuchMethod(
+        Invocation.method(
+          #handleStatusBarTap,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+        Invocation.method(
+          #didPushRoute,
+          [route],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<bool> didPushRouteInformation(
+          _i20.RouteInformation? routeInformation) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #didPushRouteInformation,
+          [routeInformation],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+        returnValueForMissingStub: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  void didChangeMetrics() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeMetrics,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeTextScaleFactor() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeTextScaleFactor,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangePlatformBrightness() => super.noSuchMethod(
+        Invocation.method(
+          #didChangePlatformBrightness,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeLocales,
+          [locales],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+        Invocation.method(
+          #didChangeViewFocus,
+          [event],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+        Invocation.method(
+          #didRequestAppExit,
+          [],
+        ),
+        returnValue:
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+        returnValueForMissingStub:
+            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i5.Future<_i18.AppExitResponse>);
+
+  @override
+  void didHaveMemoryPressure() => super.noSuchMethod(
+        Invocation.method(
+          #didHaveMemoryPressure,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void didChangeAccessibilityFeatures() => super.noSuchMethod(
+        Invocation.method(
+          #didChangeAccessibilityFeatures,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
 }
 
 /// A class which mocks [Room].
@@ -126,11 +8228,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i4.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i4.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -160,11 +8262,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_0(
+        returnValue: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_0(
+        returnValueForMissingStub: _FakeRoomSummary_73(
           this,
           Invocation.getter(#summary),
         ),
@@ -217,11 +8319,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i4.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i4.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -230,11 +8332,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i3.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_1<String>(
+        returnValue: _FakeCachedStreamController_6<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_1<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_6<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
@@ -244,11 +8346,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   _i3.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_1<String>(
+        returnValue: _FakeCachedStreamController_6<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_1<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_6<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
@@ -257,11 +8359,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i4.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i4.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -277,11 +8379,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i4.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i4.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -290,11 +8392,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i4.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i4.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -317,11 +8419,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_2(
+        returnValue: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
-        returnValueForMissingStub: _FakeClient_2(
+        returnValueForMissingStub: _FakeClient_67(
           this,
           Invocation.getter(#client),
         ),
@@ -337,11 +8439,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i4.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i4.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -350,11 +8452,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_3(
+        returnValue: _FakeDateTime_7(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_3(
+        returnValueForMissingStub: _FakeDateTime_7(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -384,11 +8486,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_4(
+        returnValue: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_4(
+        returnValueForMissingStub: _FakeLatestReceiptState_74(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -411,12 +8513,12 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i5.Future<_i2.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i5.Future<_i2.SyncUpdate>.value(_FakeSyncUpdate_5(
+        returnValue: _i5.Future<_i2.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.SyncUpdate>.value(_FakeSyncUpdate_5(
+            _i5.Future<_i2.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.getter(#waitForSync),
         )),
@@ -600,18 +8702,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i6.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i6.SpaceParent>[],
-        returnValueForMissingStub: <_i6.SpaceParent>[],
-      ) as List<_i6.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i6.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i6.SpaceChild>[],
-        returnValueForMissingStub: <_i6.SpaceChild>[],
-      ) as List<_i6.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -778,14 +8880,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i4.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i4.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -833,7 +8935,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i4.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -841,7 +8943,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i4.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -856,7 +8958,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i4.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -864,7 +8966,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i4.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -904,7 +9006,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i5.Future<_i2.SyncUpdate>.value(_FakeSyncUpdate_5(
+        returnValue: _i5.Future<_i2.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -912,7 +9014,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.SyncUpdate>.value(_FakeSyncUpdate_5(
+            _i5.Future<_i2.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -948,7 +9050,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i4.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -956,7 +9058,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i4.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -1198,7 +9300,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i4.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -1209,7 +9311,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i4.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -1298,15 +9400,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i7.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i7.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i7.TimelineChunk?>.value(),
-      ) as _i5.Future<_i7.TimelineChunk?>);
+        returnValue: _i5.Future<_i22.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i22.TimelineChunk?>.value(),
+      ) as _i5.Future<_i22.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -1347,7 +9449,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_6(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -1364,7 +9466,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_6(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
           this,
           Invocation.method(
             #getTimeline,
@@ -1428,14 +9530,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_7(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_7(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -1451,14 +9553,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_7(
+        returnValue: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_7(
+        returnValueForMissingStub: _FakeUser_76(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -1514,7 +9616,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i4.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -1522,7 +9624,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i4.dummyValue<String>(
+            _i5.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -1751,14 +9853,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i5.Future<Uri>.value(_FakeUri_8(
+        returnValue: _i5.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i5.Future<Uri>.value(_FakeUri_8(
+        returnValueForMissingStub: _i5.Future<Uri>.value(_FakeUri_20(
           this,
           Invocation.method(
             #matrixToInviteLink,


### PR DESCRIPTION
The invite-user dialog was a plain MXID text field. Add user-directory
search and recent-contact suggestions (matching the new-DM and new-room
dialogs), filtering out users already in the room. Tapping a suggestion
invites that user directly. Also removes the duplicate _InviteUserDialog
in room_details_panel and routes it through the shared widget.