### PR TITLE
fix(spaces): make create/join space dialogs scrollable

### DIFF
--- a/lib/features/spaces/widgets/space_action_dialog.dart
+++ b/lib/features/spaces/widgets/space_action_dialog.dart
@@ -168,9 +168,10 @@ class _CreateSpaceDialogState extends State<CreateSpaceDialog> {
     final cs = Theme.of(context).colorScheme;
 
     return AlertDialog(
+      scrollable: true,
       title: const Text('Create Space'),
-      content: SizedBox(
-        width: 400,
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 400),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -335,9 +336,10 @@ class _JoinSpaceDialogState extends State<JoinSpaceDialog> {
     final cs = Theme.of(context).colorScheme;
 
     return AlertDialog(
+      scrollable: true,
       title: const Text('Join Space'),
-      content: SizedBox(
-        width: 400,
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 400),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [


### PR DESCRIPTION
The action buttons could overlap content when the soft keyboard reduced
the dialog's vertical space, leaving Cancel/Create floating over the
"Allow federation" row on small screens.

Switch to AlertDialog.scrollable so content + actions share a single
scroll view, and replace the fixed SizedBox width with a max-width
constraint so the dialog adapts to narrow viewports.