### PR TITLE
fix(spaces): make Create/Join Space dialogs scrollable on small screens

### DIFF
--- a/lib/features/rooms/widgets/invite_user_dialog.dart
+++ b/lib/features/rooms/widgets/invite_user_dialog.dart
@@ -1,25 +1,24 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:kohera/core/utils/known_contacts.dart';
 import 'package:matrix/matrix.dart' hide Visibility;
 
-/// A reusable dialog that prompts for a Matrix user ID to invite to a room.
+/// A reusable dialog that prompts for a Matrix user ID to invite to a room
+/// or space. Suggests recent contacts and searches the homeserver's user
+/// directory as the user types.
 ///
 /// Returns the validated MXID string on success, or `null` if cancelled.
 class InviteUserDialog extends StatefulWidget {
-  const InviteUserDialog._({
-    required this.room,
-    required this.controller,
-  });
+  const InviteUserDialog._({required this.room});
 
   final Room room;
-  final TextEditingController controller;
 
-  /// Shows the invite dialog and returns the entered MXID, or `null`.
   static Future<String?> show(BuildContext context, {required Room room}) {
-    final controller = TextEditingController();
     return showDialog<String>(
       context: context,
-      builder: (_) => InviteUserDialog._(room: room, controller: controller),
-    ).whenComplete(controller.dispose);
+      builder: (_) => InviteUserDialog._(room: room),
+    );
   }
 
   @override
@@ -28,54 +27,114 @@ class InviteUserDialog extends StatefulWidget {
 
 class _InviteUserDialogState extends State<InviteUserDialog> {
   static final _mxidRegex = RegExp(r'^@[^:]+:.+$');
+  static const _debounceDuration = Duration(milliseconds: 400);
+
+  final _controller = TextEditingController();
+  final _focusNode = FocusNode();
   String? _error;
+  bool _searching = false;
+  List<Profile> _searchResults = [];
+  Timer? _debounce;
+  int _searchGeneration = 0;
+  List<Profile>? _cachedContacts;
+  Set<String>? _cachedExistingMembers;
 
   @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    return AlertDialog(
-      title: const Text('Invite user'),
-      content: SizedBox(
-        width: 400,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            TextField(
-              controller: widget.controller,
-              autofocus: true,
-              decoration: const InputDecoration(
-                labelText: 'Matrix ID',
-                hintText: '@user:server.com',
-                border: OutlineInputBorder(),
-              ),
-              onSubmitted: (_) => _submit(),
-            ),
-            if (_error != null)
-              Padding(
-                padding: const EdgeInsets.only(top: 8),
-                child: Text(
-                  _error!,
-                  style: TextStyle(color: cs.error, fontSize: 13),
-                ),
-              ),
-          ],
-        ),
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(context),
-          child: const Text('Cancel'),
-        ),
-        FilledButton(
-          onPressed: _submit,
-          child: const Text('Invite'),
-        ),
-      ],
-    );
+  void initState() {
+    super.initState();
+    _focusNode.addListener(_onFocusChanged);
+  }
+
+  @override
+  void dispose() {
+    _focusNode.removeListener(_onFocusChanged);
+    _focusNode.dispose();
+    _controller.dispose();
+    _debounce?.cancel();
+    super.dispose();
+  }
+
+  void _onFocusChanged() {
+    if (mounted) setState(() {});
+  }
+
+  Client? get _client {
+    try {
+      return widget.room.client;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Set<String> _existingMembers() {
+    if (_cachedExistingMembers != null) return _cachedExistingMembers!;
+    try {
+      _cachedExistingMembers = widget.room
+          .getParticipants()
+          .map((u) => u.id)
+          .toSet();
+    } catch (_) {
+      _cachedExistingMembers = const <String>{};
+    }
+    return _cachedExistingMembers!;
+  }
+
+  List<Profile> _knownContacts() {
+    if (_cachedContacts != null) return _cachedContacts!;
+    final client = _client;
+    if (client == null) return _cachedContacts = const [];
+    try {
+      _cachedContacts = knownContacts(client);
+    } catch (_) {
+      _cachedContacts = const [];
+    }
+    return _cachedContacts!;
+  }
+
+  void _onQueryChanged(String text) {
+    _debounce?.cancel();
+    final query = text.trim();
+    setState(() => _error = null);
+    if (query.isEmpty) {
+      setState(() {
+        _searchResults = [];
+        _searching = false;
+      });
+      return;
+    }
+    _debounce = Timer(_debounceDuration, () {
+      unawaited(_runSearch(query));
+    });
+  }
+
+  Future<void> _runSearch(String query) async {
+    final client = _client;
+    if (client == null) return;
+    _searchGeneration++;
+    final gen = _searchGeneration;
+    setState(() => _searching = true);
+    try {
+      final response = await client.searchUserDirectory(query, limit: 20);
+      if (!mounted || gen != _searchGeneration) return;
+      setState(() {
+        _searchResults = response.results;
+        _searching = false;
+      });
+    } catch (_) {
+      if (!mounted || gen != _searchGeneration) return;
+      setState(() {
+        _searchResults = [];
+        _searching = false;
+      });
+    }
+  }
+
+  void _selectProfile(Profile profile) {
+    Navigator.pop(context, profile.userId);
   }
 
   void _submit() {
-    final mxid = widget.controller.text.trim();
+    final mxid = _controller.text.trim();
     if (mxid.isEmpty) {
       setState(() => _error = 'Please enter a Matrix ID');
       return;
@@ -85,5 +144,121 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
       return;
     }
     Navigator.pop(context, mxid);
+  }
+
+  List<Widget> _buildSuggestions(ColorScheme cs) {
+    final query = _controller.text.trim();
+    final existing = _existingMembers();
+    final source = query.isEmpty ? _knownContacts() : _searchResults;
+    final filtered = source.where((p) => !existing.contains(p.userId)).toList();
+    if (filtered.isEmpty) return [];
+
+    final tiles = <Widget>[];
+    if (query.isEmpty) {
+      tiles.add(Padding(
+        padding: const EdgeInsets.only(left: 12, top: 8, bottom: 4),
+        child: Text(
+          'Recent contacts',
+          style: TextStyle(
+            fontSize: 12,
+            color: cs.onSurfaceVariant,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ),);
+    }
+    for (final p in filtered) {
+      final label = p.displayName ?? p.userId;
+      final initial = label.isNotEmpty ? label.characters.first.toUpperCase() : '?';
+      tiles.add(ListTile(
+        dense: true,
+        leading: CircleAvatar(
+          radius: 16,
+          backgroundColor: cs.primaryContainer,
+          child: Text(
+            initial,
+            style: TextStyle(color: cs.onPrimaryContainer, fontSize: 13),
+          ),
+        ),
+        title: Text(
+          label,
+          overflow: TextOverflow.ellipsis,
+          style: const TextStyle(fontSize: 14),
+        ),
+        subtitle: p.displayName != null
+            ? Text(
+                p.userId,
+                style: const TextStyle(fontSize: 11),
+                overflow: TextOverflow.ellipsis,
+              )
+            : null,
+        onTap: () => _selectProfile(p),
+      ),);
+    }
+    return tiles;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final suggestions = _buildSuggestions(cs);
+
+    return SimpleDialog(
+      title: const Text('Invite user'),
+      contentPadding: const EdgeInsets.fromLTRB(24, 20, 24, 16),
+      children: [
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 400),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextField(
+                controller: _controller,
+                focusNode: _focusNode,
+                autofocus: true,
+                decoration: InputDecoration(
+                  labelText: 'Matrix ID',
+                  hintText: '@user:server.com or display name',
+                  border: const OutlineInputBorder(),
+                  errorText: _error,
+                ),
+                onChanged: _onQueryChanged,
+                onSubmitted: (_) => _submit(),
+              ),
+              if (_searching)
+                const Padding(
+                  padding: EdgeInsets.only(top: 4),
+                  child: LinearProgressIndicator(),
+                ),
+              if (suggestions.isNotEmpty)
+                ConstrainedBox(
+                  constraints: const BoxConstraints(maxHeight: 220),
+                  child: ListView(
+                    shrinkWrap: true,
+                    padding: EdgeInsets.zero,
+                    children: suggestions,
+                  ),
+                ),
+              const SizedBox(height: 16),
+              OverflowBar(
+                alignment: MainAxisAlignment.end,
+                spacing: 8,
+                children: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: const Text('Cancel'),
+                  ),
+                  FilledButton(
+                    onPressed: _submit,
+                    child: const Text('Invite'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
   }
 }

--- a/lib/features/rooms/widgets/room_details_panel.dart
+++ b/lib/features/rooms/widgets/room_details_panel.dart
@@ -7,6 +7,7 @@ import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/e2ee/widgets/key_verification_dialog.dart';
 import 'package:kohera/features/rooms/widgets/admin_settings_section.dart';
+import 'package:kohera/features/rooms/widgets/invite_user_dialog.dart';
 import 'package:kohera/features/rooms/widgets/room_members_section.dart';
 import 'package:kohera/features/rooms/widgets/shared_media_section.dart';
 import 'package:kohera/shared/widgets/avatar_edit_overlay.dart';
@@ -103,10 +104,7 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
   });
 
   Future<void> _showInviteDialog(Room room) async {
-    final result = await showDialog<String>(
-      context: context,
-      builder: (ctx) => _InviteUserDialog(room: room),
-    );
+    final result = await InviteUserDialog.show(context, room: room);
     if (result == null || !mounted) return;
 
     final scaffold = ScaffoldMessenger.of(context);
@@ -503,82 +501,5 @@ class _ActionButton extends StatelessWidget {
         ),
       ),
     );
-  }
-}
-
-// ── Invite dialog ──────────────────────────────────────────────
-
-class _InviteUserDialog extends StatefulWidget {
-  const _InviteUserDialog({required this.room});
-
-  final Room room;
-
-  @override
-  State<_InviteUserDialog> createState() => _InviteUserDialogState();
-}
-
-class _InviteUserDialogState extends State<_InviteUserDialog> {
-  static final _mxidRegex = RegExp(r'^@[^:]+:.+$');
-  final _controller = TextEditingController();
-  String? _error;
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    return AlertDialog(
-      title: const Text('Invite user'),
-      content: SizedBox(
-        width: 400,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            TextField(
-              controller: _controller,
-              autofocus: true,
-              decoration: const InputDecoration(
-                labelText: 'Matrix ID',
-                hintText: '@user:server.com',
-                border: OutlineInputBorder(),
-              ),
-              onSubmitted: (_) => _submit(),
-            ),
-            if (_error != null)
-              Padding(
-                padding: const EdgeInsets.only(top: 8),
-                child: Text(_error!, style: TextStyle(color: cs.error, fontSize: 13)),
-              ),
-          ],
-        ),
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(context),
-          child: const Text('Cancel'),
-        ),
-        FilledButton(
-          onPressed: _submit,
-          child: const Text('Invite'),
-        ),
-      ],
-    );
-  }
-
-  void _submit() {
-    final mxid = _controller.text.trim();
-    if (mxid.isEmpty) {
-      setState(() => _error = 'Please enter a Matrix ID');
-      return;
-    }
-    if (!_mxidRegex.hasMatch(mxid)) {
-      setState(() => _error = 'Invalid Matrix ID (use @user:server)');
-      return;
-    }
-    Navigator.pop(context, mxid);
   }
 }

--- a/lib/features/spaces/widgets/space_action_dialog.dart
+++ b/lib/features/spaces/widgets/space_action_dialog.dart
@@ -181,93 +181,101 @@ class _CreateSpaceDialogState extends State<CreateSpaceDialog> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
 
-    return AlertDialog(
-      scrollable: true,
+    return SimpleDialog(
       title: const Text('Create Space'),
-      content: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 400),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            TextField(
-              controller: _nameController,
-              autofocus: true,
-              enabled: !_loading,
-              decoration: InputDecoration(
-                labelText: 'Name',
-                border: const OutlineInputBorder(),
-                errorText: _nameError,
+      contentPadding: const EdgeInsets.fromLTRB(24, 20, 24, 16),
+      children: [
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 400),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextField(
+                controller: _nameController,
+                autofocus: true,
+                enabled: !_loading,
+                decoration: InputDecoration(
+                  labelText: 'Name',
+                  border: const OutlineInputBorder(),
+                  errorText: _nameError,
+                ),
+                onSubmitted: (_) => _submit(),
               ),
-              onSubmitted: (_) => _submit(),
-            ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: _topicController,
-              enabled: !_loading,
-              decoration: const InputDecoration(
-                labelText: 'Topic (optional)',
-                border: OutlineInputBorder(),
-              ),
-            ),
-            const SizedBox(height: 8),
-            SwitchListTile(
-              title: const Text('Public space'),
-              value: _isPublic,
-              onChanged: _loading
-                  ? null
-                  : (v) => setState(() {
-                        _isPublic = v;
-                        if (v) _enableEncryption = false;
-                      }),
-              contentPadding: EdgeInsets.zero,
-            ),
-            SwitchListTile(
-              title: const Text('Enable encryption'),
-              subtitle: Text(
-                _isPublic
-                    ? 'Not available for public spaces'
-                    : 'Cannot be disabled later',
-                style: TextStyle(color: cs.onSurfaceVariant, fontSize: 12),
-              ),
-              value: _enableEncryption,
-              onChanged: _loading || _isPublic
-                  ? null
-                  : (v) => setState(() => _enableEncryption = v),
-              contentPadding: EdgeInsets.zero,
-            ),
-            SwitchListTile(
-              title: const Text('Allow federation'),
-              value: _enableFederation,
-              onChanged: _loading
-                  ? null
-                  : (v) => setState(() => _enableFederation = v),
-              contentPadding: EdgeInsets.zero,
-            ),
-            if (_networkError != null)
-              Padding(
-                padding: const EdgeInsets.only(top: 8),
-                child: Text(
-                  _networkError!,
-                  style: TextStyle(color: cs.error, fontSize: 13),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _topicController,
+                enabled: !_loading,
+                decoration: const InputDecoration(
+                  labelText: 'Topic (optional)',
+                  border: OutlineInputBorder(),
                 ),
               ),
-          ],
-        ),
-      ),
-      actions: [
-        TextButton(
-          onPressed: _loading ? null : () => Navigator.pop(context),
-          child: const Text('Cancel'),
-        ),
-        FilledButton(
-          onPressed: _loading ? null : _submit,
-          child: _loading
-              ? const SizedBox(
-                  width: 22,
-                  height: 22,
-                  child: CircularProgressIndicator(strokeWidth: 2.5),
-                )
-              : const Text('Create'),
+              const SizedBox(height: 8),
+              SwitchListTile(
+                title: const Text('Public space'),
+                value: _isPublic,
+                onChanged: _loading
+                    ? null
+                    : (v) => setState(() {
+                          _isPublic = v;
+                          if (v) _enableEncryption = false;
+                        }),
+                contentPadding: EdgeInsets.zero,
+              ),
+              SwitchListTile(
+                title: const Text('Enable encryption'),
+                subtitle: Text(
+                  _isPublic
+                      ? 'Not available for public spaces'
+                      : 'Cannot be disabled later',
+                  style: TextStyle(color: cs.onSurfaceVariant, fontSize: 12),
+                ),
+                value: _enableEncryption,
+                onChanged: _loading || _isPublic
+                    ? null
+                    : (v) => setState(() => _enableEncryption = v),
+                contentPadding: EdgeInsets.zero,
+              ),
+              SwitchListTile(
+                title: const Text('Allow federation'),
+                value: _enableFederation,
+                onChanged: _loading
+                    ? null
+                    : (v) => setState(() => _enableFederation = v),
+                contentPadding: EdgeInsets.zero,
+              ),
+              if (_networkError != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Text(
+                    _networkError!,
+                    style: TextStyle(color: cs.error, fontSize: 13),
+                  ),
+                ),
+              const SizedBox(height: 16),
+              OverflowBar(
+                alignment: MainAxisAlignment.end,
+                spacing: 8,
+                children: [
+                  TextButton(
+                    onPressed: _loading ? null : () => Navigator.pop(context),
+                    child: const Text('Cancel'),
+                  ),
+                  FilledButton(
+                    onPressed: _loading ? null : _submit,
+                    child: _loading
+                        ? const SizedBox(
+                            width: 22,
+                            height: 22,
+                            child: CircularProgressIndicator(strokeWidth: 2.5),
+                          )
+                        : const Text('Create'),
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
       ],
     );
@@ -349,51 +357,59 @@ class _JoinSpaceDialogState extends State<JoinSpaceDialog> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
 
-    return AlertDialog(
-      scrollable: true,
+    return SimpleDialog(
       title: const Text('Join Space'),
-      content: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 400),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            TextField(
-              controller: _addressController,
-              autofocus: true,
-              enabled: !_loading,
-              decoration: InputDecoration(
-                labelText: 'Space address',
-                hintText: '#space:example.com',
-                border: const OutlineInputBorder(),
-                errorText: _addressError,
-              ),
-              onSubmitted: (_) => _submit(),
-            ),
-            if (_networkError != null)
-              Padding(
-                padding: const EdgeInsets.only(top: 8),
-                child: Text(
-                  _networkError!,
-                  style: TextStyle(color: cs.error, fontSize: 13),
+      contentPadding: const EdgeInsets.fromLTRB(24, 20, 24, 16),
+      children: [
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 400),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextField(
+                controller: _addressController,
+                autofocus: true,
+                enabled: !_loading,
+                decoration: InputDecoration(
+                  labelText: 'Space address',
+                  hintText: '#space:example.com',
+                  border: const OutlineInputBorder(),
+                  errorText: _addressError,
                 ),
+                onSubmitted: (_) => _submit(),
               ),
-          ],
-        ),
-      ),
-      actions: [
-        TextButton(
-          onPressed: _loading ? null : () => Navigator.pop(context),
-          child: const Text('Cancel'),
-        ),
-        FilledButton(
-          onPressed: _loading ? null : _submit,
-          child: _loading
-              ? const SizedBox(
-                  width: 22,
-                  height: 22,
-                  child: CircularProgressIndicator(strokeWidth: 2.5),
-                )
-              : const Text('Join'),
+              if (_networkError != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Text(
+                    _networkError!,
+                    style: TextStyle(color: cs.error, fontSize: 13),
+                  ),
+                ),
+              const SizedBox(height: 16),
+              OverflowBar(
+                alignment: MainAxisAlignment.end,
+                spacing: 8,
+                children: [
+                  TextButton(
+                    onPressed: _loading ? null : () => Navigator.pop(context),
+                    child: const Text('Cancel'),
+                  ),
+                  FilledButton(
+                    onPressed: _loading ? null : _submit,
+                    child: _loading
+                        ? const SizedBox(
+                            width: 22,
+                            height: 22,
+                            child: CircularProgressIndicator(strokeWidth: 2.5),
+                          )
+                        : const Text('Join'),
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
       ],
     );

--- a/lib/features/spaces/widgets/space_action_dialog.dart
+++ b/lib/features/spaces/widgets/space_action_dialog.dart
@@ -182,9 +182,10 @@ class _CreateSpaceDialogState extends State<CreateSpaceDialog> {
     final cs = Theme.of(context).colorScheme;
 
     return AlertDialog(
+      scrollable: true,
       title: const Text('Create Space'),
-      content: SizedBox(
-        width: 400,
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 400),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -349,9 +350,10 @@ class _JoinSpaceDialogState extends State<JoinSpaceDialog> {
     final cs = Theme.of(context).colorScheme;
 
     return AlertDialog(
+      scrollable: true,
       title: const Text('Join Space'),
-      content: SizedBox(
-        width: 400,
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 400),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [


### PR DESCRIPTION
## Summary
- Fixes action-button overlap in the Create Space dialog when the soft keyboard reduces the dialog's vertical space (Cancel/Create floated mid-dialog over the "Allow federation" row).
- Migrates `CreateSpaceDialog` and `JoinSpaceDialog` from `AlertDialog` to `SimpleDialog`, which wraps its children in a `SingleChildScrollView` natively. Action buttons move into an inline `OverflowBar` at the end of the children since `SimpleDialog` has no separate actions slot.
- Replaces fixed `SizedBox(width: 400)` with `ConstrainedBox(maxWidth: 400)` so the dialog adapts to narrow viewports.

## Test plan
- [x] `flutter test` — all 1660 tests pass
- [x] `flutter analyze lib/features/spaces/widgets/space_action_dialog.dart` — no issues
- [ ] Manually verify Create Space dialog on iOS with keyboard open: content scrolls, no button/row overlap
- [ ] Manually verify Join Space dialog on iOS with keyboard open
- [ ] Verify desktop layout (wide screen) still caps at 400px width