### PR TITLE
fix(e2ee): KeyBackupBanner false positives + stale state

### DIFF
--- a/lib/core/services/matrix_service.dart
+++ b/lib/core/services/matrix_service.dart
@@ -148,6 +148,7 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
     switch (state) {
       case AppLifecycleState.resumed:
         _startForegroundSync();
+        unawaited(chatBackup.refreshOnResume());
       case AppLifecycleState.inactive:
       case AppLifecycleState.paused:
       case AppLifecycleState.detached:

--- a/lib/core/services/sub_services/backup_version_manager.dart
+++ b/lib/core/services/sub_services/backup_version_manager.dart
@@ -17,7 +17,13 @@ class BackupVersionManager {
     _cachedHasVersionAt = null;
   }
 
-  Future<bool> hasVersion({bool refresh = false}) async {
+  /// Returns:
+  /// - `true` if a backup version exists on the server,
+  /// - `false` if the server explicitly returned `M_NOT_FOUND`,
+  /// - `null` if the lookup failed (network error, encryption unavailable,
+  ///   or a non-`M_NOT_FOUND` MatrixException). Unknown results are
+  ///   intentionally not cached so the next call retries.
+  Future<bool?> hasVersion({bool refresh = false}) async {
     if (!refresh &&
         _cachedHasVersion != null &&
         _cachedHasVersionAt != null &&
@@ -26,17 +32,17 @@ class BackupVersionManager {
     }
 
     final encryption = _client.encryption;
-    if (encryption == null) return _rememberHasVersion(false);
+    if (encryption == null) return null;
     try {
       await encryption.keyManager.getRoomKeysBackupInfo(false);
       return _rememberHasVersion(true);
     } on MatrixException catch (e) {
       if (e.errcode == 'M_NOT_FOUND') return _rememberHasVersion(false);
       debugPrint('[Kohera] hasVersion MatrixException: $e');
-      return _rememberHasVersion(false);
+      return null;
     } catch (e) {
       debugPrint('[Kohera] hasVersion error: $e');
-      return _rememberHasVersion(false);
+      return null;
     }
   }
 

--- a/lib/core/services/sub_services/chat_backup_service.dart
+++ b/lib/core/services/sub_services/chat_backup_service.dart
@@ -15,11 +15,24 @@ class ChatBackupService extends ChangeNotifier {
   })  : _client = client,
         _storage = storage,
         _backupVersion =
-            backupVersion ?? BackupVersionManager(client: client);
+            backupVersion ?? BackupVersionManager(client: client) {
+    _syncSub = _client.onSync.stream.listen(_onSyncUpdate);
+  }
 
   final Client _client;
   final FlutterSecureStorage _storage;
   final BackupVersionManager _backupVersion;
+
+  StreamSubscription<SyncUpdate>? _syncSub;
+  DateTime? _lastResumeRefresh;
+  static const Duration _resumeRefreshThrottle = Duration(seconds: 30);
+
+  static const _backupAccountDataTypes = <String>{
+    'm.megolm_backup.v1',
+    'm.cross_signing.master',
+    'm.cross_signing.self_signing',
+    'm.cross_signing.user_signing',
+  };
 
   // ── Chat Backup ─────────────────────────────────────────────
   bool? _chatBackupNeeded;
@@ -40,14 +53,51 @@ class ChatBackupService extends ChangeNotifier {
         '[Kohera] Backup status: initialized=${state.initialized}, '
         'connected=${state.connected}, hasBackupVersion=$hasBackupVersion',
       );
+      if (hasBackupVersion == null) {
+        // Lookup failed — leave the previous value in place rather than
+        // emitting a false-positive "backup needed".
+        return;
+      }
       _chatBackupNeeded =
           !state.initialized || !state.connected || !hasBackupVersion;
       notifyListeners();
     } catch (e) {
       debugPrint('[Kohera] checkChatBackupStatus error: $e');
-      _chatBackupNeeded = true;
-      notifyListeners();
+      // Transient failure — keep the last known value. Forcing `true` here
+      // produced false positives on sync hiccups and cross-signing rotations.
     }
+  }
+
+  void _onSyncUpdate(SyncUpdate update) {
+    final events = update.accountData;
+    if (events == null || events.isEmpty) return;
+    final relevant = events.any(
+      (e) => _backupAccountDataTypes.contains(e.type),
+    );
+    if (!relevant) return;
+    debugPrint('[Kohera] Backup-relevant account-data observed in sync');
+    _backupVersion.invalidateCache();
+    unawaited(checkChatBackupStatus());
+  }
+
+  /// Refreshes backup status after the app returns to the foreground.
+  /// Throttled so repeated resume events don't thrash the server.
+  Future<void> refreshOnResume() async {
+    final now = DateTime.now();
+    if (_lastResumeRefresh != null &&
+        now.difference(_lastResumeRefresh!) < _resumeRefreshThrottle) {
+      return;
+    }
+    _lastResumeRefresh = now;
+    _backupVersion.invalidateCache();
+    await checkChatBackupStatus();
+  }
+
+  @override
+  void dispose() {
+    unawaited(_syncSub?.cancel());
+    _syncSub = null;
+    super.dispose();
   }
 
   Future<void> disableChatBackup() async {

--- a/lib/core/services/sub_services/chat_backup_service.dart
+++ b/lib/core/services/sub_services/chat_backup_service.dart
@@ -25,14 +25,22 @@ class ChatBackupService extends ChangeNotifier {
 
   StreamSubscription<SyncUpdate>? _syncSub;
   DateTime? _lastResumeRefresh;
+  DateTime? _lastSyncRefresh;
+  bool _checking = false;
   static const Duration _resumeRefreshThrottle = Duration(seconds: 30);
+  static const Duration _syncRefreshThrottle = Duration(seconds: 5);
 
   static const _backupAccountDataTypes = <String>{
     'm.megolm_backup.v1',
     'm.cross_signing.master',
     'm.cross_signing.self_signing',
     'm.cross_signing.user_signing',
+    'm.secret_storage.default_key',
   };
+
+  static const _backupAccountDataTypePrefixes = <String>[
+    'm.secret_storage.key.',
+  ];
 
   // ── Chat Backup ─────────────────────────────────────────────
   bool? _chatBackupNeeded;
@@ -46,6 +54,8 @@ class ChatBackupService extends ChangeNotifier {
   String? get chatBackupError => _chatBackupError;
 
   Future<void> checkChatBackupStatus() async {
+    if (_checking) return;
+    _checking = true;
     try {
       final hasBackupVersion = await _backupVersion.hasVersion();
       final state = await _client.getCryptoIdentityState();
@@ -65,17 +75,30 @@ class ChatBackupService extends ChangeNotifier {
       debugPrint('[Kohera] checkChatBackupStatus error: $e');
       // Transient failure — keep the last known value. Forcing `true` here
       // produced false positives on sync hiccups and cross-signing rotations.
+    } finally {
+      _checking = false;
     }
+  }
+
+  bool _isBackupRelevantAccountData(String type) {
+    if (_backupAccountDataTypes.contains(type)) return true;
+    for (final prefix in _backupAccountDataTypePrefixes) {
+      if (type.startsWith(prefix)) return true;
+    }
+    return false;
   }
 
   void _onSyncUpdate(SyncUpdate update) {
     final events = update.accountData;
     if (events == null || events.isEmpty) return;
-    final relevant = events.any(
-      (e) => _backupAccountDataTypes.contains(e.type),
-    );
+    final relevant = events.any((e) => _isBackupRelevantAccountData(e.type));
     if (!relevant) return;
-    debugPrint('[Kohera] Backup-relevant account-data observed in sync');
+    final now = DateTime.now();
+    if (_lastSyncRefresh != null &&
+        now.difference(_lastSyncRefresh!) < _syncRefreshThrottle) {
+      return;
+    }
+    _lastSyncRefresh = now;
     _backupVersion.invalidateCache();
     unawaited(checkChatBackupStatus());
   }

--- a/test/screens/chat_search_test.mocks.dart
+++ b/test/screens/chat_search_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i17;
-import 'dart:ui' as _i19;
+import 'dart:typed_data' as _i18;
+import 'dart:ui' as _i20;
 
-import 'package:flutter/services.dart' as _i20;
-import 'package:flutter/widgets.dart' as _i21;
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,14 +23,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i15;
+import 'package:matrix/encryption.dart' as _i16;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i14;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i15;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i22;
+import 'package:matrix/src/utils/space_child.dart' as _i23;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -821,8 +822,9 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_73(
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -831,9 +833,19 @@ class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_74 extends _i1.SmartFake
+class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_74(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_75 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_74(
+  _FakeLatestReceiptState_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,8 +854,8 @@ class _FakeLatestReceiptState_74 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_75(
+class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,8 +864,8 @@ class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_76(
+class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -862,8 +874,8 @@ class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_77 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_77(
+class _FakeRoom_78 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -872,9 +884,9 @@ class _FakeRoom_77 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_78 extends _i1.SmartFake
-    implements _i14.TimelineChunk {
-  _FakeTimelineChunk_78(
+class _FakeTimelineChunk_79 extends _i1.SmartFake
+    implements _i15.TimelineChunk {
+  _FakeTimelineChunk_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -901,12 +913,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i15.KeyVerificationMethod> get verificationMethods =>
+  Set<_i16.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i15.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
-      ) as Set<_i15.KeyVerificationMethod>);
+        returnValue: <_i16.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
+      ) as Set<_i16.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1026,11 +1038,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1067,11 +1079,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1101,11 +1113,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1114,11 +1126,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1404,34 +1416,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i15.KeyVerification>
+  _i3.CachedStreamController<_i16.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i15.KeyVerification>(
+                _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i15.KeyVerification>);
+          ) as _i3.CachedStreamController<_i16.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1587,7 +1599,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1876,14 +1888,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2271,8 +2283,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2288,8 +2300,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2330,7 +2342,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2346,7 +2358,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2395,7 +2407,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2416,7 +2428,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2519,7 +2531,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2537,7 +2549,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3056,7 +3068,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i17.Uint8List? file, {
+    _i18.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3408,7 +3420,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3422,7 +3434,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3573,7 +3585,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i17.Uint8List? body,
+    _i18.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4951,7 +4963,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4973,7 +4985,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5467,7 +5479,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5479,7 +5491,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6487,7 +6499,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6498,7 +6510,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6746,7 +6758,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6758,7 +6770,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7018,7 +7030,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7031,7 +7043,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7098,7 +7110,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7111,7 +7123,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7159,7 +7171,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7171,7 +7183,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7419,7 +7431,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7430,7 +7442,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7692,7 +7704,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i17.Uint8List? body, {
+    _i18.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7719,7 +7731,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7749,11 +7761,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7852,6 +7864,19 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7931,6 +7956,15 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7975,7 +8009,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8069,7 +8103,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8078,7 +8112,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8097,7 +8131,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8108,7 +8142,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8156,7 +8190,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8194,7 +8228,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8203,7 +8237,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8212,16 +8246,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i5.Future<_i19.AppExitResponse>);
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i5.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8249,11 +8283,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8283,11 +8317,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_73(
+        returnValue: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_73(
+        returnValueForMissingStub: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
@@ -8340,11 +8374,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8380,11 +8414,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8400,11 +8434,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8413,11 +8447,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8460,11 +8494,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8507,11 +8541,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_74(
+        returnValue: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_74(
+        returnValueForMissingStub: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8723,18 +8757,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i22.SpaceParent>[],
-        returnValueForMissingStub: <_i22.SpaceParent>[],
-      ) as List<_i22.SpaceParent>);
+        returnValue: <_i23.SpaceParent>[],
+        returnValueForMissingStub: <_i23.SpaceParent>[],
+      ) as List<_i23.SpaceParent>);
 
   @override
-  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i22.SpaceChild>[],
-        returnValueForMissingStub: <_i22.SpaceChild>[],
-      ) as List<_i22.SpaceChild>);
+        returnValue: <_i23.SpaceChild>[],
+        returnValueForMissingStub: <_i23.SpaceChild>[],
+      ) as List<_i23.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8901,14 +8935,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8956,7 +8990,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8964,7 +8998,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8979,7 +9013,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8987,7 +9021,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9071,7 +9105,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9079,7 +9113,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9321,7 +9355,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9332,7 +9366,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9421,15 +9455,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i14.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i15.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i14.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i14.TimelineChunk?>.value(),
-      ) as _i5.Future<_i14.TimelineChunk?>);
+        returnValue: _i5.Future<_i15.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i15.TimelineChunk?>.value(),
+      ) as _i5.Future<_i15.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9470,7 +9504,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9487,7 +9521,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9551,14 +9585,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9574,14 +9608,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9637,7 +9671,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9645,7 +9679,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9957,11 +9991,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_77(
+        returnValue: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_77(
+        returnValueForMissingStub: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
@@ -10011,17 +10045,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i14.TimelineChunk get chunk => (super.noSuchMethod(
+  _i15.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_78(
+        returnValue: _FakeTimelineChunk_79(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_78(
+        returnValueForMissingStub: _FakeTimelineChunk_79(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i14.TimelineChunk);
+      ) as _i15.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10124,7 +10158,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i14.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i15.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,

--- a/test/screens/devices_screen_test.mocks.dart
+++ b/test/screens/devices_screen_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,12 +23,12 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -819,6 +820,17 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -837,12 +849,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -962,11 +974,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1003,11 +1015,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1037,11 +1049,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1050,11 +1062,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1340,34 +1352,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1523,7 +1535,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1812,14 +1824,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2207,8 +2219,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2224,8 +2236,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2266,7 +2278,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2282,7 +2294,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2331,7 +2343,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2352,7 +2364,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2455,7 +2467,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2473,7 +2485,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2992,7 +3004,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3344,7 +3356,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3358,7 +3370,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3509,7 +3521,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4887,7 +4899,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4909,7 +4921,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5403,7 +5415,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5415,7 +5427,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6423,7 +6435,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6434,7 +6446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6682,7 +6694,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6694,7 +6706,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6954,7 +6966,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6967,7 +6979,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7034,7 +7046,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7047,7 +7059,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7095,7 +7107,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7107,7 +7119,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7355,7 +7367,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7366,7 +7378,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7628,7 +7640,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7655,7 +7667,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7685,11 +7697,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7788,6 +7800,19 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7867,6 +7892,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7911,7 +7945,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8005,7 +8039,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8014,7 +8048,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8033,7 +8067,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8044,7 +8078,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8092,7 +8126,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8130,7 +8164,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8139,7 +8173,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8148,16 +8182,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8214,6 +8248,25 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> refreshOnResume() => (super.noSuchMethod(
+        Invocation.method(
+          #refreshOnResume,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> disableChatBackup() => (super.noSuchMethod(
         Invocation.method(
           #disableChatBackup,
@@ -8243,7 +8296,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> runKeyRecovery({_i14.OpenSSSS? ssssKey}) =>
+  _i5.Future<void> runKeyRecovery({_i15.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
@@ -8297,7 +8350,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8306,19 +8359,10 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
         ),
         returnValueForMissingStub: null,
       );

--- a/test/services/backup_version_manager_test.dart
+++ b/test/services/backup_version_manager_test.dart
@@ -114,10 +114,41 @@ void main() {
       expect(await manager.hasVersion(), isFalse);
     });
 
-    test('returns false when encryption is unavailable', () async {
+    test('returns null when encryption is unavailable', () async {
       when(mockClient.encryption).thenReturn(null);
 
-      expect(await manager.hasVersion(), isFalse);
+      expect(await manager.hasVersion(), isNull);
+    });
+
+    test('returns null on non-M_NOT_FOUND MatrixException', () async {
+      when(mockKeyManager.getRoomKeysBackupInfo(any)).thenThrow(
+        MatrixException.fromJson({
+          'errcode': 'M_FORBIDDEN',
+          'error': 'Not allowed',
+        }),
+      );
+
+      expect(await manager.hasVersion(), isNull);
+    });
+
+    test('returns null on unexpected exception', () async {
+      when(mockKeyManager.getRoomKeysBackupInfo(any))
+          .thenThrow(Exception('network'));
+
+      expect(await manager.hasVersion(), isNull);
+    });
+
+    test('null results are not cached — next call retries', () async {
+      var callCount = 0;
+      when(mockKeyManager.getRoomKeysBackupInfo(any)).thenAnswer((_) async {
+        callCount++;
+        throw Exception('network');
+      });
+
+      expect(await manager.hasVersion(), isNull);
+      expect(await manager.hasVersion(), isNull);
+
+      expect(callCount, 2);
     });
 
     test('does not attempt to recreate the version', () async {

--- a/test/services/chat_backup_service_test.dart
+++ b/test/services/chat_backup_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart';
 import 'package:matrix/matrix.dart';
+import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:mockito/mockito.dart';
 
 import 'matrix_service_test.mocks.dart';
@@ -14,6 +15,7 @@ void main() {
   late MockSSSS mockSsss;
   late MockDatabaseApi mockDatabase;
   late MockBackupVersionManager mockBackupVersion;
+  late CachedStreamController<SyncUpdate> syncController;
   late ChatBackupService service;
   late int changeCount;
 
@@ -35,7 +37,9 @@ void main() {
     mockSsss = MockSSSS();
     mockDatabase = MockDatabaseApi();
     mockBackupVersion = MockBackupVersionManager();
+    syncController = CachedStreamController<SyncUpdate>();
     changeCount = 0;
+    when(mockClient.onSync).thenReturn(syncController);
     when(mockClient.rooms).thenReturn([]);
     when(mockClient.encryption).thenReturn(mockEncryption);
     when(mockClient.database).thenReturn(mockDatabase);
@@ -88,13 +92,35 @@ void main() {
       expect(service.chatBackupNeeded, isTrue);
     });
 
-    test('sets chatBackupNeeded true on error', () async {
-      when(mockClient.encryption).thenReturn(null);
+    test('leaves chatBackupNeeded unchanged when an inner call throws',
+        () async {
+      when(mockBackupVersion.hasVersion())
+          .thenThrow(Exception('sync glitch'));
 
       await service.checkChatBackupStatus();
 
-      expect(service.chatBackupNeeded, isTrue);
-      expect(changeCount, greaterThan(0));
+      // Previous behavior forced `true` here, producing false positives.
+      // The new contract is "transient errors leave the last value in place".
+      expect(service.chatBackupNeeded, isNull);
+    });
+
+    test(
+        'leaves chatBackupNeeded unchanged when hasVersion returns null '
+        '(transient lookup failure)', () async {
+      when(mockCrossSigning.enabled).thenReturn(true);
+      when(mockKeyManager.enabled).thenReturn(true);
+      when(mockCrossSigning.isCached()).thenAnswer((_) async => true);
+      when(mockKeyManager.isCached()).thenAnswer((_) async => true);
+
+      // First call: backup exists, so banner is hidden.
+      await service.checkChatBackupStatus();
+      expect(service.chatBackupNeeded, isFalse);
+
+      // Second call: hasVersion lookup fails — must not flip to true.
+      when(mockBackupVersion.hasVersion()).thenAnswer((_) async => null);
+      await service.checkChatBackupStatus();
+
+      expect(service.chatBackupNeeded, isFalse);
     });
 
     test(
@@ -110,6 +136,72 @@ void main() {
       await service.checkChatBackupStatus();
 
       expect(service.chatBackupNeeded, isTrue);
+    });
+  });
+
+  group('account-data refresh', () {
+    test('refreshes when sync brings a m.megolm_backup.v1 account-data event',
+        () async {
+      when(mockCrossSigning.enabled).thenReturn(true);
+      when(mockKeyManager.enabled).thenReturn(true);
+      when(mockCrossSigning.isCached()).thenAnswer((_) async => true);
+      when(mockKeyManager.isCached()).thenAnswer((_) async => true);
+      when(mockBackupVersion.hasVersion()).thenAnswer((_) async => true);
+
+      syncController.add(
+        SyncUpdate(
+          nextBatch: 'tok',
+          accountData: [
+            BasicEvent(type: 'm.megolm_backup.v1', content: const {}),
+          ],
+        ),
+      );
+      // Let the listener's microtask drain.
+      await Future<void>.delayed(Duration.zero);
+
+      verify(mockBackupVersion.invalidateCache()).called(1);
+      expect(service.chatBackupNeeded, isFalse);
+    });
+
+    test('ignores sync updates without backup-relevant account-data', () async {
+      syncController.add(
+        SyncUpdate(
+          nextBatch: 'tok',
+          accountData: [
+            BasicEvent(type: 'm.push_rules', content: const {}),
+          ],
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      verifyNever(mockBackupVersion.invalidateCache());
+    });
+  });
+
+  group('refreshOnResume', () {
+    test('runs checkChatBackupStatus on first call', () async {
+      when(mockCrossSigning.enabled).thenReturn(true);
+      when(mockKeyManager.enabled).thenReturn(true);
+      when(mockCrossSigning.isCached()).thenAnswer((_) async => true);
+      when(mockKeyManager.isCached()).thenAnswer((_) async => true);
+
+      await service.refreshOnResume();
+
+      verify(mockBackupVersion.invalidateCache()).called(1);
+      verify(mockBackupVersion.hasVersion()).called(1);
+    });
+
+    test('throttles repeat calls within 30s', () async {
+      when(mockCrossSigning.enabled).thenReturn(true);
+      when(mockKeyManager.enabled).thenReturn(true);
+      when(mockCrossSigning.isCached()).thenAnswer((_) async => true);
+      when(mockKeyManager.isCached()).thenAnswer((_) async => true);
+
+      await service.refreshOnResume();
+      await service.refreshOnResume();
+
+      verify(mockBackupVersion.invalidateCache()).called(1);
+      verify(mockBackupVersion.hasVersion()).called(1);
     });
   });
 

--- a/test/services/chat_backup_service_test.dart
+++ b/test/services/chat_backup_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart';
 import 'package:matrix/matrix.dart';
@@ -175,6 +177,73 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       verifyNever(mockBackupVersion.invalidateCache());
+      verifyNever(mockBackupVersion.hasVersion());
+    });
+
+    test('refreshes on m.secret_storage.key.* (SSSS root) events', () async {
+      when(mockCrossSigning.enabled).thenReturn(true);
+      when(mockKeyManager.enabled).thenReturn(true);
+      when(mockCrossSigning.isCached()).thenAnswer((_) async => true);
+      when(mockKeyManager.isCached()).thenAnswer((_) async => true);
+      when(mockBackupVersion.hasVersion()).thenAnswer((_) async => true);
+
+      syncController.add(
+        SyncUpdate(
+          nextBatch: 'tok',
+          accountData: [
+            BasicEvent(
+              type: 'm.secret_storage.key.AbCdEf',
+              content: const {},
+            ),
+          ],
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      verify(mockBackupVersion.invalidateCache()).called(1);
+    });
+
+    test('throttles repeated sync-driven refreshes within 5s', () async {
+      when(mockCrossSigning.enabled).thenReturn(true);
+      when(mockKeyManager.enabled).thenReturn(true);
+      when(mockCrossSigning.isCached()).thenAnswer((_) async => true);
+      when(mockKeyManager.isCached()).thenAnswer((_) async => true);
+      when(mockBackupVersion.hasVersion()).thenAnswer((_) async => true);
+
+      for (var i = 0; i < 3; i++) {
+        syncController.add(
+          SyncUpdate(
+            nextBatch: 'tok$i',
+            accountData: [
+              BasicEvent(type: 'm.megolm_backup.v1', content: const {}),
+            ],
+          ),
+        );
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      verify(mockBackupVersion.invalidateCache()).called(1);
+      verify(mockBackupVersion.hasVersion()).called(1);
+    });
+  });
+
+  group('concurrent checkChatBackupStatus', () {
+    test('second concurrent call is a no-op while the first is in flight',
+        () async {
+      final completer = Completer<bool?>();
+      when(mockCrossSigning.enabled).thenReturn(true);
+      when(mockKeyManager.enabled).thenReturn(true);
+      when(mockCrossSigning.isCached()).thenAnswer((_) async => true);
+      when(mockKeyManager.isCached()).thenAnswer((_) async => true);
+      when(mockBackupVersion.hasVersion())
+          .thenAnswer((_) => completer.future);
+
+      final first = service.checkChatBackupStatus();
+      final second = service.checkChatBackupStatus();
+      completer.complete(true);
+      await Future.wait([first, second]);
+
+      verify(mockBackupVersion.hasVersion()).called(1);
     });
   });
 

--- a/test/services/chat_message_actions_test.mocks.dart
+++ b/test/services/chat_message_actions_test.mocks.dart
@@ -4,22 +4,23 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i6;
-import 'dart:typed_data' as _i21;
-import 'dart:ui' as _i24;
+import 'dart:typed_data' as _i22;
+import 'dart:ui' as _i25;
 
-import 'package:flutter/scheduler.dart' as _i18;
-import 'package:flutter/services.dart' as _i25;
-import 'package:flutter/src/foundation/assertions.dart' as _i28;
-import 'package:flutter/src/foundation/diagnostics.dart' as _i17;
-import 'package:flutter/src/material/banner.dart' as _i27;
-import 'package:flutter/src/material/scaffold.dart' as _i15;
-import 'package:flutter/src/material/snack_bar.dart' as _i26;
-import 'package:flutter/widgets.dart' as _i16;
+import 'package:flutter/scheduler.dart' as _i19;
+import 'package:flutter/services.dart' as _i26;
+import 'package:flutter/src/foundation/assertions.dart' as _i29;
+import 'package:flutter/src/foundation/diagnostics.dart' as _i18;
+import 'package:flutter/src/material/banner.dart' as _i28;
+import 'package:flutter/src/material/scaffold.dart' as _i16;
+import 'package:flutter/src/material/snack_bar.dart' as _i27;
+import 'package:flutter/widgets.dart' as _i17;
 import 'package:http/http.dart' as _i5;
-import 'package:kohera/core/services/matrix_service.dart' as _i23;
+import 'package:kohera/core/services/matrix_service.dart' as _i24;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i11;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i12;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
@@ -28,14 +29,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i8;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i9;
-import 'package:matrix/encryption.dart' as _i22;
+import 'package:matrix/encryption.dart' as _i23;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i7;
 import 'package:matrix/src/models/timeline_chunk.dart' as _i4;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i20;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -908,9 +909,20 @@ class _FakeAuthService_80 extends _i1.SmartFake implements _i14.AuthService {
         );
 }
 
-class _FakeScaffoldMessenger_81 extends _i1.SmartFake
-    implements _i15.ScaffoldMessenger {
-  _FakeScaffoldMessenger_81(
+class _FakeOutboxService_81 extends _i1.SmartFake
+    implements _i15.OutboxService {
+  _FakeOutboxService_81(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeScaffoldMessenger_82 extends _i1.SmartFake
+    implements _i16.ScaffoldMessenger {
+  _FakeScaffoldMessenger_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -920,12 +932,12 @@ class _FakeScaffoldMessenger_81 extends _i1.SmartFake
 
   @override
   String toString(
-          {_i16.DiagnosticLevel? minLevel = _i16.DiagnosticLevel.info}) =>
+          {_i17.DiagnosticLevel? minLevel = _i17.DiagnosticLevel.info}) =>
       super.toString();
 }
 
-class _FakeBuildContext_82 extends _i1.SmartFake implements _i16.BuildContext {
-  _FakeBuildContext_82(
+class _FakeBuildContext_83 extends _i1.SmartFake implements _i17.BuildContext {
+  _FakeBuildContext_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -934,9 +946,9 @@ class _FakeBuildContext_82 extends _i1.SmartFake implements _i16.BuildContext {
         );
 }
 
-class _FakeScaffoldFeatureController_83<T extends _i16.Widget, U>
-    extends _i1.SmartFake implements _i15.ScaffoldFeatureController<T, U> {
-  _FakeScaffoldFeatureController_83(
+class _FakeScaffoldFeatureController_84<T extends _i17.Widget, U>
+    extends _i1.SmartFake implements _i16.ScaffoldFeatureController<T, U> {
+  _FakeScaffoldFeatureController_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -945,8 +957,8 @@ class _FakeScaffoldFeatureController_83<T extends _i16.Widget, U>
         );
 }
 
-class _FakeWidget_84 extends _i1.SmartFake implements _i16.Widget {
-  _FakeWidget_84(
+class _FakeWidget_85 extends _i1.SmartFake implements _i17.Widget {
+  _FakeWidget_85(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -956,13 +968,13 @@ class _FakeWidget_84 extends _i1.SmartFake implements _i16.Widget {
 
   @override
   String toString(
-          {_i16.DiagnosticLevel? minLevel = _i16.DiagnosticLevel.info}) =>
+          {_i17.DiagnosticLevel? minLevel = _i17.DiagnosticLevel.info}) =>
       super.toString();
 }
 
-class _FakeDiagnosticsNode_85 extends _i1.SmartFake
-    implements _i16.DiagnosticsNode {
-  _FakeDiagnosticsNode_85(
+class _FakeDiagnosticsNode_86 extends _i1.SmartFake
+    implements _i17.DiagnosticsNode {
+  _FakeDiagnosticsNode_86(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -972,14 +984,14 @@ class _FakeDiagnosticsNode_85 extends _i1.SmartFake
 
   @override
   String toString({
-    _i17.TextTreeConfiguration? parentConfiguration,
-    _i16.DiagnosticLevel? minLevel = _i16.DiagnosticLevel.info,
+    _i18.TextTreeConfiguration? parentConfiguration,
+    _i17.DiagnosticLevel? minLevel = _i17.DiagnosticLevel.info,
   }) =>
       super.toString();
 }
 
-class _FakeTicker_86 extends _i1.SmartFake implements _i18.Ticker {
-  _FakeTicker_86(
+class _FakeTicker_87 extends _i1.SmartFake implements _i19.Ticker {
+  _FakeTicker_87(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -998,11 +1010,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1089,11 +1101,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -1129,11 +1141,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1149,11 +1161,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1162,11 +1174,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1209,11 +1221,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1472,18 +1484,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i20.SpaceParent>[],
-        returnValueForMissingStub: <_i20.SpaceParent>[],
-      ) as List<_i20.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i20.SpaceChild>[],
-        returnValueForMissingStub: <_i20.SpaceChild>[],
-      ) as List<_i20.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -1650,14 +1662,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -1705,7 +1717,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -1713,7 +1725,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i19.dummyValue<String>(
+            _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -1728,7 +1740,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -1736,7 +1748,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i19.dummyValue<String>(
+            _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -1820,7 +1832,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -1828,7 +1840,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i19.dummyValue<String>(
+            _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2070,7 +2082,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2081,7 +2093,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i19.dummyValue<String>(
+            _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2386,7 +2398,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2394,7 +2406,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i19.dummyValue<String>(
+            _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2772,11 +2784,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -2785,11 +2797,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -2798,11 +2810,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -2811,11 +2823,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -2824,11 +2836,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -2893,11 +2905,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -2906,11 +2918,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -2963,11 +2975,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -3052,11 +3064,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -3074,11 +3086,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -3289,7 +3301,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i6.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i6.Future<_i21.Uint8List> Function(Uri)? downloadCallback,
+    _i6.Future<_i22.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -3354,7 +3366,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -3369,7 +3381,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i19.dummyValue<String>(
+            _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -3406,7 +3418,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -3420,7 +3432,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -3457,7 +3469,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -3471,7 +3483,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -3505,7 +3517,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -3518,7 +3530,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -3995,12 +4007,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i22.KeyVerificationMethod> get verificationMethods =>
+  Set<_i23.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i22.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i22.KeyVerificationMethod>{},
-      ) as Set<_i22.KeyVerificationMethod>);
+        returnValue: <_i23.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i23.KeyVerificationMethod>{},
+      ) as Set<_i23.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -4120,11 +4132,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -4161,11 +4173,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -4195,11 +4207,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -4208,11 +4220,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -4499,34 +4511,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i22.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i23.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_1<_i22.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_1<_i23.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_1<_i22.RoomKeyRequest>(
+            _FakeCachedStreamController_1<_i23.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i22.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i23.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i22.KeyVerification>
+  _i3.CachedStreamController<_i23.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_1<_i22.KeyVerification>(
+            returnValue: _FakeCachedStreamController_1<_i23.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_1<_i22.KeyVerification>(
+                _FakeCachedStreamController_1<_i23.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i22.KeyVerification>);
+          ) as _i3.CachedStreamController<_i23.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -4682,7 +4694,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i22.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i23.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -4971,14 +4983,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -5366,8 +5378,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -5383,8 +5395,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -5425,7 +5437,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -5441,7 +5453,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i19.dummyValue<String>(
+            _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -5490,7 +5502,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -5511,7 +5523,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i19.dummyValue<String>(
+            _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -5614,7 +5626,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -5632,7 +5644,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i19.dummyValue<String>(
+            _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -6154,7 +6166,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i6.Future<Uri> uploadContent(
-    _i21.Uint8List? file, {
+    _i22.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -6506,7 +6518,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -6520,7 +6532,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i19.dummyValue<String>(
+            _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -6671,7 +6683,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i5.BaseResponse? response,
-    _i21.Uint8List? body,
+    _i22.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8049,7 +8061,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -8071,7 +8083,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i19.dummyValue<String>(
+            _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -8565,7 +8577,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -8577,7 +8589,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i19.dummyValue<String>(
+            _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -9585,7 +9597,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -9596,7 +9608,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i19.dummyValue<String>(
+            _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -9844,7 +9856,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9856,7 +9868,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i19.dummyValue<String>(
+            _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -10116,7 +10128,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -10129,7 +10141,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i19.dummyValue<String>(
+            _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -10196,7 +10208,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -10209,7 +10221,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i19.dummyValue<String>(
+            _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -10257,7 +10269,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -10269,7 +10281,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i19.dummyValue<String>(
+            _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -10517,7 +10529,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -10528,7 +10540,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i19.dummyValue<String>(
+            _i6.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -10790,7 +10802,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i6.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i21.Uint8List? body, {
+    _i22.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -10817,7 +10829,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
   @override
   _i8.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -10847,11 +10859,11 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -10950,6 +10962,19 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       ) as _i14.AuthService);
 
   @override
+  _i15.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_81(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_81(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i15.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -11029,6 +11054,15 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       );
 
   @override
+  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -11073,7 +11107,7 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i24.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i25.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -11167,7 +11201,7 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       ) as _i6.Future<void>);
 
   @override
-  void addListener(_i24.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i25.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -11176,7 +11210,7 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       );
 
   @override
-  void removeListener(_i24.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i25.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -11195,7 +11229,7 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       ) as _i6.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i25.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i26.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -11206,7 +11240,7 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i25.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i26.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -11254,7 +11288,7 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
 
   @override
   _i6.Future<bool> didPushRouteInformation(
-          _i16.RouteInformation? routeInformation) =>
+          _i17.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -11292,7 +11326,7 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i24.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i25.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -11301,7 +11335,7 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i24.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i25.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -11310,16 +11344,16 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
       );
 
   @override
-  _i6.Future<_i24.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i6.Future<_i25.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i6.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
+            _i6.Future<_i25.AppExitResponse>.value(_i25.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i6.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
-      ) as _i6.Future<_i24.AppExitResponse>);
+            _i6.Future<_i25.AppExitResponse>.value(_i25.AppExitResponse.exit),
+      ) as _i6.Future<_i25.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -11344,32 +11378,32 @@ class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockScaffoldMessengerState extends _i1.Mock
-    implements _i15.ScaffoldMessengerState {
+    implements _i16.ScaffoldMessengerState {
   @override
-  _i15.ScaffoldMessenger get widget => (super.noSuchMethod(
+  _i16.ScaffoldMessenger get widget => (super.noSuchMethod(
         Invocation.getter(#widget),
-        returnValue: _FakeScaffoldMessenger_81(
+        returnValue: _FakeScaffoldMessenger_82(
           this,
           Invocation.getter(#widget),
         ),
-        returnValueForMissingStub: _FakeScaffoldMessenger_81(
+        returnValueForMissingStub: _FakeScaffoldMessenger_82(
           this,
           Invocation.getter(#widget),
         ),
-      ) as _i15.ScaffoldMessenger);
+      ) as _i16.ScaffoldMessenger);
 
   @override
-  _i16.BuildContext get context => (super.noSuchMethod(
+  _i17.BuildContext get context => (super.noSuchMethod(
         Invocation.getter(#context),
-        returnValue: _FakeBuildContext_82(
+        returnValue: _FakeBuildContext_83(
           this,
           Invocation.getter(#context),
         ),
-        returnValueForMissingStub: _FakeBuildContext_82(
+        returnValueForMissingStub: _FakeBuildContext_83(
           this,
           Invocation.getter(#context),
         ),
-      ) as _i16.BuildContext);
+      ) as _i17.BuildContext);
 
   @override
   bool get mounted => (super.noSuchMethod(
@@ -11388,10 +11422,10 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  _i15.ScaffoldFeatureController<_i26.SnackBar, _i26.SnackBarClosedReason>
+  _i16.ScaffoldFeatureController<_i27.SnackBar, _i27.SnackBarClosedReason>
       showSnackBar(
-    _i26.SnackBar? snackBar, {
-    _i16.AnimationStyle? snackBarAnimationStyle,
+    _i27.SnackBar? snackBar, {
+    _i17.AnimationStyle? snackBarAnimationStyle,
   }) =>
           (super.noSuchMethod(
             Invocation.method(
@@ -11399,8 +11433,8 @@ class MockScaffoldMessengerState extends _i1.Mock
               [snackBar],
               {#snackBarAnimationStyle: snackBarAnimationStyle},
             ),
-            returnValue: _FakeScaffoldFeatureController_83<_i26.SnackBar,
-                _i26.SnackBarClosedReason>(
+            returnValue: _FakeScaffoldFeatureController_84<_i27.SnackBar,
+                _i27.SnackBarClosedReason>(
               this,
               Invocation.method(
                 #showSnackBar,
@@ -11408,8 +11442,8 @@ class MockScaffoldMessengerState extends _i1.Mock
                 {#snackBarAnimationStyle: snackBarAnimationStyle},
               ),
             ),
-            returnValueForMissingStub: _FakeScaffoldFeatureController_83<
-                _i26.SnackBar, _i26.SnackBarClosedReason>(
+            returnValueForMissingStub: _FakeScaffoldFeatureController_84<
+                _i27.SnackBar, _i27.SnackBarClosedReason>(
               this,
               Invocation.method(
                 #showSnackBar,
@@ -11417,13 +11451,13 @@ class MockScaffoldMessengerState extends _i1.Mock
                 {#snackBarAnimationStyle: snackBarAnimationStyle},
               ),
             ),
-          ) as _i15.ScaffoldFeatureController<_i26.SnackBar,
-              _i26.SnackBarClosedReason>);
+          ) as _i16.ScaffoldFeatureController<_i27.SnackBar,
+              _i27.SnackBarClosedReason>);
 
   @override
   void removeCurrentSnackBar(
-          {_i26.SnackBarClosedReason? reason =
-              _i26.SnackBarClosedReason.remove}) =>
+          {_i27.SnackBarClosedReason? reason =
+              _i27.SnackBarClosedReason.remove}) =>
       super.noSuchMethod(
         Invocation.method(
           #removeCurrentSnackBar,
@@ -11435,8 +11469,8 @@ class MockScaffoldMessengerState extends _i1.Mock
 
   @override
   void hideCurrentSnackBar(
-          {_i26.SnackBarClosedReason? reason =
-              _i26.SnackBarClosedReason.hide}) =>
+          {_i27.SnackBarClosedReason? reason =
+              _i27.SnackBarClosedReason.hide}) =>
       super.noSuchMethod(
         Invocation.method(
           #hideCurrentSnackBar,
@@ -11456,37 +11490,37 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  _i15.ScaffoldFeatureController<_i27.MaterialBanner,
-      _i27.MaterialBannerClosedReason> showMaterialBanner(
-          _i27.MaterialBanner? materialBanner) =>
+  _i16.ScaffoldFeatureController<_i28.MaterialBanner,
+      _i28.MaterialBannerClosedReason> showMaterialBanner(
+          _i28.MaterialBanner? materialBanner) =>
       (super.noSuchMethod(
         Invocation.method(
           #showMaterialBanner,
           [materialBanner],
         ),
-        returnValue: _FakeScaffoldFeatureController_83<_i27.MaterialBanner,
-            _i27.MaterialBannerClosedReason>(
+        returnValue: _FakeScaffoldFeatureController_84<_i28.MaterialBanner,
+            _i28.MaterialBannerClosedReason>(
           this,
           Invocation.method(
             #showMaterialBanner,
             [materialBanner],
           ),
         ),
-        returnValueForMissingStub: _FakeScaffoldFeatureController_83<
-            _i27.MaterialBanner, _i27.MaterialBannerClosedReason>(
+        returnValueForMissingStub: _FakeScaffoldFeatureController_84<
+            _i28.MaterialBanner, _i28.MaterialBannerClosedReason>(
           this,
           Invocation.method(
             #showMaterialBanner,
             [materialBanner],
           ),
         ),
-      ) as _i15.ScaffoldFeatureController<_i27.MaterialBanner,
-          _i27.MaterialBannerClosedReason>);
+      ) as _i16.ScaffoldFeatureController<_i28.MaterialBanner,
+          _i28.MaterialBannerClosedReason>);
 
   @override
   void removeCurrentMaterialBanner(
-          {_i27.MaterialBannerClosedReason? reason =
-              _i27.MaterialBannerClosedReason.remove}) =>
+          {_i28.MaterialBannerClosedReason? reason =
+              _i28.MaterialBannerClosedReason.remove}) =>
       super.noSuchMethod(
         Invocation.method(
           #removeCurrentMaterialBanner,
@@ -11498,8 +11532,8 @@ class MockScaffoldMessengerState extends _i1.Mock
 
   @override
   void hideCurrentMaterialBanner(
-          {_i27.MaterialBannerClosedReason? reason =
-              _i27.MaterialBannerClosedReason.hide}) =>
+          {_i28.MaterialBannerClosedReason? reason =
+              _i28.MaterialBannerClosedReason.hide}) =>
       super.noSuchMethod(
         Invocation.method(
           #hideCurrentMaterialBanner,
@@ -11519,26 +11553,26 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  _i16.Widget build(_i16.BuildContext? context) => (super.noSuchMethod(
+  _i17.Widget build(_i17.BuildContext? context) => (super.noSuchMethod(
         Invocation.method(
           #build,
           [context],
         ),
-        returnValue: _FakeWidget_84(
+        returnValue: _FakeWidget_85(
           this,
           Invocation.method(
             #build,
             [context],
           ),
         ),
-        returnValueForMissingStub: _FakeWidget_84(
+        returnValueForMissingStub: _FakeWidget_85(
           this,
           Invocation.method(
             #build,
             [context],
           ),
         ),
-      ) as _i16.Widget);
+      ) as _i17.Widget);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -11559,7 +11593,7 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  void didUpdateWidget(_i15.ScaffoldMessenger? oldWidget) => super.noSuchMethod(
+  void didUpdateWidget(_i16.ScaffoldMessenger? oldWidget) => super.noSuchMethod(
         Invocation.method(
           #didUpdateWidget,
           [oldWidget],
@@ -11577,7 +11611,7 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  void setState(_i24.VoidCallback? fn) => super.noSuchMethod(
+  void setState(_i25.VoidCallback? fn) => super.noSuchMethod(
         Invocation.method(
           #setState,
           [fn],
@@ -11604,7 +11638,7 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  void debugFillProperties(_i28.DiagnosticPropertiesBuilder? properties) =>
+  void debugFillProperties(_i29.DiagnosticPropertiesBuilder? properties) =>
       super.noSuchMethod(
         Invocation.method(
           #debugFillProperties,
@@ -11615,7 +11649,7 @@ class MockScaffoldMessengerState extends _i1.Mock
 
   @override
   String toString(
-          {_i16.DiagnosticLevel? minLevel = _i16.DiagnosticLevel.info}) =>
+          {_i17.DiagnosticLevel? minLevel = _i17.DiagnosticLevel.info}) =>
       super.toString();
 
   @override
@@ -11624,14 +11658,14 @@ class MockScaffoldMessengerState extends _i1.Mock
           #toStringShort,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #toStringShort,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #toStringShort,
@@ -11641,9 +11675,9 @@ class MockScaffoldMessengerState extends _i1.Mock
       ) as String);
 
   @override
-  _i16.DiagnosticsNode toDiagnosticsNode({
+  _i17.DiagnosticsNode toDiagnosticsNode({
     String? name,
-    _i28.DiagnosticsTreeStyle? style,
+    _i29.DiagnosticsTreeStyle? style,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -11654,7 +11688,7 @@ class MockScaffoldMessengerState extends _i1.Mock
             #style: style,
           },
         ),
-        returnValue: _FakeDiagnosticsNode_85(
+        returnValue: _FakeDiagnosticsNode_86(
           this,
           Invocation.method(
             #toDiagnosticsNode,
@@ -11665,7 +11699,7 @@ class MockScaffoldMessengerState extends _i1.Mock
             },
           ),
         ),
-        returnValueForMissingStub: _FakeDiagnosticsNode_85(
+        returnValueForMissingStub: _FakeDiagnosticsNode_86(
           this,
           Invocation.method(
             #toDiagnosticsNode,
@@ -11676,27 +11710,27 @@ class MockScaffoldMessengerState extends _i1.Mock
             },
           ),
         ),
-      ) as _i16.DiagnosticsNode);
+      ) as _i17.DiagnosticsNode);
 
   @override
-  _i18.Ticker createTicker(_i18.TickerCallback? onTick) => (super.noSuchMethod(
+  _i19.Ticker createTicker(_i19.TickerCallback? onTick) => (super.noSuchMethod(
         Invocation.method(
           #createTicker,
           [onTick],
         ),
-        returnValue: _FakeTicker_86(
+        returnValue: _FakeTicker_87(
           this,
           Invocation.method(
             #createTicker,
             [onTick],
           ),
         ),
-        returnValueForMissingStub: _FakeTicker_86(
+        returnValueForMissingStub: _FakeTicker_87(
           this,
           Invocation.method(
             #createTicker,
             [onTick],
           ),
         ),
-      ) as _i18.Ticker);
+      ) as _i19.Ticker);
 }

--- a/test/services/ios_voip_push_service_test.mocks.dart
+++ b/test/services/ios_voip_push_service_test.mocks.dart
@@ -3,43 +3,44 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i12;
-import 'dart:typed_data' as _i22;
-import 'dart:ui' as _i18;
+import 'dart:async' as _i13;
+import 'dart:typed_data' as _i23;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
-import 'package:http/http.dart' as _i11;
-import 'package:kohera/core/services/call_service.dart' as _i23;
-import 'package:kohera/core/services/matrix_service.dart' as _i14;
-import 'package:kohera/core/services/preferences_service.dart' as _i15;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
+import 'package:http/http.dart' as _i12;
+import 'package:kohera/core/services/call_service.dart' as _i24;
+import 'package:kohera/core/services/matrix_service.dart' as _i15;
+import 'package:kohera/core/services/preferences_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
-import 'package:kohera/features/calling/models/call_participant.dart' as _i26;
-import 'package:kohera/features/calling/models/call_state.dart' as _i28;
-import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i27;
-import 'package:kohera/features/calling/services/livekit_service.dart' as _i24;
-import 'package:kohera/features/calling/services/ringtone_service.dart' as _i29;
+import 'package:kohera/features/calling/models/call_participant.dart' as _i27;
+import 'package:kohera/features/calling/models/call_state.dart' as _i29;
+import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i28;
+import 'package:kohera/features/calling/services/livekit_service.dart' as _i25;
+import 'package:kohera/features/calling/services/ringtone_service.dart' as _i30;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
 import 'package:kohera/features/notifications/services/notification_service.dart'
-    as _i30;
-import 'package:livekit_client/livekit_client.dart' as _i25;
-import 'package:matrix/encryption.dart' as _i21;
+    as _i31;
+import 'package:livekit_client/livekit_client.dart' as _i26;
+import 'package:matrix/encryption.dart' as _i22;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i13;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i16;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i10;
-import 'package:matrix/src/utils/space_child.dart' as _i31;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i14;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i17;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i11;
+import 'package:matrix/src/utils/space_child.dart' as _i32;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -140,8 +141,8 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeDatabaseApi_8 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_8(
+class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
+  _FakeOutboxService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -150,8 +151,8 @@ class _FakeDatabaseApi_8 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_9 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_9(
+class _FakeDatabaseApi_9 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -160,9 +161,19 @@ class _FakeFilter_9 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_10 extends _i1.SmartFake
+class _FakeFilter_10 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_10(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeNativeImplementations_11 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_10(
+  _FakeNativeImplementations_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -171,8 +182,8 @@ class _FakeNativeImplementations_10 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_11 extends _i1.SmartFake implements Duration {
-  _FakeDuration_11(
+class _FakeDuration_12 extends _i1.SmartFake implements Duration {
+  _FakeDuration_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -181,9 +192,9 @@ class _FakeDuration_11 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_12 extends _i1.SmartFake
+class _FakePushruleEvaluator_13 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_12(
+  _FakePushruleEvaluator_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -192,8 +203,8 @@ class _FakePushruleEvaluator_12 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_13 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_13(
+class _FakeProfile_14 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -202,9 +213,9 @@ class _FakeProfile_13 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeCachedStreamController_14<T> extends _i1.SmartFake
-    implements _i10.CachedStreamController<T> {
-  _FakeCachedStreamController_14(
+class _FakeCachedStreamController_15<T> extends _i1.SmartFake
+    implements _i11.CachedStreamController<T> {
+  _FakeCachedStreamController_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -213,8 +224,8 @@ class _FakeCachedStreamController_14<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_15 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_15(
+class _FakeDateTime_16 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -223,8 +234,8 @@ class _FakeDateTime_15 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_16 extends _i1.SmartFake implements _i11.Client {
-  _FakeClient_16(
+class _FakeClient_17 extends _i1.SmartFake implements _i12.Client {
+  _FakeClient_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -233,9 +244,9 @@ class _FakeClient_16 extends _i1.SmartFake implements _i11.Client {
         );
 }
 
-class _FakeDiscoveryInformation_17 extends _i1.SmartFake
+class _FakeDiscoveryInformation_18 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_17(
+  _FakeDiscoveryInformation_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -244,9 +255,9 @@ class _FakeDiscoveryInformation_17 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_18 extends _i1.SmartFake
+class _FakeGetVersionsResponse_19 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_18(
+  _FakeGetVersionsResponse_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -255,9 +266,9 @@ class _FakeGetVersionsResponse_18 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_19 extends _i1.SmartFake
+class _FakeRegisterResponse_20 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_19(
+  _FakeRegisterResponse_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -266,8 +277,8 @@ class _FakeRegisterResponse_19 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_20 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_20(
+class _FakeLoginResponse_21 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -276,9 +287,9 @@ class _FakeLoginResponse_20 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_21 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_22 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_21(
+  _FakeGetAuthMetadataResponse_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -287,8 +298,8 @@ class _FakeGetAuthMetadataResponse_21 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_22<T1> extends _i1.SmartFake implements _i12.Future<T1> {
-  _FakeFuture_22(
+class _FakeFuture_23<T1> extends _i1.SmartFake implements _i13.Future<T1> {
+  _FakeFuture_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -297,8 +308,8 @@ class _FakeFuture_22<T1> extends _i1.SmartFake implements _i12.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_23 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_23(
+class _FakeSyncUpdate_24 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -307,9 +318,9 @@ class _FakeSyncUpdate_23 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_24 extends _i1.SmartFake
+class _FakeCachedProfileInformation_25 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_24(
+  _FakeCachedProfileInformation_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -318,8 +329,8 @@ class _FakeCachedProfileInformation_24 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_25 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_25(
+class _FakeMediaConfig_26 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -328,8 +339,8 @@ class _FakeMediaConfig_25 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_26 extends _i1.SmartFake implements _i13.FileResponse {
-  _FakeFileResponse_26(
+class _FakeFileResponse_27 extends _i1.SmartFake implements _i14.FileResponse {
+  _FakeFileResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -338,8 +349,8 @@ class _FakeFileResponse_26 extends _i1.SmartFake implements _i13.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_27 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_27(
+class _FakePreviewForUrl_28 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -348,8 +359,8 @@ class _FakePreviewForUrl_27 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeUri_28 extends _i1.SmartFake implements Uri {
-  _FakeUri_28(
+class _FakeUri_29 extends _i1.SmartFake implements Uri {
+  _FakeUri_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -358,9 +369,9 @@ class _FakeUri_28 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_29 extends _i1.SmartFake
+class _FakeCachedPresence_30 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_29(
+  _FakeCachedPresence_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -369,9 +380,9 @@ class _FakeCachedPresence_29 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_30 extends _i1.SmartFake
+class _FakeTurnServerCredentials_31 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_30(
+  _FakeTurnServerCredentials_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -380,9 +391,9 @@ class _FakeTurnServerCredentials_30 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_31 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_32 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_31(
+  _FakeRoomKeysUpdateResponse_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -391,8 +402,8 @@ class _FakeRoomKeysUpdateResponse_31 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_32 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_32(
+class _FakeKeyBackupData_33 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -401,9 +412,9 @@ class _FakeKeyBackupData_32 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_33 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_34 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_33(
+  _FakeGetWellknownSupportResponse_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -412,9 +423,9 @@ class _FakeGetWellknownSupportResponse_33 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_34 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_35 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_34(
+  _FakeGenerateLoginTokenResponse_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -423,9 +434,9 @@ class _FakeGenerateLoginTokenResponse_34 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_35 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_36 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_35(
+  _FakeGetRoomSummaryResponse$3_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -434,9 +445,9 @@ class _FakeGetRoomSummaryResponse$3_35 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_36 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_37 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_36(
+  _FakeGetSpaceHierarchyResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -445,9 +456,9 @@ class _FakeGetSpaceHierarchyResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_37 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_38 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_37(
+  _FakeGetRelatingEventsResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -456,9 +467,9 @@ class _FakeGetRelatingEventsResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_38 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_39 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_38(
+  _FakeGetRelatingEventsWithRelTypeResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -467,9 +478,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -478,9 +489,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_40 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_41 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_40(
+  _FakeGetThreadRootsResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -489,9 +500,9 @@ class _FakeGetThreadRootsResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_41 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_42 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_41(
+  _FakeGetEventByTimestampResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -500,9 +511,9 @@ class _FakeGetEventByTimestampResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_42 extends _i1.SmartFake
+class _FakeRequestTokenResponse_43 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_42(
+  _FakeRequestTokenResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -511,9 +522,9 @@ class _FakeRequestTokenResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_43 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_44 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_43(
+  _FakeTokenOwnerInfo_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -522,8 +533,8 @@ class _FakeTokenOwnerInfo_43 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_44 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_44(
+class _FakeWhoIsInfo_45 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -532,8 +543,8 @@ class _FakeWhoIsInfo_44 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_45 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_45(
+class _FakeCapabilities_46 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -542,8 +553,8 @@ class _FakeCapabilities_45 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_46 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_46(
+class _FakeDevice_47 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -552,9 +563,9 @@ class _FakeDevice_46 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_47 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_48 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_47(
+  _FakeGetRoomIdByAliasResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -563,9 +574,9 @@ class _FakeGetRoomIdByAliasResponse_47 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_48 extends _i1.SmartFake
+class _FakeGetEventsResponse_49 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_48(
+  _FakeGetEventsResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -574,9 +585,9 @@ class _FakeGetEventsResponse_48 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_49 extends _i1.SmartFake
+class _FakePeekEventsResponse_50 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_49(
+  _FakePeekEventsResponse_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -585,8 +596,8 @@ class _FakePeekEventsResponse_49 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_50 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_50(
+class _FakeMatrixEvent_51 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -595,9 +606,9 @@ class _FakeMatrixEvent_50 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_51 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_52 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_51(
+  _FakeGetKeysChangesResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -606,9 +617,9 @@ class _FakeGetKeysChangesResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_52 extends _i1.SmartFake
+class _FakeClaimKeysResponse_53 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_52(
+  _FakeClaimKeysResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -617,9 +628,9 @@ class _FakeClaimKeysResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_53 extends _i1.SmartFake
+class _FakeQueryKeysResponse_54 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_53(
+  _FakeQueryKeysResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -628,9 +639,9 @@ class _FakeQueryKeysResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_54 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_55 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_54(
+  _FakeGetNotificationsResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -639,9 +650,9 @@ class _FakeGetNotificationsResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_55 extends _i1.SmartFake
+class _FakeGetPresenceResponse_56 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_55(
+  _FakeGetPresenceResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -650,9 +661,9 @@ class _FakeGetPresenceResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_56 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_57 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_56(
+  _FakeGetPublicRoomsResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -661,9 +672,9 @@ class _FakeGetPublicRoomsResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_57 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_58 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_57(
+  _FakeQueryPublicRoomsResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -672,8 +683,8 @@ class _FakeQueryPublicRoomsResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_58 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_58(
+class _FakePushRuleSet_59 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -682,9 +693,9 @@ class _FakePushRuleSet_58 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_59 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_60 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_59(
+  _FakeGetPushRulesGlobalResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -693,8 +704,8 @@ class _FakeGetPushRulesGlobalResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_60 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_60(
+class _FakePushRule_61 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -703,9 +714,9 @@ class _FakePushRule_60 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_61 extends _i1.SmartFake
+class _FakeRefreshResponse_62 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_61(
+  _FakeRefreshResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -714,8 +725,8 @@ class _FakeRefreshResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_62 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_62(
+class _FakeRoomKeys_63 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -724,8 +735,8 @@ class _FakeRoomKeys_62 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_63 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_63(
+class _FakeRoomKeyBackup_64 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -734,9 +745,9 @@ class _FakeRoomKeyBackup_63 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_64 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_65 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_64(
+  _FakeGetRoomKeysVersionCurrentResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -745,9 +756,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_65 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_66 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_65(
+  _FakeGetRoomKeysVersionResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,8 +767,8 @@ class _FakeGetRoomKeysVersionResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_66 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_66(
+class _FakeEventContext_67 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,9 +777,9 @@ class _FakeEventContext_66 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_67 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_68 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_67(
+  _FakeGetRoomEventsResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -777,8 +788,8 @@ class _FakeGetRoomEventsResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_68 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_68(
+class _FakeSearchResults_69 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -787,9 +798,9 @@ class _FakeSearchResults_68 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_69 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_70 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_69(
+  _FakeGetProtocolMetadataResponse$2_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,9 +809,9 @@ class _FakeGetProtocolMetadataResponse$2_69 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_70 extends _i1.SmartFake
+class _FakeOpenIdCredentials_71 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_70(
+  _FakeOpenIdCredentials_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -809,9 +820,9 @@ class _FakeOpenIdCredentials_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_71 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_72 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_71(
+  _FakeSearchUserDirectoryResponse_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -820,9 +831,9 @@ class _FakeSearchUserDirectoryResponse_71 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_72 extends _i1.SmartFake
+class _FakeCreateContentResponse_73 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_72(
+  _FakeCreateContentResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -831,8 +842,8 @@ class _FakeCreateContentResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeResponse_73 extends _i1.SmartFake implements _i11.Response {
-  _FakeResponse_73(
+class _FakeResponse_74 extends _i1.SmartFake implements _i12.Response {
+  _FakeResponse_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -841,9 +852,9 @@ class _FakeResponse_73 extends _i1.SmartFake implements _i11.Response {
         );
 }
 
-class _FakeMatrixService_74 extends _i1.SmartFake
-    implements _i14.MatrixService {
-  _FakeMatrixService_74(
+class _FakeMatrixService_75 extends _i1.SmartFake
+    implements _i15.MatrixService {
+  _FakeMatrixService_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,9 +863,9 @@ class _FakeMatrixService_74 extends _i1.SmartFake
         );
 }
 
-class _FakePreferencesService_75 extends _i1.SmartFake
-    implements _i15.PreferencesService {
-  _FakePreferencesService_75(
+class _FakePreferencesService_76 extends _i1.SmartFake
+    implements _i16.PreferencesService {
+  _FakePreferencesService_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -863,8 +874,8 @@ class _FakePreferencesService_75 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_76 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_76(
+class _FakeRoomSummary_77 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -873,9 +884,9 @@ class _FakeRoomSummary_76 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_77 extends _i1.SmartFake
+class _FakeLatestReceiptState_78 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_77(
+  _FakeLatestReceiptState_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -884,8 +895,8 @@ class _FakeLatestReceiptState_77 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_78 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_78(
+class _FakeTimeline_79 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -894,8 +905,8 @@ class _FakeTimeline_78 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_79 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_79(
+class _FakeUser_80 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -904,8 +915,8 @@ class _FakeUser_79 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeRoom_80 extends _i1.SmartFake implements _i4.Room {
-  _FakeRoom_80(
+class _FakeRoom_81 extends _i1.SmartFake implements _i4.Room {
+  _FakeRoom_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -914,9 +925,9 @@ class _FakeRoom_80 extends _i1.SmartFake implements _i4.Room {
         );
 }
 
-class _FakeTimelineChunk_81 extends _i1.SmartFake
-    implements _i16.TimelineChunk {
-  _FakeTimelineChunk_81(
+class _FakeTimelineChunk_82 extends _i1.SmartFake
+    implements _i17.TimelineChunk {
+  _FakeTimelineChunk_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -928,7 +939,7 @@ class _FakeTimelineChunk_81 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -958,11 +969,11 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1061,6 +1072,19 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as _i9.AuthService);
 
   @override
+  _i10.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i10.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -1140,6 +1164,15 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
+  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -1147,14 +1180,14 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as bool);
 
   @override
-  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1184,7 +1217,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1194,18 +1227,18 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<bool> login({
+  _i13.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1220,12 +1253,12 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> completeSsoLogin({
+  _i13.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1238,12 +1271,12 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> completeRegistration(
+  _i13.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1253,32 +1286,32 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1287,7 +1320,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1296,17 +1329,17 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1317,7 +1350,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1354,26 +1387,26 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+  _i13.Future<bool> didPushRouteInformation(
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1403,7 +1436,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1412,7 +1445,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1421,16 +1454,16 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i13.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i12.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i13.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i12.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i12.Future<_i18.AppExitResponse>);
+            _i13.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i13.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1458,23 +1491,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_8(
+        returnValue: _FakeDatabaseApi_9(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_8(
+        returnValueForMissingStub: _FakeDatabaseApi_9(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i21.KeyVerificationMethod> get verificationMethods =>
+  Set<_i22.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i21.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i21.KeyVerificationMethod>{},
-      ) as Set<_i21.KeyVerificationMethod>);
+        returnValue: <_i22.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i22.KeyVerificationMethod>{},
+      ) as Set<_i22.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1535,11 +1568,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_9(
+        returnValue: _FakeFilter_10(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_9(
+        returnValueForMissingStub: _FakeFilter_10(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -1548,11 +1581,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_10(
+        returnValue: _FakeNativeImplementations_11(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_10(
+        returnValueForMissingStub: _FakeNativeImplementations_11(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -1568,11 +1601,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_11(
+        returnValue: _FakeDuration_12(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_11(
+        returnValueForMissingStub: _FakeDuration_12(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -1581,11 +1614,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_11(
+        returnValue: _FakeDuration_12(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_11(
+        returnValueForMissingStub: _FakeDuration_12(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -1594,11 +1627,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1635,11 +1668,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1669,11 +1702,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1682,11 +1715,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1709,11 +1742,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_12(
+        returnValue: _FakePushruleEvaluator_13(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_12(
+        returnValueForMissingStub: _FakePushruleEvaluator_13(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -1734,332 +1767,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i12.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i13.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_13(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_13(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i10.CachedStreamController<String> get onUserProfileUpdate =>
+  _i11.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_14<String>(
+        returnValue: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i12.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i13.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i12.Future<List<_i4.Room>>);
+            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i13.Future<List<_i4.Room>>);
 
   @override
-  _i10.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i11.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_14<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_15<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i4.EventUpdate>(
+            _FakeCachedStreamController_15<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.EventUpdate>);
+      ) as _i11.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i11.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_14<_i4.Event>(
+        returnValue: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i11.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_14<_i4.Event>(
+        returnValue: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onNotification =>
+  _i11.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_14<_i4.Event>(
+        returnValue: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i11.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_14<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_15<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_15<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i11.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i10.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i11.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_14<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_15<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_14<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_15<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i10.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i11.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i10.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i11.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_14<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_15<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i4.LoginState>(
+            _FakeCachedStreamController_15<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i10.CachedStreamController<_i4.LoginState>);
+      ) as _i11.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i10.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i11.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_14<bool>(
+        returnValue: _FakeCachedStreamController_15<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i10.CachedStreamController<bool>);
+      ) as _i11.CachedStreamController<bool>);
 
   @override
-  _i10.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i11.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_14<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_15<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i10.CachedStreamController<_i4.SdkError>);
+      ) as _i11.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i10.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i11.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_14<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_15<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i4.SyncUpdate>(
+            _FakeCachedStreamController_15<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i10.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i11.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i11.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_14<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_15<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_15<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i10.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i11.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.Presence> get onPresence =>
+  _i11.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_14<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_15<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i10.CachedStreamController<_i4.Presence>);
+      ) as _i11.CachedStreamController<_i4.Presence>);
 
   @override
-  _i10.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i11.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_14<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_15<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i4.CachedPresence>(
+            _FakeCachedStreamController_15<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i10.CachedStreamController<_i4.CachedPresence>);
+      ) as _i11.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i10.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i11.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_14<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_15<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i4.BasicEvent>(
+            _FakeCachedStreamController_15<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i10.CachedStreamController<_i4.BasicEvent>);
+      ) as _i11.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i10.CachedStreamController<_i21.RoomKeyRequest> get onRoomKeyRequest =>
+  _i11.CachedStreamController<_i22.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_14<_i21.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_15<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i21.RoomKeyRequest>(
+            _FakeCachedStreamController_15<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i10.CachedStreamController<_i21.RoomKeyRequest>);
+      ) as _i11.CachedStreamController<_i22.RoomKeyRequest>);
 
   @override
-  _i10.CachedStreamController<_i21.KeyVerification>
+  _i11.CachedStreamController<_i22.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_14<_i21.KeyVerification>(
+            returnValue: _FakeCachedStreamController_15<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_14<_i21.KeyVerification>(
+                _FakeCachedStreamController_15<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i10.CachedStreamController<_i21.KeyVerification>);
+          ) as _i11.CachedStreamController<_i22.KeyVerification>);
 
   @override
-  _i10.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i11.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_14<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_15<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_15<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i10.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i11.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i11.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_14<_i4.Event>(
+        returnValue: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<String> get onCancelSendEvent =>
+  _i11.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_14<String>(
+        returnValue: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i10.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i11.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_14<
+            returnValue: _FakeCachedStreamController_15<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_14<
+            returnValueForMissingStub: _FakeCachedStreamController_15<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i10.CachedStreamController<
+          ) as _i11.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -2079,11 +2112,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_15(
+        returnValue: _FakeDateTime_16(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_15(
+        returnValueForMissingStub: _FakeDateTime_16(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2156,7 +2189,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i21.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i22.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2211,7 +2244,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i12.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i13.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2222,7 +2255,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i12.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i13.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -2333,7 +2366,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2342,7 +2375,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2351,7 +2384,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -2378,20 +2411,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i11.Client get httpClient => (super.noSuchMethod(
+  _i12.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_16(
+        returnValue: _FakeClient_17(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_16(
+        returnValueForMissingStub: _FakeClient_17(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i11.Client);
+      ) as _i12.Client);
 
   @override
-  set httpClient(_i11.Client? value) => super.noSuchMethod(
+  set httpClient(_i12.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -2418,7 +2451,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<void> refreshAccessToken(
+  _i13.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2426,9 +2459,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -2446,14 +2479,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2490,33 +2523,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i12.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i13.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_17(
+        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_18(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_17(
+        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_18(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i12.Future<_i4.DiscoveryInformation>);
+      ) as _i13.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i12.Future<
+  _i13.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -2538,7 +2571,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i12.Future<
+        returnValue: _i13.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2546,7 +2579,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_18(
+          _FakeGetVersionsResponse_19(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2561,7 +2594,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i12.Future<
+        returnValueForMissingStub: _i13.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2569,7 +2602,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_18(
+          _FakeGetVersionsResponse_19(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2584,7 +2617,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i12.Future<
+      ) as _i13.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -2593,7 +2626,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i12.Future<_i4.DiscoveryInformation> getWellknown({
+  _i13.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2606,8 +2639,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_17(
+        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_18(
           this,
           Invocation.method(
             #getWellknown,
@@ -2618,8 +2651,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_17(
+        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_18(
           this,
           Invocation.method(
             #getWellknown,
@@ -2630,10 +2663,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.DiscoveryInformation>);
+      ) as _i13.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i12.Future<_i4.RegisterResponse> register({
+  _i13.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -2661,7 +2694,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_19(
+            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_20(
           this,
           Invocation.method(
             #register,
@@ -2680,7 +2713,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_19(
+            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_20(
           this,
           Invocation.method(
             #register,
@@ -2698,10 +2731,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RegisterResponse>);
+      ) as _i13.Future<_i4.RegisterResponse>);
 
   @override
-  _i12.Future<_i4.LoginResponse> login(
+  _i13.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -2731,7 +2764,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_20(
+        returnValue: _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_21(
           this,
           Invocation.method(
             #login,
@@ -2751,7 +2784,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_20(
+            _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_21(
           this,
           Invocation.method(
             #login,
@@ -2770,10 +2803,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.LoginResponse>);
+      ) as _i13.Future<_i4.LoginResponse>);
 
   @override
-  _i12.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i13.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2786,8 +2819,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_21(
+        returnValue: _i13.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_22(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2799,8 +2832,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_21(
+            _i13.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_22(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2811,74 +2844,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i13.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> logoutAll() => (super.noSuchMethod(
+  _i13.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<T> uiaRequestBackground<T>(
-          _i12.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i13.Future<T> uiaRequestBackground<T>(
+          _i13.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i12.Future<T>.value(v),
+              (T v) => _i13.Future<T>.value(v),
             ) ??
-            _FakeFuture_22<T>(
+            _FakeFuture_23<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i12.Future<T>.value(v),
+              (T v) => _i13.Future<T>.value(v),
             ) ??
-            _FakeFuture_22<T>(
+            _FakeFuture_23<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i12.Future<T>);
+      ) as _i13.Future<T>);
 
   @override
-  _i12.Future<String> startDirectChat(
+  _i13.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -2900,7 +2933,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2916,7 +2949,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i17.dummyValue<String>(
+            _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2931,10 +2964,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<String> createGroupChat({
+  _i13.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -2965,7 +2998,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2986,7 +3019,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i17.dummyValue<String>(
+            _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3006,10 +3039,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i13.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -3025,7 +3058,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3038,7 +3071,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3050,21 +3083,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i13.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<String> createSpace({
+  _i13.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -3089,7 +3122,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3107,7 +3140,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i17.dummyValue<String>(
+            _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3124,10 +3157,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i13.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3135,7 +3168,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_13(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3144,7 +3177,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_13(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3152,10 +3185,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i12.Future<_i4.Profile> fetchOwnProfile({
+  _i13.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3168,7 +3201,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_13(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3180,7 +3213,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_13(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3191,10 +3224,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i12.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i13.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3208,8 +3241,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i12.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_24(
+        returnValue: _i13.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_25(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3221,8 +3254,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_24(
+            _i13.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_25(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3233,10 +3266,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.CachedProfileInformation>);
+      ) as _i13.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i12.Future<_i4.Profile> getProfileFromUserId(
+  _i13.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3254,7 +3287,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_13(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3268,7 +3301,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_13(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3281,7 +3314,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -3303,31 +3336,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i12.Future<List<_i4.Room>>);
+            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i13.Future<List<_i4.Room>>);
 
   @override
-  _i12.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i13.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i12.Future<List<_i4.ArchivedRoom>>);
+            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i13.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i12.Future<_i4.GetVersionsResponse> getVersions({
+  _i13.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3340,8 +3373,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_18(
+        returnValue: _i13.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_19(
           this,
           Invocation.method(
             #getVersions,
@@ -3352,8 +3385,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_18(
+        returnValueForMissingStub: _i13.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_19(
           this,
           Invocation.method(
             #getVersions,
@@ -3364,20 +3397,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetVersionsResponse>);
+      ) as _i13.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i12.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i13.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<_i4.MediaConfig> getConfig({
+  _i13.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3390,7 +3423,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_25(
+        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
           this,
           Invocation.method(
             #getConfig,
@@ -3402,7 +3435,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_25(
+            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
           this,
           Invocation.method(
             #getConfig,
@@ -3413,10 +3446,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.MediaConfig>);
+      ) as _i13.Future<_i4.MediaConfig>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContent(
+  _i13.Future<_i14.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -3436,7 +3469,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContent,
@@ -3452,7 +3485,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContent,
@@ -3467,10 +3500,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentOverrideName(
+  _i13.Future<_i14.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -3492,7 +3525,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3509,7 +3542,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3525,10 +3558,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentThumbnail(
+  _i13.Future<_i14.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -3556,7 +3589,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3576,7 +3609,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3595,10 +3628,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i13.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -3608,7 +3641,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_27(
+        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3617,7 +3650,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_27(
+            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3625,11 +3658,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i12.Future<_i4.PreviewForUrl>);
+      ) as _i13.Future<_i4.PreviewForUrl>);
 
   @override
-  _i12.Future<Uri> uploadContent(
-    _i22.Uint8List? file, {
+  _i13.Future<Uri> uploadContent(
+    _i23.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3642,7 +3675,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i12.Future<Uri>.value(_FakeUri_28(
+        returnValue: _i13.Future<Uri>.value(_FakeUri_29(
           this,
           Invocation.method(
             #uploadContent,
@@ -3653,7 +3686,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_28(
+        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_29(
           this,
           Invocation.method(
             #uploadContent,
@@ -3664,10 +3697,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<Uri>);
+      ) as _i13.Future<Uri>);
 
   @override
-  _i12.Future<void> setTyping(
+  _i13.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -3683,42 +3716,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> exportDump() => (super.noSuchMethod(
+  _i13.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i13.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i13.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Event?> getEventByPushNotification(
+  _i13.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -3734,12 +3767,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
-  _i12.Future<void> init({
+  _i13.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -3774,9 +3807,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -3788,40 +3821,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<void> clear() => (super.noSuchMethod(
+  _i13.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i13.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ensureNotSoftLoggedOut(
+  _i13.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleSync(
+  _i13.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -3831,9 +3864,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -3846,29 +3879,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i12.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i13.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i13.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDevice(
+  _i13.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -3882,12 +3915,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDevicesOfUserIds(
+  _i13.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -3903,12 +3936,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDeviceEncrypted(
+  _i13.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -3928,12 +3961,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDeviceEncryptedChunked(
+  _i13.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -3947,23 +3980,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i13.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> joinRoom(
+  _i13.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -3981,7 +4014,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3995,7 +4028,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i17.dummyValue<String>(
+            _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4008,10 +4041,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> changePassword(
+  _i13.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -4027,22 +4060,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> clearCache() => (super.noSuchMethod(
+  _i13.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ignoreUser(
+  _i13.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4052,22 +4085,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i13.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i13.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4078,7 +4111,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_29(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_30(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4087,7 +4120,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_29(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_30(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4095,32 +4128,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i12.Future<_i4.CachedPresence>);
+      ) as _i13.Future<_i4.CachedPresence>);
 
   @override
-  _i12.Future<void> abortSync() => (super.noSuchMethod(
+  _i13.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i13.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEventWithMetadata(
+  _i13.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4140,14 +4173,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i11.BaseResponse? response,
-    _i22.Uint8List? body,
+    _i12.BaseResponse? response,
+    _i23.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4179,7 +4212,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i12.Future<Map<String, Object?>> request(
+  _i13.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -4200,13 +4233,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> postPusher(
+  _i13.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -4216,57 +4249,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i13.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i13.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i13.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i12.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_30(
+        returnValue: _i13.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_31(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_30(
+        returnValueForMissingStub: _i13.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_31(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.TurnServerCredentials>);
+      ) as _i13.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4280,8 +4313,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4293,8 +4326,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4305,10 +4338,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4324,8 +4357,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4338,8 +4371,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4351,10 +4384,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i13.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4368,7 +4401,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_32(
+        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4380,7 +4413,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_32(
+            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4391,17 +4424,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.KeyBackupData>);
+      ) as _i13.Future<_i4.KeyBackupData>);
 
   @override
-  _i12.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i13.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i12.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_33(
+        returnValue: _i13.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_34(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -4409,18 +4442,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_33(
+            _i13.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_34(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i13.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i12.Future<int> pingAppservice(
+  _i13.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -4430,12 +4463,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i12.Future<int>.value(0),
-        returnValueForMissingStub: _i12.Future<int>.value(0),
-      ) as _i12.Future<int>);
+        returnValue: _i13.Future<int>.value(0),
+        returnValueForMissingStub: _i13.Future<int>.value(0),
+      ) as _i13.Future<int>);
 
   @override
-  _i12.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i13.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4443,8 +4476,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_34(
+        returnValue: _i13.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_35(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4453,8 +4486,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_34(
+            _i13.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_35(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4462,15 +4495,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i12.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i13.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i12.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i13.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_25(
+        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -4478,17 +4511,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_25(
+            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.MediaConfig>);
+      ) as _i13.Future<_i4.MediaConfig>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentAuthed(
+  _i13.Future<_i14.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -4502,7 +4535,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4514,7 +4547,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4525,10 +4558,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentOverrideNameAuthed(
+  _i13.Future<_i14.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4544,7 +4577,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4557,7 +4590,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4569,10 +4602,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i13.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -4582,7 +4615,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_27(
+        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4591,7 +4624,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_27(
+            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4599,10 +4632,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i12.Future<_i4.PreviewForUrl>);
+      ) as _i13.Future<_i4.PreviewForUrl>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentThumbnailAuthed(
+  _i13.Future<_i14.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -4626,7 +4659,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4644,7 +4677,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4661,21 +4694,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<bool> registrationTokenValidity(String? token) =>
+  _i13.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i13.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -4685,8 +4718,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_35(
+        returnValue: _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_36(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4695,8 +4728,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_35(
+            _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_36(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4704,10 +4737,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i13.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i12.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i13.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -4725,8 +4758,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_36(
+        returnValue: _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_37(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4740,8 +4773,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_36(
+            _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_37(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4754,10 +4787,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i13.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i13.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -4781,8 +4814,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i12.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_37(
+        returnValue: _i13.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_38(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4800,8 +4833,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_37(
+            _i13.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_38(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4818,10 +4851,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i13.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -4849,8 +4882,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_38(
+                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_39(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4869,8 +4902,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_38(
+                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_39(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4888,10 +4921,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i13.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -4920,9 +4953,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i12.Future<
+            returnValue: _i13.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -4941,9 +4974,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i12.Future<
+            returnValueForMissingStub: _i13.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -4962,11 +4995,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i12
+          ) as _i13
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i12.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i13.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -4982,8 +5015,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i12.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_40(
+        returnValue: _i13.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_41(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -4996,8 +5029,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_40(
+            _i13.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_41(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5009,10 +5042,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetThreadRootsResponse>);
+      ) as _i13.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i12.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i13.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -5026,8 +5059,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i12.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_41(
+        returnValue: _i13.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_42(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5039,8 +5072,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_41(
+            _i13.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_42(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5051,33 +5084,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i13.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i13.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i12.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i13.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i12.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i13.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i12.Future<Uri?>.value(),
-        returnValueForMissingStub: _i12.Future<Uri?>.value(),
-      ) as _i12.Future<Uri?>);
+        returnValue: _i13.Future<Uri?>.value(),
+        returnValueForMissingStub: _i13.Future<Uri?>.value(),
+      ) as _i13.Future<Uri?>);
 
   @override
-  _i12.Future<void> add3PID(
+  _i13.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -5091,12 +5124,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> bind3PID(
+  _i13.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5112,12 +5145,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i13.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5131,14 +5164,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5160,8 +5193,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5177,8 +5210,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5194,10 +5227,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5221,8 +5254,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5239,8 +5272,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5257,10 +5290,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i13.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5274,14 +5307,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i13.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -5296,14 +5329,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5325,8 +5358,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5342,8 +5375,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5359,10 +5392,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5386,8 +5419,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5404,8 +5437,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5422,16 +5455,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i13.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_43(
+            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_44(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -5439,22 +5472,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_43(
+            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_44(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.TokenOwnerInfo>);
+      ) as _i13.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i12.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i13.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_44(
+        returnValue: _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_45(
           this,
           Invocation.method(
             #getWhoIs,
@@ -5462,22 +5495,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_44(
+            _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_45(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i4.WhoIsInfo>);
+      ) as _i13.Future<_i4.WhoIsInfo>);
 
   @override
-  _i12.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i13.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_45(
+        returnValue: _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_46(
           this,
           Invocation.method(
             #getCapabilities,
@@ -5485,17 +5518,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_45(
+            _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_46(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.Capabilities>);
+      ) as _i13.Future<_i4.Capabilities>);
 
   @override
-  _i12.Future<String> createRoom({
+  _i13.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -5528,7 +5561,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5550,7 +5583,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i17.dummyValue<String>(
+            _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5571,10 +5604,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> deleteDevices(
+  _i13.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5584,22 +5617,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.Device>?>.value(),
-      ) as _i12.Future<List<_i4.Device>?>);
+        returnValue: _i13.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.Device>?>.value(),
+      ) as _i13.Future<List<_i4.Device>?>);
 
   @override
-  _i12.Future<void> deleteDevice(
+  _i13.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5609,34 +5642,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i13.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i12.Future<_i4.Device>.value(_FakeDevice_46(
+        returnValue: _i13.Future<_i4.Device>.value(_FakeDevice_47(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.Device>.value(_FakeDevice_46(
+        returnValueForMissingStub: _i13.Future<_i4.Device>.value(_FakeDevice_47(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i12.Future<_i4.Device>);
+      ) as _i13.Future<_i4.Device>);
 
   @override
-  _i12.Future<void> updateDevice(
+  _i13.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -5646,12 +5679,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i13.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -5666,24 +5699,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i13.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i12.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Visibility?>.value(),
-      ) as _i12.Future<_i4.Visibility?>);
+        returnValue: _i13.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Visibility?>.value(),
+      ) as _i13.Future<_i4.Visibility?>);
 
   @override
-  _i12.Future<void> setRoomVisibilityOnDirectory(
+  _i13.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -5693,30 +5726,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i13.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i13.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_47(
+        returnValue: _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_48(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -5724,18 +5757,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_47(
+            _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_48(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i13.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i12.Future<void> setRoomAlias(
+  _i13.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -5747,12 +5780,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetEventsResponse> getEvents({
+  _i13.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -5766,7 +5799,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_48(
+            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_49(
           this,
           Invocation.method(
             #getEvents,
@@ -5778,7 +5811,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_48(
+            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_49(
           this,
           Invocation.method(
             #getEvents,
@@ -5789,10 +5822,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetEventsResponse>);
+      ) as _i13.Future<_i4.GetEventsResponse>);
 
   @override
-  _i12.Future<_i4.PeekEventsResponse> peekEvents({
+  _i13.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -5807,8 +5840,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i12.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_49(
+        returnValue: _i13.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_50(
           this,
           Invocation.method(
             #peekEvents,
@@ -5820,8 +5853,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_49(
+        returnValueForMissingStub: _i13.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_50(
           this,
           Invocation.method(
             #peekEvents,
@@ -5833,16 +5866,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.PeekEventsResponse>);
+      ) as _i13.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i12.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i13.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_50(
+        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
           this,
           Invocation.method(
             #getOneEvent,
@@ -5850,27 +5883,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_50(
+            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i12.Future<_i4.MatrixEvent>);
+      ) as _i13.Future<_i4.MatrixEvent>);
 
   @override
-  _i12.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i13.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i12.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
-      ) as _i12.Future<List<String>>);
+        returnValue: _i13.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
+      ) as _i13.Future<List<String>>);
 
   @override
-  _i12.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i13.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -5882,8 +5915,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i12.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_51(
+        returnValue: _i13.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_52(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5894,8 +5927,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_51(
+            _i13.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_52(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5905,10 +5938,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.GetKeysChangesResponse>);
+      ) as _i13.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i12.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i13.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -5919,7 +5952,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_52(
+            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_53(
           this,
           Invocation.method(
             #claimKeys,
@@ -5928,7 +5961,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_52(
+            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_53(
           this,
           Invocation.method(
             #claimKeys,
@@ -5936,10 +5969,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i12.Future<_i4.ClaimKeysResponse>);
+      ) as _i13.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i12.Future<void> uploadCrossSigningKeys({
+  _i13.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -5956,12 +5989,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.QueryKeysResponse> queryKeys(
+  _i13.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -5972,7 +6005,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_53(
+            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_54(
           this,
           Invocation.method(
             #queryKeys,
@@ -5981,7 +6014,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_53(
+            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_54(
           this,
           Invocation.method(
             #queryKeys,
@@ -5989,10 +6022,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i12.Future<_i4.QueryKeysResponse>);
+      ) as _i13.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -6000,14 +6033,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i12.Future<
+            returnValue: _i13.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i12.Future<
+            returnValueForMissingStub: _i13.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i12.Future<Map<String, int>> uploadKeys({
+  _i13.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -6022,13 +6055,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i12.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i13.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i12.Future<Map<String, int>>);
+            _i13.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i13.Future<Map<String, int>>);
 
   @override
-  _i12.Future<String> knockRoom(
+  _i13.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6042,7 +6075,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6054,7 +6087,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i17.dummyValue<String>(
+            _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6065,20 +6098,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i13.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i12.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i13.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i13.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i12.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i13.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6093,8 +6126,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i12.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_54(
+        returnValue: _i13.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_55(
           this,
           Invocation.method(
             #getNotifications,
@@ -6107,8 +6140,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_54(
+            _i13.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_55(
           this,
           Invocation.method(
             #getNotifications,
@@ -6120,35 +6153,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetNotificationsResponse>);
+      ) as _i13.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i12.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i13.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i12.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_55(
+        returnValue: _i13.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_56(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_55(
+        returnValueForMissingStub: _i13.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_56(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i4.GetPresenceResponse>);
+      ) as _i13.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i12.Future<void> setPresence(
+  _i13.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -6162,12 +6195,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, Object?>> deleteProfileField(
+  _i13.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6180,13 +6213,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getProfileField(
+  _i13.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6199,13 +6232,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<Map<String, Object?>> setProfileField(
+  _i13.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6220,13 +6253,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i13.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6241,8 +6274,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i12.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_56(
+        returnValue: _i13.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_57(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6255,8 +6288,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_56(
+            _i13.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_57(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6268,10 +6301,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i13.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i12.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i13.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -6292,8 +6325,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i12.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_57(
+        returnValue: _i13.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_58(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6309,8 +6342,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_57(
+            _i13.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_58(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6325,25 +6358,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i13.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i12.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.Pusher>?>.value(),
-      ) as _i12.Future<List<_i4.Pusher>?>);
+        returnValue: _i13.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.Pusher>?>.value(),
+      ) as _i13.Future<List<_i4.Pusher>?>);
 
   @override
-  _i12.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i13.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_58(
+        returnValue: _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_59(
           this,
           Invocation.method(
             #getPushRules,
@@ -6351,24 +6384,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_58(
+            _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_59(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.PushRuleSet>);
+      ) as _i13.Future<_i4.PushRuleSet>);
 
   @override
-  _i12.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i13.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_59(
+        returnValue: _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_60(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -6376,18 +6409,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_59(
+            _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_60(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i13.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i12.Future<void> deletePushRule(
+  _i13.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6399,12 +6432,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.PushRule> getPushRule(
+  _i13.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6416,7 +6449,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<_i4.PushRule>.value(_FakePushRule_60(
+        returnValue: _i13.Future<_i4.PushRule>.value(_FakePushRule_61(
           this,
           Invocation.method(
             #getPushRule,
@@ -6427,7 +6460,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PushRule>.value(_FakePushRule_60(
+            _i13.Future<_i4.PushRule>.value(_FakePushRule_61(
           this,
           Invocation.method(
             #getPushRule,
@@ -6437,10 +6470,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.PushRule>);
+      ) as _i13.Future<_i4.PushRule>);
 
   @override
-  _i12.Future<void> setPushRule(
+  _i13.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -6464,12 +6497,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<Object?>> getPushRuleActions(
+  _i13.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6481,13 +6514,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i13.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i12.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i12.Future<List<Object?>>);
+            _i13.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i13.Future<List<Object?>>);
 
   @override
-  _i12.Future<void> setPushRuleActions(
+  _i13.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -6501,12 +6534,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<bool> isPushRuleEnabled(
+  _i13.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6518,12 +6551,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> setPushRuleEnabled(
+  _i13.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -6537,19 +6570,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i13.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_61(
+            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_62(
           this,
           Invocation.method(
             #refresh,
@@ -6557,28 +6590,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_61(
+            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_62(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i12.Future<_i4.RefreshResponse>);
+      ) as _i13.Future<_i4.RefreshResponse>);
 
   @override
-  _i12.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i13.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i12.Future<bool?>.value(),
-        returnValueForMissingStub: _i12.Future<bool?>.value(),
-      ) as _i12.Future<bool?>);
+        returnValue: _i13.Future<bool?>.value(),
+        returnValueForMissingStub: _i13.Future<bool?>.value(),
+      ) as _i13.Future<bool?>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6600,8 +6633,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6617,8 +6650,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6634,10 +6667,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6661,8 +6694,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6679,8 +6712,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6697,17 +6730,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -6715,23 +6748,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i13.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_62(
+        returnValue: _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_63(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -6739,17 +6772,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_62(
+            _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_63(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeys>);
+      ) as _i13.Future<_i4.RoomKeys>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -6761,8 +6794,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6773,8 +6806,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6784,10 +6817,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6799,8 +6832,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6811,8 +6844,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6822,10 +6855,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6837,7 +6870,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_63(
+        returnValue: _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_64(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6848,7 +6881,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_63(
+            _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_64(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6858,10 +6891,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeyBackup>);
+      ) as _i13.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -6875,8 +6908,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6888,8 +6921,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6900,10 +6933,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6917,8 +6950,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -6930,8 +6963,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -6942,10 +6975,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i13.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6959,7 +6992,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_32(
+        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -6971,7 +7004,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_32(
+            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -6982,10 +7015,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.KeyBackupData>);
+      ) as _i13.Future<_i4.KeyBackupData>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7001,8 +7034,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7015,8 +7048,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7028,18 +7061,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_64(
+                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_65(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7047,18 +7080,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_64(
+                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_65(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i12.Future<String> postRoomKeysVersion(
+  _i13.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -7070,7 +7103,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7081,7 +7114,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i17.dummyValue<String>(
+            _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7091,29 +7124,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i13.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i13.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_65(
+        returnValue: _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_66(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7121,18 +7154,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_65(
+            _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_66(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i13.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i13.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -7147,24 +7180,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i13.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i12.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
-      ) as _i12.Future<List<String>>);
+        returnValue: _i13.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
+      ) as _i13.Future<List<String>>);
 
   @override
-  _i12.Future<void> ban(
+  _i13.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7178,12 +7211,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.EventContext> getEventContext(
+  _i13.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7201,7 +7234,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<_i4.EventContext>.value(_FakeEventContext_66(
+        returnValue: _i13.Future<_i4.EventContext>.value(_FakeEventContext_67(
           this,
           Invocation.method(
             #getEventContext,
@@ -7216,7 +7249,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.EventContext>.value(_FakeEventContext_66(
+            _i13.Future<_i4.EventContext>.value(_FakeEventContext_67(
           this,
           Invocation.method(
             #getEventContext,
@@ -7230,10 +7263,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.EventContext>);
+      ) as _i13.Future<_i4.EventContext>);
 
   @override
-  _i12.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i13.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7245,7 +7278,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_50(
+        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7256,7 +7289,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_50(
+            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7266,20 +7299,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.MatrixEvent>);
+      ) as _i13.Future<_i4.MatrixEvent>);
 
   @override
-  _i12.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i13.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> inviteBy3PID(
+  _i13.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -7291,12 +7324,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> inviteUser(
+  _i13.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7310,12 +7343,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> joinRoomById(
+  _i13.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -7329,7 +7362,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7341,7 +7374,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i17.dummyValue<String>(
+            _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7352,23 +7385,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i13.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i12.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i13.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i12.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i12.Future<Map<String, _i4.RoomMember>?>);
+            _i13.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i13.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i12.Future<void> kick(
+  _i13.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7382,12 +7415,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> leaveRoom(
+  _i13.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -7397,12 +7430,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i13.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -7418,12 +7451,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i12.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i12.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i13.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i13.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i12.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i13.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -7445,8 +7478,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_67(
+        returnValue: _i13.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_68(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7462,8 +7495,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_67(
+        returnValueForMissingStub: _i13.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_68(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7479,10 +7512,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomEventsResponse>);
+      ) as _i13.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i12.Future<void> setReadMarker(
+  _i13.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -7498,12 +7531,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> postReceipt(
+  _i13.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -7519,12 +7552,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEvent(
+  _i13.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -7540,12 +7573,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> reportRoom(
+  _i13.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -7557,12 +7590,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> reportEvent(
+  _i13.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -7580,12 +7613,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> sendMessage(
+  _i13.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -7601,7 +7634,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7614,7 +7647,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i17.dummyValue<String>(
+            _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7626,23 +7659,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i13.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i12.Future<List<_i4.MatrixEvent>>);
+            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i13.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i13.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -7659,13 +7692,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<String> setRoomStateWithKey(
+  _i13.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -7681,7 +7714,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7694,7 +7727,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i17.dummyValue<String>(
+            _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7706,10 +7739,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> unban(
+  _i13.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7723,12 +7756,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> upgradeRoom(
+  _i13.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -7742,7 +7775,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7754,7 +7787,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i17.dummyValue<String>(
+            _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7765,10 +7798,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.SearchResults> search(
+  _i13.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -7778,7 +7811,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_68(
+        returnValue: _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_69(
           this,
           Invocation.method(
             #search,
@@ -7787,7 +7820,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_68(
+            _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_69(
           this,
           Invocation.method(
             #search,
@@ -7795,10 +7828,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i12.Future<_i4.SearchResults>);
+      ) as _i13.Future<_i4.SearchResults>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> sync({
+  _i13.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -7819,7 +7852,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.method(
             #sync,
@@ -7835,7 +7868,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.method(
             #sync,
@@ -7850,22 +7883,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i13.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i12.Future<List<_i4.Location>>);
+            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i13.Future<List<_i4.Location>>);
 
   @override
-  _i12.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i13.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -7875,21 +7908,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i12.Future<List<_i4.Location>>);
+            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i13.Future<List<_i4.Location>>);
 
   @override
-  _i12.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i13.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_69(
+        returnValue: _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_70(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -7897,45 +7930,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_69(
+            _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_70(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i12.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i13.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i12.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i13.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -7946,13 +7979,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getAccountData(
+  _i13.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -7965,13 +7998,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> setAccountData(
+  _i13.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -7985,12 +8018,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> defineFilter(
+  _i13.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -8002,7 +8035,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8013,7 +8046,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i17.dummyValue<String>(
+            _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8023,10 +8056,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.Filter> getFilter(
+  _i13.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8038,7 +8071,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i12.Future<_i4.Filter>.value(_FakeFilter_9(
+        returnValue: _i13.Future<_i4.Filter>.value(_FakeFilter_10(
           this,
           Invocation.method(
             #getFilter,
@@ -8048,7 +8081,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.Filter>.value(_FakeFilter_9(
+        returnValueForMissingStub: _i13.Future<_i4.Filter>.value(_FakeFilter_10(
           this,
           Invocation.method(
             #getFilter,
@@ -8058,10 +8091,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.Filter>);
+      ) as _i13.Future<_i4.Filter>);
 
   @override
-  _i12.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i13.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8074,7 +8107,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_70(
+            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_71(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8085,7 +8118,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_70(
+            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_71(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8095,10 +8128,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.OpenIdCredentials>);
+      ) as _i13.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i12.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i13.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8113,13 +8146,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> setAccountDataPerRoom(
+  _i13.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8135,12 +8168,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i13.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8152,12 +8185,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i12.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i12.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i12.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i13.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i13.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i13.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i12.Future<void> deleteRoomTag(
+  _i13.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8171,12 +8204,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setRoomTag(
+  _i13.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8192,12 +8225,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i13.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8207,8 +8240,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i12.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_71(
+        returnValue: _i13.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_72(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8217,8 +8250,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_71(
+            _i13.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_72(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8226,10 +8259,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i12.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i13.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> reportUser(
+  _i13.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8242,40 +8275,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i13.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i12.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_72(
+        returnValue: _i13.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_73(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_72(
+        returnValueForMissingStub: _i13.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_73(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.CreateContentResponse>);
+      ) as _i13.Future<_i4.CreateContentResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> uploadContentToMXC(
+  _i13.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i22.Uint8List? body, {
+    _i23.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8293,16 +8326,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [CallService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCallService extends _i1.Mock implements _i23.CallService {
+class MockCallService extends _i1.Mock implements _i24.CallService {
   @override
   _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -8324,36 +8357,36 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       ) as bool);
 
   @override
-  _i24.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
+  _i25.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
         Invocation.getter(#httpPostForTest),
         returnValue: (
-          _i11.Client httpClient,
+          _i12.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i12.Future<_i11.Response>.value(_FakeResponse_73(
+            _i13.Future<_i12.Response>.value(_FakeResponse_74(
           this,
           Invocation.getter(#httpPostForTest),
         )),
         returnValueForMissingStub: (
-          _i11.Client httpClient,
+          _i12.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i12.Future<_i11.Response>.value(_FakeResponse_73(
+            _i13.Future<_i12.Response>.value(_FakeResponse_74(
           this,
           Invocation.getter(#httpPostForTest),
         )),
-      ) as _i24.HttpPostFunction);
+      ) as _i25.HttpPostFunction);
 
   @override
-  List<_i25.RemoteParticipant> get participants => (super.noSuchMethod(
+  List<_i26.RemoteParticipant> get participants => (super.noSuchMethod(
         Invocation.getter(#participants),
-        returnValue: <_i25.RemoteParticipant>[],
-        returnValueForMissingStub: <_i25.RemoteParticipant>[],
-      ) as List<_i25.RemoteParticipant>);
+        returnValue: <_i26.RemoteParticipant>[],
+        returnValueForMissingStub: <_i26.RemoteParticipant>[],
+      ) as List<_i26.RemoteParticipant>);
 
   @override
   bool get isMicEnabled => (super.noSuchMethod(
@@ -8384,14 +8417,14 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       ) as bool);
 
   @override
-  List<_i25.Participant<_i25.TrackPublication<_i25.Track>>>
+  List<_i26.Participant<_i26.TrackPublication<_i26.Track>>>
       get activeSpeakers => (super.noSuchMethod(
             Invocation.getter(#activeSpeakers),
-            returnValue: <_i25
-                .Participant<_i25.TrackPublication<_i25.Track>>>[],
-            returnValueForMissingStub: <_i25
-                .Participant<_i25.TrackPublication<_i25.Track>>>[],
-          ) as List<_i25.Participant<_i25.TrackPublication<_i25.Track>>>);
+            returnValue: <_i26
+                .Participant<_i26.TrackPublication<_i26.Track>>>[],
+            returnValueForMissingStub: <_i26
+                .Participant<_i26.TrackPublication<_i26.Track>>>[],
+          ) as List<_i26.Participant<_i26.TrackPublication<_i26.Track>>>);
 
   @override
   bool get isCallingAvailable => (super.noSuchMethod(
@@ -8401,11 +8434,11 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       ) as bool);
 
   @override
-  List<_i26.CallParticipant> get allParticipants => (super.noSuchMethod(
+  List<_i27.CallParticipant> get allParticipants => (super.noSuchMethod(
         Invocation.getter(#allParticipants),
-        returnValue: <_i26.CallParticipant>[],
-        returnValueForMissingStub: <_i26.CallParticipant>[],
-      ) as List<_i26.CallParticipant>);
+        returnValue: <_i27.CallParticipant>[],
+        returnValueForMissingStub: <_i27.CallParticipant>[],
+      ) as List<_i27.CallParticipant>);
 
   @override
   bool get isSpeakerOn => (super.noSuchMethod(
@@ -8415,29 +8448,29 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       ) as bool);
 
   @override
-  _i12.Stream<_i27.IncomingCallInfo> get incomingCallStream =>
+  _i13.Stream<_i28.IncomingCallInfo> get incomingCallStream =>
       (super.noSuchMethod(
         Invocation.getter(#incomingCallStream),
-        returnValue: _i12.Stream<_i27.IncomingCallInfo>.empty(),
-        returnValueForMissingStub: _i12.Stream<_i27.IncomingCallInfo>.empty(),
-      ) as _i12.Stream<_i27.IncomingCallInfo>);
+        returnValue: _i13.Stream<_i28.IncomingCallInfo>.empty(),
+        returnValueForMissingStub: _i13.Stream<_i28.IncomingCallInfo>.empty(),
+      ) as _i13.Stream<_i28.IncomingCallInfo>);
 
   @override
-  _i12.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
+  _i13.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
         Invocation.getter(#nativeAcceptedCallStream),
-        returnValue: _i12.Stream<String>.empty(),
-        returnValueForMissingStub: _i12.Stream<String>.empty(),
-      ) as _i12.Stream<String>);
+        returnValue: _i13.Stream<String>.empty(),
+        returnValueForMissingStub: _i13.Stream<String>.empty(),
+      ) as _i13.Stream<String>);
 
   @override
-  _i28.KoheraCallState get callState => (super.noSuchMethod(
+  _i29.KoheraCallState get callState => (super.noSuchMethod(
         Invocation.getter(#callState),
-        returnValue: _i28.KoheraCallState.idle,
-        returnValueForMissingStub: _i28.KoheraCallState.idle,
-      ) as _i28.KoheraCallState);
+        returnValue: _i29.KoheraCallState.idle,
+        returnValueForMissingStub: _i29.KoheraCallState.idle,
+      ) as _i29.KoheraCallState);
 
   @override
-  set preferencesService(_i15.PreferencesService? prefs) => super.noSuchMethod(
+  set preferencesService(_i16.PreferencesService? prefs) => super.noSuchMethod(
         Invocation.setter(
           #preferencesService,
           prefs,
@@ -8446,7 +8479,7 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  set ringtoneService(_i29.RingtoneService? service) => super.noSuchMethod(
+  set ringtoneService(_i30.RingtoneService? service) => super.noSuchMethod(
         Invocation.setter(
           #ringtoneService,
           service,
@@ -8455,7 +8488,7 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  set roomFactoryForTest(_i24.LiveKitRoomFactory? factory) =>
+  set roomFactoryForTest(_i25.LiveKitRoomFactory? factory) =>
       super.noSuchMethod(
         Invocation.setter(
           #roomFactoryForTest,
@@ -8465,7 +8498,7 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  set httpPostForTest(_i24.HttpPostFunction? fn) => super.noSuchMethod(
+  set httpPostForTest(_i25.HttpPostFunction? fn) => super.noSuchMethod(
         Invocation.setter(
           #httpPostForTest,
           fn,
@@ -8499,27 +8532,27 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  _i12.Future<void> toggleMicrophone() => (super.noSuchMethod(
+  _i13.Future<void> toggleMicrophone() => (super.noSuchMethod(
         Invocation.method(
           #toggleMicrophone,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> toggleCamera() => (super.noSuchMethod(
+  _i13.Future<void> toggleCamera() => (super.noSuchMethod(
         Invocation.method(
           #toggleCamera,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> toggleScreenShare({
+  _i13.Future<void> toggleScreenShare({
     String? sourceId,
     bool? captureScreenAudio = false,
   }) =>
@@ -8532,39 +8565,39 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
             #captureScreenAudio: captureScreenAudio,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> toggleScreenAudio() => (super.noSuchMethod(
+  _i13.Future<void> toggleScreenAudio() => (super.noSuchMethod(
         Invocation.method(
           #toggleScreenAudio,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
+  _i13.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
         Invocation.method(
           #setOutputVolume,
           [volume],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> toggleSpeaker() => (super.noSuchMethod(
+  _i13.Future<void> toggleSpeaker() => (super.noSuchMethod(
         Invocation.method(
           #toggleSpeaker,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void setVoipPushHandlesCallKit(bool? value) => super.noSuchMethod(
@@ -8594,7 +8627,7 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8622,36 +8655,36 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  _i12.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
+  _i13.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #joinCall,
           [roomId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> leaveCall() => (super.noSuchMethod(
+  _i13.Future<void> leaveCall() => (super.noSuchMethod(
         Invocation.method(
           #leaveCall,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> acceptCall({bool? withVideo = false}) =>
+  _i13.Future<void> acceptCall({bool? withVideo = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #acceptCall,
           [],
           {#withVideo: withVideo},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void declineCall() => super.noSuchMethod(
@@ -8673,9 +8706,9 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  _i12.Future<void> initiateCall(
+  _i13.Future<void> initiateCall(
     String? roomId, {
-    _i27.CallType? type = _i27.CallType.voice,
+    _i28.CallType? type = _i28.CallType.voice,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8683,9 +8716,9 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
           [roomId],
           {#type: type},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   bool roomHasActiveCall(String? roomId) => (super.noSuchMethod(
@@ -8778,7 +8811,7 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8787,7 +8820,7 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8796,17 +8829,17 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8817,7 +8850,7 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8854,26 +8887,26 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+  _i13.Future<bool> didPushRouteInformation(
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -8903,7 +8936,7 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8912,7 +8945,7 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8921,16 +8954,16 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  _i12.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i13.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i12.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i13.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i12.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i12.Future<_i18.AppExitResponse>);
+            _i13.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i13.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8955,32 +8988,32 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockNotificationService extends _i1.Mock
-    implements _i30.NotificationService {
+    implements _i31.NotificationService {
   @override
-  _i14.MatrixService get matrixService => (super.noSuchMethod(
+  _i15.MatrixService get matrixService => (super.noSuchMethod(
         Invocation.getter(#matrixService),
-        returnValue: _FakeMatrixService_74(
+        returnValue: _FakeMatrixService_75(
           this,
           Invocation.getter(#matrixService),
         ),
-        returnValueForMissingStub: _FakeMatrixService_74(
+        returnValueForMissingStub: _FakeMatrixService_75(
           this,
           Invocation.getter(#matrixService),
         ),
-      ) as _i14.MatrixService);
+      ) as _i15.MatrixService);
 
   @override
-  _i15.PreferencesService get preferencesService => (super.noSuchMethod(
+  _i16.PreferencesService get preferencesService => (super.noSuchMethod(
         Invocation.getter(#preferencesService),
-        returnValue: _FakePreferencesService_75(
+        returnValue: _FakePreferencesService_76(
           this,
           Invocation.getter(#preferencesService),
         ),
-        returnValueForMissingStub: _FakePreferencesService_75(
+        returnValueForMissingStub: _FakePreferencesService_76(
           this,
           Invocation.getter(#preferencesService),
         ),
-      ) as _i15.PreferencesService);
+      ) as _i16.PreferencesService);
 
   @override
   bool get isAppResumed => (super.noSuchMethod(
@@ -8999,14 +9032,14 @@ class MockNotificationService extends _i1.Mock
       );
 
   @override
-  _i12.Future<void> init() => (super.noSuchMethod(
+  _i13.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void startListening() => super.noSuchMethod(
@@ -9027,7 +9060,7 @@ class MockNotificationService extends _i1.Mock
       );
 
   @override
-  _i12.Future<String?> downloadAvatarToTemp(
+  _i13.Future<String?> downloadAvatarToTemp(
     _i4.Client? client,
     Uri? avatarUrl,
     String? userId,
@@ -9041,9 +9074,9 @@ class MockNotificationService extends _i1.Mock
             userId,
           ],
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
   void navigateToRoom(String? roomId) => super.noSuchMethod(
@@ -9055,7 +9088,7 @@ class MockNotificationService extends _i1.Mock
       );
 
   @override
-  _i12.Future<void> showPushNotification({
+  _i13.Future<void> showPushNotification({
     required String? roomId,
     required String? title,
     required String? body,
@@ -9072,29 +9105,29 @@ class MockNotificationService extends _i1.Mock
             #senderName: senderName,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> cancelForRoom(String? roomId) => (super.noSuchMethod(
+  _i13.Future<void> cancelForRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #cancelForRoom,
           [roomId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> cancelAll() => (super.noSuchMethod(
+  _i13.Future<void> cancelAll() => (super.noSuchMethod(
         Invocation.method(
           #cancelAll,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -9113,11 +9146,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -9147,11 +9180,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_76(
+        returnValue: _FakeRoomSummary_77(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_76(
+        returnValueForMissingStub: _FakeRoomSummary_77(
           this,
           Invocation.getter(#summary),
         ),
@@ -9181,11 +9214,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i12.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i13.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i12.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i12.Completer<dynamic>>[],
-      ) as List<_i12.Completer<dynamic>>);
+        returnValue: <_i13.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i13.Completer<dynamic>>[],
+      ) as List<_i13.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -9204,51 +9237,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i10.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i11.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_14<String>(
+        returnValue: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i10.CachedStreamController<String> get onSessionKeyReceived =>
+  _i11.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_14<String>(
+        returnValue: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -9264,11 +9297,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -9277,11 +9310,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -9324,11 +9357,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -9337,11 +9370,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_15(
+        returnValue: _FakeDateTime_16(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_15(
+        returnValueForMissingStub: _FakeDateTime_16(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -9371,11 +9404,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_77(
+        returnValue: _FakeLatestReceiptState_78(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_77(
+        returnValueForMissingStub: _FakeLatestReceiptState_78(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -9396,18 +9429,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i12.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i13.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -9587,18 +9620,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i31.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i32.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i31.SpaceParent>[],
-        returnValueForMissingStub: <_i31.SpaceParent>[],
-      ) as List<_i31.SpaceParent>);
+        returnValue: <_i32.SpaceParent>[],
+        returnValueForMissingStub: <_i32.SpaceParent>[],
+      ) as List<_i32.SpaceParent>);
 
   @override
-  List<_i31.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i32.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i31.SpaceChild>[],
-        returnValueForMissingStub: <_i31.SpaceChild>[],
-      ) as List<_i31.SpaceChild>);
+        returnValue: <_i32.SpaceChild>[],
+        returnValueForMissingStub: <_i32.SpaceChild>[],
+      ) as List<_i32.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -9711,14 +9744,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i12.Future<void> postLoad() => (super.noSuchMethod(
+  _i13.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -9746,15 +9779,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i12.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i13.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i12.Future<List<_i4.User>>);
+            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i13.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -9765,14 +9798,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9782,18 +9815,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i12.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i13.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Event?> refreshLastEvent(
+  _i13.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9801,9 +9834,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -9815,12 +9848,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i12.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i13.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9828,22 +9861,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i17.dummyValue<String>(
+            _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i13.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9851,17 +9884,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i17.dummyValue<String>(
+            _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> addTag(
+  _i13.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -9871,27 +9904,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i13.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i13.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -9899,43 +9932,43 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i13.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i13.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i13.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9943,14 +9976,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i17.dummyValue<String>(
+            _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -9962,7 +9995,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i12.Future<String?> sendTextEvent(
+  _i13.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -9994,12 +10027,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendReaction(
+  _i13.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -10013,12 +10046,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendLocation(
+  _i13.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -10032,12 +10065,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendFileEvent(
+  _i13.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -10065,25 +10098,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i13.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i12.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i13.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i12.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i13.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i12.Future<_i4.EncryptionHealthState>);
+      ) as _i13.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i12.Future<String?> sendEvent(
+  _i13.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -10107,73 +10140,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i13.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> leave() => (super.noSuchMethod(
+  _i13.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> forget() => (super.noSuchMethod(
+  _i13.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> setPower(
+  _i13.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -10185,7 +10218,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10196,7 +10229,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i17.dummyValue<String>(
+            _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10206,10 +10239,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> invite(
+  _i13.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -10219,12 +10252,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<int> requestHistory({
+  _i13.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -10241,32 +10274,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<int>.value(0),
-        returnValueForMissingStub: _i12.Future<int>.value(0),
-      ) as _i12.Future<int>);
+        returnValue: _i13.Future<int>.value(0),
+        returnValueForMissingStub: _i13.Future<int>.value(0),
+      ) as _i13.Future<int>);
 
   @override
-  _i12.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i13.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setReadMarker(
+  _i13.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -10280,23 +10313,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i16.TimelineChunk?> getEventContext(String? eventId) =>
+  _i13.Future<_i17.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i12.Future<_i16.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i12.Future<_i16.TimelineChunk?>.value(),
-      ) as _i12.Future<_i16.TimelineChunk?>);
+        returnValue: _i13.Future<_i17.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i13.Future<_i17.TimelineChunk?>.value(),
+      ) as _i13.Future<_i17.TimelineChunk?>);
 
   @override
-  _i12.Future<void> postReceipt(
+  _i13.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -10306,12 +10339,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Timeline> getTimeline({
+  _i13.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -10334,7 +10367,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i12.Future<_i4.Timeline>.value(_FakeTimeline_78(
+        returnValue: _i13.Future<_i4.Timeline>.value(_FakeTimeline_79(
           this,
           Invocation.method(
             #getTimeline,
@@ -10351,7 +10384,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Timeline>.value(_FakeTimeline_78(
+            _i13.Future<_i4.Timeline>.value(_FakeTimeline_79(
           this,
           Invocation.method(
             #getTimeline,
@@ -10367,7 +10400,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Timeline>);
+      ) as _i13.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -10386,7 +10419,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i12.Future<List<_i4.User>> requestParticipants([
+  _i13.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -10404,10 +10437,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i12.Future<List<_i4.User>>);
+            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i13.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -10415,14 +10448,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_79(
+        returnValue: _FakeUser_80(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_79(
+        returnValueForMissingStub: _FakeUser_80(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -10438,14 +10471,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_79(
+        returnValue: _FakeUser_80(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_79(
+        returnValueForMissingStub: _FakeUser_80(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -10455,7 +10488,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i12.Future<_i4.User?> requestUser(
+  _i13.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -10471,19 +10504,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i12.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.User?>.value(),
-      ) as _i12.Future<_i4.User?>);
+        returnValue: _i13.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.User?>.value(),
+      ) as _i13.Future<_i4.User?>);
 
   @override
-  _i12.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i13.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -10496,12 +10529,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i12.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i13.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i12.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10509,14 +10542,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i17.dummyValue<String>(
+            _i13.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -10539,14 +10572,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i12.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i13.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -10585,18 +10618,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i12.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i13.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEvent(
+  _i13.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -10610,12 +10643,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> setTyping(
+  _i13.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -10625,12 +10658,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setJoinRules(
+  _i13.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -10644,59 +10677,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i13.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setHistoryVisibility(
+  _i13.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i13.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i13.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i12.Future<List<_i4.DeviceKeys>>);
+            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i13.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i12.Future<void> requestSessionKey(
+  _i13.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -10708,12 +10741,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setSpaceChild(
+  _i13.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -10729,44 +10762,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i13.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i12.Future<Uri>.value(_FakeUri_28(
+        returnValue: _i13.Future<Uri>.value(_FakeUri_29(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_28(
+        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_29(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i12.Future<Uri>);
+      ) as _i13.Future<Uri>);
 
   @override
-  _i12.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i13.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<
+  _i13.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -10793,21 +10826,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i12.Future<
+        returnValue: _i13.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i12.Future<
+        returnValueForMissingStub: _i13.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i12.Future<
+      ) as _i13.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -10822,11 +10855,11 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
   @override
   _i4.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_80(
+        returnValue: _FakeRoom_81(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_80(
+        returnValueForMissingStub: _FakeRoom_81(
           this,
           Invocation.getter(#room),
         ),
@@ -10876,17 +10909,17 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       ) as bool);
 
   @override
-  _i16.TimelineChunk get chunk => (super.noSuchMethod(
+  _i17.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_81(
+        returnValue: _FakeTimelineChunk_82(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_81(
+        returnValueForMissingStub: _FakeTimelineChunk_82(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i16.TimelineChunk);
+      ) as _i17.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10903,7 +10936,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       ) as bool);
 
   @override
-  set timelineSub(_i12.StreamSubscription<_i4.Event>? value) =>
+  set timelineSub(_i13.StreamSubscription<_i4.Event>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #timelineSub,
@@ -10913,7 +10946,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set historySub(_i12.StreamSubscription<_i4.Event>? value) =>
+  set historySub(_i13.StreamSubscription<_i4.Event>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #historySub,
@@ -10923,7 +10956,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set roomSub(_i12.StreamSubscription<_i4.SyncUpdate>? value) =>
+  set roomSub(_i13.StreamSubscription<_i4.SyncUpdate>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #roomSub,
@@ -10933,7 +10966,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set sessionIdReceivedSub(_i12.StreamSubscription<String>? value) =>
+  set sessionIdReceivedSub(_i13.StreamSubscription<String>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #sessionIdReceivedSub,
@@ -10943,7 +10976,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set cancelSendEventSub(_i12.StreamSubscription<String>? value) =>
+  set cancelSendEventSub(_i13.StreamSubscription<String>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #cancelSendEventSub,
@@ -10989,7 +11022,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set chunk(_i16.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i17.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -10998,17 +11031,17 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  _i12.Future<_i4.Event?> getEventById(String? id) => (super.noSuchMethod(
+  _i13.Future<_i4.Event?> getEventById(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [id],
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
-  _i12.Future<void> requestHistory({
+  _i13.Future<void> requestHistory({
     int? historyCount = 30,
     _i4.StateFilter? filter,
   }) =>
@@ -11021,12 +11054,12 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> requestFuture({
+  _i13.Future<void> requestFuture({
     int? historyCount = 30,
     _i4.StateFilter? filter,
   }) =>
@@ -11039,12 +11072,12 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<int> getRoomEvents({
+  _i13.Future<int> getRoomEvents({
     int? historyCount = 30,
     dynamic direction = _i4.Direction.b,
     _i4.StateFilter? filter,
@@ -11059,9 +11092,9 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<int>.value(0),
-        returnValueForMissingStub: _i12.Future<int>.value(0),
-      ) as _i12.Future<int>);
+        returnValue: _i13.Future<int>.value(0),
+        returnValueForMissingStub: _i13.Future<int>.value(0),
+      ) as _i13.Future<int>);
 
   @override
   void cancelSubscriptions() => super.noSuchMethod(
@@ -11090,7 +11123,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  _i12.Future<void> setReadMarker({
+  _i13.Future<void> setReadMarker({
     String? eventId,
     bool? public,
   }) =>
@@ -11103,9 +11136,9 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #public: public,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void addAggregatedEvent(_i4.Event? event) => super.noSuchMethod(
@@ -11126,7 +11159,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  _i12.Stream<List<_i4.Event>> searchEvent({
+  _i13.Stream<List<_i4.Event>> searchEvent({
     String? searchTerm,
     int? requestHistoryCount = 100,
     int? maxHistoryRequests = 10,
@@ -11147,12 +11180,12 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #searchFunc: searchFunc,
           },
         ),
-        returnValue: _i12.Stream<List<_i4.Event>>.empty(),
-        returnValueForMissingStub: _i12.Stream<List<_i4.Event>>.empty(),
-      ) as _i12.Stream<List<_i4.Event>>);
+        returnValue: _i13.Stream<List<_i4.Event>>.empty(),
+        returnValueForMissingStub: _i13.Stream<List<_i4.Event>>.empty(),
+      ) as _i13.Stream<List<_i4.Event>>);
 
   @override
-  _i12.Stream<(List<_i4.Event>, String?)> startSearch({
+  _i13.Stream<(List<_i4.Event>, String?)> startSearch({
     String? searchTerm,
     int? requestHistoryCount = 100,
     int? maxHistoryRequests = 10,
@@ -11175,8 +11208,8 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #searchFunc: searchFunc,
           },
         ),
-        returnValue: _i12.Stream<(List<_i4.Event>, String?)>.empty(),
+        returnValue: _i13.Stream<(List<_i4.Event>, String?)>.empty(),
         returnValueForMissingStub:
-            _i12.Stream<(List<_i4.Event>, String?)>.empty(),
-      ) as _i12.Stream<(List<_i4.Event>, String?)>);
+            _i13.Stream<(List<_i4.Event>, String?)>.empty(),
+      ) as _i13.Stream<(List<_i4.Event>, String?)>);
 }

--- a/test/services/matrix_service_test.dart
+++ b/test/services/matrix_service_test.dart
@@ -585,14 +585,16 @@ void main() {
         expect(service.chatBackup.chatBackupEnabled, isTrue);
       });
 
-      test('sets chatBackupNeeded true when client.encryption is null',
+      test('leaves chatBackupNeeded unchanged when client.encryption is null',
           () async {
         when(mockClient.encryption).thenReturn(null);
 
         await service.chatBackup.checkChatBackupStatus();
 
-        expect(service.chatBackup.chatBackupNeeded, isTrue);
-        expect(service.chatBackup.chatBackupEnabled, isFalse);
+        // Encryption being unavailable is treated as "unknown", not a
+        // positive signal that backup is missing — avoids transient
+        // false-positive banners during sync/init.
+        expect(service.chatBackup.chatBackupNeeded, isNull);
       });
 
       test('sets chatBackupNeeded true when cross-signing not cached',
@@ -619,13 +621,15 @@ void main() {
         expect(service.chatBackup.chatBackupNeeded, isTrue);
       });
 
-      test('catches exceptions and sets chatBackupNeeded true', () async {
+      test('leaves chatBackupNeeded unchanged when an inner call throws',
+          () async {
         when(mockClient.encryption).thenReturn(mockEncryption);
         when(mockKeyManager.enabled).thenThrow(Exception('network error'));
 
         await service.chatBackup.checkChatBackupStatus();
 
-        expect(service.chatBackup.chatBackupNeeded, isTrue);
+        // Transient errors must not flip the banner to "needed".
+        expect(service.chatBackup.chatBackupNeeded, isNull);
       });
     });
 

--- a/test/services/matrix_service_test.mocks.dart
+++ b/test/services/matrix_service_test.mocks.dart
@@ -12907,15 +12907,15 @@ class MockBackupVersionManager extends _i1.Mock
       );
 
   @override
-  _i5.Future<bool> hasVersion({bool? refresh = false}) => (super.noSuchMethod(
+  _i5.Future<bool?> hasVersion({bool? refresh = false}) => (super.noSuchMethod(
         Invocation.method(
           #hasVersion,
           [],
           {#refresh: refresh},
         ),
-        returnValue: _i5.Future<bool>.value(false),
-        returnValueForMissingStub: _i5.Future<bool>.value(false),
-      ) as _i5.Future<bool>);
+        returnValue: _i5.Future<bool?>.value(),
+        returnValueForMissingStub: _i5.Future<bool?>.value(),
+      ) as _i5.Future<bool?>);
 
   @override
   _i5.Future<_i2.GetRoomKeysVersionCurrentResponse?> ensureExists() =>

--- a/test/services/notification_service_test.mocks.dart
+++ b/test/services/notification_service_test.mocks.dart
@@ -3,28 +3,29 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i12;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i16;
+import 'dart:async' as _i13;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i17;
 
-import 'package:flutter/services.dart' as _i17;
-import 'package:flutter/widgets.dart' as _i18;
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
 import 'package:flutter_local_notifications/src/flutter_local_notifications_plugin.dart'
-    as _i23;
-import 'package:flutter_local_notifications/src/initialization_settings.dart'
     as _i24;
-import 'package:flutter_local_notifications/src/notification_details.dart'
-    as _i26;
-import 'package:flutter_local_notifications/src/platform_specifics/android/schedule_mode.dart'
-    as _i28;
-import 'package:flutter_local_notifications/src/types.dart' as _i29;
-import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart'
+import 'package:flutter_local_notifications/src/initialization_settings.dart'
     as _i25;
-import 'package:http/http.dart' as _i11;
-import 'package:kohera/core/services/matrix_service.dart' as _i14;
+import 'package:flutter_local_notifications/src/notification_details.dart'
+    as _i27;
+import 'package:flutter_local_notifications/src/platform_specifics/android/schedule_mode.dart'
+    as _i29;
+import 'package:flutter_local_notifications/src/types.dart' as _i30;
+import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart'
+    as _i26;
+import 'package:http/http.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
@@ -33,15 +34,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i19;
+import 'package:matrix/encryption.dart' as _i20;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i13;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i10;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i14;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i11;
+import 'package:matrix/src/utils/space_child.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
-import 'package:timezone/timezone.dart' as _i27;
+import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:timezone/timezone.dart' as _i28;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -142,8 +143,8 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeDatabaseApi_8 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_8(
+class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
+  _FakeOutboxService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -152,8 +153,8 @@ class _FakeDatabaseApi_8 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_9 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_9(
+class _FakeDatabaseApi_9 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -162,9 +163,19 @@ class _FakeFilter_9 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_10 extends _i1.SmartFake
+class _FakeFilter_10 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_10(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeNativeImplementations_11 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_10(
+  _FakeNativeImplementations_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -173,8 +184,8 @@ class _FakeNativeImplementations_10 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_11 extends _i1.SmartFake implements Duration {
-  _FakeDuration_11(
+class _FakeDuration_12 extends _i1.SmartFake implements Duration {
+  _FakeDuration_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -183,9 +194,9 @@ class _FakeDuration_11 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_12 extends _i1.SmartFake
+class _FakePushruleEvaluator_13 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_12(
+  _FakePushruleEvaluator_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -194,8 +205,8 @@ class _FakePushruleEvaluator_12 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_13 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_13(
+class _FakeProfile_14 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -204,9 +215,9 @@ class _FakeProfile_13 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeCachedStreamController_14<T> extends _i1.SmartFake
-    implements _i10.CachedStreamController<T> {
-  _FakeCachedStreamController_14(
+class _FakeCachedStreamController_15<T> extends _i1.SmartFake
+    implements _i11.CachedStreamController<T> {
+  _FakeCachedStreamController_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -215,8 +226,8 @@ class _FakeCachedStreamController_14<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_15 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_15(
+class _FakeDateTime_16 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -225,8 +236,8 @@ class _FakeDateTime_15 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_16 extends _i1.SmartFake implements _i11.Client {
-  _FakeClient_16(
+class _FakeClient_17 extends _i1.SmartFake implements _i12.Client {
+  _FakeClient_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -235,9 +246,9 @@ class _FakeClient_16 extends _i1.SmartFake implements _i11.Client {
         );
 }
 
-class _FakeDiscoveryInformation_17 extends _i1.SmartFake
+class _FakeDiscoveryInformation_18 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_17(
+  _FakeDiscoveryInformation_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -246,9 +257,9 @@ class _FakeDiscoveryInformation_17 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_18 extends _i1.SmartFake
+class _FakeGetVersionsResponse_19 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_18(
+  _FakeGetVersionsResponse_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -257,9 +268,9 @@ class _FakeGetVersionsResponse_18 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_19 extends _i1.SmartFake
+class _FakeRegisterResponse_20 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_19(
+  _FakeRegisterResponse_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -268,8 +279,8 @@ class _FakeRegisterResponse_19 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_20 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_20(
+class _FakeLoginResponse_21 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -278,9 +289,9 @@ class _FakeLoginResponse_20 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_21 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_22 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_21(
+  _FakeGetAuthMetadataResponse_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -289,8 +300,8 @@ class _FakeGetAuthMetadataResponse_21 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_22<T1> extends _i1.SmartFake implements _i12.Future<T1> {
-  _FakeFuture_22(
+class _FakeFuture_23<T1> extends _i1.SmartFake implements _i13.Future<T1> {
+  _FakeFuture_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -299,8 +310,8 @@ class _FakeFuture_22<T1> extends _i1.SmartFake implements _i12.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_23 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_23(
+class _FakeSyncUpdate_24 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -309,9 +320,9 @@ class _FakeSyncUpdate_23 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_24 extends _i1.SmartFake
+class _FakeCachedProfileInformation_25 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_24(
+  _FakeCachedProfileInformation_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -320,8 +331,8 @@ class _FakeCachedProfileInformation_24 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_25 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_25(
+class _FakeMediaConfig_26 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -330,8 +341,8 @@ class _FakeMediaConfig_25 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_26 extends _i1.SmartFake implements _i13.FileResponse {
-  _FakeFileResponse_26(
+class _FakeFileResponse_27 extends _i1.SmartFake implements _i14.FileResponse {
+  _FakeFileResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -340,8 +351,8 @@ class _FakeFileResponse_26 extends _i1.SmartFake implements _i13.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_27 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_27(
+class _FakePreviewForUrl_28 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -350,8 +361,8 @@ class _FakePreviewForUrl_27 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeUri_28 extends _i1.SmartFake implements Uri {
-  _FakeUri_28(
+class _FakeUri_29 extends _i1.SmartFake implements Uri {
+  _FakeUri_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -360,9 +371,9 @@ class _FakeUri_28 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_29 extends _i1.SmartFake
+class _FakeCachedPresence_30 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_29(
+  _FakeCachedPresence_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -371,9 +382,9 @@ class _FakeCachedPresence_29 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_30 extends _i1.SmartFake
+class _FakeTurnServerCredentials_31 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_30(
+  _FakeTurnServerCredentials_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -382,9 +393,9 @@ class _FakeTurnServerCredentials_30 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_31 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_32 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_31(
+  _FakeRoomKeysUpdateResponse_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -393,8 +404,8 @@ class _FakeRoomKeysUpdateResponse_31 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_32 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_32(
+class _FakeKeyBackupData_33 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -403,9 +414,9 @@ class _FakeKeyBackupData_32 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_33 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_34 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_33(
+  _FakeGetWellknownSupportResponse_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -414,9 +425,9 @@ class _FakeGetWellknownSupportResponse_33 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_34 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_35 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_34(
+  _FakeGenerateLoginTokenResponse_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -425,9 +436,9 @@ class _FakeGenerateLoginTokenResponse_34 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_35 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_36 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_35(
+  _FakeGetRoomSummaryResponse$3_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -436,9 +447,9 @@ class _FakeGetRoomSummaryResponse$3_35 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_36 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_37 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_36(
+  _FakeGetSpaceHierarchyResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -447,9 +458,9 @@ class _FakeGetSpaceHierarchyResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_37 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_38 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_37(
+  _FakeGetRelatingEventsResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -458,9 +469,9 @@ class _FakeGetRelatingEventsResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_38 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_39 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_38(
+  _FakeGetRelatingEventsWithRelTypeResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -469,9 +480,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -480,9 +491,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_40 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_41 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_40(
+  _FakeGetThreadRootsResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -491,9 +502,9 @@ class _FakeGetThreadRootsResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_41 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_42 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_41(
+  _FakeGetEventByTimestampResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -502,9 +513,9 @@ class _FakeGetEventByTimestampResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_42 extends _i1.SmartFake
+class _FakeRequestTokenResponse_43 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_42(
+  _FakeRequestTokenResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -513,9 +524,9 @@ class _FakeRequestTokenResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_43 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_44 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_43(
+  _FakeTokenOwnerInfo_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -524,8 +535,8 @@ class _FakeTokenOwnerInfo_43 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_44 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_44(
+class _FakeWhoIsInfo_45 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -534,8 +545,8 @@ class _FakeWhoIsInfo_44 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_45 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_45(
+class _FakeCapabilities_46 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -544,8 +555,8 @@ class _FakeCapabilities_45 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_46 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_46(
+class _FakeDevice_47 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -554,9 +565,9 @@ class _FakeDevice_46 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_47 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_48 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_47(
+  _FakeGetRoomIdByAliasResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -565,9 +576,9 @@ class _FakeGetRoomIdByAliasResponse_47 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_48 extends _i1.SmartFake
+class _FakeGetEventsResponse_49 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_48(
+  _FakeGetEventsResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -576,9 +587,9 @@ class _FakeGetEventsResponse_48 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_49 extends _i1.SmartFake
+class _FakePeekEventsResponse_50 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_49(
+  _FakePeekEventsResponse_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -587,8 +598,8 @@ class _FakePeekEventsResponse_49 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_50 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_50(
+class _FakeMatrixEvent_51 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -597,9 +608,9 @@ class _FakeMatrixEvent_50 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_51 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_52 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_51(
+  _FakeGetKeysChangesResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -608,9 +619,9 @@ class _FakeGetKeysChangesResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_52 extends _i1.SmartFake
+class _FakeClaimKeysResponse_53 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_52(
+  _FakeClaimKeysResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -619,9 +630,9 @@ class _FakeClaimKeysResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_53 extends _i1.SmartFake
+class _FakeQueryKeysResponse_54 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_53(
+  _FakeQueryKeysResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -630,9 +641,9 @@ class _FakeQueryKeysResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_54 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_55 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_54(
+  _FakeGetNotificationsResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -641,9 +652,9 @@ class _FakeGetNotificationsResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_55 extends _i1.SmartFake
+class _FakeGetPresenceResponse_56 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_55(
+  _FakeGetPresenceResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -652,9 +663,9 @@ class _FakeGetPresenceResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_56 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_57 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_56(
+  _FakeGetPublicRoomsResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -663,9 +674,9 @@ class _FakeGetPublicRoomsResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_57 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_58 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_57(
+  _FakeQueryPublicRoomsResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -674,8 +685,8 @@ class _FakeQueryPublicRoomsResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_58 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_58(
+class _FakePushRuleSet_59 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -684,9 +695,9 @@ class _FakePushRuleSet_58 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_59 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_60 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_59(
+  _FakeGetPushRulesGlobalResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -695,8 +706,8 @@ class _FakeGetPushRulesGlobalResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_60 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_60(
+class _FakePushRule_61 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -705,9 +716,9 @@ class _FakePushRule_60 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_61 extends _i1.SmartFake
+class _FakeRefreshResponse_62 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_61(
+  _FakeRefreshResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -716,8 +727,8 @@ class _FakeRefreshResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_62 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_62(
+class _FakeRoomKeys_63 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -726,8 +737,8 @@ class _FakeRoomKeys_62 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_63 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_63(
+class _FakeRoomKeyBackup_64 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -736,9 +747,9 @@ class _FakeRoomKeyBackup_63 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_64 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_65 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_64(
+  _FakeGetRoomKeysVersionCurrentResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -747,9 +758,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_65 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_66 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_65(
+  _FakeGetRoomKeysVersionResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -758,8 +769,8 @@ class _FakeGetRoomKeysVersionResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_66 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_66(
+class _FakeEventContext_67 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -768,9 +779,9 @@ class _FakeEventContext_66 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_67 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_68 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_67(
+  _FakeGetRoomEventsResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -779,8 +790,8 @@ class _FakeGetRoomEventsResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_68 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_68(
+class _FakeSearchResults_69 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -789,9 +800,9 @@ class _FakeSearchResults_68 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_69 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_70 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_69(
+  _FakeGetProtocolMetadataResponse$2_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -800,9 +811,9 @@ class _FakeGetProtocolMetadataResponse$2_69 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_70 extends _i1.SmartFake
+class _FakeOpenIdCredentials_71 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_70(
+  _FakeOpenIdCredentials_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -811,9 +822,9 @@ class _FakeOpenIdCredentials_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_71 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_72 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_71(
+  _FakeSearchUserDirectoryResponse_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -822,9 +833,9 @@ class _FakeSearchUserDirectoryResponse_71 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_72 extends _i1.SmartFake
+class _FakeCreateContentResponse_73 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_72(
+  _FakeCreateContentResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -833,8 +844,8 @@ class _FakeCreateContentResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_73 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_73(
+class _FakeRoomSummary_74 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -843,9 +854,9 @@ class _FakeRoomSummary_73 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_74 extends _i1.SmartFake
+class _FakeLatestReceiptState_75 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_74(
+  _FakeLatestReceiptState_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -854,8 +865,8 @@ class _FakeLatestReceiptState_74 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_75 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_75(
+class _FakeTimeline_76 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -864,8 +875,8 @@ class _FakeTimeline_75 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_76 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_76(
+class _FakeUser_77 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -877,7 +888,7 @@ class _FakeUser_76 extends _i1.SmartFake implements _i4.User {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -907,11 +918,11 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1010,6 +1021,19 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as _i9.AuthService);
 
   @override
+  _i10.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i10.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -1089,6 +1113,15 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
+  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -1096,14 +1129,14 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as bool);
 
   @override
-  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1133,7 +1166,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i16.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1143,18 +1176,18 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<bool> login({
+  _i13.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1169,12 +1202,12 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> completeSsoLogin({
+  _i13.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1187,12 +1220,12 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> completeRegistration(
+  _i13.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1202,32 +1235,32 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1236,7 +1269,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1245,17 +1278,17 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i17.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1266,7 +1299,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i17.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1303,26 +1336,26 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> didPushRouteInformation(
-          _i18.RouteInformation? routeInformation) =>
+  _i13.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1352,7 +1385,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i16.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1361,7 +1394,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i16.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1370,16 +1403,16 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<_i16.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i13.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
+            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
-      ) as _i12.Future<_i16.AppExitResponse>);
+            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i13.Future<_i17.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1407,23 +1440,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_8(
+        returnValue: _FakeDatabaseApi_9(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_8(
+        returnValueForMissingStub: _FakeDatabaseApi_9(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i19.KeyVerificationMethod> get verificationMethods =>
+  Set<_i20.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i19.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
-      ) as Set<_i19.KeyVerificationMethod>);
+        returnValue: <_i20.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
+      ) as Set<_i20.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1484,11 +1517,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_9(
+        returnValue: _FakeFilter_10(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_9(
+        returnValueForMissingStub: _FakeFilter_10(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -1497,11 +1530,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_10(
+        returnValue: _FakeNativeImplementations_11(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_10(
+        returnValueForMissingStub: _FakeNativeImplementations_11(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -1517,11 +1550,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_11(
+        returnValue: _FakeDuration_12(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_11(
+        returnValueForMissingStub: _FakeDuration_12(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -1530,11 +1563,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_11(
+        returnValue: _FakeDuration_12(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_11(
+        returnValueForMissingStub: _FakeDuration_12(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -1543,11 +1576,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1584,11 +1617,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1618,11 +1651,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1631,11 +1664,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1658,11 +1691,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_12(
+        returnValue: _FakePushruleEvaluator_13(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_12(
+        returnValueForMissingStub: _FakePushruleEvaluator_13(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -1683,332 +1716,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i12.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i13.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_13(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_13(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i10.CachedStreamController<String> get onUserProfileUpdate =>
+  _i11.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_14<String>(
+        returnValue: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i12.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i13.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i12.Future<List<_i4.Room>>);
+            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i13.Future<List<_i4.Room>>);
 
   @override
-  _i10.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i11.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_14<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_15<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i4.EventUpdate>(
+            _FakeCachedStreamController_15<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.EventUpdate>);
+      ) as _i11.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i11.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_14<_i4.Event>(
+        returnValue: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i11.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_14<_i4.Event>(
+        returnValue: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onNotification =>
+  _i11.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_14<_i4.Event>(
+        returnValue: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i11.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_14<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_15<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_15<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i11.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i10.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i11.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_14<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_15<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_14<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_15<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i10.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i11.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i10.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i11.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_14<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_15<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i4.LoginState>(
+            _FakeCachedStreamController_15<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i10.CachedStreamController<_i4.LoginState>);
+      ) as _i11.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i10.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i11.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_14<bool>(
+        returnValue: _FakeCachedStreamController_15<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i10.CachedStreamController<bool>);
+      ) as _i11.CachedStreamController<bool>);
 
   @override
-  _i10.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i11.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_14<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_15<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i10.CachedStreamController<_i4.SdkError>);
+      ) as _i11.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i10.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i11.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_14<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_15<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i4.SyncUpdate>(
+            _FakeCachedStreamController_15<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i10.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i11.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i11.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_14<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_15<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_15<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i10.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i11.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.Presence> get onPresence =>
+  _i11.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_14<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_15<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i10.CachedStreamController<_i4.Presence>);
+      ) as _i11.CachedStreamController<_i4.Presence>);
 
   @override
-  _i10.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i11.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_14<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_15<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i4.CachedPresence>(
+            _FakeCachedStreamController_15<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i10.CachedStreamController<_i4.CachedPresence>);
+      ) as _i11.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i10.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i11.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_14<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_15<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i4.BasicEvent>(
+            _FakeCachedStreamController_15<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i10.CachedStreamController<_i4.BasicEvent>);
+      ) as _i11.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i10.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
+  _i11.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_14<_i19.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_15<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i19.RoomKeyRequest>(
+            _FakeCachedStreamController_15<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i10.CachedStreamController<_i19.RoomKeyRequest>);
+      ) as _i11.CachedStreamController<_i20.RoomKeyRequest>);
 
   @override
-  _i10.CachedStreamController<_i19.KeyVerification>
+  _i11.CachedStreamController<_i20.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_14<_i19.KeyVerification>(
+            returnValue: _FakeCachedStreamController_15<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_14<_i19.KeyVerification>(
+                _FakeCachedStreamController_15<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i10.CachedStreamController<_i19.KeyVerification>);
+          ) as _i11.CachedStreamController<_i20.KeyVerification>);
 
   @override
-  _i10.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i11.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_14<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_15<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_14<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_15<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i10.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i11.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i11.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_14<_i4.Event>(
+        returnValue: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<String> get onCancelSendEvent =>
+  _i11.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_14<String>(
+        returnValue: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i10.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i11.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_14<
+            returnValue: _FakeCachedStreamController_15<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_14<
+            returnValueForMissingStub: _FakeCachedStreamController_15<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i10.CachedStreamController<
+          ) as _i11.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -2028,11 +2061,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_15(
+        returnValue: _FakeDateTime_16(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_15(
+        returnValueForMissingStub: _FakeDateTime_16(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2105,7 +2138,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2160,7 +2193,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i12.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i13.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2171,7 +2204,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i12.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i13.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -2282,7 +2315,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2291,7 +2324,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2300,7 +2333,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -2327,20 +2360,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i11.Client get httpClient => (super.noSuchMethod(
+  _i12.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_16(
+        returnValue: _FakeClient_17(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_16(
+        returnValueForMissingStub: _FakeClient_17(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i11.Client);
+      ) as _i12.Client);
 
   @override
-  set httpClient(_i11.Client? value) => super.noSuchMethod(
+  set httpClient(_i12.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -2367,7 +2400,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<void> refreshAccessToken(
+  _i13.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2375,9 +2408,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -2395,14 +2428,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2439,33 +2472,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i12.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i13.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_17(
+        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_18(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_17(
+        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_18(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i12.Future<_i4.DiscoveryInformation>);
+      ) as _i13.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i12.Future<
+  _i13.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -2487,7 +2520,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i12.Future<
+        returnValue: _i13.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2495,7 +2528,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_18(
+          _FakeGetVersionsResponse_19(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2510,7 +2543,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i12.Future<
+        returnValueForMissingStub: _i13.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2518,7 +2551,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_18(
+          _FakeGetVersionsResponse_19(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2533,7 +2566,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i12.Future<
+      ) as _i13.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -2542,7 +2575,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i12.Future<_i4.DiscoveryInformation> getWellknown({
+  _i13.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2555,8 +2588,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_17(
+        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_18(
           this,
           Invocation.method(
             #getWellknown,
@@ -2567,8 +2600,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_17(
+        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_18(
           this,
           Invocation.method(
             #getWellknown,
@@ -2579,10 +2612,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.DiscoveryInformation>);
+      ) as _i13.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i12.Future<_i4.RegisterResponse> register({
+  _i13.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -2610,7 +2643,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_19(
+            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_20(
           this,
           Invocation.method(
             #register,
@@ -2629,7 +2662,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_19(
+            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_20(
           this,
           Invocation.method(
             #register,
@@ -2647,10 +2680,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RegisterResponse>);
+      ) as _i13.Future<_i4.RegisterResponse>);
 
   @override
-  _i12.Future<_i4.LoginResponse> login(
+  _i13.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -2680,7 +2713,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_20(
+        returnValue: _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_21(
           this,
           Invocation.method(
             #login,
@@ -2700,7 +2733,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_20(
+            _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_21(
           this,
           Invocation.method(
             #login,
@@ -2719,10 +2752,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.LoginResponse>);
+      ) as _i13.Future<_i4.LoginResponse>);
 
   @override
-  _i12.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i13.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2735,8 +2768,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_21(
+        returnValue: _i13.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_22(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2748,8 +2781,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_21(
+            _i13.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_22(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2760,74 +2793,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i13.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> logoutAll() => (super.noSuchMethod(
+  _i13.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<T> uiaRequestBackground<T>(
-          _i12.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i13.Future<T> uiaRequestBackground<T>(
+          _i13.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i12.Future<T>.value(v),
+              (T v) => _i13.Future<T>.value(v),
             ) ??
-            _FakeFuture_22<T>(
+            _FakeFuture_23<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i12.Future<T>.value(v),
+              (T v) => _i13.Future<T>.value(v),
             ) ??
-            _FakeFuture_22<T>(
+            _FakeFuture_23<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i12.Future<T>);
+      ) as _i13.Future<T>);
 
   @override
-  _i12.Future<String> startDirectChat(
+  _i13.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -2849,7 +2882,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2865,7 +2898,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2880,10 +2913,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<String> createGroupChat({
+  _i13.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -2914,7 +2947,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2935,7 +2968,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2955,10 +2988,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i13.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -2974,7 +3007,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2987,7 +3020,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2999,21 +3032,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i13.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<String> createSpace({
+  _i13.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -3038,7 +3071,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3056,7 +3089,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3073,10 +3106,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i13.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3084,7 +3117,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_13(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3093,7 +3126,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_13(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3101,10 +3134,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i12.Future<_i4.Profile> fetchOwnProfile({
+  _i13.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3117,7 +3150,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_13(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3129,7 +3162,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_13(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3140,10 +3173,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i12.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i13.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3157,8 +3190,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i12.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_24(
+        returnValue: _i13.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_25(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3170,8 +3203,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_24(
+            _i13.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_25(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3182,10 +3215,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.CachedProfileInformation>);
+      ) as _i13.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i12.Future<_i4.Profile> getProfileFromUserId(
+  _i13.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3203,7 +3236,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_13(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3217,7 +3250,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_13(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3230,7 +3263,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -3252,31 +3285,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i12.Future<List<_i4.Room>>);
+            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i13.Future<List<_i4.Room>>);
 
   @override
-  _i12.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i13.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i12.Future<List<_i4.ArchivedRoom>>);
+            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i13.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i12.Future<_i4.GetVersionsResponse> getVersions({
+  _i13.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3289,8 +3322,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_18(
+        returnValue: _i13.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_19(
           this,
           Invocation.method(
             #getVersions,
@@ -3301,8 +3334,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_18(
+        returnValueForMissingStub: _i13.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_19(
           this,
           Invocation.method(
             #getVersions,
@@ -3313,20 +3346,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetVersionsResponse>);
+      ) as _i13.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i12.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i13.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<_i4.MediaConfig> getConfig({
+  _i13.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3339,7 +3372,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_25(
+        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
           this,
           Invocation.method(
             #getConfig,
@@ -3351,7 +3384,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_25(
+            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
           this,
           Invocation.method(
             #getConfig,
@@ -3362,10 +3395,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.MediaConfig>);
+      ) as _i13.Future<_i4.MediaConfig>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContent(
+  _i13.Future<_i14.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -3385,7 +3418,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContent,
@@ -3401,7 +3434,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContent,
@@ -3416,10 +3449,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentOverrideName(
+  _i13.Future<_i14.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -3441,7 +3474,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3458,7 +3491,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3474,10 +3507,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentThumbnail(
+  _i13.Future<_i14.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -3505,7 +3538,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3525,7 +3558,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3544,10 +3577,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i13.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -3557,7 +3590,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_27(
+        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3566,7 +3599,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_27(
+            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3574,11 +3607,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i12.Future<_i4.PreviewForUrl>);
+      ) as _i13.Future<_i4.PreviewForUrl>);
 
   @override
-  _i12.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+  _i13.Future<Uri> uploadContent(
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3591,7 +3624,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i12.Future<Uri>.value(_FakeUri_28(
+        returnValue: _i13.Future<Uri>.value(_FakeUri_29(
           this,
           Invocation.method(
             #uploadContent,
@@ -3602,7 +3635,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_28(
+        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_29(
           this,
           Invocation.method(
             #uploadContent,
@@ -3613,10 +3646,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<Uri>);
+      ) as _i13.Future<Uri>);
 
   @override
-  _i12.Future<void> setTyping(
+  _i13.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -3632,42 +3665,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> exportDump() => (super.noSuchMethod(
+  _i13.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i13.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i13.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Event?> getEventByPushNotification(
+  _i13.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -3683,12 +3716,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
-  _i12.Future<void> init({
+  _i13.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -3723,9 +3756,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -3737,40 +3770,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<void> clear() => (super.noSuchMethod(
+  _i13.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i13.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ensureNotSoftLoggedOut(
+  _i13.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleSync(
+  _i13.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -3780,9 +3813,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -3795,29 +3828,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i12.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i13.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i13.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDevice(
+  _i13.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -3831,12 +3864,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDevicesOfUserIds(
+  _i13.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -3852,12 +3885,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDeviceEncrypted(
+  _i13.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -3877,12 +3910,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDeviceEncryptedChunked(
+  _i13.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -3896,23 +3929,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i13.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> joinRoom(
+  _i13.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -3930,7 +3963,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3944,7 +3977,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3957,10 +3990,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> changePassword(
+  _i13.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -3976,22 +4009,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> clearCache() => (super.noSuchMethod(
+  _i13.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ignoreUser(
+  _i13.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4001,22 +4034,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i13.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i13.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4027,7 +4060,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_29(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_30(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4036,7 +4069,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_29(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_30(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4044,32 +4077,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i12.Future<_i4.CachedPresence>);
+      ) as _i13.Future<_i4.CachedPresence>);
 
   @override
-  _i12.Future<void> abortSync() => (super.noSuchMethod(
+  _i13.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i13.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEventWithMetadata(
+  _i13.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4089,14 +4122,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i11.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i12.BaseResponse? response,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4128,7 +4161,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i12.Future<Map<String, Object?>> request(
+  _i13.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -4149,13 +4182,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> postPusher(
+  _i13.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -4165,57 +4198,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i13.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i13.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i13.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i12.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_30(
+        returnValue: _i13.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_31(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_30(
+        returnValueForMissingStub: _i13.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_31(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.TurnServerCredentials>);
+      ) as _i13.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4229,8 +4262,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4242,8 +4275,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4254,10 +4287,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4273,8 +4306,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4287,8 +4320,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4300,10 +4333,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i13.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4317,7 +4350,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_32(
+        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4329,7 +4362,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_32(
+            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4340,17 +4373,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.KeyBackupData>);
+      ) as _i13.Future<_i4.KeyBackupData>);
 
   @override
-  _i12.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i13.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i12.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_33(
+        returnValue: _i13.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_34(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -4358,18 +4391,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_33(
+            _i13.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_34(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i13.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i12.Future<int> pingAppservice(
+  _i13.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -4379,12 +4412,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i12.Future<int>.value(0),
-        returnValueForMissingStub: _i12.Future<int>.value(0),
-      ) as _i12.Future<int>);
+        returnValue: _i13.Future<int>.value(0),
+        returnValueForMissingStub: _i13.Future<int>.value(0),
+      ) as _i13.Future<int>);
 
   @override
-  _i12.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i13.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4392,8 +4425,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_34(
+        returnValue: _i13.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_35(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4402,8 +4435,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_34(
+            _i13.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_35(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4411,15 +4444,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i12.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i13.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i12.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i13.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_25(
+        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -4427,17 +4460,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_25(
+            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.MediaConfig>);
+      ) as _i13.Future<_i4.MediaConfig>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentAuthed(
+  _i13.Future<_i14.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -4451,7 +4484,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4463,7 +4496,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4474,10 +4507,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentOverrideNameAuthed(
+  _i13.Future<_i14.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4493,7 +4526,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4506,7 +4539,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4518,10 +4551,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i13.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -4531,7 +4564,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_27(
+        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4540,7 +4573,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_27(
+            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4548,10 +4581,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i12.Future<_i4.PreviewForUrl>);
+      ) as _i13.Future<_i4.PreviewForUrl>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentThumbnailAuthed(
+  _i13.Future<_i14.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -4575,7 +4608,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4593,7 +4626,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_26(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4610,21 +4643,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<bool> registrationTokenValidity(String? token) =>
+  _i13.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i13.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -4634,8 +4667,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_35(
+        returnValue: _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_36(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4644,8 +4677,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_35(
+            _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_36(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4653,10 +4686,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i13.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i12.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i13.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -4674,8 +4707,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_36(
+        returnValue: _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_37(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4689,8 +4722,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_36(
+            _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_37(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4703,10 +4736,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i13.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i13.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -4730,8 +4763,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i12.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_37(
+        returnValue: _i13.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_38(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4749,8 +4782,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_37(
+            _i13.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_38(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4767,10 +4800,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i13.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -4798,8 +4831,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_38(
+                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_39(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4818,8 +4851,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_38(
+                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_39(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4837,10 +4870,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i13.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -4869,9 +4902,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i12.Future<
+            returnValue: _i13.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -4890,9 +4923,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i12.Future<
+            returnValueForMissingStub: _i13.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_39(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -4911,11 +4944,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i12
+          ) as _i13
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i12.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i13.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -4931,8 +4964,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i12.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_40(
+        returnValue: _i13.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_41(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -4945,8 +4978,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_40(
+            _i13.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_41(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -4958,10 +4991,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetThreadRootsResponse>);
+      ) as _i13.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i12.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i13.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -4975,8 +5008,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i12.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_41(
+        returnValue: _i13.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_42(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -4988,8 +5021,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_41(
+            _i13.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_42(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5000,33 +5033,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i13.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i13.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i12.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i13.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i12.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i13.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i12.Future<Uri?>.value(),
-        returnValueForMissingStub: _i12.Future<Uri?>.value(),
-      ) as _i12.Future<Uri?>);
+        returnValue: _i13.Future<Uri?>.value(),
+        returnValueForMissingStub: _i13.Future<Uri?>.value(),
+      ) as _i13.Future<Uri?>);
 
   @override
-  _i12.Future<void> add3PID(
+  _i13.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -5040,12 +5073,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> bind3PID(
+  _i13.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5061,12 +5094,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i13.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5080,14 +5113,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5109,8 +5142,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5126,8 +5159,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5143,10 +5176,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5170,8 +5203,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5188,8 +5221,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5206,10 +5239,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i13.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5223,14 +5256,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i13.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -5245,14 +5278,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5274,8 +5307,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5291,8 +5324,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5308,10 +5341,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5335,8 +5368,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5353,8 +5386,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5371,16 +5404,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i13.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_43(
+            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_44(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -5388,22 +5421,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_43(
+            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_44(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.TokenOwnerInfo>);
+      ) as _i13.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i12.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i13.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_44(
+        returnValue: _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_45(
           this,
           Invocation.method(
             #getWhoIs,
@@ -5411,22 +5444,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_44(
+            _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_45(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i4.WhoIsInfo>);
+      ) as _i13.Future<_i4.WhoIsInfo>);
 
   @override
-  _i12.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i13.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_45(
+        returnValue: _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_46(
           this,
           Invocation.method(
             #getCapabilities,
@@ -5434,17 +5467,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_45(
+            _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_46(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.Capabilities>);
+      ) as _i13.Future<_i4.Capabilities>);
 
   @override
-  _i12.Future<String> createRoom({
+  _i13.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -5477,7 +5510,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5499,7 +5532,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5520,10 +5553,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> deleteDevices(
+  _i13.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5533,22 +5566,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.Device>?>.value(),
-      ) as _i12.Future<List<_i4.Device>?>);
+        returnValue: _i13.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.Device>?>.value(),
+      ) as _i13.Future<List<_i4.Device>?>);
 
   @override
-  _i12.Future<void> deleteDevice(
+  _i13.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5558,34 +5591,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i13.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i12.Future<_i4.Device>.value(_FakeDevice_46(
+        returnValue: _i13.Future<_i4.Device>.value(_FakeDevice_47(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.Device>.value(_FakeDevice_46(
+        returnValueForMissingStub: _i13.Future<_i4.Device>.value(_FakeDevice_47(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i12.Future<_i4.Device>);
+      ) as _i13.Future<_i4.Device>);
 
   @override
-  _i12.Future<void> updateDevice(
+  _i13.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -5595,12 +5628,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i13.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -5615,24 +5648,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i13.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i12.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Visibility?>.value(),
-      ) as _i12.Future<_i4.Visibility?>);
+        returnValue: _i13.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Visibility?>.value(),
+      ) as _i13.Future<_i4.Visibility?>);
 
   @override
-  _i12.Future<void> setRoomVisibilityOnDirectory(
+  _i13.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -5642,30 +5675,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i13.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i13.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_47(
+        returnValue: _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_48(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -5673,18 +5706,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_47(
+            _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_48(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i13.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i12.Future<void> setRoomAlias(
+  _i13.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -5696,12 +5729,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetEventsResponse> getEvents({
+  _i13.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -5715,7 +5748,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_48(
+            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_49(
           this,
           Invocation.method(
             #getEvents,
@@ -5727,7 +5760,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_48(
+            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_49(
           this,
           Invocation.method(
             #getEvents,
@@ -5738,10 +5771,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetEventsResponse>);
+      ) as _i13.Future<_i4.GetEventsResponse>);
 
   @override
-  _i12.Future<_i4.PeekEventsResponse> peekEvents({
+  _i13.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -5756,8 +5789,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i12.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_49(
+        returnValue: _i13.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_50(
           this,
           Invocation.method(
             #peekEvents,
@@ -5769,8 +5802,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_49(
+        returnValueForMissingStub: _i13.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_50(
           this,
           Invocation.method(
             #peekEvents,
@@ -5782,16 +5815,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.PeekEventsResponse>);
+      ) as _i13.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i12.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i13.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_50(
+        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
           this,
           Invocation.method(
             #getOneEvent,
@@ -5799,27 +5832,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_50(
+            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i12.Future<_i4.MatrixEvent>);
+      ) as _i13.Future<_i4.MatrixEvent>);
 
   @override
-  _i12.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i13.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i12.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
-      ) as _i12.Future<List<String>>);
+        returnValue: _i13.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
+      ) as _i13.Future<List<String>>);
 
   @override
-  _i12.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i13.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -5831,8 +5864,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i12.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_51(
+        returnValue: _i13.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_52(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5843,8 +5876,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_51(
+            _i13.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_52(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5854,10 +5887,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.GetKeysChangesResponse>);
+      ) as _i13.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i12.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i13.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -5868,7 +5901,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_52(
+            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_53(
           this,
           Invocation.method(
             #claimKeys,
@@ -5877,7 +5910,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_52(
+            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_53(
           this,
           Invocation.method(
             #claimKeys,
@@ -5885,10 +5918,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i12.Future<_i4.ClaimKeysResponse>);
+      ) as _i13.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i12.Future<void> uploadCrossSigningKeys({
+  _i13.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -5905,12 +5938,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.QueryKeysResponse> queryKeys(
+  _i13.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -5921,7 +5954,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_53(
+            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_54(
           this,
           Invocation.method(
             #queryKeys,
@@ -5930,7 +5963,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_53(
+            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_54(
           this,
           Invocation.method(
             #queryKeys,
@@ -5938,10 +5971,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i12.Future<_i4.QueryKeysResponse>);
+      ) as _i13.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -5949,14 +5982,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i12.Future<
+            returnValue: _i13.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i12.Future<
+            returnValueForMissingStub: _i13.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i12.Future<Map<String, int>> uploadKeys({
+  _i13.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -5971,13 +6004,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i12.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i13.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i12.Future<Map<String, int>>);
+            _i13.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i13.Future<Map<String, int>>);
 
   @override
-  _i12.Future<String> knockRoom(
+  _i13.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -5991,7 +6024,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6003,7 +6036,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6014,20 +6047,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i13.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i12.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i13.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i13.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i12.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i13.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6042,8 +6075,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i12.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_54(
+        returnValue: _i13.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_55(
           this,
           Invocation.method(
             #getNotifications,
@@ -6056,8 +6089,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_54(
+            _i13.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_55(
           this,
           Invocation.method(
             #getNotifications,
@@ -6069,35 +6102,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetNotificationsResponse>);
+      ) as _i13.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i12.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i13.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i12.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_55(
+        returnValue: _i13.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_56(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_55(
+        returnValueForMissingStub: _i13.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_56(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i4.GetPresenceResponse>);
+      ) as _i13.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i12.Future<void> setPresence(
+  _i13.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -6111,12 +6144,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, Object?>> deleteProfileField(
+  _i13.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6129,13 +6162,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getProfileField(
+  _i13.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6148,13 +6181,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<Map<String, Object?>> setProfileField(
+  _i13.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6169,13 +6202,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i13.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6190,8 +6223,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i12.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_56(
+        returnValue: _i13.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_57(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6204,8 +6237,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_56(
+            _i13.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_57(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6217,10 +6250,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i13.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i12.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i13.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -6241,8 +6274,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i12.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_57(
+        returnValue: _i13.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_58(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6258,8 +6291,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_57(
+            _i13.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_58(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6274,25 +6307,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i13.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i12.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.Pusher>?>.value(),
-      ) as _i12.Future<List<_i4.Pusher>?>);
+        returnValue: _i13.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.Pusher>?>.value(),
+      ) as _i13.Future<List<_i4.Pusher>?>);
 
   @override
-  _i12.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i13.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_58(
+        returnValue: _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_59(
           this,
           Invocation.method(
             #getPushRules,
@@ -6300,24 +6333,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_58(
+            _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_59(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.PushRuleSet>);
+      ) as _i13.Future<_i4.PushRuleSet>);
 
   @override
-  _i12.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i13.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_59(
+        returnValue: _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_60(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -6325,18 +6358,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_59(
+            _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_60(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i13.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i12.Future<void> deletePushRule(
+  _i13.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6348,12 +6381,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.PushRule> getPushRule(
+  _i13.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6365,7 +6398,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<_i4.PushRule>.value(_FakePushRule_60(
+        returnValue: _i13.Future<_i4.PushRule>.value(_FakePushRule_61(
           this,
           Invocation.method(
             #getPushRule,
@@ -6376,7 +6409,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PushRule>.value(_FakePushRule_60(
+            _i13.Future<_i4.PushRule>.value(_FakePushRule_61(
           this,
           Invocation.method(
             #getPushRule,
@@ -6386,10 +6419,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.PushRule>);
+      ) as _i13.Future<_i4.PushRule>);
 
   @override
-  _i12.Future<void> setPushRule(
+  _i13.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -6413,12 +6446,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<Object?>> getPushRuleActions(
+  _i13.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6430,13 +6463,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i13.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i12.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i12.Future<List<Object?>>);
+            _i13.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i13.Future<List<Object?>>);
 
   @override
-  _i12.Future<void> setPushRuleActions(
+  _i13.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -6450,12 +6483,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<bool> isPushRuleEnabled(
+  _i13.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6467,12 +6500,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> setPushRuleEnabled(
+  _i13.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -6486,19 +6519,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i13.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_61(
+            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_62(
           this,
           Invocation.method(
             #refresh,
@@ -6506,28 +6539,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_61(
+            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_62(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i12.Future<_i4.RefreshResponse>);
+      ) as _i13.Future<_i4.RefreshResponse>);
 
   @override
-  _i12.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i13.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i12.Future<bool?>.value(),
-        returnValueForMissingStub: _i12.Future<bool?>.value(),
-      ) as _i12.Future<bool?>);
+        returnValue: _i13.Future<bool?>.value(),
+        returnValueForMissingStub: _i13.Future<bool?>.value(),
+      ) as _i13.Future<bool?>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6549,8 +6582,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6566,8 +6599,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6583,10 +6616,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6610,8 +6643,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6628,8 +6661,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_42(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_43(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6646,17 +6679,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -6664,23 +6697,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i13.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_62(
+        returnValue: _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_63(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -6688,17 +6721,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_62(
+            _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_63(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeys>);
+      ) as _i13.Future<_i4.RoomKeys>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -6710,8 +6743,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6722,8 +6755,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6733,10 +6766,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6748,8 +6781,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6760,8 +6793,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6771,10 +6804,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6786,7 +6819,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_63(
+        returnValue: _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_64(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6797,7 +6830,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_63(
+            _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_64(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6807,10 +6840,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeyBackup>);
+      ) as _i13.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -6824,8 +6857,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6837,8 +6870,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6849,10 +6882,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6866,8 +6899,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -6879,8 +6912,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -6891,10 +6924,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i13.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6908,7 +6941,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_32(
+        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -6920,7 +6953,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_32(
+            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -6931,10 +6964,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.KeyBackupData>);
+      ) as _i13.Future<_i4.KeyBackupData>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6950,8 +6983,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_31(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -6964,8 +6997,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_31(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_32(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -6977,18 +7010,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_64(
+                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_65(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -6996,18 +7029,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_64(
+                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_65(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i12.Future<String> postRoomKeysVersion(
+  _i13.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -7019,7 +7052,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7030,7 +7063,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7040,29 +7073,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i13.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i13.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_65(
+        returnValue: _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_66(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7070,18 +7103,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_65(
+            _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_66(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i13.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i13.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -7096,24 +7129,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i13.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i12.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
-      ) as _i12.Future<List<String>>);
+        returnValue: _i13.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
+      ) as _i13.Future<List<String>>);
 
   @override
-  _i12.Future<void> ban(
+  _i13.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7127,12 +7160,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.EventContext> getEventContext(
+  _i13.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7150,7 +7183,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<_i4.EventContext>.value(_FakeEventContext_66(
+        returnValue: _i13.Future<_i4.EventContext>.value(_FakeEventContext_67(
           this,
           Invocation.method(
             #getEventContext,
@@ -7165,7 +7198,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.EventContext>.value(_FakeEventContext_66(
+            _i13.Future<_i4.EventContext>.value(_FakeEventContext_67(
           this,
           Invocation.method(
             #getEventContext,
@@ -7179,10 +7212,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.EventContext>);
+      ) as _i13.Future<_i4.EventContext>);
 
   @override
-  _i12.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i13.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7194,7 +7227,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_50(
+        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7205,7 +7238,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_50(
+            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7215,20 +7248,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.MatrixEvent>);
+      ) as _i13.Future<_i4.MatrixEvent>);
 
   @override
-  _i12.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i13.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> inviteBy3PID(
+  _i13.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -7240,12 +7273,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> inviteUser(
+  _i13.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7259,12 +7292,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> joinRoomById(
+  _i13.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -7278,7 +7311,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7290,7 +7323,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7301,23 +7334,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i13.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i12.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i13.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i12.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i12.Future<Map<String, _i4.RoomMember>?>);
+            _i13.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i13.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i12.Future<void> kick(
+  _i13.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7331,12 +7364,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> leaveRoom(
+  _i13.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -7346,12 +7379,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i13.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -7367,12 +7400,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i12.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i12.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i13.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i13.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i12.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i13.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -7394,8 +7427,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_67(
+        returnValue: _i13.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_68(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7411,8 +7444,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_67(
+        returnValueForMissingStub: _i13.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_68(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7428,10 +7461,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomEventsResponse>);
+      ) as _i13.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i12.Future<void> setReadMarker(
+  _i13.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -7447,12 +7480,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> postReceipt(
+  _i13.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -7468,12 +7501,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEvent(
+  _i13.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -7489,12 +7522,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> reportRoom(
+  _i13.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -7506,12 +7539,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> reportEvent(
+  _i13.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -7529,12 +7562,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> sendMessage(
+  _i13.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -7550,7 +7583,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7563,7 +7596,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7575,23 +7608,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i13.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i12.Future<List<_i4.MatrixEvent>>);
+            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i13.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i13.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -7608,13 +7641,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<String> setRoomStateWithKey(
+  _i13.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -7630,7 +7663,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7643,7 +7676,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7655,10 +7688,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> unban(
+  _i13.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7672,12 +7705,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> upgradeRoom(
+  _i13.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -7691,7 +7724,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7703,7 +7736,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7714,10 +7747,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.SearchResults> search(
+  _i13.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -7727,7 +7760,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_68(
+        returnValue: _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_69(
           this,
           Invocation.method(
             #search,
@@ -7736,7 +7769,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_68(
+            _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_69(
           this,
           Invocation.method(
             #search,
@@ -7744,10 +7777,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i12.Future<_i4.SearchResults>);
+      ) as _i13.Future<_i4.SearchResults>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> sync({
+  _i13.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -7768,7 +7801,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.method(
             #sync,
@@ -7784,7 +7817,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.method(
             #sync,
@@ -7799,22 +7832,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i13.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i12.Future<List<_i4.Location>>);
+            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i13.Future<List<_i4.Location>>);
 
   @override
-  _i12.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i13.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -7824,21 +7857,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i12.Future<List<_i4.Location>>);
+            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i13.Future<List<_i4.Location>>);
 
   @override
-  _i12.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i13.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_69(
+        returnValue: _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_70(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -7846,45 +7879,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_69(
+            _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_70(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i12.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i13.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i12.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i13.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -7895,13 +7928,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getAccountData(
+  _i13.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -7914,13 +7947,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> setAccountData(
+  _i13.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -7934,12 +7967,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> defineFilter(
+  _i13.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -7951,7 +7984,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7962,7 +7995,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7972,10 +8005,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.Filter> getFilter(
+  _i13.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -7987,7 +8020,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i12.Future<_i4.Filter>.value(_FakeFilter_9(
+        returnValue: _i13.Future<_i4.Filter>.value(_FakeFilter_10(
           this,
           Invocation.method(
             #getFilter,
@@ -7997,7 +8030,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.Filter>.value(_FakeFilter_9(
+        returnValueForMissingStub: _i13.Future<_i4.Filter>.value(_FakeFilter_10(
           this,
           Invocation.method(
             #getFilter,
@@ -8007,10 +8040,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.Filter>);
+      ) as _i13.Future<_i4.Filter>);
 
   @override
-  _i12.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i13.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8023,7 +8056,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_70(
+            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_71(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8034,7 +8067,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_70(
+            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_71(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8044,10 +8077,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.OpenIdCredentials>);
+      ) as _i13.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i12.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i13.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8062,13 +8095,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> setAccountDataPerRoom(
+  _i13.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8084,12 +8117,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i13.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8101,12 +8134,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i12.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i12.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i12.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i13.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i13.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i13.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i12.Future<void> deleteRoomTag(
+  _i13.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8120,12 +8153,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setRoomTag(
+  _i13.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8141,12 +8174,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i13.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8156,8 +8189,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i12.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_71(
+        returnValue: _i13.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_72(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8166,8 +8199,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_71(
+            _i13.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_72(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8175,10 +8208,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i12.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i13.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> reportUser(
+  _i13.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8191,40 +8224,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i13.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i12.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_72(
+        returnValue: _i13.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_73(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_72(
+        returnValueForMissingStub: _i13.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_73(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.CreateContentResponse>);
+      ) as _i13.Future<_i4.CreateContentResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> uploadContentToMXC(
+  _i13.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8242,10 +8275,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [Room].
@@ -8255,11 +8288,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8289,11 +8322,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_73(
+        returnValue: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_73(
+        returnValueForMissingStub: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
@@ -8323,11 +8356,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i12.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i13.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i12.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i12.Completer<dynamic>>[],
-      ) as List<_i12.Completer<dynamic>>);
+        returnValue: <_i13.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i13.Completer<dynamic>>[],
+      ) as List<_i13.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -8346,51 +8379,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i10.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i11.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_14<String>(
+        returnValue: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i10.CachedStreamController<String> get onSessionKeyReceived =>
+  _i11.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_14<String>(
+        returnValue: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_14<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8406,11 +8439,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8419,11 +8452,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8466,11 +8499,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8479,11 +8512,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_15(
+        returnValue: _FakeDateTime_16(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_15(
+        returnValueForMissingStub: _FakeDateTime_16(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -8513,11 +8546,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_74(
+        returnValue: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_74(
+        returnValueForMissingStub: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8538,18 +8571,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i12.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i13.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -8729,18 +8762,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i22.SpaceParent>[],
+        returnValueForMissingStub: <_i22.SpaceParent>[],
+      ) as List<_i22.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i22.SpaceChild>[],
+        returnValueForMissingStub: <_i22.SpaceChild>[],
+      ) as List<_i22.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -8853,14 +8886,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i12.Future<void> postLoad() => (super.noSuchMethod(
+  _i13.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -8888,15 +8921,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i12.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i13.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i12.Future<List<_i4.User>>);
+            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i13.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -8907,14 +8940,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8924,18 +8957,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i12.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i13.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Event?> refreshLastEvent(
+  _i13.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8943,9 +8976,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -8957,12 +8990,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i12.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i13.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8970,22 +9003,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i13.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8993,17 +9026,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> addTag(
+  _i13.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -9013,27 +9046,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i13.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i13.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -9041,43 +9074,43 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_23(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i13.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i13.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i13.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9085,14 +9118,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -9104,7 +9137,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i12.Future<String?> sendTextEvent(
+  _i13.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -9136,12 +9169,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendReaction(
+  _i13.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -9155,12 +9188,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendLocation(
+  _i13.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -9174,12 +9207,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendFileEvent(
+  _i13.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -9207,25 +9240,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i13.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i12.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i13.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i12.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i13.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i12.Future<_i4.EncryptionHealthState>);
+      ) as _i13.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i12.Future<String?> sendEvent(
+  _i13.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -9249,73 +9282,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i13.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> leave() => (super.noSuchMethod(
+  _i13.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> forget() => (super.noSuchMethod(
+  _i13.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> setPower(
+  _i13.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -9327,7 +9360,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9338,7 +9371,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9348,10 +9381,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> invite(
+  _i13.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -9361,12 +9394,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<int> requestHistory({
+  _i13.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -9383,32 +9416,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<int>.value(0),
-        returnValueForMissingStub: _i12.Future<int>.value(0),
-      ) as _i12.Future<int>);
+        returnValue: _i13.Future<int>.value(0),
+        returnValueForMissingStub: _i13.Future<int>.value(0),
+      ) as _i13.Future<int>);
 
   @override
-  _i12.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i13.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setReadMarker(
+  _i13.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -9422,23 +9455,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
+  _i13.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i12.Future<_i22.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i12.Future<_i22.TimelineChunk?>.value(),
-      ) as _i12.Future<_i22.TimelineChunk?>);
+        returnValue: _i13.Future<_i23.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i13.Future<_i23.TimelineChunk?>.value(),
+      ) as _i13.Future<_i23.TimelineChunk?>);
 
   @override
-  _i12.Future<void> postReceipt(
+  _i13.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -9448,12 +9481,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Timeline> getTimeline({
+  _i13.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -9476,7 +9509,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i12.Future<_i4.Timeline>.value(_FakeTimeline_75(
+        returnValue: _i13.Future<_i4.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9493,7 +9526,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Timeline>.value(_FakeTimeline_75(
+            _i13.Future<_i4.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9509,7 +9542,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Timeline>);
+      ) as _i13.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -9528,7 +9561,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i12.Future<List<_i4.User>> requestParticipants([
+  _i13.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -9546,10 +9579,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i12.Future<List<_i4.User>>);
+            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i13.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -9557,14 +9590,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9580,14 +9613,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9597,7 +9630,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i12.Future<_i4.User?> requestUser(
+  _i13.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -9613,19 +9646,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i12.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.User?>.value(),
-      ) as _i12.Future<_i4.User?>);
+        returnValue: _i13.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.User?>.value(),
+      ) as _i13.Future<_i4.User?>);
 
   @override
-  _i12.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i13.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -9638,12 +9671,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i12.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i13.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9651,14 +9684,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -9681,14 +9714,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i12.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i13.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -9727,18 +9760,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i12.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i13.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEvent(
+  _i13.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -9752,12 +9785,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> setTyping(
+  _i13.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -9767,12 +9800,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setJoinRules(
+  _i13.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -9786,59 +9819,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i13.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setHistoryVisibility(
+  _i13.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i13.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i13.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i12.Future<List<_i4.DeviceKeys>>);
+            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i13.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i12.Future<void> requestSessionKey(
+  _i13.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -9850,12 +9883,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setSpaceChild(
+  _i13.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -9871,44 +9904,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i13.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i12.Future<Uri>.value(_FakeUri_28(
+        returnValue: _i13.Future<Uri>.value(_FakeUri_29(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_28(
+        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_29(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i12.Future<Uri>);
+      ) as _i13.Future<Uri>);
 
   @override
-  _i12.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i13.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<
+  _i13.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -9935,21 +9968,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i12.Future<
+        returnValue: _i13.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i12.Future<
+        returnValueForMissingStub: _i13.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i12.Future<
+      ) as _i13.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -9961,13 +9994,13 @@ class MockRoom extends _i1.Mock implements _i4.Room {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockFlutterLocalNotificationsPlugin extends _i1.Mock
-    implements _i23.FlutterLocalNotificationsPlugin {
+    implements _i24.FlutterLocalNotificationsPlugin {
   @override
-  _i12.Future<bool?> initialize({
-    required _i24.InitializationSettings? settings,
-    _i25.DidReceiveNotificationResponseCallback?
+  _i13.Future<bool?> initialize({
+    required _i25.InitializationSettings? settings,
+    _i26.DidReceiveNotificationResponseCallback?
         onDidReceiveNotificationResponse,
-    _i25.DidReceiveBackgroundNotificationResponseCallback?
+    _i26.DidReceiveBackgroundNotificationResponseCallback?
         onDidReceiveBackgroundNotificationResponse,
   }) =>
       (super.noSuchMethod(
@@ -9981,29 +10014,29 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
                 onDidReceiveBackgroundNotificationResponse,
           },
         ),
-        returnValue: _i12.Future<bool?>.value(),
-        returnValueForMissingStub: _i12.Future<bool?>.value(),
-      ) as _i12.Future<bool?>);
+        returnValue: _i13.Future<bool?>.value(),
+        returnValueForMissingStub: _i13.Future<bool?>.value(),
+      ) as _i13.Future<bool?>);
 
   @override
-  _i12.Future<_i25.NotificationAppLaunchDetails?>
+  _i13.Future<_i26.NotificationAppLaunchDetails?>
       getNotificationAppLaunchDetails() => (super.noSuchMethod(
             Invocation.method(
               #getNotificationAppLaunchDetails,
               [],
             ),
             returnValue:
-                _i12.Future<_i25.NotificationAppLaunchDetails?>.value(),
+                _i13.Future<_i26.NotificationAppLaunchDetails?>.value(),
             returnValueForMissingStub:
-                _i12.Future<_i25.NotificationAppLaunchDetails?>.value(),
-          ) as _i12.Future<_i25.NotificationAppLaunchDetails?>);
+                _i13.Future<_i26.NotificationAppLaunchDetails?>.value(),
+          ) as _i13.Future<_i26.NotificationAppLaunchDetails?>);
 
   @override
-  _i12.Future<void> show({
+  _i13.Future<void> show({
     required int? id,
     String? title,
     String? body,
-    _i26.NotificationDetails? notificationDetails,
+    _i27.NotificationDetails? notificationDetails,
     String? payload,
   }) =>
       (super.noSuchMethod(
@@ -10018,12 +10051,12 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #payload: payload,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> cancel({
+  _i13.Future<void> cancel({
     required int? id,
     String? tag,
   }) =>
@@ -10036,40 +10069,40 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #tag: tag,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> cancelAll() => (super.noSuchMethod(
+  _i13.Future<void> cancelAll() => (super.noSuchMethod(
         Invocation.method(
           #cancelAll,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> cancelAllPendingNotifications() => (super.noSuchMethod(
+  _i13.Future<void> cancelAllPendingNotifications() => (super.noSuchMethod(
         Invocation.method(
           #cancelAllPendingNotifications,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> zonedSchedule({
+  _i13.Future<void> zonedSchedule({
     required int? id,
-    required _i27.TZDateTime? scheduledDate,
-    required _i26.NotificationDetails? notificationDetails,
-    required _i28.AndroidScheduleMode? androidScheduleMode,
+    required _i28.TZDateTime? scheduledDate,
+    required _i27.NotificationDetails? notificationDetails,
+    required _i29.AndroidScheduleMode? androidScheduleMode,
     String? title,
     String? body,
     String? payload,
-    _i29.DateTimeComponents? matchDateTimeComponents,
+    _i30.DateTimeComponents? matchDateTimeComponents,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -10086,16 +10119,16 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #matchDateTimeComponents: matchDateTimeComponents,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> periodicallyShow({
+  _i13.Future<void> periodicallyShow({
     required int? id,
-    required _i25.RepeatInterval? repeatInterval,
-    required _i26.NotificationDetails? notificationDetails,
-    required _i28.AndroidScheduleMode? androidScheduleMode,
+    required _i26.RepeatInterval? repeatInterval,
+    required _i27.NotificationDetails? notificationDetails,
+    required _i29.AndroidScheduleMode? androidScheduleMode,
     String? title,
     String? body,
     String? payload,
@@ -10114,19 +10147,19 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #payload: payload,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> periodicallyShowWithDuration({
+  _i13.Future<void> periodicallyShowWithDuration({
     required int? id,
     required Duration? repeatDurationInterval,
-    required _i26.NotificationDetails? notificationDetails,
+    required _i27.NotificationDetails? notificationDetails,
     String? title,
     String? body,
-    _i28.AndroidScheduleMode? androidScheduleMode =
-        _i28.AndroidScheduleMode.exact,
+    _i29.AndroidScheduleMode? androidScheduleMode =
+        _i29.AndroidScheduleMode.exact,
     String? payload,
   }) =>
       (super.noSuchMethod(
@@ -10143,36 +10176,36 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #payload: payload,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i25.PendingNotificationRequest>>
+  _i13.Future<List<_i26.PendingNotificationRequest>>
       pendingNotificationRequests() => (super.noSuchMethod(
             Invocation.method(
               #pendingNotificationRequests,
               [],
             ),
             returnValue:
-                _i12.Future<List<_i25.PendingNotificationRequest>>.value(
-                    <_i25.PendingNotificationRequest>[]),
+                _i13.Future<List<_i26.PendingNotificationRequest>>.value(
+                    <_i26.PendingNotificationRequest>[]),
             returnValueForMissingStub:
-                _i12.Future<List<_i25.PendingNotificationRequest>>.value(
-                    <_i25.PendingNotificationRequest>[]),
-          ) as _i12.Future<List<_i25.PendingNotificationRequest>>);
+                _i13.Future<List<_i26.PendingNotificationRequest>>.value(
+                    <_i26.PendingNotificationRequest>[]),
+          ) as _i13.Future<List<_i26.PendingNotificationRequest>>);
 
   @override
-  _i12.Future<List<_i25.ActiveNotification>> getActiveNotifications() =>
+  _i13.Future<List<_i26.ActiveNotification>> getActiveNotifications() =>
       (super.noSuchMethod(
         Invocation.method(
           #getActiveNotifications,
           [],
         ),
-        returnValue: _i12.Future<List<_i25.ActiveNotification>>.value(
-            <_i25.ActiveNotification>[]),
+        returnValue: _i13.Future<List<_i26.ActiveNotification>>.value(
+            <_i26.ActiveNotification>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i25.ActiveNotification>>.value(
-                <_i25.ActiveNotification>[]),
-      ) as _i12.Future<List<_i25.ActiveNotification>>);
+            _i13.Future<List<_i26.ActiveNotification>>.value(
+                <_i26.ActiveNotification>[]),
+      ) as _i13.Future<List<_i26.ActiveNotification>>);
 }

--- a/test/widgets/add_existing_rooms_dialog_test.mocks.dart
+++ b/test/widgets/add_existing_rooms_dialog_test.mocks.dart
@@ -3,17 +3,18 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i12;
-import 'dart:typed_data' as _i22;
-import 'dart:ui' as _i16;
+import 'dart:async' as _i13;
+import 'dart:typed_data' as _i23;
+import 'dart:ui' as _i17;
 
-import 'package:flutter/services.dart' as _i17;
-import 'package:flutter/widgets.dart' as _i18;
-import 'package:http/http.dart' as _i11;
-import 'package:kohera/core/services/matrix_service.dart' as _i14;
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
+import 'package:http/http.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
@@ -22,14 +23,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i21;
+import 'package:matrix/encryption.dart' as _i22;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i13;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i20;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i10;
-import 'package:matrix/src/utils/space_child.dart' as _i19;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i14;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i11;
+import 'package:matrix/src/utils/space_child.dart' as _i20;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -130,8 +131,8 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeRoomSummary_8 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_8(
+class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
+  _FakeOutboxService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -140,9 +141,8 @@ class _FakeRoomSummary_8 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_9<T> extends _i1.SmartFake
-    implements _i10.CachedStreamController<T> {
-  _FakeCachedStreamController_9(
+class _FakeRoomSummary_9 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -151,8 +151,9 @@ class _FakeCachedStreamController_9<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_10 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_10(
+class _FakeCachedStreamController_10<T> extends _i1.SmartFake
+    implements _i11.CachedStreamController<T> {
+  _FakeCachedStreamController_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -161,9 +162,19 @@ class _FakeDateTime_10 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_11 extends _i1.SmartFake
+class _FakeDateTime_11 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_11(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_12 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_11(
+  _FakeLatestReceiptState_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -172,8 +183,8 @@ class _FakeLatestReceiptState_11 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_12 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_12(
+class _FakeSyncUpdate_13 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -182,8 +193,8 @@ class _FakeSyncUpdate_12 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_13 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_13(
+class _FakeTimeline_14 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -192,8 +203,8 @@ class _FakeTimeline_13 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_14 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_14(
+class _FakeUser_15 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -202,8 +213,8 @@ class _FakeUser_14 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_15 extends _i1.SmartFake implements Uri {
-  _FakeUri_15(
+class _FakeUri_16 extends _i1.SmartFake implements Uri {
+  _FakeUri_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -212,8 +223,8 @@ class _FakeUri_15 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_16 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_16(
+class _FakeDatabaseApi_17 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -222,8 +233,8 @@ class _FakeDatabaseApi_16 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_17 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_17(
+class _FakeFilter_18 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -232,9 +243,9 @@ class _FakeFilter_17 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_18 extends _i1.SmartFake
+class _FakeNativeImplementations_19 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_18(
+  _FakeNativeImplementations_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -243,8 +254,8 @@ class _FakeNativeImplementations_18 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_19 extends _i1.SmartFake implements Duration {
-  _FakeDuration_19(
+class _FakeDuration_20 extends _i1.SmartFake implements Duration {
+  _FakeDuration_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -253,9 +264,9 @@ class _FakeDuration_19 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_20 extends _i1.SmartFake
+class _FakePushruleEvaluator_21 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_20(
+  _FakePushruleEvaluator_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -264,8 +275,8 @@ class _FakePushruleEvaluator_20 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_21 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_21(
+class _FakeProfile_22 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -274,8 +285,8 @@ class _FakeProfile_21 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_22 extends _i1.SmartFake implements _i11.Client {
-  _FakeClient_22(
+class _FakeClient_23 extends _i1.SmartFake implements _i12.Client {
+  _FakeClient_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -284,9 +295,9 @@ class _FakeClient_22 extends _i1.SmartFake implements _i11.Client {
         );
 }
 
-class _FakeDiscoveryInformation_23 extends _i1.SmartFake
+class _FakeDiscoveryInformation_24 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_23(
+  _FakeDiscoveryInformation_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -295,9 +306,9 @@ class _FakeDiscoveryInformation_23 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_24 extends _i1.SmartFake
+class _FakeGetVersionsResponse_25 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_24(
+  _FakeGetVersionsResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -306,9 +317,9 @@ class _FakeGetVersionsResponse_24 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_25 extends _i1.SmartFake
+class _FakeRegisterResponse_26 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_25(
+  _FakeRegisterResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -317,8 +328,8 @@ class _FakeRegisterResponse_25 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_26 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_26(
+class _FakeLoginResponse_27 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -327,9 +338,9 @@ class _FakeLoginResponse_26 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_27 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_28 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_27(
+  _FakeGetAuthMetadataResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -338,8 +349,8 @@ class _FakeGetAuthMetadataResponse_27 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_28<T1> extends _i1.SmartFake implements _i12.Future<T1> {
-  _FakeFuture_28(
+class _FakeFuture_29<T1> extends _i1.SmartFake implements _i13.Future<T1> {
+  _FakeFuture_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -348,9 +359,9 @@ class _FakeFuture_28<T1> extends _i1.SmartFake implements _i12.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_29 extends _i1.SmartFake
+class _FakeCachedProfileInformation_30 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_29(
+  _FakeCachedProfileInformation_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -359,8 +370,8 @@ class _FakeCachedProfileInformation_29 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_30(
+class _FakeMediaConfig_31 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -369,8 +380,8 @@ class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_31 extends _i1.SmartFake implements _i13.FileResponse {
-  _FakeFileResponse_31(
+class _FakeFileResponse_32 extends _i1.SmartFake implements _i14.FileResponse {
+  _FakeFileResponse_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -379,8 +390,8 @@ class _FakeFileResponse_31 extends _i1.SmartFake implements _i13.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_32(
+class _FakePreviewForUrl_33 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -389,9 +400,9 @@ class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_33 extends _i1.SmartFake
+class _FakeCachedPresence_34 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_33(
+  _FakeCachedPresence_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -400,9 +411,9 @@ class _FakeCachedPresence_33 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_34 extends _i1.SmartFake
+class _FakeTurnServerCredentials_35 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_34(
+  _FakeTurnServerCredentials_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -411,9 +422,9 @@ class _FakeTurnServerCredentials_34 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_35(
+  _FakeRoomKeysUpdateResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -422,8 +433,8 @@ class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_36(
+class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -432,9 +443,9 @@ class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_37(
+  _FakeGetWellknownSupportResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -443,9 +454,9 @@ class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_38(
+  _FakeGenerateLoginTokenResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -454,9 +465,9 @@ class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_39(
+  _FakeGetRoomSummaryResponse$3_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -465,9 +476,9 @@ class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_40(
+  _FakeGetSpaceHierarchyResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -476,9 +487,9 @@ class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_41(
+  _FakeGetRelatingEventsResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -487,9 +498,9 @@ class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_42(
+  _FakeGetRelatingEventsWithRelTypeResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -498,9 +509,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -509,9 +520,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_44(
+  _FakeGetThreadRootsResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -520,9 +531,9 @@ class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_45(
+  _FakeGetEventByTimestampResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -531,9 +542,9 @@ class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_46 extends _i1.SmartFake
+class _FakeRequestTokenResponse_47 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_46(
+  _FakeRequestTokenResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -542,9 +553,9 @@ class _FakeRequestTokenResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_47(
+  _FakeTokenOwnerInfo_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -553,8 +564,8 @@ class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_48(
+class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -563,8 +574,8 @@ class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_49(
+class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -573,8 +584,8 @@ class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_50(
+class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -583,9 +594,9 @@ class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_51(
+  _FakeGetRoomIdByAliasResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -594,9 +605,9 @@ class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_52 extends _i1.SmartFake
+class _FakeGetEventsResponse_53 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_52(
+  _FakeGetEventsResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -605,9 +616,9 @@ class _FakeGetEventsResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_53 extends _i1.SmartFake
+class _FakePeekEventsResponse_54 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_53(
+  _FakePeekEventsResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -616,8 +627,8 @@ class _FakePeekEventsResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_54(
+class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -626,9 +637,9 @@ class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_55(
+  _FakeGetKeysChangesResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -637,9 +648,9 @@ class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_56 extends _i1.SmartFake
+class _FakeClaimKeysResponse_57 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_56(
+  _FakeClaimKeysResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -648,9 +659,9 @@ class _FakeClaimKeysResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_57 extends _i1.SmartFake
+class _FakeQueryKeysResponse_58 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_57(
+  _FakeQueryKeysResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -659,9 +670,9 @@ class _FakeQueryKeysResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_58(
+  _FakeGetNotificationsResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -670,9 +681,9 @@ class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_59 extends _i1.SmartFake
+class _FakeGetPresenceResponse_60 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_59(
+  _FakeGetPresenceResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -681,9 +692,9 @@ class _FakeGetPresenceResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_60(
+  _FakeGetPublicRoomsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -692,9 +703,9 @@ class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_61(
+  _FakeQueryPublicRoomsResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -703,8 +714,8 @@ class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_62(
+class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -713,9 +724,9 @@ class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_63(
+  _FakeGetPushRulesGlobalResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -724,8 +735,8 @@ class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_64(
+class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -734,9 +745,9 @@ class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_65 extends _i1.SmartFake
+class _FakeRefreshResponse_66 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_65(
+  _FakeRefreshResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -745,8 +756,8 @@ class _FakeRefreshResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_66(
+class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -755,8 +766,8 @@ class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_67(
+class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -765,9 +776,9 @@ class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_68(
+  _FakeGetRoomKeysVersionCurrentResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -776,9 +787,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_69(
+  _FakeGetRoomKeysVersionResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -787,8 +798,8 @@ class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_70(
+class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -797,9 +808,9 @@ class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_71(
+  _FakeGetRoomEventsResponse_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,8 +819,8 @@ class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_72(
+class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -818,9 +829,9 @@ class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_73(
+  _FakeGetProtocolMetadataResponse$2_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,9 +840,9 @@ class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_74 extends _i1.SmartFake
+class _FakeOpenIdCredentials_75 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_74(
+  _FakeOpenIdCredentials_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -840,9 +851,9 @@ class _FakeOpenIdCredentials_74 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_75(
+  _FakeSearchUserDirectoryResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -851,9 +862,9 @@ class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_76 extends _i1.SmartFake
+class _FakeCreateContentResponse_77 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_76(
+  _FakeCreateContentResponse_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -865,7 +876,7 @@ class _FakeCreateContentResponse_76 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -895,11 +906,11 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -998,6 +1009,19 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as _i9.AuthService);
 
   @override
+  _i10.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i10.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -1077,6 +1101,15 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
+  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -1084,14 +1117,14 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as bool);
 
   @override
-  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1121,7 +1154,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i16.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1131,18 +1164,18 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<bool> login({
+  _i13.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1157,12 +1190,12 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> completeSsoLogin({
+  _i13.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1175,12 +1208,12 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> completeRegistration(
+  _i13.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1190,32 +1223,32 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1224,7 +1257,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1233,17 +1266,17 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i17.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1254,7 +1287,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i17.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1291,26 +1324,26 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> didPushRouteInformation(
-          _i18.RouteInformation? routeInformation) =>
+  _i13.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1340,7 +1373,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i16.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1349,7 +1382,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i16.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1358,16 +1391,16 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<_i16.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i13.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
+            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
-      ) as _i12.Future<_i16.AppExitResponse>);
+            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i13.Future<_i17.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1395,11 +1428,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1429,11 +1462,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_8(
+        returnValue: _FakeRoomSummary_9(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_8(
+        returnValueForMissingStub: _FakeRoomSummary_9(
           this,
           Invocation.getter(#summary),
         ),
@@ -1463,11 +1496,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i12.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i13.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i12.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i12.Completer<dynamic>>[],
-      ) as List<_i12.Completer<dynamic>>);
+        returnValue: <_i13.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i13.Completer<dynamic>>[],
+      ) as List<_i13.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1486,51 +1519,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i10.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i11.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i10.CachedStreamController<String> get onSessionKeyReceived =>
+  _i11.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1546,11 +1579,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1559,11 +1592,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1606,11 +1639,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1619,11 +1652,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_10(
+        returnValue: _FakeDateTime_11(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_10(
+        returnValueForMissingStub: _FakeDateTime_11(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1653,11 +1686,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_11(
+        returnValue: _FakeLatestReceiptState_12(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_11(
+        returnValueForMissingStub: _FakeLatestReceiptState_12(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1678,18 +1711,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i12.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i13.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -1869,18 +1902,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i19.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i19.SpaceParent>[],
-        returnValueForMissingStub: <_i19.SpaceParent>[],
-      ) as List<_i19.SpaceParent>);
+        returnValue: <_i20.SpaceParent>[],
+        returnValueForMissingStub: <_i20.SpaceParent>[],
+      ) as List<_i20.SpaceParent>);
 
   @override
-  List<_i19.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i19.SpaceChild>[],
-        returnValueForMissingStub: <_i19.SpaceChild>[],
-      ) as List<_i19.SpaceChild>);
+        returnValue: <_i20.SpaceChild>[],
+        returnValueForMissingStub: <_i20.SpaceChild>[],
+      ) as List<_i20.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -1993,14 +2026,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i12.Future<void> postLoad() => (super.noSuchMethod(
+  _i13.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2028,15 +2061,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i12.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i13.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i12.Future<List<_i4.User>>);
+            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i13.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2047,14 +2080,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2064,18 +2097,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i12.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i13.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Event?> refreshLastEvent(
+  _i13.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2083,9 +2116,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2097,12 +2130,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i12.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i13.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2110,22 +2143,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i13.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2133,17 +2166,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> addTag(
+  _i13.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2153,27 +2186,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i13.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i13.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2181,43 +2214,43 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i13.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i13.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i13.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2225,14 +2258,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2244,7 +2277,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i12.Future<String?> sendTextEvent(
+  _i13.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2276,12 +2309,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendReaction(
+  _i13.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2295,12 +2328,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendLocation(
+  _i13.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2314,12 +2347,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendFileEvent(
+  _i13.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2347,25 +2380,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i13.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i12.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i13.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i12.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i13.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i12.Future<_i4.EncryptionHealthState>);
+      ) as _i13.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i12.Future<String?> sendEvent(
+  _i13.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2389,73 +2422,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i13.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> leave() => (super.noSuchMethod(
+  _i13.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> forget() => (super.noSuchMethod(
+  _i13.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> setPower(
+  _i13.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2467,7 +2500,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2478,7 +2511,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2488,10 +2521,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> invite(
+  _i13.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2501,12 +2534,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<int> requestHistory({
+  _i13.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2523,32 +2556,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<int>.value(0),
-        returnValueForMissingStub: _i12.Future<int>.value(0),
-      ) as _i12.Future<int>);
+        returnValue: _i13.Future<int>.value(0),
+        returnValueForMissingStub: _i13.Future<int>.value(0),
+      ) as _i13.Future<int>);
 
   @override
-  _i12.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i13.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setReadMarker(
+  _i13.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2562,23 +2595,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i20.TimelineChunk?> getEventContext(String? eventId) =>
+  _i13.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i12.Future<_i20.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i12.Future<_i20.TimelineChunk?>.value(),
-      ) as _i12.Future<_i20.TimelineChunk?>);
+        returnValue: _i13.Future<_i21.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i13.Future<_i21.TimelineChunk?>.value(),
+      ) as _i13.Future<_i21.TimelineChunk?>);
 
   @override
-  _i12.Future<void> postReceipt(
+  _i13.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2588,12 +2621,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Timeline> getTimeline({
+  _i13.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2616,7 +2649,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
+        returnValue: _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
           this,
           Invocation.method(
             #getTimeline,
@@ -2633,7 +2666,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
+            _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
           this,
           Invocation.method(
             #getTimeline,
@@ -2649,7 +2682,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Timeline>);
+      ) as _i13.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2668,7 +2701,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i12.Future<List<_i4.User>> requestParticipants([
+  _i13.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2686,10 +2719,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i12.Future<List<_i4.User>>);
+            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i13.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2697,14 +2730,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_14(
+        returnValue: _FakeUser_15(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_14(
+        returnValueForMissingStub: _FakeUser_15(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2720,14 +2753,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_14(
+        returnValue: _FakeUser_15(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_14(
+        returnValueForMissingStub: _FakeUser_15(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2737,7 +2770,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i12.Future<_i4.User?> requestUser(
+  _i13.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2753,19 +2786,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i12.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.User?>.value(),
-      ) as _i12.Future<_i4.User?>);
+        returnValue: _i13.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.User?>.value(),
+      ) as _i13.Future<_i4.User?>);
 
   @override
-  _i12.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i13.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2778,12 +2811,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i12.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i13.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2791,14 +2824,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2821,14 +2854,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i12.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i13.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -2867,18 +2900,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i12.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i13.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEvent(
+  _i13.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -2892,12 +2925,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> setTyping(
+  _i13.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -2907,12 +2940,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setJoinRules(
+  _i13.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -2926,59 +2959,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i13.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setHistoryVisibility(
+  _i13.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i13.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i13.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i12.Future<List<_i4.DeviceKeys>>);
+            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i13.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i12.Future<void> requestSessionKey(
+  _i13.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -2990,12 +3023,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setSpaceChild(
+  _i13.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3011,44 +3044,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i13.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i12.Future<Uri>);
+      ) as _i13.Future<Uri>);
 
   @override
-  _i12.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i13.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<
+  _i13.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3075,21 +3108,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i12.Future<
+        returnValue: _i13.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i12.Future<
+        returnValueForMissingStub: _i13.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i12.Future<
+      ) as _i13.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3104,23 +3137,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_16(
+        returnValue: _FakeDatabaseApi_17(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_16(
+        returnValueForMissingStub: _FakeDatabaseApi_17(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i21.KeyVerificationMethod> get verificationMethods =>
+  Set<_i22.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i21.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i21.KeyVerificationMethod>{},
-      ) as Set<_i21.KeyVerificationMethod>);
+        returnValue: <_i22.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i22.KeyVerificationMethod>{},
+      ) as Set<_i22.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3181,11 +3214,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_17(
+        returnValue: _FakeFilter_18(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_17(
+        returnValueForMissingStub: _FakeFilter_18(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3194,11 +3227,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_18(
+        returnValue: _FakeNativeImplementations_19(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_18(
+        returnValueForMissingStub: _FakeNativeImplementations_19(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3214,11 +3247,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_19(
+        returnValue: _FakeDuration_20(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_19(
+        returnValueForMissingStub: _FakeDuration_20(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3227,11 +3260,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_19(
+        returnValue: _FakeDuration_20(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_19(
+        returnValueForMissingStub: _FakeDuration_20(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3240,11 +3273,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3281,11 +3314,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3315,11 +3348,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3328,11 +3361,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3355,11 +3388,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_20(
+        returnValue: _FakePushruleEvaluator_21(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_20(
+        returnValueForMissingStub: _FakePushruleEvaluator_21(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3380,332 +3413,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i12.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i13.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i10.CachedStreamController<String> get onUserProfileUpdate =>
+  _i11.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i12.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i13.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i12.Future<List<_i4.Room>>);
+            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i13.Future<List<_i4.Room>>);
 
   @override
-  _i10.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i11.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_10<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.EventUpdate>(
+            _FakeCachedStreamController_10<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.EventUpdate>);
+      ) as _i11.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i11.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i11.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onNotification =>
+  _i11.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i11.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i11.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i10.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i11.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i10.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i11.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i10.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i11.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_9<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_10<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.LoginState>(
+            _FakeCachedStreamController_10<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i10.CachedStreamController<_i4.LoginState>);
+      ) as _i11.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i10.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i11.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_9<bool>(
+        returnValue: _FakeCachedStreamController_10<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i10.CachedStreamController<bool>);
+      ) as _i11.CachedStreamController<bool>);
 
   @override
-  _i10.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i11.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_9<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_10<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i10.CachedStreamController<_i4.SdkError>);
+      ) as _i11.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i10.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i11.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_9<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_10<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.SyncUpdate>(
+            _FakeCachedStreamController_10<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i10.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i11.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i11.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i10.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i11.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.Presence> get onPresence =>
+  _i11.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_9<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_10<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i10.CachedStreamController<_i4.Presence>);
+      ) as _i11.CachedStreamController<_i4.Presence>);
 
   @override
-  _i10.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i11.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_9<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_10<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.CachedPresence>(
+            _FakeCachedStreamController_10<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i10.CachedStreamController<_i4.CachedPresence>);
+      ) as _i11.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i10.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i11.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_9<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_10<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.BasicEvent>(
+            _FakeCachedStreamController_10<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i10.CachedStreamController<_i4.BasicEvent>);
+      ) as _i11.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i10.CachedStreamController<_i21.RoomKeyRequest> get onRoomKeyRequest =>
+  _i11.CachedStreamController<_i22.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
+            _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i10.CachedStreamController<_i21.RoomKeyRequest>);
+      ) as _i11.CachedStreamController<_i22.RoomKeyRequest>);
 
   @override
-  _i10.CachedStreamController<_i21.KeyVerification>
+  _i11.CachedStreamController<_i22.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_9<_i21.KeyVerification>(
+            returnValue: _FakeCachedStreamController_10<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_9<_i21.KeyVerification>(
+                _FakeCachedStreamController_10<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i10.CachedStreamController<_i21.KeyVerification>);
+          ) as _i11.CachedStreamController<_i22.KeyVerification>);
 
   @override
-  _i10.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i11.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i10.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i11.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i11.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<String> get onCancelSendEvent =>
+  _i11.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i10.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i11.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_9<
+            returnValue: _FakeCachedStreamController_10<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_9<
+            returnValueForMissingStub: _FakeCachedStreamController_10<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i10.CachedStreamController<
+          ) as _i11.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3725,11 +3758,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_10(
+        returnValue: _FakeDateTime_11(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_10(
+        returnValueForMissingStub: _FakeDateTime_11(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3802,7 +3835,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i21.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i22.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3857,7 +3890,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i12.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i13.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3868,7 +3901,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i12.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i13.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -3979,7 +4012,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -3988,7 +4021,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -3997,7 +4030,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4024,20 +4057,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i11.Client get httpClient => (super.noSuchMethod(
+  _i12.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_22(
+        returnValue: _FakeClient_23(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_22(
+        returnValueForMissingStub: _FakeClient_23(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i11.Client);
+      ) as _i12.Client);
 
   @override
-  set httpClient(_i11.Client? value) => super.noSuchMethod(
+  set httpClient(_i12.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4064,7 +4097,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<void> refreshAccessToken(
+  _i13.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4072,9 +4105,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4092,14 +4125,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4136,33 +4169,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i12.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i13.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i12.Future<_i4.DiscoveryInformation>);
+      ) as _i13.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i12.Future<
+  _i13.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4184,7 +4217,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i12.Future<
+        returnValue: _i13.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4192,7 +4225,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_24(
+          _FakeGetVersionsResponse_25(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4207,7 +4240,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i12.Future<
+        returnValueForMissingStub: _i13.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4215,7 +4248,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_24(
+          _FakeGetVersionsResponse_25(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4230,7 +4263,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i12.Future<
+      ) as _i13.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4239,7 +4272,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i12.Future<_i4.DiscoveryInformation> getWellknown({
+  _i13.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4252,8 +4285,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getWellknown,
@@ -4264,8 +4297,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getWellknown,
@@ -4276,10 +4309,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.DiscoveryInformation>);
+      ) as _i13.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i12.Future<_i4.RegisterResponse> register({
+  _i13.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4307,7 +4340,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
+            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
           this,
           Invocation.method(
             #register,
@@ -4326,7 +4359,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
+            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
           this,
           Invocation.method(
             #register,
@@ -4344,10 +4377,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RegisterResponse>);
+      ) as _i13.Future<_i4.RegisterResponse>);
 
   @override
-  _i12.Future<_i4.LoginResponse> login(
+  _i13.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4377,7 +4410,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
+        returnValue: _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
           this,
           Invocation.method(
             #login,
@@ -4397,7 +4430,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
+            _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
           this,
           Invocation.method(
             #login,
@@ -4416,10 +4449,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.LoginResponse>);
+      ) as _i13.Future<_i4.LoginResponse>);
 
   @override
-  _i12.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i13.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4432,8 +4465,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_27(
+        returnValue: _i13.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_28(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4445,8 +4478,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_27(
+            _i13.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_28(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4457,74 +4490,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i13.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> logoutAll() => (super.noSuchMethod(
+  _i13.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<T> uiaRequestBackground<T>(
-          _i12.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i13.Future<T> uiaRequestBackground<T>(
+          _i13.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i12.Future<T>.value(v),
+              (T v) => _i13.Future<T>.value(v),
             ) ??
-            _FakeFuture_28<T>(
+            _FakeFuture_29<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i12.Future<T>.value(v),
+              (T v) => _i13.Future<T>.value(v),
             ) ??
-            _FakeFuture_28<T>(
+            _FakeFuture_29<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i12.Future<T>);
+      ) as _i13.Future<T>);
 
   @override
-  _i12.Future<String> startDirectChat(
+  _i13.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4546,7 +4579,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4562,7 +4595,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4577,10 +4610,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<String> createGroupChat({
+  _i13.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4611,7 +4644,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4632,7 +4665,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4652,10 +4685,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i13.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4671,7 +4704,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4684,7 +4717,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4696,21 +4729,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i13.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<String> createSpace({
+  _i13.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4735,7 +4768,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4753,7 +4786,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4770,10 +4803,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i13.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4781,7 +4814,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4790,7 +4823,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4798,10 +4831,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i12.Future<_i4.Profile> fetchOwnProfile({
+  _i13.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4814,7 +4847,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4826,7 +4859,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4837,10 +4870,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i12.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i13.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4854,8 +4887,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i12.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_29(
+        returnValue: _i13.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_30(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4867,8 +4900,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_29(
+            _i13.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_30(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4879,10 +4912,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.CachedProfileInformation>);
+      ) as _i13.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i12.Future<_i4.Profile> getProfileFromUserId(
+  _i13.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4900,7 +4933,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4914,7 +4947,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4927,7 +4960,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -4949,31 +4982,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i12.Future<List<_i4.Room>>);
+            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i13.Future<List<_i4.Room>>);
 
   @override
-  _i12.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i13.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i12.Future<List<_i4.ArchivedRoom>>);
+            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i13.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i12.Future<_i4.GetVersionsResponse> getVersions({
+  _i13.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4986,8 +5019,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_24(
+        returnValue: _i13.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_25(
           this,
           Invocation.method(
             #getVersions,
@@ -4998,8 +5031,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_24(
+        returnValueForMissingStub: _i13.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_25(
           this,
           Invocation.method(
             #getVersions,
@@ -5010,20 +5043,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetVersionsResponse>);
+      ) as _i13.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i12.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i13.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<_i4.MediaConfig> getConfig({
+  _i13.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5036,7 +5069,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfig,
@@ -5048,7 +5081,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfig,
@@ -5059,10 +5092,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.MediaConfig>);
+      ) as _i13.Future<_i4.MediaConfig>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContent(
+  _i13.Future<_i14.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5082,7 +5115,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContent,
@@ -5098,7 +5131,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContent,
@@ -5113,10 +5146,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentOverrideName(
+  _i13.Future<_i14.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5138,7 +5171,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5155,7 +5188,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5171,10 +5204,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentThumbnail(
+  _i13.Future<_i14.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5202,7 +5235,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5222,7 +5255,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5241,10 +5274,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i13.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5254,7 +5287,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5263,7 +5296,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5271,11 +5304,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i12.Future<_i4.PreviewForUrl>);
+      ) as _i13.Future<_i4.PreviewForUrl>);
 
   @override
-  _i12.Future<Uri> uploadContent(
-    _i22.Uint8List? file, {
+  _i13.Future<Uri> uploadContent(
+    _i23.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5288,7 +5321,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #uploadContent,
@@ -5299,7 +5332,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #uploadContent,
@@ -5310,10 +5343,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<Uri>);
+      ) as _i13.Future<Uri>);
 
   @override
-  _i12.Future<void> setTyping(
+  _i13.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5329,42 +5362,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> exportDump() => (super.noSuchMethod(
+  _i13.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i13.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i13.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Event?> getEventByPushNotification(
+  _i13.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5380,12 +5413,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
-  _i12.Future<void> init({
+  _i13.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5420,9 +5453,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5434,40 +5467,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<void> clear() => (super.noSuchMethod(
+  _i13.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i13.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ensureNotSoftLoggedOut(
+  _i13.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleSync(
+  _i13.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5477,9 +5510,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5492,29 +5525,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i12.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i13.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i13.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDevice(
+  _i13.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5528,12 +5561,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDevicesOfUserIds(
+  _i13.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5549,12 +5582,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDeviceEncrypted(
+  _i13.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5574,12 +5607,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDeviceEncryptedChunked(
+  _i13.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5593,23 +5626,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i13.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> joinRoom(
+  _i13.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5627,7 +5660,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5641,7 +5674,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5654,10 +5687,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> changePassword(
+  _i13.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5673,22 +5706,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> clearCache() => (super.noSuchMethod(
+  _i13.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ignoreUser(
+  _i13.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5698,22 +5731,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i13.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i13.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5724,7 +5757,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5733,7 +5766,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5741,32 +5774,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i12.Future<_i4.CachedPresence>);
+      ) as _i13.Future<_i4.CachedPresence>);
 
   @override
-  _i12.Future<void> abortSync() => (super.noSuchMethod(
+  _i13.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i13.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEventWithMetadata(
+  _i13.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5786,14 +5819,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i11.BaseResponse? response,
-    _i22.Uint8List? body,
+    _i12.BaseResponse? response,
+    _i23.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5825,7 +5858,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i12.Future<Map<String, Object?>> request(
+  _i13.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -5846,13 +5879,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> postPusher(
+  _i13.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -5862,57 +5895,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i13.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i13.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i13.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i12.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_34(
+        returnValue: _i13.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_35(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_34(
+        returnValueForMissingStub: _i13.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_35(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.TurnServerCredentials>);
+      ) as _i13.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5926,8 +5959,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5939,8 +5972,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5951,10 +5984,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5970,8 +6003,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5984,8 +6017,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5997,10 +6030,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i13.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6014,7 +6047,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6026,7 +6059,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6037,17 +6070,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.KeyBackupData>);
+      ) as _i13.Future<_i4.KeyBackupData>);
 
   @override
-  _i12.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i13.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i12.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_37(
+        returnValue: _i13.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_38(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6055,18 +6088,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_37(
+            _i13.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_38(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i13.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i12.Future<int> pingAppservice(
+  _i13.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6076,12 +6109,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i12.Future<int>.value(0),
-        returnValueForMissingStub: _i12.Future<int>.value(0),
-      ) as _i12.Future<int>);
+        returnValue: _i13.Future<int>.value(0),
+        returnValueForMissingStub: _i13.Future<int>.value(0),
+      ) as _i13.Future<int>);
 
   @override
-  _i12.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i13.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6089,8 +6122,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_38(
+        returnValue: _i13.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_39(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6099,8 +6132,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_38(
+            _i13.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_39(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6108,15 +6141,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i12.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i13.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i12.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i13.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6124,17 +6157,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.MediaConfig>);
+      ) as _i13.Future<_i4.MediaConfig>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentAuthed(
+  _i13.Future<_i14.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6148,7 +6181,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6160,7 +6193,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6171,10 +6204,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentOverrideNameAuthed(
+  _i13.Future<_i14.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6190,7 +6223,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6203,7 +6236,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6215,10 +6248,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i13.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6228,7 +6261,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6237,7 +6270,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6245,10 +6278,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i12.Future<_i4.PreviewForUrl>);
+      ) as _i13.Future<_i4.PreviewForUrl>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentThumbnailAuthed(
+  _i13.Future<_i14.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6272,7 +6305,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6290,7 +6323,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6307,21 +6340,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<bool> registrationTokenValidity(String? token) =>
+  _i13.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i13.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6331,8 +6364,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_39(
+        returnValue: _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_40(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6341,8 +6374,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_39(
+            _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_40(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6350,10 +6383,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i13.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i12.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i13.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6371,8 +6404,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_40(
+        returnValue: _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_41(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6386,8 +6419,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_40(
+            _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_41(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6400,10 +6433,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i13.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i13.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6427,8 +6460,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i12.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_41(
+        returnValue: _i13.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_42(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6446,8 +6479,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_41(
+            _i13.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_42(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6464,10 +6497,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i13.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6495,8 +6528,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_42(
+                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6515,8 +6548,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_42(
+                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6534,10 +6567,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i13.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6566,9 +6599,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i12.Future<
+            returnValue: _i13.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6587,9 +6620,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i12.Future<
+            returnValueForMissingStub: _i13.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6608,11 +6641,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i12
+          ) as _i13
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i12.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i13.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6628,8 +6661,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i12.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_44(
+        returnValue: _i13.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_45(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6642,8 +6675,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_44(
+            _i13.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_45(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6655,10 +6688,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetThreadRootsResponse>);
+      ) as _i13.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i12.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i13.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6672,8 +6705,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i12.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_45(
+        returnValue: _i13.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_46(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6685,8 +6718,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_45(
+            _i13.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_46(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6697,33 +6730,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i13.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i13.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i12.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i13.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i12.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i13.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i12.Future<Uri?>.value(),
-        returnValueForMissingStub: _i12.Future<Uri?>.value(),
-      ) as _i12.Future<Uri?>);
+        returnValue: _i13.Future<Uri?>.value(),
+        returnValueForMissingStub: _i13.Future<Uri?>.value(),
+      ) as _i13.Future<Uri?>);
 
   @override
-  _i12.Future<void> add3PID(
+  _i13.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6737,12 +6770,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> bind3PID(
+  _i13.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6758,12 +6791,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i13.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6777,14 +6810,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6806,8 +6839,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6823,8 +6856,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6840,10 +6873,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6867,8 +6900,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6885,8 +6918,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6903,10 +6936,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i13.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6920,14 +6953,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i13.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -6942,14 +6975,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6971,8 +7004,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -6988,8 +7021,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7005,10 +7038,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7032,8 +7065,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7050,8 +7083,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7068,16 +7101,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i13.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
+            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7085,22 +7118,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
+            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.TokenOwnerInfo>);
+      ) as _i13.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i12.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i13.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
+        returnValue: _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7108,22 +7141,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
+            _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i4.WhoIsInfo>);
+      ) as _i13.Future<_i4.WhoIsInfo>);
 
   @override
-  _i12.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i13.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
+        returnValue: _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7131,17 +7164,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
+            _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.Capabilities>);
+      ) as _i13.Future<_i4.Capabilities>);
 
   @override
-  _i12.Future<String> createRoom({
+  _i13.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7174,7 +7207,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7196,7 +7229,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7217,10 +7250,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> deleteDevices(
+  _i13.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7230,22 +7263,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.Device>?>.value(),
-      ) as _i12.Future<List<_i4.Device>?>);
+        returnValue: _i13.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.Device>?>.value(),
+      ) as _i13.Future<List<_i4.Device>?>);
 
   @override
-  _i12.Future<void> deleteDevice(
+  _i13.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7255,34 +7288,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i13.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i12.Future<_i4.Device>.value(_FakeDevice_50(
+        returnValue: _i13.Future<_i4.Device>.value(_FakeDevice_51(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.Device>.value(_FakeDevice_50(
+        returnValueForMissingStub: _i13.Future<_i4.Device>.value(_FakeDevice_51(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i12.Future<_i4.Device>);
+      ) as _i13.Future<_i4.Device>);
 
   @override
-  _i12.Future<void> updateDevice(
+  _i13.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7292,12 +7325,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i13.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7312,24 +7345,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i13.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i12.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Visibility?>.value(),
-      ) as _i12.Future<_i4.Visibility?>);
+        returnValue: _i13.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Visibility?>.value(),
+      ) as _i13.Future<_i4.Visibility?>);
 
   @override
-  _i12.Future<void> setRoomVisibilityOnDirectory(
+  _i13.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7339,30 +7372,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i13.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i13.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_51(
+        returnValue: _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_52(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7370,18 +7403,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_51(
+            _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_52(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i13.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i12.Future<void> setRoomAlias(
+  _i13.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7393,12 +7426,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetEventsResponse> getEvents({
+  _i13.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7412,7 +7445,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
+            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
           this,
           Invocation.method(
             #getEvents,
@@ -7424,7 +7457,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
+            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
           this,
           Invocation.method(
             #getEvents,
@@ -7435,10 +7468,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetEventsResponse>);
+      ) as _i13.Future<_i4.GetEventsResponse>);
 
   @override
-  _i12.Future<_i4.PeekEventsResponse> peekEvents({
+  _i13.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7453,8 +7486,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i12.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_53(
+        returnValue: _i13.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_54(
           this,
           Invocation.method(
             #peekEvents,
@@ -7466,8 +7499,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_53(
+        returnValueForMissingStub: _i13.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_54(
           this,
           Invocation.method(
             #peekEvents,
@@ -7479,16 +7512,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.PeekEventsResponse>);
+      ) as _i13.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i12.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i13.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7496,27 +7529,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i12.Future<_i4.MatrixEvent>);
+      ) as _i13.Future<_i4.MatrixEvent>);
 
   @override
-  _i12.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i13.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i12.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
-      ) as _i12.Future<List<String>>);
+        returnValue: _i13.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
+      ) as _i13.Future<List<String>>);
 
   @override
-  _i12.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i13.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7528,8 +7561,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i12.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_55(
+        returnValue: _i13.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_56(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7540,8 +7573,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_55(
+            _i13.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_56(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7551,10 +7584,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.GetKeysChangesResponse>);
+      ) as _i13.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i12.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i13.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7565,7 +7598,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
+            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
           this,
           Invocation.method(
             #claimKeys,
@@ -7574,7 +7607,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
+            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
           this,
           Invocation.method(
             #claimKeys,
@@ -7582,10 +7615,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i12.Future<_i4.ClaimKeysResponse>);
+      ) as _i13.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i12.Future<void> uploadCrossSigningKeys({
+  _i13.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7602,12 +7635,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.QueryKeysResponse> queryKeys(
+  _i13.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7618,7 +7651,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
+            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
           this,
           Invocation.method(
             #queryKeys,
@@ -7627,7 +7660,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
+            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
           this,
           Invocation.method(
             #queryKeys,
@@ -7635,10 +7668,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i12.Future<_i4.QueryKeysResponse>);
+      ) as _i13.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7646,14 +7679,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i12.Future<
+            returnValue: _i13.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i12.Future<
+            returnValueForMissingStub: _i13.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i12.Future<Map<String, int>> uploadKeys({
+  _i13.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7668,13 +7701,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i12.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i13.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i12.Future<Map<String, int>>);
+            _i13.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i13.Future<Map<String, int>>);
 
   @override
-  _i12.Future<String> knockRoom(
+  _i13.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7688,7 +7721,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7700,7 +7733,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7711,20 +7744,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i13.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i12.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i13.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i13.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i12.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i13.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7739,8 +7772,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i12.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_58(
+        returnValue: _i13.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_59(
           this,
           Invocation.method(
             #getNotifications,
@@ -7753,8 +7786,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_58(
+            _i13.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_59(
           this,
           Invocation.method(
             #getNotifications,
@@ -7766,35 +7799,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetNotificationsResponse>);
+      ) as _i13.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i12.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i13.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i12.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_59(
+        returnValue: _i13.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_60(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_59(
+        returnValueForMissingStub: _i13.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_60(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i4.GetPresenceResponse>);
+      ) as _i13.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i12.Future<void> setPresence(
+  _i13.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -7808,12 +7841,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, Object?>> deleteProfileField(
+  _i13.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7826,13 +7859,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getProfileField(
+  _i13.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7845,13 +7878,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<Map<String, Object?>> setProfileField(
+  _i13.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7866,13 +7899,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i13.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7887,8 +7920,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i12.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_60(
+        returnValue: _i13.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_61(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7901,8 +7934,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_60(
+            _i13.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_61(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7914,10 +7947,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i13.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i12.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i13.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -7938,8 +7971,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i12.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_61(
+        returnValue: _i13.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_62(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7955,8 +7988,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_61(
+            _i13.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_62(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7971,25 +8004,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i13.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i12.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.Pusher>?>.value(),
-      ) as _i12.Future<List<_i4.Pusher>?>);
+        returnValue: _i13.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.Pusher>?>.value(),
+      ) as _i13.Future<List<_i4.Pusher>?>);
 
   @override
-  _i12.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i13.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
+        returnValue: _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
           this,
           Invocation.method(
             #getPushRules,
@@ -7997,24 +8030,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
+            _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.PushRuleSet>);
+      ) as _i13.Future<_i4.PushRuleSet>);
 
   @override
-  _i12.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i13.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_63(
+        returnValue: _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_64(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8022,18 +8055,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_63(
+            _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_64(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i13.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i12.Future<void> deletePushRule(
+  _i13.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8045,12 +8078,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.PushRule> getPushRule(
+  _i13.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8062,7 +8095,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
+        returnValue: _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
           this,
           Invocation.method(
             #getPushRule,
@@ -8073,7 +8106,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
+            _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
           this,
           Invocation.method(
             #getPushRule,
@@ -8083,10 +8116,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.PushRule>);
+      ) as _i13.Future<_i4.PushRule>);
 
   @override
-  _i12.Future<void> setPushRule(
+  _i13.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8110,12 +8143,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<Object?>> getPushRuleActions(
+  _i13.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8127,13 +8160,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i13.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i12.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i12.Future<List<Object?>>);
+            _i13.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i13.Future<List<Object?>>);
 
   @override
-  _i12.Future<void> setPushRuleActions(
+  _i13.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8147,12 +8180,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<bool> isPushRuleEnabled(
+  _i13.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8164,12 +8197,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> setPushRuleEnabled(
+  _i13.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8183,19 +8216,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i13.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
+            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
           this,
           Invocation.method(
             #refresh,
@@ -8203,28 +8236,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
+            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i12.Future<_i4.RefreshResponse>);
+      ) as _i13.Future<_i4.RefreshResponse>);
 
   @override
-  _i12.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i13.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i12.Future<bool?>.value(),
-        returnValueForMissingStub: _i12.Future<bool?>.value(),
-      ) as _i12.Future<bool?>);
+        returnValue: _i13.Future<bool?>.value(),
+        returnValueForMissingStub: _i13.Future<bool?>.value(),
+      ) as _i13.Future<bool?>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8246,8 +8279,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8263,8 +8296,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8280,10 +8313,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8307,8 +8340,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8325,8 +8358,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8343,17 +8376,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8361,23 +8394,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i13.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
+        returnValue: _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8385,17 +8418,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
+            _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeys>);
+      ) as _i13.Future<_i4.RoomKeys>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8407,8 +8440,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8419,8 +8452,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8430,10 +8463,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8445,8 +8478,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8457,8 +8490,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8468,10 +8501,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8483,7 +8516,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
+        returnValue: _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8494,7 +8527,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
+            _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8504,10 +8537,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeyBackup>);
+      ) as _i13.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8521,8 +8554,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8534,8 +8567,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8546,10 +8579,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8563,8 +8596,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8576,8 +8609,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8588,10 +8621,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i13.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8605,7 +8638,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8617,7 +8650,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8628,10 +8661,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.KeyBackupData>);
+      ) as _i13.Future<_i4.KeyBackupData>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8647,8 +8680,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8661,8 +8694,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8674,18 +8707,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_68(
+                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_69(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8693,18 +8726,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_68(
+                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_69(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i12.Future<String> postRoomKeysVersion(
+  _i13.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8716,7 +8749,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8727,7 +8760,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8737,29 +8770,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i13.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i13.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_69(
+        returnValue: _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_70(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8767,18 +8800,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_69(
+            _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_70(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i13.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i13.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8793,24 +8826,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i13.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i12.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
-      ) as _i12.Future<List<String>>);
+        returnValue: _i13.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
+      ) as _i13.Future<List<String>>);
 
   @override
-  _i12.Future<void> ban(
+  _i13.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8824,12 +8857,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.EventContext> getEventContext(
+  _i13.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8847,7 +8880,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
+        returnValue: _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
           this,
           Invocation.method(
             #getEventContext,
@@ -8862,7 +8895,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
+            _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
           this,
           Invocation.method(
             #getEventContext,
@@ -8876,10 +8909,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.EventContext>);
+      ) as _i13.Future<_i4.EventContext>);
 
   @override
-  _i12.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i13.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8891,7 +8924,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8902,7 +8935,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8912,20 +8945,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.MatrixEvent>);
+      ) as _i13.Future<_i4.MatrixEvent>);
 
   @override
-  _i12.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i13.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> inviteBy3PID(
+  _i13.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -8937,12 +8970,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> inviteUser(
+  _i13.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8956,12 +8989,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> joinRoomById(
+  _i13.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -8975,7 +9008,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8987,7 +9020,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8998,23 +9031,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i13.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i12.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i13.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i12.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i12.Future<Map<String, _i4.RoomMember>?>);
+            _i13.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i13.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i12.Future<void> kick(
+  _i13.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9028,12 +9061,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> leaveRoom(
+  _i13.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9043,12 +9076,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i13.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9064,12 +9097,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i12.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i12.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i13.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i13.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i12.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i13.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9091,8 +9124,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_71(
+        returnValue: _i13.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_72(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9108,8 +9141,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_71(
+        returnValueForMissingStub: _i13.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_72(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9125,10 +9158,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomEventsResponse>);
+      ) as _i13.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i12.Future<void> setReadMarker(
+  _i13.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9144,12 +9177,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> postReceipt(
+  _i13.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9165,12 +9198,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEvent(
+  _i13.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9186,12 +9219,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> reportRoom(
+  _i13.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9203,12 +9236,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> reportEvent(
+  _i13.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9226,12 +9259,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> sendMessage(
+  _i13.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9247,7 +9280,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9260,7 +9293,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9272,23 +9305,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i13.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i12.Future<List<_i4.MatrixEvent>>);
+            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i13.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i13.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9305,13 +9338,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<String> setRoomStateWithKey(
+  _i13.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9327,7 +9360,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9340,7 +9373,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9352,10 +9385,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> unban(
+  _i13.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9369,12 +9402,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> upgradeRoom(
+  _i13.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9388,7 +9421,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9400,7 +9433,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9411,10 +9444,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.SearchResults> search(
+  _i13.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9424,7 +9457,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
+        returnValue: _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
           this,
           Invocation.method(
             #search,
@@ -9433,7 +9466,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
+            _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
           this,
           Invocation.method(
             #search,
@@ -9441,10 +9474,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i12.Future<_i4.SearchResults>);
+      ) as _i13.Future<_i4.SearchResults>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> sync({
+  _i13.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9465,7 +9498,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #sync,
@@ -9481,7 +9514,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #sync,
@@ -9496,22 +9529,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i13.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i12.Future<List<_i4.Location>>);
+            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i13.Future<List<_i4.Location>>);
 
   @override
-  _i12.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i13.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9521,21 +9554,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i12.Future<List<_i4.Location>>);
+            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i13.Future<List<_i4.Location>>);
 
   @override
-  _i12.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i13.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_73(
+        returnValue: _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_74(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9543,45 +9576,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_73(
+            _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_74(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i12.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i13.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i12.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i13.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9592,13 +9625,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getAccountData(
+  _i13.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9611,13 +9644,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> setAccountData(
+  _i13.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9631,12 +9664,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> defineFilter(
+  _i13.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9648,7 +9681,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9659,7 +9692,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9669,10 +9702,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.Filter> getFilter(
+  _i13.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9684,7 +9717,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
+        returnValue: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
           this,
           Invocation.method(
             #getFilter,
@@ -9694,7 +9727,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
+        returnValueForMissingStub: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
           this,
           Invocation.method(
             #getFilter,
@@ -9704,10 +9737,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.Filter>);
+      ) as _i13.Future<_i4.Filter>);
 
   @override
-  _i12.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i13.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9720,7 +9753,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
+            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9731,7 +9764,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
+            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9741,10 +9774,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.OpenIdCredentials>);
+      ) as _i13.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i12.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i13.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9759,13 +9792,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> setAccountDataPerRoom(
+  _i13.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9781,12 +9814,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i13.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9798,12 +9831,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i12.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i12.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i12.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i13.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i13.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i13.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i12.Future<void> deleteRoomTag(
+  _i13.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9817,12 +9850,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setRoomTag(
+  _i13.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9838,12 +9871,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i13.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9853,8 +9886,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i12.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_75(
+        returnValue: _i13.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_76(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9863,8 +9896,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_75(
+            _i13.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_76(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9872,10 +9905,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i12.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i13.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> reportUser(
+  _i13.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9888,40 +9921,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i13.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i12.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_76(
+        returnValue: _i13.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_77(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_76(
+        returnValueForMissingStub: _i13.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_77(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.CreateContentResponse>);
+      ) as _i13.Future<_i4.CreateContentResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> uploadContentToMXC(
+  _i13.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i22.Uint8List? body, {
+    _i23.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -9939,8 +9972,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 }

--- a/test/widgets/add_room_to_space_dialog_test.mocks.dart
+++ b/test/widgets/add_room_to_space_dialog_test.mocks.dart
@@ -3,17 +3,18 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i12;
-import 'dart:typed_data' as _i22;
-import 'dart:ui' as _i16;
+import 'dart:async' as _i13;
+import 'dart:typed_data' as _i23;
+import 'dart:ui' as _i17;
 
-import 'package:flutter/services.dart' as _i17;
-import 'package:flutter/widgets.dart' as _i18;
-import 'package:http/http.dart' as _i11;
-import 'package:kohera/core/services/matrix_service.dart' as _i14;
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
+import 'package:http/http.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
@@ -22,14 +23,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i21;
+import 'package:matrix/encryption.dart' as _i22;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i13;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i20;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i10;
-import 'package:matrix/src/utils/space_child.dart' as _i19;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i14;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i11;
+import 'package:matrix/src/utils/space_child.dart' as _i20;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -130,8 +131,8 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeRoomSummary_8 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_8(
+class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
+  _FakeOutboxService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -140,9 +141,8 @@ class _FakeRoomSummary_8 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_9<T> extends _i1.SmartFake
-    implements _i10.CachedStreamController<T> {
-  _FakeCachedStreamController_9(
+class _FakeRoomSummary_9 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -151,8 +151,9 @@ class _FakeCachedStreamController_9<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_10 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_10(
+class _FakeCachedStreamController_10<T> extends _i1.SmartFake
+    implements _i11.CachedStreamController<T> {
+  _FakeCachedStreamController_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -161,9 +162,19 @@ class _FakeDateTime_10 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_11 extends _i1.SmartFake
+class _FakeDateTime_11 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_11(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_12 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_11(
+  _FakeLatestReceiptState_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -172,8 +183,8 @@ class _FakeLatestReceiptState_11 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_12 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_12(
+class _FakeSyncUpdate_13 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -182,8 +193,8 @@ class _FakeSyncUpdate_12 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_13 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_13(
+class _FakeTimeline_14 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -192,8 +203,8 @@ class _FakeTimeline_13 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_14 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_14(
+class _FakeUser_15 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -202,8 +213,8 @@ class _FakeUser_14 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_15 extends _i1.SmartFake implements Uri {
-  _FakeUri_15(
+class _FakeUri_16 extends _i1.SmartFake implements Uri {
+  _FakeUri_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -212,8 +223,8 @@ class _FakeUri_15 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_16 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_16(
+class _FakeDatabaseApi_17 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -222,8 +233,8 @@ class _FakeDatabaseApi_16 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_17 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_17(
+class _FakeFilter_18 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -232,9 +243,9 @@ class _FakeFilter_17 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_18 extends _i1.SmartFake
+class _FakeNativeImplementations_19 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_18(
+  _FakeNativeImplementations_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -243,8 +254,8 @@ class _FakeNativeImplementations_18 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_19 extends _i1.SmartFake implements Duration {
-  _FakeDuration_19(
+class _FakeDuration_20 extends _i1.SmartFake implements Duration {
+  _FakeDuration_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -253,9 +264,9 @@ class _FakeDuration_19 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_20 extends _i1.SmartFake
+class _FakePushruleEvaluator_21 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_20(
+  _FakePushruleEvaluator_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -264,8 +275,8 @@ class _FakePushruleEvaluator_20 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_21 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_21(
+class _FakeProfile_22 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -274,8 +285,8 @@ class _FakeProfile_21 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_22 extends _i1.SmartFake implements _i11.Client {
-  _FakeClient_22(
+class _FakeClient_23 extends _i1.SmartFake implements _i12.Client {
+  _FakeClient_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -284,9 +295,9 @@ class _FakeClient_22 extends _i1.SmartFake implements _i11.Client {
         );
 }
 
-class _FakeDiscoveryInformation_23 extends _i1.SmartFake
+class _FakeDiscoveryInformation_24 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_23(
+  _FakeDiscoveryInformation_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -295,9 +306,9 @@ class _FakeDiscoveryInformation_23 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_24 extends _i1.SmartFake
+class _FakeGetVersionsResponse_25 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_24(
+  _FakeGetVersionsResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -306,9 +317,9 @@ class _FakeGetVersionsResponse_24 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_25 extends _i1.SmartFake
+class _FakeRegisterResponse_26 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_25(
+  _FakeRegisterResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -317,8 +328,8 @@ class _FakeRegisterResponse_25 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_26 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_26(
+class _FakeLoginResponse_27 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -327,9 +338,9 @@ class _FakeLoginResponse_26 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_27 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_28 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_27(
+  _FakeGetAuthMetadataResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -338,8 +349,8 @@ class _FakeGetAuthMetadataResponse_27 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_28<T1> extends _i1.SmartFake implements _i12.Future<T1> {
-  _FakeFuture_28(
+class _FakeFuture_29<T1> extends _i1.SmartFake implements _i13.Future<T1> {
+  _FakeFuture_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -348,9 +359,9 @@ class _FakeFuture_28<T1> extends _i1.SmartFake implements _i12.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_29 extends _i1.SmartFake
+class _FakeCachedProfileInformation_30 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_29(
+  _FakeCachedProfileInformation_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -359,8 +370,8 @@ class _FakeCachedProfileInformation_29 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_30(
+class _FakeMediaConfig_31 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -369,8 +380,8 @@ class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_31 extends _i1.SmartFake implements _i13.FileResponse {
-  _FakeFileResponse_31(
+class _FakeFileResponse_32 extends _i1.SmartFake implements _i14.FileResponse {
+  _FakeFileResponse_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -379,8 +390,8 @@ class _FakeFileResponse_31 extends _i1.SmartFake implements _i13.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_32(
+class _FakePreviewForUrl_33 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -389,9 +400,9 @@ class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_33 extends _i1.SmartFake
+class _FakeCachedPresence_34 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_33(
+  _FakeCachedPresence_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -400,9 +411,9 @@ class _FakeCachedPresence_33 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_34 extends _i1.SmartFake
+class _FakeTurnServerCredentials_35 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_34(
+  _FakeTurnServerCredentials_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -411,9 +422,9 @@ class _FakeTurnServerCredentials_34 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_35(
+  _FakeRoomKeysUpdateResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -422,8 +433,8 @@ class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_36(
+class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -432,9 +443,9 @@ class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_37(
+  _FakeGetWellknownSupportResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -443,9 +454,9 @@ class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_38(
+  _FakeGenerateLoginTokenResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -454,9 +465,9 @@ class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_39(
+  _FakeGetRoomSummaryResponse$3_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -465,9 +476,9 @@ class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_40(
+  _FakeGetSpaceHierarchyResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -476,9 +487,9 @@ class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_41(
+  _FakeGetRelatingEventsResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -487,9 +498,9 @@ class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_42(
+  _FakeGetRelatingEventsWithRelTypeResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -498,9 +509,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -509,9 +520,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_44(
+  _FakeGetThreadRootsResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -520,9 +531,9 @@ class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_45(
+  _FakeGetEventByTimestampResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -531,9 +542,9 @@ class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_46 extends _i1.SmartFake
+class _FakeRequestTokenResponse_47 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_46(
+  _FakeRequestTokenResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -542,9 +553,9 @@ class _FakeRequestTokenResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_47(
+  _FakeTokenOwnerInfo_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -553,8 +564,8 @@ class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_48(
+class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -563,8 +574,8 @@ class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_49(
+class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -573,8 +584,8 @@ class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_50(
+class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -583,9 +594,9 @@ class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_51(
+  _FakeGetRoomIdByAliasResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -594,9 +605,9 @@ class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_52 extends _i1.SmartFake
+class _FakeGetEventsResponse_53 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_52(
+  _FakeGetEventsResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -605,9 +616,9 @@ class _FakeGetEventsResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_53 extends _i1.SmartFake
+class _FakePeekEventsResponse_54 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_53(
+  _FakePeekEventsResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -616,8 +627,8 @@ class _FakePeekEventsResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_54(
+class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -626,9 +637,9 @@ class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_55(
+  _FakeGetKeysChangesResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -637,9 +648,9 @@ class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_56 extends _i1.SmartFake
+class _FakeClaimKeysResponse_57 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_56(
+  _FakeClaimKeysResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -648,9 +659,9 @@ class _FakeClaimKeysResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_57 extends _i1.SmartFake
+class _FakeQueryKeysResponse_58 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_57(
+  _FakeQueryKeysResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -659,9 +670,9 @@ class _FakeQueryKeysResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_58(
+  _FakeGetNotificationsResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -670,9 +681,9 @@ class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_59 extends _i1.SmartFake
+class _FakeGetPresenceResponse_60 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_59(
+  _FakeGetPresenceResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -681,9 +692,9 @@ class _FakeGetPresenceResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_60(
+  _FakeGetPublicRoomsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -692,9 +703,9 @@ class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_61(
+  _FakeQueryPublicRoomsResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -703,8 +714,8 @@ class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_62(
+class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -713,9 +724,9 @@ class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_63(
+  _FakeGetPushRulesGlobalResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -724,8 +735,8 @@ class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_64(
+class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -734,9 +745,9 @@ class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_65 extends _i1.SmartFake
+class _FakeRefreshResponse_66 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_65(
+  _FakeRefreshResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -745,8 +756,8 @@ class _FakeRefreshResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_66(
+class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -755,8 +766,8 @@ class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_67(
+class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -765,9 +776,9 @@ class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_68(
+  _FakeGetRoomKeysVersionCurrentResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -776,9 +787,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_69(
+  _FakeGetRoomKeysVersionResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -787,8 +798,8 @@ class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_70(
+class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -797,9 +808,9 @@ class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_71(
+  _FakeGetRoomEventsResponse_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,8 +819,8 @@ class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_72(
+class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -818,9 +829,9 @@ class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_73(
+  _FakeGetProtocolMetadataResponse$2_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,9 +840,9 @@ class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_74 extends _i1.SmartFake
+class _FakeOpenIdCredentials_75 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_74(
+  _FakeOpenIdCredentials_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -840,9 +851,9 @@ class _FakeOpenIdCredentials_74 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_75(
+  _FakeSearchUserDirectoryResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -851,9 +862,9 @@ class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_76 extends _i1.SmartFake
+class _FakeCreateContentResponse_77 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_76(
+  _FakeCreateContentResponse_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -865,7 +876,7 @@ class _FakeCreateContentResponse_76 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -895,11 +906,11 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -998,6 +1009,19 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as _i9.AuthService);
 
   @override
+  _i10.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i10.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -1077,6 +1101,15 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
+  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -1084,14 +1117,14 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as bool);
 
   @override
-  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1121,7 +1154,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i16.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1131,18 +1164,18 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<bool> login({
+  _i13.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1157,12 +1190,12 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> completeSsoLogin({
+  _i13.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1175,12 +1208,12 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> completeRegistration(
+  _i13.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1190,32 +1223,32 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1224,7 +1257,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1233,17 +1266,17 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i17.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1254,7 +1287,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i17.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1291,26 +1324,26 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> didPushRouteInformation(
-          _i18.RouteInformation? routeInformation) =>
+  _i13.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1340,7 +1373,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i16.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1349,7 +1382,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i16.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1358,16 +1391,16 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<_i16.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i13.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
+            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
-      ) as _i12.Future<_i16.AppExitResponse>);
+            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i13.Future<_i17.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1395,11 +1428,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1429,11 +1462,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_8(
+        returnValue: _FakeRoomSummary_9(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_8(
+        returnValueForMissingStub: _FakeRoomSummary_9(
           this,
           Invocation.getter(#summary),
         ),
@@ -1463,11 +1496,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i12.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i13.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i12.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i12.Completer<dynamic>>[],
-      ) as List<_i12.Completer<dynamic>>);
+        returnValue: <_i13.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i13.Completer<dynamic>>[],
+      ) as List<_i13.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1486,51 +1519,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i10.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i11.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i10.CachedStreamController<String> get onSessionKeyReceived =>
+  _i11.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1546,11 +1579,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1559,11 +1592,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1606,11 +1639,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1619,11 +1652,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_10(
+        returnValue: _FakeDateTime_11(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_10(
+        returnValueForMissingStub: _FakeDateTime_11(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1653,11 +1686,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_11(
+        returnValue: _FakeLatestReceiptState_12(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_11(
+        returnValueForMissingStub: _FakeLatestReceiptState_12(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1678,18 +1711,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i12.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i13.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -1869,18 +1902,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i19.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i19.SpaceParent>[],
-        returnValueForMissingStub: <_i19.SpaceParent>[],
-      ) as List<_i19.SpaceParent>);
+        returnValue: <_i20.SpaceParent>[],
+        returnValueForMissingStub: <_i20.SpaceParent>[],
+      ) as List<_i20.SpaceParent>);
 
   @override
-  List<_i19.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i19.SpaceChild>[],
-        returnValueForMissingStub: <_i19.SpaceChild>[],
-      ) as List<_i19.SpaceChild>);
+        returnValue: <_i20.SpaceChild>[],
+        returnValueForMissingStub: <_i20.SpaceChild>[],
+      ) as List<_i20.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -1993,14 +2026,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i12.Future<void> postLoad() => (super.noSuchMethod(
+  _i13.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2028,15 +2061,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i12.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i13.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i12.Future<List<_i4.User>>);
+            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i13.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2047,14 +2080,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2064,18 +2097,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i12.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i13.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Event?> refreshLastEvent(
+  _i13.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2083,9 +2116,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2097,12 +2130,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i12.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i13.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2110,22 +2143,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i13.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2133,17 +2166,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> addTag(
+  _i13.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2153,27 +2186,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i13.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i13.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2181,43 +2214,43 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i13.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i13.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i13.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2225,14 +2258,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2244,7 +2277,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i12.Future<String?> sendTextEvent(
+  _i13.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2276,12 +2309,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendReaction(
+  _i13.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2295,12 +2328,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendLocation(
+  _i13.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2314,12 +2347,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendFileEvent(
+  _i13.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2347,25 +2380,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i13.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i12.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i13.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i12.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i13.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i12.Future<_i4.EncryptionHealthState>);
+      ) as _i13.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i12.Future<String?> sendEvent(
+  _i13.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2389,73 +2422,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i13.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> leave() => (super.noSuchMethod(
+  _i13.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> forget() => (super.noSuchMethod(
+  _i13.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> setPower(
+  _i13.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2467,7 +2500,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2478,7 +2511,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2488,10 +2521,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> invite(
+  _i13.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2501,12 +2534,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<int> requestHistory({
+  _i13.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2523,32 +2556,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<int>.value(0),
-        returnValueForMissingStub: _i12.Future<int>.value(0),
-      ) as _i12.Future<int>);
+        returnValue: _i13.Future<int>.value(0),
+        returnValueForMissingStub: _i13.Future<int>.value(0),
+      ) as _i13.Future<int>);
 
   @override
-  _i12.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i13.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setReadMarker(
+  _i13.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2562,23 +2595,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i20.TimelineChunk?> getEventContext(String? eventId) =>
+  _i13.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i12.Future<_i20.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i12.Future<_i20.TimelineChunk?>.value(),
-      ) as _i12.Future<_i20.TimelineChunk?>);
+        returnValue: _i13.Future<_i21.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i13.Future<_i21.TimelineChunk?>.value(),
+      ) as _i13.Future<_i21.TimelineChunk?>);
 
   @override
-  _i12.Future<void> postReceipt(
+  _i13.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2588,12 +2621,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Timeline> getTimeline({
+  _i13.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2616,7 +2649,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
+        returnValue: _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
           this,
           Invocation.method(
             #getTimeline,
@@ -2633,7 +2666,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
+            _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
           this,
           Invocation.method(
             #getTimeline,
@@ -2649,7 +2682,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Timeline>);
+      ) as _i13.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2668,7 +2701,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i12.Future<List<_i4.User>> requestParticipants([
+  _i13.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2686,10 +2719,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i12.Future<List<_i4.User>>);
+            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i13.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2697,14 +2730,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_14(
+        returnValue: _FakeUser_15(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_14(
+        returnValueForMissingStub: _FakeUser_15(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2720,14 +2753,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_14(
+        returnValue: _FakeUser_15(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_14(
+        returnValueForMissingStub: _FakeUser_15(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2737,7 +2770,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i12.Future<_i4.User?> requestUser(
+  _i13.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2753,19 +2786,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i12.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.User?>.value(),
-      ) as _i12.Future<_i4.User?>);
+        returnValue: _i13.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.User?>.value(),
+      ) as _i13.Future<_i4.User?>);
 
   @override
-  _i12.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i13.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2778,12 +2811,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i12.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i13.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2791,14 +2824,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2821,14 +2854,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i12.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i13.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -2867,18 +2900,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i12.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i13.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEvent(
+  _i13.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -2892,12 +2925,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> setTyping(
+  _i13.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -2907,12 +2940,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setJoinRules(
+  _i13.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -2926,59 +2959,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i13.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setHistoryVisibility(
+  _i13.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i13.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i13.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i12.Future<List<_i4.DeviceKeys>>);
+            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i13.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i12.Future<void> requestSessionKey(
+  _i13.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -2990,12 +3023,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setSpaceChild(
+  _i13.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3011,44 +3044,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i13.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i12.Future<Uri>);
+      ) as _i13.Future<Uri>);
 
   @override
-  _i12.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i13.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<
+  _i13.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3075,21 +3108,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i12.Future<
+        returnValue: _i13.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i12.Future<
+        returnValueForMissingStub: _i13.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i12.Future<
+      ) as _i13.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3104,23 +3137,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_16(
+        returnValue: _FakeDatabaseApi_17(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_16(
+        returnValueForMissingStub: _FakeDatabaseApi_17(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i21.KeyVerificationMethod> get verificationMethods =>
+  Set<_i22.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i21.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i21.KeyVerificationMethod>{},
-      ) as Set<_i21.KeyVerificationMethod>);
+        returnValue: <_i22.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i22.KeyVerificationMethod>{},
+      ) as Set<_i22.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3181,11 +3214,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_17(
+        returnValue: _FakeFilter_18(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_17(
+        returnValueForMissingStub: _FakeFilter_18(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3194,11 +3227,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_18(
+        returnValue: _FakeNativeImplementations_19(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_18(
+        returnValueForMissingStub: _FakeNativeImplementations_19(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3214,11 +3247,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_19(
+        returnValue: _FakeDuration_20(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_19(
+        returnValueForMissingStub: _FakeDuration_20(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3227,11 +3260,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_19(
+        returnValue: _FakeDuration_20(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_19(
+        returnValueForMissingStub: _FakeDuration_20(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3240,11 +3273,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3281,11 +3314,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3315,11 +3348,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3328,11 +3361,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3355,11 +3388,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_20(
+        returnValue: _FakePushruleEvaluator_21(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_20(
+        returnValueForMissingStub: _FakePushruleEvaluator_21(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3380,332 +3413,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i12.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i13.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i10.CachedStreamController<String> get onUserProfileUpdate =>
+  _i11.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i12.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i13.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i12.Future<List<_i4.Room>>);
+            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i13.Future<List<_i4.Room>>);
 
   @override
-  _i10.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i11.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_10<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.EventUpdate>(
+            _FakeCachedStreamController_10<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.EventUpdate>);
+      ) as _i11.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i11.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i11.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onNotification =>
+  _i11.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i11.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i11.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i10.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i11.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i10.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i11.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i10.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i11.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_9<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_10<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.LoginState>(
+            _FakeCachedStreamController_10<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i10.CachedStreamController<_i4.LoginState>);
+      ) as _i11.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i10.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i11.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_9<bool>(
+        returnValue: _FakeCachedStreamController_10<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i10.CachedStreamController<bool>);
+      ) as _i11.CachedStreamController<bool>);
 
   @override
-  _i10.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i11.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_9<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_10<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i10.CachedStreamController<_i4.SdkError>);
+      ) as _i11.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i10.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i11.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_9<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_10<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.SyncUpdate>(
+            _FakeCachedStreamController_10<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i10.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i11.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i11.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i10.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i11.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.Presence> get onPresence =>
+  _i11.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_9<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_10<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i10.CachedStreamController<_i4.Presence>);
+      ) as _i11.CachedStreamController<_i4.Presence>);
 
   @override
-  _i10.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i11.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_9<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_10<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.CachedPresence>(
+            _FakeCachedStreamController_10<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i10.CachedStreamController<_i4.CachedPresence>);
+      ) as _i11.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i10.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i11.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_9<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_10<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.BasicEvent>(
+            _FakeCachedStreamController_10<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i10.CachedStreamController<_i4.BasicEvent>);
+      ) as _i11.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i10.CachedStreamController<_i21.RoomKeyRequest> get onRoomKeyRequest =>
+  _i11.CachedStreamController<_i22.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
+            _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i10.CachedStreamController<_i21.RoomKeyRequest>);
+      ) as _i11.CachedStreamController<_i22.RoomKeyRequest>);
 
   @override
-  _i10.CachedStreamController<_i21.KeyVerification>
+  _i11.CachedStreamController<_i22.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_9<_i21.KeyVerification>(
+            returnValue: _FakeCachedStreamController_10<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_9<_i21.KeyVerification>(
+                _FakeCachedStreamController_10<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i10.CachedStreamController<_i21.KeyVerification>);
+          ) as _i11.CachedStreamController<_i22.KeyVerification>);
 
   @override
-  _i10.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i11.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i10.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i11.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i11.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<String> get onCancelSendEvent =>
+  _i11.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i10.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i11.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_9<
+            returnValue: _FakeCachedStreamController_10<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_9<
+            returnValueForMissingStub: _FakeCachedStreamController_10<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i10.CachedStreamController<
+          ) as _i11.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3725,11 +3758,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_10(
+        returnValue: _FakeDateTime_11(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_10(
+        returnValueForMissingStub: _FakeDateTime_11(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3802,7 +3835,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i21.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i22.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3857,7 +3890,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i12.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i13.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3868,7 +3901,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i12.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i13.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -3979,7 +4012,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -3988,7 +4021,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -3997,7 +4030,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4024,20 +4057,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i11.Client get httpClient => (super.noSuchMethod(
+  _i12.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_22(
+        returnValue: _FakeClient_23(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_22(
+        returnValueForMissingStub: _FakeClient_23(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i11.Client);
+      ) as _i12.Client);
 
   @override
-  set httpClient(_i11.Client? value) => super.noSuchMethod(
+  set httpClient(_i12.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4064,7 +4097,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<void> refreshAccessToken(
+  _i13.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4072,9 +4105,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4092,14 +4125,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4136,33 +4169,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i12.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i13.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i12.Future<_i4.DiscoveryInformation>);
+      ) as _i13.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i12.Future<
+  _i13.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4184,7 +4217,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i12.Future<
+        returnValue: _i13.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4192,7 +4225,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_24(
+          _FakeGetVersionsResponse_25(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4207,7 +4240,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i12.Future<
+        returnValueForMissingStub: _i13.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4215,7 +4248,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_24(
+          _FakeGetVersionsResponse_25(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4230,7 +4263,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i12.Future<
+      ) as _i13.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4239,7 +4272,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i12.Future<_i4.DiscoveryInformation> getWellknown({
+  _i13.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4252,8 +4285,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getWellknown,
@@ -4264,8 +4297,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getWellknown,
@@ -4276,10 +4309,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.DiscoveryInformation>);
+      ) as _i13.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i12.Future<_i4.RegisterResponse> register({
+  _i13.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4307,7 +4340,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
+            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
           this,
           Invocation.method(
             #register,
@@ -4326,7 +4359,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
+            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
           this,
           Invocation.method(
             #register,
@@ -4344,10 +4377,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RegisterResponse>);
+      ) as _i13.Future<_i4.RegisterResponse>);
 
   @override
-  _i12.Future<_i4.LoginResponse> login(
+  _i13.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4377,7 +4410,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
+        returnValue: _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
           this,
           Invocation.method(
             #login,
@@ -4397,7 +4430,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
+            _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
           this,
           Invocation.method(
             #login,
@@ -4416,10 +4449,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.LoginResponse>);
+      ) as _i13.Future<_i4.LoginResponse>);
 
   @override
-  _i12.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i13.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4432,8 +4465,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_27(
+        returnValue: _i13.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_28(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4445,8 +4478,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_27(
+            _i13.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_28(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4457,74 +4490,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i13.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> logoutAll() => (super.noSuchMethod(
+  _i13.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<T> uiaRequestBackground<T>(
-          _i12.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i13.Future<T> uiaRequestBackground<T>(
+          _i13.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i12.Future<T>.value(v),
+              (T v) => _i13.Future<T>.value(v),
             ) ??
-            _FakeFuture_28<T>(
+            _FakeFuture_29<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i12.Future<T>.value(v),
+              (T v) => _i13.Future<T>.value(v),
             ) ??
-            _FakeFuture_28<T>(
+            _FakeFuture_29<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i12.Future<T>);
+      ) as _i13.Future<T>);
 
   @override
-  _i12.Future<String> startDirectChat(
+  _i13.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4546,7 +4579,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4562,7 +4595,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4577,10 +4610,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<String> createGroupChat({
+  _i13.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4611,7 +4644,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4632,7 +4665,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4652,10 +4685,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i13.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4671,7 +4704,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4684,7 +4717,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4696,21 +4729,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i13.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<String> createSpace({
+  _i13.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4735,7 +4768,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4753,7 +4786,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4770,10 +4803,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i13.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4781,7 +4814,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4790,7 +4823,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4798,10 +4831,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i12.Future<_i4.Profile> fetchOwnProfile({
+  _i13.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4814,7 +4847,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4826,7 +4859,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4837,10 +4870,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i12.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i13.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4854,8 +4887,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i12.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_29(
+        returnValue: _i13.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_30(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4867,8 +4900,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_29(
+            _i13.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_30(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4879,10 +4912,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.CachedProfileInformation>);
+      ) as _i13.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i12.Future<_i4.Profile> getProfileFromUserId(
+  _i13.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4900,7 +4933,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4914,7 +4947,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4927,7 +4960,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -4949,31 +4982,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i12.Future<List<_i4.Room>>);
+            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i13.Future<List<_i4.Room>>);
 
   @override
-  _i12.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i13.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i12.Future<List<_i4.ArchivedRoom>>);
+            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i13.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i12.Future<_i4.GetVersionsResponse> getVersions({
+  _i13.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4986,8 +5019,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_24(
+        returnValue: _i13.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_25(
           this,
           Invocation.method(
             #getVersions,
@@ -4998,8 +5031,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_24(
+        returnValueForMissingStub: _i13.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_25(
           this,
           Invocation.method(
             #getVersions,
@@ -5010,20 +5043,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetVersionsResponse>);
+      ) as _i13.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i12.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i13.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<_i4.MediaConfig> getConfig({
+  _i13.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5036,7 +5069,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfig,
@@ -5048,7 +5081,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfig,
@@ -5059,10 +5092,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.MediaConfig>);
+      ) as _i13.Future<_i4.MediaConfig>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContent(
+  _i13.Future<_i14.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5082,7 +5115,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContent,
@@ -5098,7 +5131,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContent,
@@ -5113,10 +5146,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentOverrideName(
+  _i13.Future<_i14.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5138,7 +5171,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5155,7 +5188,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5171,10 +5204,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentThumbnail(
+  _i13.Future<_i14.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5202,7 +5235,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5222,7 +5255,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5241,10 +5274,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i13.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5254,7 +5287,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5263,7 +5296,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5271,11 +5304,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i12.Future<_i4.PreviewForUrl>);
+      ) as _i13.Future<_i4.PreviewForUrl>);
 
   @override
-  _i12.Future<Uri> uploadContent(
-    _i22.Uint8List? file, {
+  _i13.Future<Uri> uploadContent(
+    _i23.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5288,7 +5321,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #uploadContent,
@@ -5299,7 +5332,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #uploadContent,
@@ -5310,10 +5343,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<Uri>);
+      ) as _i13.Future<Uri>);
 
   @override
-  _i12.Future<void> setTyping(
+  _i13.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5329,42 +5362,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> exportDump() => (super.noSuchMethod(
+  _i13.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i13.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i13.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Event?> getEventByPushNotification(
+  _i13.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5380,12 +5413,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
-  _i12.Future<void> init({
+  _i13.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5420,9 +5453,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5434,40 +5467,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<void> clear() => (super.noSuchMethod(
+  _i13.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i13.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ensureNotSoftLoggedOut(
+  _i13.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleSync(
+  _i13.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5477,9 +5510,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5492,29 +5525,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i12.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i13.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i13.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDevice(
+  _i13.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5528,12 +5561,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDevicesOfUserIds(
+  _i13.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5549,12 +5582,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDeviceEncrypted(
+  _i13.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5574,12 +5607,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDeviceEncryptedChunked(
+  _i13.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5593,23 +5626,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i13.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> joinRoom(
+  _i13.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5627,7 +5660,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5641,7 +5674,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5654,10 +5687,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> changePassword(
+  _i13.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5673,22 +5706,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> clearCache() => (super.noSuchMethod(
+  _i13.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ignoreUser(
+  _i13.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5698,22 +5731,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i13.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i13.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5724,7 +5757,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5733,7 +5766,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5741,32 +5774,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i12.Future<_i4.CachedPresence>);
+      ) as _i13.Future<_i4.CachedPresence>);
 
   @override
-  _i12.Future<void> abortSync() => (super.noSuchMethod(
+  _i13.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i13.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEventWithMetadata(
+  _i13.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5786,14 +5819,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i11.BaseResponse? response,
-    _i22.Uint8List? body,
+    _i12.BaseResponse? response,
+    _i23.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5825,7 +5858,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i12.Future<Map<String, Object?>> request(
+  _i13.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -5846,13 +5879,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> postPusher(
+  _i13.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -5862,57 +5895,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i13.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i13.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i13.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i12.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_34(
+        returnValue: _i13.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_35(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_34(
+        returnValueForMissingStub: _i13.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_35(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.TurnServerCredentials>);
+      ) as _i13.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5926,8 +5959,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5939,8 +5972,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5951,10 +5984,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5970,8 +6003,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5984,8 +6017,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5997,10 +6030,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i13.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6014,7 +6047,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6026,7 +6059,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6037,17 +6070,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.KeyBackupData>);
+      ) as _i13.Future<_i4.KeyBackupData>);
 
   @override
-  _i12.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i13.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i12.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_37(
+        returnValue: _i13.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_38(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6055,18 +6088,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_37(
+            _i13.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_38(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i13.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i12.Future<int> pingAppservice(
+  _i13.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6076,12 +6109,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i12.Future<int>.value(0),
-        returnValueForMissingStub: _i12.Future<int>.value(0),
-      ) as _i12.Future<int>);
+        returnValue: _i13.Future<int>.value(0),
+        returnValueForMissingStub: _i13.Future<int>.value(0),
+      ) as _i13.Future<int>);
 
   @override
-  _i12.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i13.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6089,8 +6122,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_38(
+        returnValue: _i13.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_39(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6099,8 +6132,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_38(
+            _i13.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_39(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6108,15 +6141,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i12.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i13.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i12.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i13.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6124,17 +6157,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.MediaConfig>);
+      ) as _i13.Future<_i4.MediaConfig>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentAuthed(
+  _i13.Future<_i14.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6148,7 +6181,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6160,7 +6193,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6171,10 +6204,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentOverrideNameAuthed(
+  _i13.Future<_i14.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6190,7 +6223,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6203,7 +6236,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6215,10 +6248,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i13.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6228,7 +6261,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6237,7 +6270,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6245,10 +6278,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i12.Future<_i4.PreviewForUrl>);
+      ) as _i13.Future<_i4.PreviewForUrl>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentThumbnailAuthed(
+  _i13.Future<_i14.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6272,7 +6305,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6290,7 +6323,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6307,21 +6340,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<bool> registrationTokenValidity(String? token) =>
+  _i13.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i13.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6331,8 +6364,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_39(
+        returnValue: _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_40(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6341,8 +6374,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_39(
+            _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_40(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6350,10 +6383,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i13.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i12.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i13.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6371,8 +6404,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_40(
+        returnValue: _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_41(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6386,8 +6419,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_40(
+            _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_41(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6400,10 +6433,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i13.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i13.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6427,8 +6460,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i12.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_41(
+        returnValue: _i13.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_42(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6446,8 +6479,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_41(
+            _i13.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_42(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6464,10 +6497,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i13.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6495,8 +6528,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_42(
+                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6515,8 +6548,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_42(
+                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6534,10 +6567,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i13.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6566,9 +6599,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i12.Future<
+            returnValue: _i13.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6587,9 +6620,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i12.Future<
+            returnValueForMissingStub: _i13.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6608,11 +6641,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i12
+          ) as _i13
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i12.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i13.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6628,8 +6661,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i12.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_44(
+        returnValue: _i13.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_45(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6642,8 +6675,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_44(
+            _i13.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_45(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6655,10 +6688,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetThreadRootsResponse>);
+      ) as _i13.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i12.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i13.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6672,8 +6705,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i12.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_45(
+        returnValue: _i13.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_46(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6685,8 +6718,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_45(
+            _i13.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_46(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6697,33 +6730,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i13.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i13.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i12.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i13.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i12.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i13.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i12.Future<Uri?>.value(),
-        returnValueForMissingStub: _i12.Future<Uri?>.value(),
-      ) as _i12.Future<Uri?>);
+        returnValue: _i13.Future<Uri?>.value(),
+        returnValueForMissingStub: _i13.Future<Uri?>.value(),
+      ) as _i13.Future<Uri?>);
 
   @override
-  _i12.Future<void> add3PID(
+  _i13.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6737,12 +6770,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> bind3PID(
+  _i13.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6758,12 +6791,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i13.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6777,14 +6810,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6806,8 +6839,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6823,8 +6856,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6840,10 +6873,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6867,8 +6900,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6885,8 +6918,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6903,10 +6936,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i13.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6920,14 +6953,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i13.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -6942,14 +6975,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6971,8 +7004,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -6988,8 +7021,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7005,10 +7038,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7032,8 +7065,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7050,8 +7083,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7068,16 +7101,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i13.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
+            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7085,22 +7118,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
+            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.TokenOwnerInfo>);
+      ) as _i13.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i12.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i13.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
+        returnValue: _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7108,22 +7141,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
+            _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i4.WhoIsInfo>);
+      ) as _i13.Future<_i4.WhoIsInfo>);
 
   @override
-  _i12.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i13.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
+        returnValue: _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7131,17 +7164,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
+            _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.Capabilities>);
+      ) as _i13.Future<_i4.Capabilities>);
 
   @override
-  _i12.Future<String> createRoom({
+  _i13.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7174,7 +7207,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7196,7 +7229,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7217,10 +7250,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> deleteDevices(
+  _i13.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7230,22 +7263,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.Device>?>.value(),
-      ) as _i12.Future<List<_i4.Device>?>);
+        returnValue: _i13.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.Device>?>.value(),
+      ) as _i13.Future<List<_i4.Device>?>);
 
   @override
-  _i12.Future<void> deleteDevice(
+  _i13.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7255,34 +7288,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i13.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i12.Future<_i4.Device>.value(_FakeDevice_50(
+        returnValue: _i13.Future<_i4.Device>.value(_FakeDevice_51(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.Device>.value(_FakeDevice_50(
+        returnValueForMissingStub: _i13.Future<_i4.Device>.value(_FakeDevice_51(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i12.Future<_i4.Device>);
+      ) as _i13.Future<_i4.Device>);
 
   @override
-  _i12.Future<void> updateDevice(
+  _i13.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7292,12 +7325,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i13.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7312,24 +7345,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i13.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i12.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Visibility?>.value(),
-      ) as _i12.Future<_i4.Visibility?>);
+        returnValue: _i13.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Visibility?>.value(),
+      ) as _i13.Future<_i4.Visibility?>);
 
   @override
-  _i12.Future<void> setRoomVisibilityOnDirectory(
+  _i13.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7339,30 +7372,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i13.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i13.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_51(
+        returnValue: _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_52(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7370,18 +7403,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_51(
+            _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_52(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i13.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i12.Future<void> setRoomAlias(
+  _i13.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7393,12 +7426,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetEventsResponse> getEvents({
+  _i13.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7412,7 +7445,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
+            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
           this,
           Invocation.method(
             #getEvents,
@@ -7424,7 +7457,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
+            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
           this,
           Invocation.method(
             #getEvents,
@@ -7435,10 +7468,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetEventsResponse>);
+      ) as _i13.Future<_i4.GetEventsResponse>);
 
   @override
-  _i12.Future<_i4.PeekEventsResponse> peekEvents({
+  _i13.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7453,8 +7486,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i12.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_53(
+        returnValue: _i13.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_54(
           this,
           Invocation.method(
             #peekEvents,
@@ -7466,8 +7499,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_53(
+        returnValueForMissingStub: _i13.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_54(
           this,
           Invocation.method(
             #peekEvents,
@@ -7479,16 +7512,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.PeekEventsResponse>);
+      ) as _i13.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i12.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i13.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7496,27 +7529,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i12.Future<_i4.MatrixEvent>);
+      ) as _i13.Future<_i4.MatrixEvent>);
 
   @override
-  _i12.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i13.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i12.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
-      ) as _i12.Future<List<String>>);
+        returnValue: _i13.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
+      ) as _i13.Future<List<String>>);
 
   @override
-  _i12.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i13.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7528,8 +7561,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i12.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_55(
+        returnValue: _i13.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_56(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7540,8 +7573,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_55(
+            _i13.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_56(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7551,10 +7584,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.GetKeysChangesResponse>);
+      ) as _i13.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i12.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i13.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7565,7 +7598,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
+            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
           this,
           Invocation.method(
             #claimKeys,
@@ -7574,7 +7607,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
+            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
           this,
           Invocation.method(
             #claimKeys,
@@ -7582,10 +7615,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i12.Future<_i4.ClaimKeysResponse>);
+      ) as _i13.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i12.Future<void> uploadCrossSigningKeys({
+  _i13.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7602,12 +7635,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.QueryKeysResponse> queryKeys(
+  _i13.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7618,7 +7651,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
+            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
           this,
           Invocation.method(
             #queryKeys,
@@ -7627,7 +7660,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
+            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
           this,
           Invocation.method(
             #queryKeys,
@@ -7635,10 +7668,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i12.Future<_i4.QueryKeysResponse>);
+      ) as _i13.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7646,14 +7679,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i12.Future<
+            returnValue: _i13.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i12.Future<
+            returnValueForMissingStub: _i13.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i12.Future<Map<String, int>> uploadKeys({
+  _i13.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7668,13 +7701,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i12.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i13.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i12.Future<Map<String, int>>);
+            _i13.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i13.Future<Map<String, int>>);
 
   @override
-  _i12.Future<String> knockRoom(
+  _i13.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7688,7 +7721,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7700,7 +7733,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7711,20 +7744,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i13.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i12.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i13.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i13.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i12.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i13.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7739,8 +7772,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i12.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_58(
+        returnValue: _i13.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_59(
           this,
           Invocation.method(
             #getNotifications,
@@ -7753,8 +7786,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_58(
+            _i13.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_59(
           this,
           Invocation.method(
             #getNotifications,
@@ -7766,35 +7799,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetNotificationsResponse>);
+      ) as _i13.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i12.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i13.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i12.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_59(
+        returnValue: _i13.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_60(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_59(
+        returnValueForMissingStub: _i13.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_60(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i4.GetPresenceResponse>);
+      ) as _i13.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i12.Future<void> setPresence(
+  _i13.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -7808,12 +7841,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, Object?>> deleteProfileField(
+  _i13.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7826,13 +7859,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getProfileField(
+  _i13.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7845,13 +7878,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<Map<String, Object?>> setProfileField(
+  _i13.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7866,13 +7899,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i13.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7887,8 +7920,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i12.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_60(
+        returnValue: _i13.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_61(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7901,8 +7934,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_60(
+            _i13.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_61(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7914,10 +7947,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i13.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i12.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i13.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -7938,8 +7971,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i12.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_61(
+        returnValue: _i13.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_62(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7955,8 +7988,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_61(
+            _i13.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_62(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7971,25 +8004,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i13.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i12.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.Pusher>?>.value(),
-      ) as _i12.Future<List<_i4.Pusher>?>);
+        returnValue: _i13.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.Pusher>?>.value(),
+      ) as _i13.Future<List<_i4.Pusher>?>);
 
   @override
-  _i12.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i13.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
+        returnValue: _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
           this,
           Invocation.method(
             #getPushRules,
@@ -7997,24 +8030,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
+            _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.PushRuleSet>);
+      ) as _i13.Future<_i4.PushRuleSet>);
 
   @override
-  _i12.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i13.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_63(
+        returnValue: _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_64(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8022,18 +8055,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_63(
+            _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_64(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i13.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i12.Future<void> deletePushRule(
+  _i13.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8045,12 +8078,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.PushRule> getPushRule(
+  _i13.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8062,7 +8095,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
+        returnValue: _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
           this,
           Invocation.method(
             #getPushRule,
@@ -8073,7 +8106,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
+            _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
           this,
           Invocation.method(
             #getPushRule,
@@ -8083,10 +8116,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.PushRule>);
+      ) as _i13.Future<_i4.PushRule>);
 
   @override
-  _i12.Future<void> setPushRule(
+  _i13.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8110,12 +8143,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<Object?>> getPushRuleActions(
+  _i13.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8127,13 +8160,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i13.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i12.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i12.Future<List<Object?>>);
+            _i13.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i13.Future<List<Object?>>);
 
   @override
-  _i12.Future<void> setPushRuleActions(
+  _i13.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8147,12 +8180,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<bool> isPushRuleEnabled(
+  _i13.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8164,12 +8197,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> setPushRuleEnabled(
+  _i13.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8183,19 +8216,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i13.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
+            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
           this,
           Invocation.method(
             #refresh,
@@ -8203,28 +8236,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
+            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i12.Future<_i4.RefreshResponse>);
+      ) as _i13.Future<_i4.RefreshResponse>);
 
   @override
-  _i12.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i13.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i12.Future<bool?>.value(),
-        returnValueForMissingStub: _i12.Future<bool?>.value(),
-      ) as _i12.Future<bool?>);
+        returnValue: _i13.Future<bool?>.value(),
+        returnValueForMissingStub: _i13.Future<bool?>.value(),
+      ) as _i13.Future<bool?>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8246,8 +8279,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8263,8 +8296,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8280,10 +8313,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8307,8 +8340,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8325,8 +8358,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8343,17 +8376,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8361,23 +8394,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i13.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
+        returnValue: _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8385,17 +8418,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
+            _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeys>);
+      ) as _i13.Future<_i4.RoomKeys>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8407,8 +8440,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8419,8 +8452,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8430,10 +8463,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8445,8 +8478,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8457,8 +8490,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8468,10 +8501,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8483,7 +8516,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
+        returnValue: _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8494,7 +8527,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
+            _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8504,10 +8537,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeyBackup>);
+      ) as _i13.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8521,8 +8554,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8534,8 +8567,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8546,10 +8579,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8563,8 +8596,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8576,8 +8609,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8588,10 +8621,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i13.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8605,7 +8638,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8617,7 +8650,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8628,10 +8661,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.KeyBackupData>);
+      ) as _i13.Future<_i4.KeyBackupData>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8647,8 +8680,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8661,8 +8694,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8674,18 +8707,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_68(
+                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_69(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8693,18 +8726,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_68(
+                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_69(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i12.Future<String> postRoomKeysVersion(
+  _i13.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8716,7 +8749,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8727,7 +8760,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8737,29 +8770,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i13.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i13.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_69(
+        returnValue: _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_70(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8767,18 +8800,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_69(
+            _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_70(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i13.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i13.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8793,24 +8826,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i13.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i12.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
-      ) as _i12.Future<List<String>>);
+        returnValue: _i13.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
+      ) as _i13.Future<List<String>>);
 
   @override
-  _i12.Future<void> ban(
+  _i13.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8824,12 +8857,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.EventContext> getEventContext(
+  _i13.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8847,7 +8880,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
+        returnValue: _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
           this,
           Invocation.method(
             #getEventContext,
@@ -8862,7 +8895,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
+            _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
           this,
           Invocation.method(
             #getEventContext,
@@ -8876,10 +8909,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.EventContext>);
+      ) as _i13.Future<_i4.EventContext>);
 
   @override
-  _i12.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i13.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8891,7 +8924,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8902,7 +8935,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8912,20 +8945,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.MatrixEvent>);
+      ) as _i13.Future<_i4.MatrixEvent>);
 
   @override
-  _i12.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i13.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> inviteBy3PID(
+  _i13.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -8937,12 +8970,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> inviteUser(
+  _i13.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8956,12 +8989,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> joinRoomById(
+  _i13.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -8975,7 +9008,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8987,7 +9020,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8998,23 +9031,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i13.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i12.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i13.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i12.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i12.Future<Map<String, _i4.RoomMember>?>);
+            _i13.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i13.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i12.Future<void> kick(
+  _i13.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9028,12 +9061,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> leaveRoom(
+  _i13.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9043,12 +9076,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i13.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9064,12 +9097,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i12.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i12.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i13.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i13.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i12.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i13.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9091,8 +9124,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_71(
+        returnValue: _i13.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_72(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9108,8 +9141,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_71(
+        returnValueForMissingStub: _i13.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_72(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9125,10 +9158,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomEventsResponse>);
+      ) as _i13.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i12.Future<void> setReadMarker(
+  _i13.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9144,12 +9177,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> postReceipt(
+  _i13.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9165,12 +9198,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEvent(
+  _i13.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9186,12 +9219,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> reportRoom(
+  _i13.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9203,12 +9236,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> reportEvent(
+  _i13.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9226,12 +9259,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> sendMessage(
+  _i13.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9247,7 +9280,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9260,7 +9293,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9272,23 +9305,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i13.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i12.Future<List<_i4.MatrixEvent>>);
+            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i13.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i13.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9305,13 +9338,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<String> setRoomStateWithKey(
+  _i13.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9327,7 +9360,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9340,7 +9373,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9352,10 +9385,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> unban(
+  _i13.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9369,12 +9402,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> upgradeRoom(
+  _i13.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9388,7 +9421,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9400,7 +9433,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9411,10 +9444,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.SearchResults> search(
+  _i13.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9424,7 +9457,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
+        returnValue: _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
           this,
           Invocation.method(
             #search,
@@ -9433,7 +9466,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
+            _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
           this,
           Invocation.method(
             #search,
@@ -9441,10 +9474,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i12.Future<_i4.SearchResults>);
+      ) as _i13.Future<_i4.SearchResults>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> sync({
+  _i13.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9465,7 +9498,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #sync,
@@ -9481,7 +9514,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #sync,
@@ -9496,22 +9529,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i13.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i12.Future<List<_i4.Location>>);
+            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i13.Future<List<_i4.Location>>);
 
   @override
-  _i12.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i13.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9521,21 +9554,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i12.Future<List<_i4.Location>>);
+            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i13.Future<List<_i4.Location>>);
 
   @override
-  _i12.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i13.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_73(
+        returnValue: _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_74(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9543,45 +9576,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_73(
+            _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_74(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i12.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i13.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i12.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i13.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9592,13 +9625,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getAccountData(
+  _i13.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9611,13 +9644,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> setAccountData(
+  _i13.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9631,12 +9664,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> defineFilter(
+  _i13.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9648,7 +9681,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9659,7 +9692,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9669,10 +9702,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.Filter> getFilter(
+  _i13.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9684,7 +9717,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
+        returnValue: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
           this,
           Invocation.method(
             #getFilter,
@@ -9694,7 +9727,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
+        returnValueForMissingStub: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
           this,
           Invocation.method(
             #getFilter,
@@ -9704,10 +9737,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.Filter>);
+      ) as _i13.Future<_i4.Filter>);
 
   @override
-  _i12.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i13.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9720,7 +9753,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
+            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9731,7 +9764,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
+            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9741,10 +9774,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.OpenIdCredentials>);
+      ) as _i13.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i12.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i13.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9759,13 +9792,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> setAccountDataPerRoom(
+  _i13.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9781,12 +9814,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i13.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9798,12 +9831,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i12.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i12.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i12.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i13.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i13.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i13.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i12.Future<void> deleteRoomTag(
+  _i13.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9817,12 +9850,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setRoomTag(
+  _i13.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9838,12 +9871,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i13.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9853,8 +9886,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i12.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_75(
+        returnValue: _i13.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_76(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9863,8 +9896,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_75(
+            _i13.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_76(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9872,10 +9905,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i12.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i13.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> reportUser(
+  _i13.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9888,40 +9921,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i13.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i12.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_76(
+        returnValue: _i13.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_77(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_76(
+        returnValueForMissingStub: _i13.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_77(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.CreateContentResponse>);
+      ) as _i13.Future<_i4.CreateContentResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> uploadContentToMXC(
+  _i13.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i22.Uint8List? body, {
+    _i23.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -9939,8 +9972,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 }

--- a/test/widgets/bootstrap_controller_test.mocks.dart
+++ b/test/widgets/bootstrap_controller_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i19;
-import 'dart:ui' as _i21;
+import 'dart:typed_data' as _i20;
+import 'dart:ui' as _i22;
 
-import 'package:flutter/services.dart' as _i22;
-import 'package:flutter/widgets.dart' as _i23;
+import 'package:flutter/services.dart' as _i23;
+import 'package:flutter/widgets.dart' as _i24;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/matrix_service.dart' as _i21;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,15 +23,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i14;
-import 'package:matrix/encryption/cross_signing.dart' as _i17;
-import 'package:matrix/encryption/key_verification_manager.dart' as _i16;
-import 'package:matrix/encryption/olm_manager.dart' as _i15;
+import 'package:matrix/encryption.dart' as _i15;
+import 'package:matrix/encryption/cross_signing.dart' as _i18;
+import 'package:matrix/encryption/key_verification_manager.dart' as _i17;
+import 'package:matrix/encryption/olm_manager.dart' as _i16;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i18;
+import 'package:mockito/src/dummies.dart' as _i19;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -822,8 +823,9 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeKeyManager_73 extends _i1.SmartFake implements _i14.KeyManager {
-  _FakeKeyManager_73(
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -832,8 +834,8 @@ class _FakeKeyManager_73 extends _i1.SmartFake implements _i14.KeyManager {
         );
 }
 
-class _FakeOlmManager_74 extends _i1.SmartFake implements _i15.OlmManager {
-  _FakeOlmManager_74(
+class _FakeKeyManager_74 extends _i1.SmartFake implements _i15.KeyManager {
+  _FakeKeyManager_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,9 +844,8 @@ class _FakeOlmManager_74 extends _i1.SmartFake implements _i15.OlmManager {
         );
 }
 
-class _FakeKeyVerificationManager_75 extends _i1.SmartFake
-    implements _i16.KeyVerificationManager {
-  _FakeKeyVerificationManager_75(
+class _FakeOlmManager_75 extends _i1.SmartFake implements _i16.OlmManager {
+  _FakeOlmManager_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -853,8 +854,9 @@ class _FakeKeyVerificationManager_75 extends _i1.SmartFake
         );
 }
 
-class _FakeCrossSigning_76 extends _i1.SmartFake implements _i17.CrossSigning {
-  _FakeCrossSigning_76(
+class _FakeKeyVerificationManager_76 extends _i1.SmartFake
+    implements _i17.KeyVerificationManager {
+  _FakeKeyVerificationManager_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -863,8 +865,8 @@ class _FakeCrossSigning_76 extends _i1.SmartFake implements _i17.CrossSigning {
         );
 }
 
-class _FakeSSSS_77 extends _i1.SmartFake implements _i14.SSSS {
-  _FakeSSSS_77(
+class _FakeCrossSigning_77 extends _i1.SmartFake implements _i18.CrossSigning {
+  _FakeCrossSigning_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -873,8 +875,8 @@ class _FakeSSSS_77 extends _i1.SmartFake implements _i14.SSSS {
         );
 }
 
-class _FakeBootstrap_78 extends _i1.SmartFake implements _i14.Bootstrap {
-  _FakeBootstrap_78(
+class _FakeSSSS_78 extends _i1.SmartFake implements _i15.SSSS {
+  _FakeSSSS_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -883,8 +885,8 @@ class _FakeBootstrap_78 extends _i1.SmartFake implements _i14.Bootstrap {
         );
 }
 
-class _FakeToDeviceEvent_79 extends _i1.SmartFake implements _i2.ToDeviceEvent {
-  _FakeToDeviceEvent_79(
+class _FakeBootstrap_79 extends _i1.SmartFake implements _i15.Bootstrap {
+  _FakeBootstrap_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -893,8 +895,8 @@ class _FakeToDeviceEvent_79 extends _i1.SmartFake implements _i2.ToDeviceEvent {
         );
 }
 
-class _FakeEvent_80 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_80(
+class _FakeToDeviceEvent_80 extends _i1.SmartFake implements _i2.ToDeviceEvent {
+  _FakeToDeviceEvent_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -903,8 +905,8 @@ class _FakeEvent_80 extends _i1.SmartFake implements _i2.Event {
         );
 }
 
-class _FakeEncryption_81 extends _i1.SmartFake implements _i14.Encryption {
-  _FakeEncryption_81(
+class _FakeEvent_81 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -913,9 +915,19 @@ class _FakeEncryption_81 extends _i1.SmartFake implements _i14.Encryption {
         );
 }
 
-class _FakeSecretStorageKeyContent_82 extends _i1.SmartFake
+class _FakeEncryption_82 extends _i1.SmartFake implements _i15.Encryption {
+  _FakeEncryption_82(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeSecretStorageKeyContent_83 extends _i1.SmartFake
     implements _i2.SecretStorageKeyContent {
-  _FakeSecretStorageKeyContent_82(
+  _FakeSecretStorageKeyContent_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -942,12 +954,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1067,11 +1079,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1108,11 +1120,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1142,11 +1154,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1155,11 +1167,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1445,34 +1457,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1628,7 +1640,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1917,14 +1929,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2312,8 +2324,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValue: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2329,8 +2341,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2371,7 +2383,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2387,7 +2399,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2436,7 +2448,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2457,7 +2469,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2560,7 +2572,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2578,7 +2590,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3097,7 +3109,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i19.Uint8List? file, {
+    _i20.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3449,7 +3461,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3463,7 +3475,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3614,7 +3626,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i19.Uint8List? body,
+    _i20.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4992,7 +5004,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5014,7 +5026,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5508,7 +5520,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5520,7 +5532,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6528,7 +6540,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6539,7 +6551,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6787,7 +6799,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6799,7 +6811,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7059,7 +7071,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7072,7 +7084,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7139,7 +7151,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7152,7 +7164,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7200,7 +7212,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7212,7 +7224,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7460,7 +7472,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7471,7 +7483,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7733,7 +7745,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i19.Uint8List? body, {
+    _i20.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7760,7 +7772,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7790,11 +7802,11 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7893,6 +7905,19 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7972,6 +7997,15 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -8016,7 +8050,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8110,7 +8144,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8119,7 +8153,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8138,7 +8172,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8149,7 +8183,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8197,7 +8231,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i23.RouteInformation? routeInformation) =>
+          _i24.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8235,7 +8269,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8244,7 +8278,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8253,16 +8287,16 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
-      ) as _i5.Future<_i21.AppExitResponse>);
+            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+      ) as _i5.Future<_i22.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8319,6 +8353,25 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> refreshOnResume() => (super.noSuchMethod(
+        Invocation.method(
+          #refreshOnResume,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> disableChatBackup() => (super.noSuchMethod(
         Invocation.method(
           #disableChatBackup,
@@ -8348,7 +8401,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> runKeyRecovery({_i14.OpenSSSS? ssssKey}) =>
+  _i5.Future<void> runKeyRecovery({_i15.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
@@ -8402,7 +8455,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8411,19 +8464,10 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       );
 
   @override
-  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -8441,7 +8485,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
 /// A class which mocks [Encryption].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEncryption extends _i1.Mock implements _i14.Encryption {
+class MockEncryption extends _i1.Mock implements _i15.Encryption {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -8470,85 +8514,85 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       ) as bool);
 
   @override
-  _i14.KeyManager get keyManager => (super.noSuchMethod(
+  _i15.KeyManager get keyManager => (super.noSuchMethod(
         Invocation.getter(#keyManager),
-        returnValue: _FakeKeyManager_73(
+        returnValue: _FakeKeyManager_74(
           this,
           Invocation.getter(#keyManager),
         ),
-        returnValueForMissingStub: _FakeKeyManager_73(
+        returnValueForMissingStub: _FakeKeyManager_74(
           this,
           Invocation.getter(#keyManager),
         ),
-      ) as _i14.KeyManager);
+      ) as _i15.KeyManager);
 
   @override
-  _i15.OlmManager get olmManager => (super.noSuchMethod(
+  _i16.OlmManager get olmManager => (super.noSuchMethod(
         Invocation.getter(#olmManager),
-        returnValue: _FakeOlmManager_74(
+        returnValue: _FakeOlmManager_75(
           this,
           Invocation.getter(#olmManager),
         ),
-        returnValueForMissingStub: _FakeOlmManager_74(
+        returnValueForMissingStub: _FakeOlmManager_75(
           this,
           Invocation.getter(#olmManager),
         ),
-      ) as _i15.OlmManager);
+      ) as _i16.OlmManager);
 
   @override
-  _i16.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
+  _i17.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
         Invocation.getter(#keyVerificationManager),
-        returnValue: _FakeKeyVerificationManager_75(
+        returnValue: _FakeKeyVerificationManager_76(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-        returnValueForMissingStub: _FakeKeyVerificationManager_75(
+        returnValueForMissingStub: _FakeKeyVerificationManager_76(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-      ) as _i16.KeyVerificationManager);
+      ) as _i17.KeyVerificationManager);
 
   @override
-  _i17.CrossSigning get crossSigning => (super.noSuchMethod(
+  _i18.CrossSigning get crossSigning => (super.noSuchMethod(
         Invocation.getter(#crossSigning),
-        returnValue: _FakeCrossSigning_76(
+        returnValue: _FakeCrossSigning_77(
           this,
           Invocation.getter(#crossSigning),
         ),
-        returnValueForMissingStub: _FakeCrossSigning_76(
+        returnValueForMissingStub: _FakeCrossSigning_77(
           this,
           Invocation.getter(#crossSigning),
         ),
-      ) as _i17.CrossSigning);
+      ) as _i18.CrossSigning);
 
   @override
-  _i14.SSSS get ssss => (super.noSuchMethod(
+  _i15.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_77(
+        returnValue: _FakeSSSS_78(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_77(
+        returnValueForMissingStub: _FakeSSSS_78(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i14.SSSS);
+      ) as _i15.SSSS);
 
   @override
   String get ourDeviceId => (super.noSuchMethod(
         Invocation.getter(#ourDeviceId),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
       ) as String);
 
   @override
-  set keyManager(_i14.KeyManager? value) => super.noSuchMethod(
+  set keyManager(_i15.KeyManager? value) => super.noSuchMethod(
         Invocation.setter(
           #keyManager,
           value,
@@ -8557,7 +8601,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       );
 
   @override
-  set olmManager(_i15.OlmManager? value) => super.noSuchMethod(
+  set olmManager(_i16.OlmManager? value) => super.noSuchMethod(
         Invocation.setter(
           #olmManager,
           value,
@@ -8566,7 +8610,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       );
 
   @override
-  set keyVerificationManager(_i16.KeyVerificationManager? value) =>
+  set keyVerificationManager(_i17.KeyVerificationManager? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #keyVerificationManager,
@@ -8576,7 +8620,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       );
 
   @override
-  set crossSigning(_i17.CrossSigning? value) => super.noSuchMethod(
+  set crossSigning(_i18.CrossSigning? value) => super.noSuchMethod(
         Invocation.setter(
           #crossSigning,
           value,
@@ -8585,7 +8629,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       );
 
   @override
-  set ssss(_i14.SSSS? value) => super.noSuchMethod(
+  set ssss(_i15.SSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #ssss,
           value,
@@ -8624,14 +8668,14 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       ) as _i5.Future<void>);
 
   @override
-  _i14.Bootstrap bootstrap({void Function(_i14.Bootstrap)? onUpdate}) =>
+  _i15.Bootstrap bootstrap({void Function(_i15.Bootstrap)? onUpdate}) =>
       (super.noSuchMethod(
         Invocation.method(
           #bootstrap,
           [],
           {#onUpdate: onUpdate},
         ),
-        returnValue: _FakeBootstrap_78(
+        returnValue: _FakeBootstrap_79(
           this,
           Invocation.method(
             #bootstrap,
@@ -8639,7 +8683,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-        returnValueForMissingStub: _FakeBootstrap_78(
+        returnValueForMissingStub: _FakeBootstrap_79(
           this,
           Invocation.method(
             #bootstrap,
@@ -8647,7 +8691,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-      ) as _i14.Bootstrap);
+      ) as _i15.Bootstrap);
 
   @override
   void handleDeviceOneTimeKeysCount(
@@ -8710,7 +8754,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
           #decryptToDeviceEvent,
           [event],
         ),
-        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_79(
+        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_80(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8718,7 +8762,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_79(
+            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_80(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8733,14 +8777,14 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
           #decryptRoomEventSync,
           [event],
         ),
-        returnValue: _FakeEvent_80(
+        returnValue: _FakeEvent_81(
           this,
           Invocation.method(
             #decryptRoomEventSync,
             [event],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_80(
+        returnValueForMissingStub: _FakeEvent_81(
           this,
           Invocation.method(
             #decryptRoomEventSync,
@@ -8764,7 +8808,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
             #updateType: updateType,
           },
         ),
-        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_80(
+        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_81(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -8775,7 +8819,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
             },
           ),
         )),
-        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_80(
+        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_81(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -8857,19 +8901,19 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
 /// A class which mocks [Bootstrap].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
+class MockBootstrap extends _i1.Mock implements _i15.Bootstrap {
   @override
-  _i14.Encryption get encryption => (super.noSuchMethod(
+  _i15.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_81(
+        returnValue: _FakeEncryption_82(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_81(
+        returnValueForMissingStub: _FakeEncryption_82(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i14.Encryption);
+      ) as _i15.Encryption);
 
   @override
   _i2.Client get client => (super.noSuchMethod(
@@ -8885,14 +8929,14 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
       ) as _i2.Client);
 
   @override
-  _i14.BootstrapState get state => (super.noSuchMethod(
+  _i15.BootstrapState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i14.BootstrapState.loading,
-        returnValueForMissingStub: _i14.BootstrapState.loading,
-      ) as _i14.BootstrapState);
+        returnValue: _i15.BootstrapState.loading,
+        returnValueForMissingStub: _i15.BootstrapState.loading,
+      ) as _i15.BootstrapState);
 
   @override
-  set onUpdate(void Function(_i14.Bootstrap)? value) => super.noSuchMethod(
+  set onUpdate(void Function(_i15.Bootstrap)? value) => super.noSuchMethod(
         Invocation.setter(
           #onUpdate,
           value,
@@ -8901,7 +8945,7 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
       );
 
   @override
-  set oldSsssKeys(Map<String, _i14.OpenSSSS>? value) => super.noSuchMethod(
+  set oldSsssKeys(Map<String, _i15.OpenSSSS>? value) => super.noSuchMethod(
         Invocation.setter(
           #oldSsssKeys,
           value,
@@ -8910,7 +8954,7 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
       );
 
   @override
-  set newSsssKey(_i14.OpenSSSS? value) => super.noSuchMethod(
+  set newSsssKey(_i15.OpenSSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #newSsssKey,
           value,
@@ -8928,7 +8972,7 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
       );
 
   @override
-  set state(_i14.BootstrapState? newState) => super.noSuchMethod(
+  set state(_i15.BootstrapState? newState) => super.noSuchMethod(
         Invocation.setter(
           #state,
           newState,
@@ -8962,14 +9006,14 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
           #mostUsedKey,
           [secrets],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
             [secrets],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
@@ -9136,28 +9180,28 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
 /// A class which mocks [OpenSSSS].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockOpenSSSS extends _i1.Mock implements _i14.OpenSSSS {
+class MockOpenSSSS extends _i1.Mock implements _i15.OpenSSSS {
   @override
-  _i14.SSSS get ssss => (super.noSuchMethod(
+  _i15.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_77(
+        returnValue: _FakeSSSS_78(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_77(
+        returnValueForMissingStub: _FakeSSSS_78(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i14.SSSS);
+      ) as _i15.SSSS);
 
   @override
   String get keyId => (super.noSuchMethod(
         Invocation.getter(#keyId),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
@@ -9166,11 +9210,11 @@ class MockOpenSSSS extends _i1.Mock implements _i14.OpenSSSS {
   @override
   _i2.SecretStorageKeyContent get keyData => (super.noSuchMethod(
         Invocation.getter(#keyData),
-        returnValue: _FakeSecretStorageKeyContent_82(
+        returnValue: _FakeSecretStorageKeyContent_83(
           this,
           Invocation.getter(#keyData),
         ),
-        returnValueForMissingStub: _FakeSecretStorageKeyContent_82(
+        returnValueForMissingStub: _FakeSecretStorageKeyContent_83(
           this,
           Invocation.getter(#keyData),
         ),
@@ -9191,7 +9235,7 @@ class MockOpenSSSS extends _i1.Mock implements _i14.OpenSSSS {
       ) as bool);
 
   @override
-  set privateKey(_i19.Uint8List? value) => super.noSuchMethod(
+  set privateKey(_i20.Uint8List? value) => super.noSuchMethod(
         Invocation.setter(
           #privateKey,
           value,
@@ -9222,7 +9266,7 @@ class MockOpenSSSS extends _i1.Mock implements _i14.OpenSSSS {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setPrivateKey(_i19.Uint8List? key) => (super.noSuchMethod(
+  _i5.Future<void> setPrivateKey(_i20.Uint8List? key) => (super.noSuchMethod(
         Invocation.method(
           #setPrivateKey,
           [key],
@@ -9237,7 +9281,7 @@ class MockOpenSSSS extends _i1.Mock implements _i14.OpenSSSS {
           #getStored,
           [type],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,
@@ -9245,7 +9289,7 @@ class MockOpenSSSS extends _i1.Mock implements _i14.OpenSSSS {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,

--- a/test/widgets/bootstrap_driver_test.mocks.dart
+++ b/test/widgets/bootstrap_driver_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i19;
-import 'dart:ui' as _i21;
+import 'dart:typed_data' as _i20;
+import 'dart:ui' as _i22;
 
-import 'package:flutter/services.dart' as _i22;
-import 'package:flutter/widgets.dart' as _i23;
+import 'package:flutter/services.dart' as _i23;
+import 'package:flutter/widgets.dart' as _i24;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/matrix_service.dart' as _i21;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,15 +23,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i14;
-import 'package:matrix/encryption/cross_signing.dart' as _i17;
-import 'package:matrix/encryption/key_verification_manager.dart' as _i16;
-import 'package:matrix/encryption/olm_manager.dart' as _i15;
+import 'package:matrix/encryption.dart' as _i15;
+import 'package:matrix/encryption/cross_signing.dart' as _i18;
+import 'package:matrix/encryption/key_verification_manager.dart' as _i17;
+import 'package:matrix/encryption/olm_manager.dart' as _i16;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i18;
+import 'package:mockito/src/dummies.dart' as _i19;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -822,8 +823,9 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeKeyManager_73 extends _i1.SmartFake implements _i14.KeyManager {
-  _FakeKeyManager_73(
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -832,8 +834,8 @@ class _FakeKeyManager_73 extends _i1.SmartFake implements _i14.KeyManager {
         );
 }
 
-class _FakeOlmManager_74 extends _i1.SmartFake implements _i15.OlmManager {
-  _FakeOlmManager_74(
+class _FakeKeyManager_74 extends _i1.SmartFake implements _i15.KeyManager {
+  _FakeKeyManager_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,9 +844,8 @@ class _FakeOlmManager_74 extends _i1.SmartFake implements _i15.OlmManager {
         );
 }
 
-class _FakeKeyVerificationManager_75 extends _i1.SmartFake
-    implements _i16.KeyVerificationManager {
-  _FakeKeyVerificationManager_75(
+class _FakeOlmManager_75 extends _i1.SmartFake implements _i16.OlmManager {
+  _FakeOlmManager_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -853,8 +854,9 @@ class _FakeKeyVerificationManager_75 extends _i1.SmartFake
         );
 }
 
-class _FakeCrossSigning_76 extends _i1.SmartFake implements _i17.CrossSigning {
-  _FakeCrossSigning_76(
+class _FakeKeyVerificationManager_76 extends _i1.SmartFake
+    implements _i17.KeyVerificationManager {
+  _FakeKeyVerificationManager_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -863,8 +865,8 @@ class _FakeCrossSigning_76 extends _i1.SmartFake implements _i17.CrossSigning {
         );
 }
 
-class _FakeSSSS_77 extends _i1.SmartFake implements _i14.SSSS {
-  _FakeSSSS_77(
+class _FakeCrossSigning_77 extends _i1.SmartFake implements _i18.CrossSigning {
+  _FakeCrossSigning_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -873,8 +875,8 @@ class _FakeSSSS_77 extends _i1.SmartFake implements _i14.SSSS {
         );
 }
 
-class _FakeBootstrap_78 extends _i1.SmartFake implements _i14.Bootstrap {
-  _FakeBootstrap_78(
+class _FakeSSSS_78 extends _i1.SmartFake implements _i15.SSSS {
+  _FakeSSSS_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -883,8 +885,8 @@ class _FakeBootstrap_78 extends _i1.SmartFake implements _i14.Bootstrap {
         );
 }
 
-class _FakeToDeviceEvent_79 extends _i1.SmartFake implements _i2.ToDeviceEvent {
-  _FakeToDeviceEvent_79(
+class _FakeBootstrap_79 extends _i1.SmartFake implements _i15.Bootstrap {
+  _FakeBootstrap_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -893,8 +895,8 @@ class _FakeToDeviceEvent_79 extends _i1.SmartFake implements _i2.ToDeviceEvent {
         );
 }
 
-class _FakeEvent_80 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_80(
+class _FakeToDeviceEvent_80 extends _i1.SmartFake implements _i2.ToDeviceEvent {
+  _FakeToDeviceEvent_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -903,8 +905,18 @@ class _FakeEvent_80 extends _i1.SmartFake implements _i2.Event {
         );
 }
 
-class _FakeEncryption_81 extends _i1.SmartFake implements _i14.Encryption {
-  _FakeEncryption_81(
+class _FakeEvent_81 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_81(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeEncryption_82 extends _i1.SmartFake implements _i15.Encryption {
+  _FakeEncryption_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -931,12 +943,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1056,11 +1068,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1097,11 +1109,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1131,11 +1143,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1144,11 +1156,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1434,34 +1446,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1617,7 +1629,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1906,14 +1918,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2301,8 +2313,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValue: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2318,8 +2330,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2360,7 +2372,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2376,7 +2388,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2425,7 +2437,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2446,7 +2458,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2549,7 +2561,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2567,7 +2579,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3086,7 +3098,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i19.Uint8List? file, {
+    _i20.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3438,7 +3450,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3452,7 +3464,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3603,7 +3615,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i19.Uint8List? body,
+    _i20.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4981,7 +4993,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5003,7 +5015,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5497,7 +5509,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5509,7 +5521,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6517,7 +6529,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6528,7 +6540,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6776,7 +6788,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6788,7 +6800,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7048,7 +7060,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7061,7 +7073,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7128,7 +7140,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7141,7 +7153,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7189,7 +7201,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7201,7 +7213,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7449,7 +7461,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7460,7 +7472,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7722,7 +7734,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i19.Uint8List? body, {
+    _i20.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7749,7 +7761,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7779,11 +7791,11 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7882,6 +7894,19 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7961,6 +7986,15 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -8005,7 +8039,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8099,7 +8133,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8108,7 +8142,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8127,7 +8161,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8138,7 +8172,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8186,7 +8220,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i23.RouteInformation? routeInformation) =>
+          _i24.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8224,7 +8258,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8233,7 +8267,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8242,16 +8276,16 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
-      ) as _i5.Future<_i21.AppExitResponse>);
+            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+      ) as _i5.Future<_i22.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8275,7 +8309,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
 /// A class which mocks [Encryption].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEncryption extends _i1.Mock implements _i14.Encryption {
+class MockEncryption extends _i1.Mock implements _i15.Encryption {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -8304,85 +8338,85 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       ) as bool);
 
   @override
-  _i14.KeyManager get keyManager => (super.noSuchMethod(
+  _i15.KeyManager get keyManager => (super.noSuchMethod(
         Invocation.getter(#keyManager),
-        returnValue: _FakeKeyManager_73(
+        returnValue: _FakeKeyManager_74(
           this,
           Invocation.getter(#keyManager),
         ),
-        returnValueForMissingStub: _FakeKeyManager_73(
+        returnValueForMissingStub: _FakeKeyManager_74(
           this,
           Invocation.getter(#keyManager),
         ),
-      ) as _i14.KeyManager);
+      ) as _i15.KeyManager);
 
   @override
-  _i15.OlmManager get olmManager => (super.noSuchMethod(
+  _i16.OlmManager get olmManager => (super.noSuchMethod(
         Invocation.getter(#olmManager),
-        returnValue: _FakeOlmManager_74(
+        returnValue: _FakeOlmManager_75(
           this,
           Invocation.getter(#olmManager),
         ),
-        returnValueForMissingStub: _FakeOlmManager_74(
+        returnValueForMissingStub: _FakeOlmManager_75(
           this,
           Invocation.getter(#olmManager),
         ),
-      ) as _i15.OlmManager);
+      ) as _i16.OlmManager);
 
   @override
-  _i16.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
+  _i17.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
         Invocation.getter(#keyVerificationManager),
-        returnValue: _FakeKeyVerificationManager_75(
+        returnValue: _FakeKeyVerificationManager_76(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-        returnValueForMissingStub: _FakeKeyVerificationManager_75(
+        returnValueForMissingStub: _FakeKeyVerificationManager_76(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-      ) as _i16.KeyVerificationManager);
+      ) as _i17.KeyVerificationManager);
 
   @override
-  _i17.CrossSigning get crossSigning => (super.noSuchMethod(
+  _i18.CrossSigning get crossSigning => (super.noSuchMethod(
         Invocation.getter(#crossSigning),
-        returnValue: _FakeCrossSigning_76(
+        returnValue: _FakeCrossSigning_77(
           this,
           Invocation.getter(#crossSigning),
         ),
-        returnValueForMissingStub: _FakeCrossSigning_76(
+        returnValueForMissingStub: _FakeCrossSigning_77(
           this,
           Invocation.getter(#crossSigning),
         ),
-      ) as _i17.CrossSigning);
+      ) as _i18.CrossSigning);
 
   @override
-  _i14.SSSS get ssss => (super.noSuchMethod(
+  _i15.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_77(
+        returnValue: _FakeSSSS_78(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_77(
+        returnValueForMissingStub: _FakeSSSS_78(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i14.SSSS);
+      ) as _i15.SSSS);
 
   @override
   String get ourDeviceId => (super.noSuchMethod(
         Invocation.getter(#ourDeviceId),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
       ) as String);
 
   @override
-  set keyManager(_i14.KeyManager? value) => super.noSuchMethod(
+  set keyManager(_i15.KeyManager? value) => super.noSuchMethod(
         Invocation.setter(
           #keyManager,
           value,
@@ -8391,7 +8425,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       );
 
   @override
-  set olmManager(_i15.OlmManager? value) => super.noSuchMethod(
+  set olmManager(_i16.OlmManager? value) => super.noSuchMethod(
         Invocation.setter(
           #olmManager,
           value,
@@ -8400,7 +8434,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       );
 
   @override
-  set keyVerificationManager(_i16.KeyVerificationManager? value) =>
+  set keyVerificationManager(_i17.KeyVerificationManager? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #keyVerificationManager,
@@ -8410,7 +8444,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       );
 
   @override
-  set crossSigning(_i17.CrossSigning? value) => super.noSuchMethod(
+  set crossSigning(_i18.CrossSigning? value) => super.noSuchMethod(
         Invocation.setter(
           #crossSigning,
           value,
@@ -8419,7 +8453,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       );
 
   @override
-  set ssss(_i14.SSSS? value) => super.noSuchMethod(
+  set ssss(_i15.SSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #ssss,
           value,
@@ -8458,14 +8492,14 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
       ) as _i5.Future<void>);
 
   @override
-  _i14.Bootstrap bootstrap({void Function(_i14.Bootstrap)? onUpdate}) =>
+  _i15.Bootstrap bootstrap({void Function(_i15.Bootstrap)? onUpdate}) =>
       (super.noSuchMethod(
         Invocation.method(
           #bootstrap,
           [],
           {#onUpdate: onUpdate},
         ),
-        returnValue: _FakeBootstrap_78(
+        returnValue: _FakeBootstrap_79(
           this,
           Invocation.method(
             #bootstrap,
@@ -8473,7 +8507,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-        returnValueForMissingStub: _FakeBootstrap_78(
+        returnValueForMissingStub: _FakeBootstrap_79(
           this,
           Invocation.method(
             #bootstrap,
@@ -8481,7 +8515,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-      ) as _i14.Bootstrap);
+      ) as _i15.Bootstrap);
 
   @override
   void handleDeviceOneTimeKeysCount(
@@ -8544,7 +8578,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
           #decryptToDeviceEvent,
           [event],
         ),
-        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_79(
+        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_80(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8552,7 +8586,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_79(
+            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_80(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8567,14 +8601,14 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
           #decryptRoomEventSync,
           [event],
         ),
-        returnValue: _FakeEvent_80(
+        returnValue: _FakeEvent_81(
           this,
           Invocation.method(
             #decryptRoomEventSync,
             [event],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_80(
+        returnValueForMissingStub: _FakeEvent_81(
           this,
           Invocation.method(
             #decryptRoomEventSync,
@@ -8598,7 +8632,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
             #updateType: updateType,
           },
         ),
-        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_80(
+        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_81(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -8609,7 +8643,7 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
             },
           ),
         )),
-        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_80(
+        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_81(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -8691,19 +8725,19 @@ class MockEncryption extends _i1.Mock implements _i14.Encryption {
 /// A class which mocks [Bootstrap].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
+class MockBootstrap extends _i1.Mock implements _i15.Bootstrap {
   @override
-  _i14.Encryption get encryption => (super.noSuchMethod(
+  _i15.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_81(
+        returnValue: _FakeEncryption_82(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_81(
+        returnValueForMissingStub: _FakeEncryption_82(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i14.Encryption);
+      ) as _i15.Encryption);
 
   @override
   _i2.Client get client => (super.noSuchMethod(
@@ -8719,14 +8753,14 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
       ) as _i2.Client);
 
   @override
-  _i14.BootstrapState get state => (super.noSuchMethod(
+  _i15.BootstrapState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i14.BootstrapState.loading,
-        returnValueForMissingStub: _i14.BootstrapState.loading,
-      ) as _i14.BootstrapState);
+        returnValue: _i15.BootstrapState.loading,
+        returnValueForMissingStub: _i15.BootstrapState.loading,
+      ) as _i15.BootstrapState);
 
   @override
-  set onUpdate(void Function(_i14.Bootstrap)? value) => super.noSuchMethod(
+  set onUpdate(void Function(_i15.Bootstrap)? value) => super.noSuchMethod(
         Invocation.setter(
           #onUpdate,
           value,
@@ -8735,7 +8769,7 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
       );
 
   @override
-  set oldSsssKeys(Map<String, _i14.OpenSSSS>? value) => super.noSuchMethod(
+  set oldSsssKeys(Map<String, _i15.OpenSSSS>? value) => super.noSuchMethod(
         Invocation.setter(
           #oldSsssKeys,
           value,
@@ -8744,7 +8778,7 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
       );
 
   @override
-  set newSsssKey(_i14.OpenSSSS? value) => super.noSuchMethod(
+  set newSsssKey(_i15.OpenSSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #newSsssKey,
           value,
@@ -8762,7 +8796,7 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
       );
 
   @override
-  set state(_i14.BootstrapState? newState) => super.noSuchMethod(
+  set state(_i15.BootstrapState? newState) => super.noSuchMethod(
         Invocation.setter(
           #state,
           newState,
@@ -8796,14 +8830,14 @@ class MockBootstrap extends _i1.Mock implements _i14.Bootstrap {
           #mostUsedKey,
           [secrets],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
             [secrets],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,

--- a/test/widgets/chat/message_actions_test.mocks.dart
+++ b/test/widgets/chat/message_actions_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i17;
-import 'dart:ui' as _i19;
+import 'dart:typed_data' as _i18;
+import 'dart:ui' as _i20;
 
-import 'package:flutter/services.dart' as _i20;
-import 'package:flutter/widgets.dart' as _i21;
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,14 +23,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i15;
+import 'package:matrix/encryption.dart' as _i16;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i14;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i15;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i22;
+import 'package:matrix/src/utils/space_child.dart' as _i23;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -821,8 +822,9 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_73(
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -831,9 +833,19 @@ class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_74 extends _i1.SmartFake
+class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_74(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_75 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_74(
+  _FakeLatestReceiptState_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,8 +854,8 @@ class _FakeLatestReceiptState_74 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_75(
+class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,8 +864,8 @@ class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_76(
+class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -862,8 +874,8 @@ class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_77 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_77(
+class _FakeRoom_78 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -872,9 +884,9 @@ class _FakeRoom_77 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_78 extends _i1.SmartFake
-    implements _i14.TimelineChunk {
-  _FakeTimelineChunk_78(
+class _FakeTimelineChunk_79 extends _i1.SmartFake
+    implements _i15.TimelineChunk {
+  _FakeTimelineChunk_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -883,8 +895,8 @@ class _FakeTimelineChunk_78 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixFile_79 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_79(
+class _FakeMatrixFile_80 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -893,8 +905,8 @@ class _FakeMatrixFile_79 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_80 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_80(
+class _FakeEvent_81 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -921,12 +933,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i15.KeyVerificationMethod> get verificationMethods =>
+  Set<_i16.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i15.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
-      ) as Set<_i15.KeyVerificationMethod>);
+        returnValue: <_i16.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
+      ) as Set<_i16.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1046,11 +1058,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1087,11 +1099,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1121,11 +1133,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1134,11 +1146,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1424,34 +1436,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i15.KeyVerification>
+  _i3.CachedStreamController<_i16.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i15.KeyVerification>(
+                _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i15.KeyVerification>);
+          ) as _i3.CachedStreamController<_i16.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1607,7 +1619,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1896,14 +1908,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2291,8 +2303,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2308,8 +2320,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2350,7 +2362,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2366,7 +2378,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2415,7 +2427,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2436,7 +2448,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2539,7 +2551,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2557,7 +2569,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3076,7 +3088,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i17.Uint8List? file, {
+    _i18.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3428,7 +3440,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3442,7 +3454,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3593,7 +3605,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i17.Uint8List? body,
+    _i18.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4971,7 +4983,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4993,7 +5005,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5487,7 +5499,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5499,7 +5511,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6507,7 +6519,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6518,7 +6530,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6766,7 +6778,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6778,7 +6790,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7038,7 +7050,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7051,7 +7063,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7118,7 +7130,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7131,7 +7143,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7179,7 +7191,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7191,7 +7203,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7439,7 +7451,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7450,7 +7462,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7712,7 +7724,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i17.Uint8List? body, {
+    _i18.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7739,7 +7751,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7769,11 +7781,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7872,6 +7884,19 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7951,6 +7976,15 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7995,7 +8029,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8089,7 +8123,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8098,7 +8132,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8117,7 +8151,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8128,7 +8162,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8176,7 +8210,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8214,7 +8248,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8223,7 +8257,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8232,16 +8266,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i5.Future<_i19.AppExitResponse>);
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i5.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8269,11 +8303,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8303,11 +8337,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_73(
+        returnValue: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_73(
+        returnValueForMissingStub: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
@@ -8360,11 +8394,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8400,11 +8434,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8420,11 +8454,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8433,11 +8467,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8480,11 +8514,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8527,11 +8561,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_74(
+        returnValue: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_74(
+        returnValueForMissingStub: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8743,18 +8777,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i22.SpaceParent>[],
-        returnValueForMissingStub: <_i22.SpaceParent>[],
-      ) as List<_i22.SpaceParent>);
+        returnValue: <_i23.SpaceParent>[],
+        returnValueForMissingStub: <_i23.SpaceParent>[],
+      ) as List<_i23.SpaceParent>);
 
   @override
-  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i22.SpaceChild>[],
-        returnValueForMissingStub: <_i22.SpaceChild>[],
-      ) as List<_i22.SpaceChild>);
+        returnValue: <_i23.SpaceChild>[],
+        returnValueForMissingStub: <_i23.SpaceChild>[],
+      ) as List<_i23.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8921,14 +8955,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8976,7 +9010,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8984,7 +9018,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8999,7 +9033,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9007,7 +9041,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9091,7 +9125,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9099,7 +9133,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9341,7 +9375,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9352,7 +9386,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9441,15 +9475,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i14.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i15.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i14.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i14.TimelineChunk?>.value(),
-      ) as _i5.Future<_i14.TimelineChunk?>);
+        returnValue: _i5.Future<_i15.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i15.TimelineChunk?>.value(),
+      ) as _i5.Future<_i15.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9490,7 +9524,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9507,7 +9541,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9571,14 +9605,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9594,14 +9628,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9657,7 +9691,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9665,7 +9699,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9977,11 +10011,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_77(
+        returnValue: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_77(
+        returnValueForMissingStub: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
@@ -10031,17 +10065,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i14.TimelineChunk get chunk => (super.noSuchMethod(
+  _i15.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_78(
+        returnValue: _FakeTimelineChunk_79(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_78(
+        returnValueForMissingStub: _FakeTimelineChunk_79(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i14.TimelineChunk);
+      ) as _i15.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10144,7 +10178,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i14.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i15.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -10343,11 +10377,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.getter(#sender),
         ),
@@ -10356,11 +10390,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10369,11 +10403,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_77(
+        returnValue: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_77(
+        returnValueForMissingStub: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
@@ -10396,11 +10430,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10409,11 +10443,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10422,11 +10456,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10435,11 +10469,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10448,11 +10482,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10461,11 +10495,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10530,11 +10564,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10543,11 +10577,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10600,11 +10634,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10689,11 +10723,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10711,11 +10745,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10926,7 +10960,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i17.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i18.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10941,7 +10975,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_79(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_80(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10955,7 +10989,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_79(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_80(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10991,7 +11025,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11006,7 +11040,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11043,7 +11077,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11057,7 +11091,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11094,7 +11128,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11108,7 +11142,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11142,7 +11176,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11155,7 +11189,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11231,14 +11265,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_80(
+        returnValue: _FakeEvent_81(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_80(
+        returnValueForMissingStub: _FakeEvent_81(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -11255,11 +11289,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_77(
+        returnValue: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_77(
+        returnValueForMissingStub: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
@@ -11268,11 +11302,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -11338,11 +11372,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11367,11 +11401,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11389,11 +11423,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11440,7 +11474,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11452,7 +11486,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11522,7 +11556,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11535,7 +11569,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/chat/pinned_messages_test.mocks.dart
+++ b/test/widgets/chat/pinned_messages_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i17;
-import 'dart:ui' as _i19;
+import 'dart:typed_data' as _i18;
+import 'dart:ui' as _i20;
 
-import 'package:flutter/services.dart' as _i20;
-import 'package:flutter/widgets.dart' as _i21;
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,14 +23,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i15;
+import 'package:matrix/encryption.dart' as _i16;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i14;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i15;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i22;
+import 'package:matrix/src/utils/space_child.dart' as _i23;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -821,8 +822,9 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_73(
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -831,9 +833,19 @@ class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_74 extends _i1.SmartFake
+class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_74(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_75 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_74(
+  _FakeLatestReceiptState_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,8 +854,8 @@ class _FakeLatestReceiptState_74 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_75(
+class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,8 +864,8 @@ class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_76(
+class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -862,8 +874,8 @@ class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_77 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_77(
+class _FakeRoom_78 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -872,9 +884,9 @@ class _FakeRoom_77 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_78 extends _i1.SmartFake
-    implements _i14.TimelineChunk {
-  _FakeTimelineChunk_78(
+class _FakeTimelineChunk_79 extends _i1.SmartFake
+    implements _i15.TimelineChunk {
+  _FakeTimelineChunk_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -883,8 +895,8 @@ class _FakeTimelineChunk_78 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixFile_79 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_79(
+class _FakeMatrixFile_80 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -893,8 +905,8 @@ class _FakeMatrixFile_79 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_80 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_80(
+class _FakeEvent_81 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -921,12 +933,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i15.KeyVerificationMethod> get verificationMethods =>
+  Set<_i16.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i15.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
-      ) as Set<_i15.KeyVerificationMethod>);
+        returnValue: <_i16.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
+      ) as Set<_i16.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1046,11 +1058,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1087,11 +1099,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1121,11 +1133,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1134,11 +1146,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1424,34 +1436,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i15.KeyVerification>
+  _i3.CachedStreamController<_i16.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i15.KeyVerification>(
+                _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i15.KeyVerification>);
+          ) as _i3.CachedStreamController<_i16.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1607,7 +1619,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1896,14 +1908,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2291,8 +2303,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2308,8 +2320,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2350,7 +2362,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2366,7 +2378,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2415,7 +2427,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2436,7 +2448,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2539,7 +2551,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2557,7 +2569,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3076,7 +3088,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i17.Uint8List? file, {
+    _i18.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3428,7 +3440,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3442,7 +3454,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3593,7 +3605,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i17.Uint8List? body,
+    _i18.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4971,7 +4983,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4993,7 +5005,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5487,7 +5499,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5499,7 +5511,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6507,7 +6519,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6518,7 +6530,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6766,7 +6778,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6778,7 +6790,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7038,7 +7050,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7051,7 +7063,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7118,7 +7130,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7131,7 +7143,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7179,7 +7191,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7191,7 +7203,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7439,7 +7451,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7450,7 +7462,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7712,7 +7724,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i17.Uint8List? body, {
+    _i18.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7739,7 +7751,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7769,11 +7781,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7872,6 +7884,19 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7951,6 +7976,15 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7995,7 +8029,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8089,7 +8123,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8098,7 +8132,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8117,7 +8151,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8128,7 +8162,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8176,7 +8210,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8214,7 +8248,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8223,7 +8257,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8232,16 +8266,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i5.Future<_i19.AppExitResponse>);
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i5.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8269,11 +8303,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8303,11 +8337,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_73(
+        returnValue: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_73(
+        returnValueForMissingStub: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
@@ -8360,11 +8394,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8400,11 +8434,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8420,11 +8454,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8433,11 +8467,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8480,11 +8514,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8527,11 +8561,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_74(
+        returnValue: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_74(
+        returnValueForMissingStub: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8743,18 +8777,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i22.SpaceParent>[],
-        returnValueForMissingStub: <_i22.SpaceParent>[],
-      ) as List<_i22.SpaceParent>);
+        returnValue: <_i23.SpaceParent>[],
+        returnValueForMissingStub: <_i23.SpaceParent>[],
+      ) as List<_i23.SpaceParent>);
 
   @override
-  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i22.SpaceChild>[],
-        returnValueForMissingStub: <_i22.SpaceChild>[],
-      ) as List<_i22.SpaceChild>);
+        returnValue: <_i23.SpaceChild>[],
+        returnValueForMissingStub: <_i23.SpaceChild>[],
+      ) as List<_i23.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8921,14 +8955,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8976,7 +9010,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8984,7 +9018,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8999,7 +9033,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9007,7 +9041,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9091,7 +9125,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9099,7 +9133,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9341,7 +9375,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9352,7 +9386,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9441,15 +9475,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i14.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i15.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i14.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i14.TimelineChunk?>.value(),
-      ) as _i5.Future<_i14.TimelineChunk?>);
+        returnValue: _i5.Future<_i15.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i15.TimelineChunk?>.value(),
+      ) as _i5.Future<_i15.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9490,7 +9524,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9507,7 +9541,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9571,14 +9605,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9594,14 +9628,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9657,7 +9691,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9665,7 +9699,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9977,11 +10011,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_77(
+        returnValue: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_77(
+        returnValueForMissingStub: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
@@ -10031,17 +10065,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i14.TimelineChunk get chunk => (super.noSuchMethod(
+  _i15.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_78(
+        returnValue: _FakeTimelineChunk_79(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_78(
+        returnValueForMissingStub: _FakeTimelineChunk_79(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i14.TimelineChunk);
+      ) as _i15.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10144,7 +10178,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i14.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i15.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -10343,11 +10377,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.getter(#sender),
         ),
@@ -10356,11 +10390,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10369,11 +10403,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_77(
+        returnValue: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_77(
+        returnValueForMissingStub: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
@@ -10396,11 +10430,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10409,11 +10443,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10422,11 +10456,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10435,11 +10469,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10448,11 +10482,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10461,11 +10495,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10530,11 +10564,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10543,11 +10577,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10600,11 +10634,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10689,11 +10723,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10711,11 +10745,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10926,7 +10960,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i17.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i18.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10941,7 +10975,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_79(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_80(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10955,7 +10989,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_79(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_80(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10991,7 +11025,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11006,7 +11040,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11043,7 +11077,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11057,7 +11091,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11094,7 +11128,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11108,7 +11142,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11142,7 +11176,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11155,7 +11189,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11231,14 +11265,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_80(
+        returnValue: _FakeEvent_81(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_80(
+        returnValueForMissingStub: _FakeEvent_81(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -11255,11 +11289,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_77(
+        returnValue: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_77(
+        returnValueForMissingStub: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
@@ -11268,11 +11302,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -11338,11 +11372,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11367,11 +11401,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11389,11 +11423,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11440,7 +11474,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11452,7 +11486,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11522,7 +11556,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11535,7 +11569,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/create_subspace_dialog_test.mocks.dart
+++ b/test/widgets/create_subspace_dialog_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,14 +23,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/src/utils/space_child.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -821,8 +822,9 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_73(
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -831,9 +833,19 @@ class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_74 extends _i1.SmartFake
+class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_74(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_75 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_74(
+  _FakeLatestReceiptState_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,8 +854,8 @@ class _FakeLatestReceiptState_74 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_75(
+class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,8 +864,8 @@ class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_76(
+class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -880,12 +892,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1005,11 +1017,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1046,11 +1058,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1080,11 +1092,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1093,11 +1105,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1383,34 +1395,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1566,7 +1578,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1855,14 +1867,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2250,8 +2262,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2267,8 +2279,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2309,7 +2321,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2325,7 +2337,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2374,7 +2386,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2395,7 +2407,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2498,7 +2510,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2516,7 +2528,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3035,7 +3047,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3387,7 +3399,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3401,7 +3413,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3552,7 +3564,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4930,7 +4942,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4952,7 +4964,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5446,7 +5458,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5458,7 +5470,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6466,7 +6478,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6477,7 +6489,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6725,7 +6737,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6737,7 +6749,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6997,7 +7009,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7010,7 +7022,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7077,7 +7089,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7090,7 +7102,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7138,7 +7150,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7150,7 +7162,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7398,7 +7410,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7409,7 +7421,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7671,7 +7683,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7698,7 +7710,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7728,11 +7740,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7831,6 +7843,19 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7910,6 +7935,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7954,7 +7988,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8048,7 +8082,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8057,7 +8091,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8076,7 +8110,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8087,7 +8121,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8135,7 +8169,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8173,7 +8207,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8182,7 +8216,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8191,16 +8225,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8228,11 +8262,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8262,11 +8296,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_73(
+        returnValue: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_73(
+        returnValueForMissingStub: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
@@ -8319,11 +8353,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8359,11 +8393,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8379,11 +8413,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8392,11 +8426,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8439,11 +8473,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8486,11 +8520,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_74(
+        returnValue: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_74(
+        returnValueForMissingStub: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8702,18 +8736,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i22.SpaceParent>[],
+        returnValueForMissingStub: <_i22.SpaceParent>[],
+      ) as List<_i22.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i22.SpaceChild>[],
+        returnValueForMissingStub: <_i22.SpaceChild>[],
+      ) as List<_i22.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8880,14 +8914,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8935,7 +8969,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8943,7 +8977,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8958,7 +8992,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8966,7 +9000,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9050,7 +9084,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9058,7 +9092,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9300,7 +9334,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9311,7 +9345,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9400,15 +9434,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i22.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i22.TimelineChunk?>.value(),
-      ) as _i5.Future<_i22.TimelineChunk?>);
+        returnValue: _i5.Future<_i23.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i23.TimelineChunk?>.value(),
+      ) as _i5.Future<_i23.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9449,7 +9483,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9466,7 +9500,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9530,14 +9564,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9553,14 +9587,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9616,7 +9650,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9624,7 +9658,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/homeserver_controller_test.mocks.dart
+++ b/test/widgets/homeserver_controller_test.mocks.dart
@@ -3,16 +3,17 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i13;
-import 'dart:ui' as _i14;
+import 'dart:async' as _i14;
+import 'dart:ui' as _i15;
 
-import 'package:flutter/services.dart' as _i15;
-import 'package:flutter/widgets.dart' as _i16;
-import 'package:kohera/core/models/server_auth_capabilities.dart' as _i10;
-import 'package:kohera/core/services/matrix_service.dart' as _i11;
+import 'package:flutter/services.dart' as _i16;
+import 'package:flutter/widgets.dart' as _i17;
+import 'package:kohera/core/models/server_auth_capabilities.dart' as _i11;
+import 'package:kohera/core/services/matrix_service.dart' as _i12;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
@@ -23,7 +24,7 @@ import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
 import 'package:matrix/matrix.dart' as _i4;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i12;
+import 'package:mockito/src/dummies.dart' as _i13;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -124,9 +125,19 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeServerAuthCapabilities_8 extends _i1.SmartFake
-    implements _i10.ServerAuthCapabilities {
-  _FakeServerAuthCapabilities_8(
+class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
+  _FakeOutboxService_8(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeServerAuthCapabilities_9 extends _i1.SmartFake
+    implements _i11.ServerAuthCapabilities {
+  _FakeServerAuthCapabilities_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -138,7 +149,7 @@ class _FakeServerAuthCapabilities_8 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -168,11 +179,11 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i12.dummyValue<String>(
+        returnValue: _i13.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i12.dummyValue<String>(
+        returnValueForMissingStub: _i13.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -271,6 +282,19 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       ) as _i9.AuthService);
 
   @override
+  _i10.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i10.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -350,6 +374,15 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
+  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -357,14 +390,14 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       ) as bool);
 
   @override
-  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -394,7 +427,7 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i14.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i15.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -404,18 +437,18 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
-  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<bool> login({
+  _i14.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -430,12 +463,12 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> completeSsoLogin({
+  _i14.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -448,12 +481,12 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> completeRegistration(
+  _i14.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -463,32 +496,32 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  void addListener(_i14.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i15.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -497,7 +530,7 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
-  void removeListener(_i14.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i15.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -506,17 +539,17 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i15.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i16.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -527,7 +560,7 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i15.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i16.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -564,26 +597,26 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> didPushRouteInformation(
-          _i16.RouteInformation? routeInformation) =>
+  _i14.Future<bool> didPushRouteInformation(
+          _i17.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -613,7 +646,7 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i14.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i15.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -622,7 +655,7 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i14.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i15.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -631,16 +664,16 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
-  _i13.Future<_i14.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i14.Future<_i15.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i13.Future<_i14.AppExitResponse>.value(_i14.AppExitResponse.exit),
+            _i14.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i13.Future<_i14.AppExitResponse>.value(_i14.AppExitResponse.exit),
-      ) as _i13.Future<_i14.AppExitResponse>);
+            _i14.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+      ) as _i14.Future<_i15.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -698,7 +731,7 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
       ) as bool);
 
   @override
-  _i13.Future<bool> login({
+  _i14.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -713,12 +746,12 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
             #password: password,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> completeSsoLogin({
+  _i14.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -731,12 +764,12 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> completeRegistration(
+  _i14.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -746,9 +779,9 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
           [response],
           {#password: password},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void activateRestoredSession() => super.noSuchMethod(
@@ -760,37 +793,37 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
       );
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleServerLogout() => (super.noSuchMethod(
+  _i14.Future<void> handleServerLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleServerLogout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> saveSessionBackup() => (super.noSuchMethod(
+  _i14.Future<void> saveSessionBackup() => (super.noSuchMethod(
         Invocation.method(
           #saveSessionBackup,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i10.ServerAuthCapabilities> getServerAuthCapabilities(
+  _i14.Future<_i11.ServerAuthCapabilities> getServerAuthCapabilities(
     String? homeserver, {
     required bool? isLoggedIn,
   }) =>
@@ -800,8 +833,8 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
           [homeserver],
           {#isLoggedIn: isLoggedIn},
         ),
-        returnValue: _i13.Future<_i10.ServerAuthCapabilities>.value(
-            _FakeServerAuthCapabilities_8(
+        returnValue: _i14.Future<_i11.ServerAuthCapabilities>.value(
+            _FakeServerAuthCapabilities_9(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -810,8 +843,8 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i10.ServerAuthCapabilities>.value(
-                _FakeServerAuthCapabilities_8(
+            _i14.Future<_i11.ServerAuthCapabilities>.value(
+                _FakeServerAuthCapabilities_9(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -819,7 +852,7 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
             {#isLoggedIn: isLoggedIn},
           ),
         )),
-      ) as _i13.Future<_i10.ServerAuthCapabilities>);
+      ) as _i14.Future<_i11.ServerAuthCapabilities>);
 
   @override
   bool isPermanentAuthFailure(Object? error) => (super.noSuchMethod(
@@ -832,37 +865,37 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
       ) as bool);
 
   @override
-  _i13.Future<void> clearSessionKeys() => (super.noSuchMethod(
+  _i14.Future<void> clearSessionKeys() => (super.noSuchMethod(
         Invocation.method(
           #clearSessionKeys,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> migrateStorageKeys() => (super.noSuchMethod(
+  _i14.Future<void> migrateStorageKeys() => (super.noSuchMethod(
         Invocation.method(
           #migrateStorageKeys,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> persistCredentials() => (super.noSuchMethod(
+  _i14.Future<void> persistCredentials() => (super.noSuchMethod(
         Invocation.method(
           #persistCredentials,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  void addListener(_i14.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i15.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -871,7 +904,7 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
       );
 
   @override
-  void removeListener(_i14.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i15.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/test/widgets/invite_dialog_test.mocks.dart
+++ b/test/widgets/invite_dialog_test.mocks.dart
@@ -3,17 +3,18 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i12;
-import 'dart:typed_data' as _i22;
-import 'dart:ui' as _i16;
+import 'dart:async' as _i13;
+import 'dart:typed_data' as _i23;
+import 'dart:ui' as _i17;
 
-import 'package:flutter/services.dart' as _i17;
-import 'package:flutter/widgets.dart' as _i18;
-import 'package:http/http.dart' as _i11;
-import 'package:kohera/core/services/matrix_service.dart' as _i14;
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
+import 'package:http/http.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
@@ -22,14 +23,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i21;
+import 'package:matrix/encryption.dart' as _i22;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i13;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i20;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i10;
-import 'package:matrix/src/utils/space_child.dart' as _i19;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i14;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i11;
+import 'package:matrix/src/utils/space_child.dart' as _i20;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -130,8 +131,8 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeRoomSummary_8 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_8(
+class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
+  _FakeOutboxService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -140,9 +141,8 @@ class _FakeRoomSummary_8 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_9<T> extends _i1.SmartFake
-    implements _i10.CachedStreamController<T> {
-  _FakeCachedStreamController_9(
+class _FakeRoomSummary_9 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -151,8 +151,9 @@ class _FakeCachedStreamController_9<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_10 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_10(
+class _FakeCachedStreamController_10<T> extends _i1.SmartFake
+    implements _i11.CachedStreamController<T> {
+  _FakeCachedStreamController_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -161,9 +162,19 @@ class _FakeDateTime_10 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_11 extends _i1.SmartFake
+class _FakeDateTime_11 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_11(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_12 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_11(
+  _FakeLatestReceiptState_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -172,8 +183,8 @@ class _FakeLatestReceiptState_11 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_12 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_12(
+class _FakeSyncUpdate_13 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -182,8 +193,8 @@ class _FakeSyncUpdate_12 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_13 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_13(
+class _FakeTimeline_14 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -192,8 +203,8 @@ class _FakeTimeline_13 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_14 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_14(
+class _FakeUser_15 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -202,8 +213,8 @@ class _FakeUser_14 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_15 extends _i1.SmartFake implements Uri {
-  _FakeUri_15(
+class _FakeUri_16 extends _i1.SmartFake implements Uri {
+  _FakeUri_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -212,8 +223,8 @@ class _FakeUri_15 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_16 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_16(
+class _FakeDatabaseApi_17 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -222,8 +233,8 @@ class _FakeDatabaseApi_16 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_17 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_17(
+class _FakeFilter_18 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -232,9 +243,9 @@ class _FakeFilter_17 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_18 extends _i1.SmartFake
+class _FakeNativeImplementations_19 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_18(
+  _FakeNativeImplementations_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -243,8 +254,8 @@ class _FakeNativeImplementations_18 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_19 extends _i1.SmartFake implements Duration {
-  _FakeDuration_19(
+class _FakeDuration_20 extends _i1.SmartFake implements Duration {
+  _FakeDuration_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -253,9 +264,9 @@ class _FakeDuration_19 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_20 extends _i1.SmartFake
+class _FakePushruleEvaluator_21 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_20(
+  _FakePushruleEvaluator_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -264,8 +275,8 @@ class _FakePushruleEvaluator_20 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_21 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_21(
+class _FakeProfile_22 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -274,8 +285,8 @@ class _FakeProfile_21 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_22 extends _i1.SmartFake implements _i11.Client {
-  _FakeClient_22(
+class _FakeClient_23 extends _i1.SmartFake implements _i12.Client {
+  _FakeClient_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -284,9 +295,9 @@ class _FakeClient_22 extends _i1.SmartFake implements _i11.Client {
         );
 }
 
-class _FakeDiscoveryInformation_23 extends _i1.SmartFake
+class _FakeDiscoveryInformation_24 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_23(
+  _FakeDiscoveryInformation_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -295,9 +306,9 @@ class _FakeDiscoveryInformation_23 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_24 extends _i1.SmartFake
+class _FakeGetVersionsResponse_25 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_24(
+  _FakeGetVersionsResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -306,9 +317,9 @@ class _FakeGetVersionsResponse_24 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_25 extends _i1.SmartFake
+class _FakeRegisterResponse_26 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_25(
+  _FakeRegisterResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -317,8 +328,8 @@ class _FakeRegisterResponse_25 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_26 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_26(
+class _FakeLoginResponse_27 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -327,9 +338,9 @@ class _FakeLoginResponse_26 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_27 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_28 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_27(
+  _FakeGetAuthMetadataResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -338,8 +349,8 @@ class _FakeGetAuthMetadataResponse_27 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_28<T1> extends _i1.SmartFake implements _i12.Future<T1> {
-  _FakeFuture_28(
+class _FakeFuture_29<T1> extends _i1.SmartFake implements _i13.Future<T1> {
+  _FakeFuture_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -348,9 +359,9 @@ class _FakeFuture_28<T1> extends _i1.SmartFake implements _i12.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_29 extends _i1.SmartFake
+class _FakeCachedProfileInformation_30 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_29(
+  _FakeCachedProfileInformation_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -359,8 +370,8 @@ class _FakeCachedProfileInformation_29 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_30(
+class _FakeMediaConfig_31 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -369,8 +380,8 @@ class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_31 extends _i1.SmartFake implements _i13.FileResponse {
-  _FakeFileResponse_31(
+class _FakeFileResponse_32 extends _i1.SmartFake implements _i14.FileResponse {
+  _FakeFileResponse_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -379,8 +390,8 @@ class _FakeFileResponse_31 extends _i1.SmartFake implements _i13.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_32(
+class _FakePreviewForUrl_33 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -389,9 +400,9 @@ class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_33 extends _i1.SmartFake
+class _FakeCachedPresence_34 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_33(
+  _FakeCachedPresence_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -400,9 +411,9 @@ class _FakeCachedPresence_33 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_34 extends _i1.SmartFake
+class _FakeTurnServerCredentials_35 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_34(
+  _FakeTurnServerCredentials_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -411,9 +422,9 @@ class _FakeTurnServerCredentials_34 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_35(
+  _FakeRoomKeysUpdateResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -422,8 +433,8 @@ class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_36(
+class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -432,9 +443,9 @@ class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_37(
+  _FakeGetWellknownSupportResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -443,9 +454,9 @@ class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_38(
+  _FakeGenerateLoginTokenResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -454,9 +465,9 @@ class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_39(
+  _FakeGetRoomSummaryResponse$3_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -465,9 +476,9 @@ class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_40(
+  _FakeGetSpaceHierarchyResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -476,9 +487,9 @@ class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_41(
+  _FakeGetRelatingEventsResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -487,9 +498,9 @@ class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_42(
+  _FakeGetRelatingEventsWithRelTypeResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -498,9 +509,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -509,9 +520,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_44(
+  _FakeGetThreadRootsResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -520,9 +531,9 @@ class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_45(
+  _FakeGetEventByTimestampResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -531,9 +542,9 @@ class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_46 extends _i1.SmartFake
+class _FakeRequestTokenResponse_47 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_46(
+  _FakeRequestTokenResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -542,9 +553,9 @@ class _FakeRequestTokenResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_47(
+  _FakeTokenOwnerInfo_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -553,8 +564,8 @@ class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_48(
+class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -563,8 +574,8 @@ class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_49(
+class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -573,8 +584,8 @@ class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_50(
+class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -583,9 +594,9 @@ class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_51(
+  _FakeGetRoomIdByAliasResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -594,9 +605,9 @@ class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_52 extends _i1.SmartFake
+class _FakeGetEventsResponse_53 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_52(
+  _FakeGetEventsResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -605,9 +616,9 @@ class _FakeGetEventsResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_53 extends _i1.SmartFake
+class _FakePeekEventsResponse_54 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_53(
+  _FakePeekEventsResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -616,8 +627,8 @@ class _FakePeekEventsResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_54(
+class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -626,9 +637,9 @@ class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_55(
+  _FakeGetKeysChangesResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -637,9 +648,9 @@ class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_56 extends _i1.SmartFake
+class _FakeClaimKeysResponse_57 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_56(
+  _FakeClaimKeysResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -648,9 +659,9 @@ class _FakeClaimKeysResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_57 extends _i1.SmartFake
+class _FakeQueryKeysResponse_58 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_57(
+  _FakeQueryKeysResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -659,9 +670,9 @@ class _FakeQueryKeysResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_58(
+  _FakeGetNotificationsResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -670,9 +681,9 @@ class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_59 extends _i1.SmartFake
+class _FakeGetPresenceResponse_60 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_59(
+  _FakeGetPresenceResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -681,9 +692,9 @@ class _FakeGetPresenceResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_60(
+  _FakeGetPublicRoomsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -692,9 +703,9 @@ class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_61(
+  _FakeQueryPublicRoomsResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -703,8 +714,8 @@ class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_62(
+class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -713,9 +724,9 @@ class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_63(
+  _FakeGetPushRulesGlobalResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -724,8 +735,8 @@ class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_64(
+class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -734,9 +745,9 @@ class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_65 extends _i1.SmartFake
+class _FakeRefreshResponse_66 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_65(
+  _FakeRefreshResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -745,8 +756,8 @@ class _FakeRefreshResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_66(
+class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -755,8 +766,8 @@ class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_67(
+class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -765,9 +776,9 @@ class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_68(
+  _FakeGetRoomKeysVersionCurrentResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -776,9 +787,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_69(
+  _FakeGetRoomKeysVersionResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -787,8 +798,8 @@ class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_70(
+class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -797,9 +808,9 @@ class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_71(
+  _FakeGetRoomEventsResponse_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,8 +819,8 @@ class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_72(
+class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -818,9 +829,9 @@ class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_73(
+  _FakeGetProtocolMetadataResponse$2_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,9 +840,9 @@ class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_74 extends _i1.SmartFake
+class _FakeOpenIdCredentials_75 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_74(
+  _FakeOpenIdCredentials_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -840,9 +851,9 @@ class _FakeOpenIdCredentials_74 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_75(
+  _FakeSearchUserDirectoryResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -851,9 +862,9 @@ class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_76 extends _i1.SmartFake
+class _FakeCreateContentResponse_77 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_76(
+  _FakeCreateContentResponse_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -865,7 +876,7 @@ class _FakeCreateContentResponse_76 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -895,11 +906,11 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -998,6 +1009,19 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as _i9.AuthService);
 
   @override
+  _i10.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i10.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -1077,6 +1101,15 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
+  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -1084,14 +1117,14 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as bool);
 
   @override
-  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1121,7 +1154,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i16.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1131,18 +1164,18 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<bool> login({
+  _i13.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1157,12 +1190,12 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> completeSsoLogin({
+  _i13.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1175,12 +1208,12 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> completeRegistration(
+  _i13.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1190,32 +1223,32 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1224,7 +1257,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1233,17 +1266,17 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i17.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1254,7 +1287,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i17.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1291,26 +1324,26 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> didPushRouteInformation(
-          _i18.RouteInformation? routeInformation) =>
+  _i13.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1340,7 +1373,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i16.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1349,7 +1382,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i16.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1358,16 +1391,16 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<_i16.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i13.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
+            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
-      ) as _i12.Future<_i16.AppExitResponse>);
+            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i13.Future<_i17.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1395,11 +1428,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1429,11 +1462,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_8(
+        returnValue: _FakeRoomSummary_9(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_8(
+        returnValueForMissingStub: _FakeRoomSummary_9(
           this,
           Invocation.getter(#summary),
         ),
@@ -1463,11 +1496,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i12.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i13.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i12.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i12.Completer<dynamic>>[],
-      ) as List<_i12.Completer<dynamic>>);
+        returnValue: <_i13.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i13.Completer<dynamic>>[],
+      ) as List<_i13.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1486,51 +1519,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i10.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i11.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i10.CachedStreamController<String> get onSessionKeyReceived =>
+  _i11.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1546,11 +1579,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1559,11 +1592,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1606,11 +1639,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1619,11 +1652,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_10(
+        returnValue: _FakeDateTime_11(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_10(
+        returnValueForMissingStub: _FakeDateTime_11(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1653,11 +1686,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_11(
+        returnValue: _FakeLatestReceiptState_12(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_11(
+        returnValueForMissingStub: _FakeLatestReceiptState_12(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1678,18 +1711,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i12.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i13.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -1869,18 +1902,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i19.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i19.SpaceParent>[],
-        returnValueForMissingStub: <_i19.SpaceParent>[],
-      ) as List<_i19.SpaceParent>);
+        returnValue: <_i20.SpaceParent>[],
+        returnValueForMissingStub: <_i20.SpaceParent>[],
+      ) as List<_i20.SpaceParent>);
 
   @override
-  List<_i19.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i19.SpaceChild>[],
-        returnValueForMissingStub: <_i19.SpaceChild>[],
-      ) as List<_i19.SpaceChild>);
+        returnValue: <_i20.SpaceChild>[],
+        returnValueForMissingStub: <_i20.SpaceChild>[],
+      ) as List<_i20.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -1993,14 +2026,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i12.Future<void> postLoad() => (super.noSuchMethod(
+  _i13.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2028,15 +2061,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i12.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i13.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i12.Future<List<_i4.User>>);
+            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i13.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2047,14 +2080,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2064,18 +2097,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i12.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i13.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Event?> refreshLastEvent(
+  _i13.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2083,9 +2116,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2097,12 +2130,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i12.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i13.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2110,22 +2143,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i13.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2133,17 +2166,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> addTag(
+  _i13.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2153,27 +2186,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i13.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i13.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2181,43 +2214,43 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i13.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i13.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i13.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2225,14 +2258,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2244,7 +2277,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i12.Future<String?> sendTextEvent(
+  _i13.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2276,12 +2309,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendReaction(
+  _i13.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2295,12 +2328,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendLocation(
+  _i13.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2314,12 +2347,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendFileEvent(
+  _i13.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2347,25 +2380,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i13.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i12.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i13.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i12.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i13.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i12.Future<_i4.EncryptionHealthState>);
+      ) as _i13.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i12.Future<String?> sendEvent(
+  _i13.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2389,73 +2422,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i13.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> leave() => (super.noSuchMethod(
+  _i13.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> forget() => (super.noSuchMethod(
+  _i13.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> setPower(
+  _i13.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2467,7 +2500,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2478,7 +2511,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2488,10 +2521,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> invite(
+  _i13.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2501,12 +2534,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<int> requestHistory({
+  _i13.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2523,32 +2556,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<int>.value(0),
-        returnValueForMissingStub: _i12.Future<int>.value(0),
-      ) as _i12.Future<int>);
+        returnValue: _i13.Future<int>.value(0),
+        returnValueForMissingStub: _i13.Future<int>.value(0),
+      ) as _i13.Future<int>);
 
   @override
-  _i12.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i13.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setReadMarker(
+  _i13.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2562,23 +2595,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i20.TimelineChunk?> getEventContext(String? eventId) =>
+  _i13.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i12.Future<_i20.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i12.Future<_i20.TimelineChunk?>.value(),
-      ) as _i12.Future<_i20.TimelineChunk?>);
+        returnValue: _i13.Future<_i21.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i13.Future<_i21.TimelineChunk?>.value(),
+      ) as _i13.Future<_i21.TimelineChunk?>);
 
   @override
-  _i12.Future<void> postReceipt(
+  _i13.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2588,12 +2621,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Timeline> getTimeline({
+  _i13.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2616,7 +2649,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
+        returnValue: _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
           this,
           Invocation.method(
             #getTimeline,
@@ -2633,7 +2666,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
+            _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
           this,
           Invocation.method(
             #getTimeline,
@@ -2649,7 +2682,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Timeline>);
+      ) as _i13.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2668,7 +2701,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i12.Future<List<_i4.User>> requestParticipants([
+  _i13.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2686,10 +2719,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i12.Future<List<_i4.User>>);
+            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i13.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2697,14 +2730,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_14(
+        returnValue: _FakeUser_15(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_14(
+        returnValueForMissingStub: _FakeUser_15(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2720,14 +2753,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_14(
+        returnValue: _FakeUser_15(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_14(
+        returnValueForMissingStub: _FakeUser_15(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2737,7 +2770,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i12.Future<_i4.User?> requestUser(
+  _i13.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2753,19 +2786,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i12.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.User?>.value(),
-      ) as _i12.Future<_i4.User?>);
+        returnValue: _i13.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.User?>.value(),
+      ) as _i13.Future<_i4.User?>);
 
   @override
-  _i12.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i13.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2778,12 +2811,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i12.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i13.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2791,14 +2824,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2821,14 +2854,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i12.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i13.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -2867,18 +2900,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i12.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i13.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEvent(
+  _i13.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -2892,12 +2925,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> setTyping(
+  _i13.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -2907,12 +2940,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setJoinRules(
+  _i13.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -2926,59 +2959,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i13.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setHistoryVisibility(
+  _i13.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i13.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i13.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i12.Future<List<_i4.DeviceKeys>>);
+            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i13.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i12.Future<void> requestSessionKey(
+  _i13.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -2990,12 +3023,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setSpaceChild(
+  _i13.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3011,44 +3044,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i13.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i12.Future<Uri>);
+      ) as _i13.Future<Uri>);
 
   @override
-  _i12.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i13.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<
+  _i13.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3075,21 +3108,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i12.Future<
+        returnValue: _i13.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i12.Future<
+        returnValueForMissingStub: _i13.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i12.Future<
+      ) as _i13.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3104,23 +3137,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_16(
+        returnValue: _FakeDatabaseApi_17(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_16(
+        returnValueForMissingStub: _FakeDatabaseApi_17(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i21.KeyVerificationMethod> get verificationMethods =>
+  Set<_i22.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i21.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i21.KeyVerificationMethod>{},
-      ) as Set<_i21.KeyVerificationMethod>);
+        returnValue: <_i22.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i22.KeyVerificationMethod>{},
+      ) as Set<_i22.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3181,11 +3214,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_17(
+        returnValue: _FakeFilter_18(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_17(
+        returnValueForMissingStub: _FakeFilter_18(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3194,11 +3227,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_18(
+        returnValue: _FakeNativeImplementations_19(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_18(
+        returnValueForMissingStub: _FakeNativeImplementations_19(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3214,11 +3247,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_19(
+        returnValue: _FakeDuration_20(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_19(
+        returnValueForMissingStub: _FakeDuration_20(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3227,11 +3260,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_19(
+        returnValue: _FakeDuration_20(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_19(
+        returnValueForMissingStub: _FakeDuration_20(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3240,11 +3273,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3281,11 +3314,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3315,11 +3348,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3328,11 +3361,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3355,11 +3388,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_20(
+        returnValue: _FakePushruleEvaluator_21(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_20(
+        returnValueForMissingStub: _FakePushruleEvaluator_21(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3380,332 +3413,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i12.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i13.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i10.CachedStreamController<String> get onUserProfileUpdate =>
+  _i11.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i12.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i13.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i12.Future<List<_i4.Room>>);
+            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i13.Future<List<_i4.Room>>);
 
   @override
-  _i10.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i11.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_10<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.EventUpdate>(
+            _FakeCachedStreamController_10<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.EventUpdate>);
+      ) as _i11.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i11.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i11.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onNotification =>
+  _i11.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i11.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i11.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i10.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i11.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i10.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i11.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i10.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i11.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_9<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_10<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.LoginState>(
+            _FakeCachedStreamController_10<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i10.CachedStreamController<_i4.LoginState>);
+      ) as _i11.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i10.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i11.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_9<bool>(
+        returnValue: _FakeCachedStreamController_10<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i10.CachedStreamController<bool>);
+      ) as _i11.CachedStreamController<bool>);
 
   @override
-  _i10.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i11.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_9<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_10<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i10.CachedStreamController<_i4.SdkError>);
+      ) as _i11.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i10.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i11.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_9<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_10<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.SyncUpdate>(
+            _FakeCachedStreamController_10<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i10.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i11.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i11.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i10.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i11.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.Presence> get onPresence =>
+  _i11.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_9<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_10<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i10.CachedStreamController<_i4.Presence>);
+      ) as _i11.CachedStreamController<_i4.Presence>);
 
   @override
-  _i10.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i11.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_9<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_10<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.CachedPresence>(
+            _FakeCachedStreamController_10<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i10.CachedStreamController<_i4.CachedPresence>);
+      ) as _i11.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i10.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i11.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_9<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_10<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.BasicEvent>(
+            _FakeCachedStreamController_10<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i10.CachedStreamController<_i4.BasicEvent>);
+      ) as _i11.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i10.CachedStreamController<_i21.RoomKeyRequest> get onRoomKeyRequest =>
+  _i11.CachedStreamController<_i22.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
+            _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i10.CachedStreamController<_i21.RoomKeyRequest>);
+      ) as _i11.CachedStreamController<_i22.RoomKeyRequest>);
 
   @override
-  _i10.CachedStreamController<_i21.KeyVerification>
+  _i11.CachedStreamController<_i22.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_9<_i21.KeyVerification>(
+            returnValue: _FakeCachedStreamController_10<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_9<_i21.KeyVerification>(
+                _FakeCachedStreamController_10<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i10.CachedStreamController<_i21.KeyVerification>);
+          ) as _i11.CachedStreamController<_i22.KeyVerification>);
 
   @override
-  _i10.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i11.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i10.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i11.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i11.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<String> get onCancelSendEvent =>
+  _i11.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i10.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i11.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_9<
+            returnValue: _FakeCachedStreamController_10<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_9<
+            returnValueForMissingStub: _FakeCachedStreamController_10<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i10.CachedStreamController<
+          ) as _i11.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3725,11 +3758,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_10(
+        returnValue: _FakeDateTime_11(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_10(
+        returnValueForMissingStub: _FakeDateTime_11(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3802,7 +3835,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i21.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i22.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3857,7 +3890,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i12.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i13.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3868,7 +3901,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i12.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i13.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -3979,7 +4012,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -3988,7 +4021,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -3997,7 +4030,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4024,20 +4057,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i11.Client get httpClient => (super.noSuchMethod(
+  _i12.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_22(
+        returnValue: _FakeClient_23(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_22(
+        returnValueForMissingStub: _FakeClient_23(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i11.Client);
+      ) as _i12.Client);
 
   @override
-  set httpClient(_i11.Client? value) => super.noSuchMethod(
+  set httpClient(_i12.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4064,7 +4097,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<void> refreshAccessToken(
+  _i13.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4072,9 +4105,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4092,14 +4125,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4136,33 +4169,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i12.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i13.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i12.Future<_i4.DiscoveryInformation>);
+      ) as _i13.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i12.Future<
+  _i13.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4184,7 +4217,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i12.Future<
+        returnValue: _i13.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4192,7 +4225,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_24(
+          _FakeGetVersionsResponse_25(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4207,7 +4240,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i12.Future<
+        returnValueForMissingStub: _i13.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4215,7 +4248,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_24(
+          _FakeGetVersionsResponse_25(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4230,7 +4263,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i12.Future<
+      ) as _i13.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4239,7 +4272,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i12.Future<_i4.DiscoveryInformation> getWellknown({
+  _i13.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4252,8 +4285,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getWellknown,
@@ -4264,8 +4297,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getWellknown,
@@ -4276,10 +4309,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.DiscoveryInformation>);
+      ) as _i13.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i12.Future<_i4.RegisterResponse> register({
+  _i13.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4307,7 +4340,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
+            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
           this,
           Invocation.method(
             #register,
@@ -4326,7 +4359,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
+            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
           this,
           Invocation.method(
             #register,
@@ -4344,10 +4377,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RegisterResponse>);
+      ) as _i13.Future<_i4.RegisterResponse>);
 
   @override
-  _i12.Future<_i4.LoginResponse> login(
+  _i13.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4377,7 +4410,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
+        returnValue: _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
           this,
           Invocation.method(
             #login,
@@ -4397,7 +4430,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
+            _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
           this,
           Invocation.method(
             #login,
@@ -4416,10 +4449,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.LoginResponse>);
+      ) as _i13.Future<_i4.LoginResponse>);
 
   @override
-  _i12.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i13.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4432,8 +4465,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_27(
+        returnValue: _i13.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_28(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4445,8 +4478,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_27(
+            _i13.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_28(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4457,74 +4490,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i13.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> logoutAll() => (super.noSuchMethod(
+  _i13.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<T> uiaRequestBackground<T>(
-          _i12.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i13.Future<T> uiaRequestBackground<T>(
+          _i13.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i12.Future<T>.value(v),
+              (T v) => _i13.Future<T>.value(v),
             ) ??
-            _FakeFuture_28<T>(
+            _FakeFuture_29<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i12.Future<T>.value(v),
+              (T v) => _i13.Future<T>.value(v),
             ) ??
-            _FakeFuture_28<T>(
+            _FakeFuture_29<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i12.Future<T>);
+      ) as _i13.Future<T>);
 
   @override
-  _i12.Future<String> startDirectChat(
+  _i13.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4546,7 +4579,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4562,7 +4595,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4577,10 +4610,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<String> createGroupChat({
+  _i13.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4611,7 +4644,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4632,7 +4665,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4652,10 +4685,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i13.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4671,7 +4704,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4684,7 +4717,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4696,21 +4729,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i13.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<String> createSpace({
+  _i13.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4735,7 +4768,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4753,7 +4786,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4770,10 +4803,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i13.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4781,7 +4814,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4790,7 +4823,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4798,10 +4831,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i12.Future<_i4.Profile> fetchOwnProfile({
+  _i13.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4814,7 +4847,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4826,7 +4859,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4837,10 +4870,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i12.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i13.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4854,8 +4887,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i12.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_29(
+        returnValue: _i13.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_30(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4867,8 +4900,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_29(
+            _i13.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_30(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4879,10 +4912,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.CachedProfileInformation>);
+      ) as _i13.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i12.Future<_i4.Profile> getProfileFromUserId(
+  _i13.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4900,7 +4933,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4914,7 +4947,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4927,7 +4960,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -4949,31 +4982,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i12.Future<List<_i4.Room>>);
+            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i13.Future<List<_i4.Room>>);
 
   @override
-  _i12.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i13.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i12.Future<List<_i4.ArchivedRoom>>);
+            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i13.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i12.Future<_i4.GetVersionsResponse> getVersions({
+  _i13.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4986,8 +5019,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_24(
+        returnValue: _i13.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_25(
           this,
           Invocation.method(
             #getVersions,
@@ -4998,8 +5031,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_24(
+        returnValueForMissingStub: _i13.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_25(
           this,
           Invocation.method(
             #getVersions,
@@ -5010,20 +5043,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetVersionsResponse>);
+      ) as _i13.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i12.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i13.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<_i4.MediaConfig> getConfig({
+  _i13.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5036,7 +5069,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfig,
@@ -5048,7 +5081,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfig,
@@ -5059,10 +5092,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.MediaConfig>);
+      ) as _i13.Future<_i4.MediaConfig>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContent(
+  _i13.Future<_i14.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5082,7 +5115,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContent,
@@ -5098,7 +5131,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContent,
@@ -5113,10 +5146,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentOverrideName(
+  _i13.Future<_i14.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5138,7 +5171,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5155,7 +5188,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5171,10 +5204,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentThumbnail(
+  _i13.Future<_i14.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5202,7 +5235,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5222,7 +5255,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5241,10 +5274,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i13.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5254,7 +5287,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5263,7 +5296,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5271,11 +5304,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i12.Future<_i4.PreviewForUrl>);
+      ) as _i13.Future<_i4.PreviewForUrl>);
 
   @override
-  _i12.Future<Uri> uploadContent(
-    _i22.Uint8List? file, {
+  _i13.Future<Uri> uploadContent(
+    _i23.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5288,7 +5321,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #uploadContent,
@@ -5299,7 +5332,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #uploadContent,
@@ -5310,10 +5343,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<Uri>);
+      ) as _i13.Future<Uri>);
 
   @override
-  _i12.Future<void> setTyping(
+  _i13.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5329,42 +5362,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> exportDump() => (super.noSuchMethod(
+  _i13.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i13.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i13.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Event?> getEventByPushNotification(
+  _i13.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5380,12 +5413,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
-  _i12.Future<void> init({
+  _i13.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5420,9 +5453,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5434,40 +5467,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<void> clear() => (super.noSuchMethod(
+  _i13.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i13.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ensureNotSoftLoggedOut(
+  _i13.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleSync(
+  _i13.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5477,9 +5510,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5492,29 +5525,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i12.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i13.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i13.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDevice(
+  _i13.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5528,12 +5561,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDevicesOfUserIds(
+  _i13.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5549,12 +5582,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDeviceEncrypted(
+  _i13.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5574,12 +5607,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDeviceEncryptedChunked(
+  _i13.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5593,23 +5626,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i13.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> joinRoom(
+  _i13.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5627,7 +5660,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5641,7 +5674,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5654,10 +5687,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> changePassword(
+  _i13.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5673,22 +5706,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> clearCache() => (super.noSuchMethod(
+  _i13.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ignoreUser(
+  _i13.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5698,22 +5731,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i13.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i13.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5724,7 +5757,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5733,7 +5766,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5741,32 +5774,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i12.Future<_i4.CachedPresence>);
+      ) as _i13.Future<_i4.CachedPresence>);
 
   @override
-  _i12.Future<void> abortSync() => (super.noSuchMethod(
+  _i13.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i13.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEventWithMetadata(
+  _i13.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5786,14 +5819,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i11.BaseResponse? response,
-    _i22.Uint8List? body,
+    _i12.BaseResponse? response,
+    _i23.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5825,7 +5858,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i12.Future<Map<String, Object?>> request(
+  _i13.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -5846,13 +5879,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> postPusher(
+  _i13.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -5862,57 +5895,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i13.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i13.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i13.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i12.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_34(
+        returnValue: _i13.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_35(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_34(
+        returnValueForMissingStub: _i13.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_35(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.TurnServerCredentials>);
+      ) as _i13.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5926,8 +5959,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5939,8 +5972,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5951,10 +5984,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5970,8 +6003,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5984,8 +6017,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5997,10 +6030,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i13.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6014,7 +6047,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6026,7 +6059,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6037,17 +6070,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.KeyBackupData>);
+      ) as _i13.Future<_i4.KeyBackupData>);
 
   @override
-  _i12.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i13.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i12.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_37(
+        returnValue: _i13.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_38(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6055,18 +6088,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_37(
+            _i13.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_38(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i13.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i12.Future<int> pingAppservice(
+  _i13.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6076,12 +6109,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i12.Future<int>.value(0),
-        returnValueForMissingStub: _i12.Future<int>.value(0),
-      ) as _i12.Future<int>);
+        returnValue: _i13.Future<int>.value(0),
+        returnValueForMissingStub: _i13.Future<int>.value(0),
+      ) as _i13.Future<int>);
 
   @override
-  _i12.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i13.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6089,8 +6122,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_38(
+        returnValue: _i13.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_39(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6099,8 +6132,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_38(
+            _i13.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_39(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6108,15 +6141,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i12.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i13.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i12.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i13.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6124,17 +6157,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.MediaConfig>);
+      ) as _i13.Future<_i4.MediaConfig>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentAuthed(
+  _i13.Future<_i14.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6148,7 +6181,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6160,7 +6193,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6171,10 +6204,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentOverrideNameAuthed(
+  _i13.Future<_i14.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6190,7 +6223,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6203,7 +6236,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6215,10 +6248,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i13.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6228,7 +6261,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6237,7 +6270,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6245,10 +6278,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i12.Future<_i4.PreviewForUrl>);
+      ) as _i13.Future<_i4.PreviewForUrl>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentThumbnailAuthed(
+  _i13.Future<_i14.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6272,7 +6305,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6290,7 +6323,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6307,21 +6340,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<bool> registrationTokenValidity(String? token) =>
+  _i13.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i13.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6331,8 +6364,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_39(
+        returnValue: _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_40(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6341,8 +6374,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_39(
+            _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_40(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6350,10 +6383,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i13.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i12.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i13.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6371,8 +6404,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_40(
+        returnValue: _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_41(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6386,8 +6419,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_40(
+            _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_41(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6400,10 +6433,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i13.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i13.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6427,8 +6460,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i12.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_41(
+        returnValue: _i13.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_42(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6446,8 +6479,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_41(
+            _i13.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_42(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6464,10 +6497,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i13.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6495,8 +6528,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_42(
+                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6515,8 +6548,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_42(
+                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6534,10 +6567,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i13.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6566,9 +6599,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i12.Future<
+            returnValue: _i13.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6587,9 +6620,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i12.Future<
+            returnValueForMissingStub: _i13.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6608,11 +6641,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i12
+          ) as _i13
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i12.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i13.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6628,8 +6661,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i12.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_44(
+        returnValue: _i13.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_45(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6642,8 +6675,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_44(
+            _i13.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_45(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6655,10 +6688,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetThreadRootsResponse>);
+      ) as _i13.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i12.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i13.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6672,8 +6705,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i12.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_45(
+        returnValue: _i13.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_46(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6685,8 +6718,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_45(
+            _i13.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_46(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6697,33 +6730,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i13.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i13.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i12.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i13.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i12.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i13.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i12.Future<Uri?>.value(),
-        returnValueForMissingStub: _i12.Future<Uri?>.value(),
-      ) as _i12.Future<Uri?>);
+        returnValue: _i13.Future<Uri?>.value(),
+        returnValueForMissingStub: _i13.Future<Uri?>.value(),
+      ) as _i13.Future<Uri?>);
 
   @override
-  _i12.Future<void> add3PID(
+  _i13.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6737,12 +6770,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> bind3PID(
+  _i13.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6758,12 +6791,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i13.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6777,14 +6810,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6806,8 +6839,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6823,8 +6856,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6840,10 +6873,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6867,8 +6900,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6885,8 +6918,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6903,10 +6936,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i13.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6920,14 +6953,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i13.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -6942,14 +6975,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6971,8 +7004,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -6988,8 +7021,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7005,10 +7038,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7032,8 +7065,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7050,8 +7083,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7068,16 +7101,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i13.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
+            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7085,22 +7118,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
+            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.TokenOwnerInfo>);
+      ) as _i13.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i12.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i13.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
+        returnValue: _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7108,22 +7141,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
+            _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i4.WhoIsInfo>);
+      ) as _i13.Future<_i4.WhoIsInfo>);
 
   @override
-  _i12.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i13.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
+        returnValue: _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7131,17 +7164,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
+            _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.Capabilities>);
+      ) as _i13.Future<_i4.Capabilities>);
 
   @override
-  _i12.Future<String> createRoom({
+  _i13.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7174,7 +7207,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7196,7 +7229,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7217,10 +7250,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> deleteDevices(
+  _i13.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7230,22 +7263,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.Device>?>.value(),
-      ) as _i12.Future<List<_i4.Device>?>);
+        returnValue: _i13.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.Device>?>.value(),
+      ) as _i13.Future<List<_i4.Device>?>);
 
   @override
-  _i12.Future<void> deleteDevice(
+  _i13.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7255,34 +7288,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i13.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i12.Future<_i4.Device>.value(_FakeDevice_50(
+        returnValue: _i13.Future<_i4.Device>.value(_FakeDevice_51(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.Device>.value(_FakeDevice_50(
+        returnValueForMissingStub: _i13.Future<_i4.Device>.value(_FakeDevice_51(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i12.Future<_i4.Device>);
+      ) as _i13.Future<_i4.Device>);
 
   @override
-  _i12.Future<void> updateDevice(
+  _i13.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7292,12 +7325,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i13.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7312,24 +7345,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i13.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i12.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Visibility?>.value(),
-      ) as _i12.Future<_i4.Visibility?>);
+        returnValue: _i13.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Visibility?>.value(),
+      ) as _i13.Future<_i4.Visibility?>);
 
   @override
-  _i12.Future<void> setRoomVisibilityOnDirectory(
+  _i13.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7339,30 +7372,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i13.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i13.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_51(
+        returnValue: _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_52(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7370,18 +7403,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_51(
+            _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_52(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i13.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i12.Future<void> setRoomAlias(
+  _i13.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7393,12 +7426,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetEventsResponse> getEvents({
+  _i13.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7412,7 +7445,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
+            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
           this,
           Invocation.method(
             #getEvents,
@@ -7424,7 +7457,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
+            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
           this,
           Invocation.method(
             #getEvents,
@@ -7435,10 +7468,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetEventsResponse>);
+      ) as _i13.Future<_i4.GetEventsResponse>);
 
   @override
-  _i12.Future<_i4.PeekEventsResponse> peekEvents({
+  _i13.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7453,8 +7486,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i12.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_53(
+        returnValue: _i13.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_54(
           this,
           Invocation.method(
             #peekEvents,
@@ -7466,8 +7499,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_53(
+        returnValueForMissingStub: _i13.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_54(
           this,
           Invocation.method(
             #peekEvents,
@@ -7479,16 +7512,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.PeekEventsResponse>);
+      ) as _i13.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i12.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i13.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7496,27 +7529,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i12.Future<_i4.MatrixEvent>);
+      ) as _i13.Future<_i4.MatrixEvent>);
 
   @override
-  _i12.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i13.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i12.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
-      ) as _i12.Future<List<String>>);
+        returnValue: _i13.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
+      ) as _i13.Future<List<String>>);
 
   @override
-  _i12.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i13.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7528,8 +7561,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i12.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_55(
+        returnValue: _i13.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_56(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7540,8 +7573,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_55(
+            _i13.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_56(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7551,10 +7584,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.GetKeysChangesResponse>);
+      ) as _i13.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i12.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i13.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7565,7 +7598,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
+            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
           this,
           Invocation.method(
             #claimKeys,
@@ -7574,7 +7607,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
+            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
           this,
           Invocation.method(
             #claimKeys,
@@ -7582,10 +7615,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i12.Future<_i4.ClaimKeysResponse>);
+      ) as _i13.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i12.Future<void> uploadCrossSigningKeys({
+  _i13.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7602,12 +7635,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.QueryKeysResponse> queryKeys(
+  _i13.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7618,7 +7651,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
+            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
           this,
           Invocation.method(
             #queryKeys,
@@ -7627,7 +7660,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
+            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
           this,
           Invocation.method(
             #queryKeys,
@@ -7635,10 +7668,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i12.Future<_i4.QueryKeysResponse>);
+      ) as _i13.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7646,14 +7679,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i12.Future<
+            returnValue: _i13.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i12.Future<
+            returnValueForMissingStub: _i13.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i12.Future<Map<String, int>> uploadKeys({
+  _i13.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7668,13 +7701,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i12.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i13.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i12.Future<Map<String, int>>);
+            _i13.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i13.Future<Map<String, int>>);
 
   @override
-  _i12.Future<String> knockRoom(
+  _i13.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7688,7 +7721,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7700,7 +7733,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7711,20 +7744,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i13.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i12.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i13.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i13.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i12.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i13.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7739,8 +7772,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i12.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_58(
+        returnValue: _i13.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_59(
           this,
           Invocation.method(
             #getNotifications,
@@ -7753,8 +7786,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_58(
+            _i13.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_59(
           this,
           Invocation.method(
             #getNotifications,
@@ -7766,35 +7799,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetNotificationsResponse>);
+      ) as _i13.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i12.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i13.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i12.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_59(
+        returnValue: _i13.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_60(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_59(
+        returnValueForMissingStub: _i13.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_60(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i4.GetPresenceResponse>);
+      ) as _i13.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i12.Future<void> setPresence(
+  _i13.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -7808,12 +7841,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, Object?>> deleteProfileField(
+  _i13.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7826,13 +7859,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getProfileField(
+  _i13.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7845,13 +7878,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<Map<String, Object?>> setProfileField(
+  _i13.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7866,13 +7899,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i13.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7887,8 +7920,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i12.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_60(
+        returnValue: _i13.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_61(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7901,8 +7934,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_60(
+            _i13.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_61(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7914,10 +7947,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i13.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i12.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i13.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -7938,8 +7971,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i12.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_61(
+        returnValue: _i13.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_62(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7955,8 +7988,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_61(
+            _i13.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_62(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7971,25 +8004,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i13.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i12.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.Pusher>?>.value(),
-      ) as _i12.Future<List<_i4.Pusher>?>);
+        returnValue: _i13.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.Pusher>?>.value(),
+      ) as _i13.Future<List<_i4.Pusher>?>);
 
   @override
-  _i12.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i13.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
+        returnValue: _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
           this,
           Invocation.method(
             #getPushRules,
@@ -7997,24 +8030,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
+            _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.PushRuleSet>);
+      ) as _i13.Future<_i4.PushRuleSet>);
 
   @override
-  _i12.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i13.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_63(
+        returnValue: _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_64(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8022,18 +8055,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_63(
+            _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_64(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i13.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i12.Future<void> deletePushRule(
+  _i13.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8045,12 +8078,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.PushRule> getPushRule(
+  _i13.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8062,7 +8095,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
+        returnValue: _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
           this,
           Invocation.method(
             #getPushRule,
@@ -8073,7 +8106,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
+            _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
           this,
           Invocation.method(
             #getPushRule,
@@ -8083,10 +8116,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.PushRule>);
+      ) as _i13.Future<_i4.PushRule>);
 
   @override
-  _i12.Future<void> setPushRule(
+  _i13.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8110,12 +8143,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<Object?>> getPushRuleActions(
+  _i13.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8127,13 +8160,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i13.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i12.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i12.Future<List<Object?>>);
+            _i13.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i13.Future<List<Object?>>);
 
   @override
-  _i12.Future<void> setPushRuleActions(
+  _i13.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8147,12 +8180,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<bool> isPushRuleEnabled(
+  _i13.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8164,12 +8197,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> setPushRuleEnabled(
+  _i13.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8183,19 +8216,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i13.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
+            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
           this,
           Invocation.method(
             #refresh,
@@ -8203,28 +8236,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
+            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i12.Future<_i4.RefreshResponse>);
+      ) as _i13.Future<_i4.RefreshResponse>);
 
   @override
-  _i12.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i13.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i12.Future<bool?>.value(),
-        returnValueForMissingStub: _i12.Future<bool?>.value(),
-      ) as _i12.Future<bool?>);
+        returnValue: _i13.Future<bool?>.value(),
+        returnValueForMissingStub: _i13.Future<bool?>.value(),
+      ) as _i13.Future<bool?>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8246,8 +8279,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8263,8 +8296,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8280,10 +8313,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8307,8 +8340,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8325,8 +8358,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8343,17 +8376,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8361,23 +8394,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i13.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
+        returnValue: _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8385,17 +8418,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
+            _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeys>);
+      ) as _i13.Future<_i4.RoomKeys>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8407,8 +8440,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8419,8 +8452,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8430,10 +8463,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8445,8 +8478,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8457,8 +8490,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8468,10 +8501,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8483,7 +8516,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
+        returnValue: _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8494,7 +8527,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
+            _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8504,10 +8537,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeyBackup>);
+      ) as _i13.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8521,8 +8554,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8534,8 +8567,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8546,10 +8579,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8563,8 +8596,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8576,8 +8609,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8588,10 +8621,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i13.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8605,7 +8638,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8617,7 +8650,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8628,10 +8661,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.KeyBackupData>);
+      ) as _i13.Future<_i4.KeyBackupData>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8647,8 +8680,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8661,8 +8694,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8674,18 +8707,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_68(
+                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_69(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8693,18 +8726,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_68(
+                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_69(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i12.Future<String> postRoomKeysVersion(
+  _i13.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8716,7 +8749,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8727,7 +8760,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8737,29 +8770,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i13.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i13.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_69(
+        returnValue: _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_70(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8767,18 +8800,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_69(
+            _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_70(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i13.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i13.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8793,24 +8826,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i13.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i12.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
-      ) as _i12.Future<List<String>>);
+        returnValue: _i13.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
+      ) as _i13.Future<List<String>>);
 
   @override
-  _i12.Future<void> ban(
+  _i13.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8824,12 +8857,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.EventContext> getEventContext(
+  _i13.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8847,7 +8880,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
+        returnValue: _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
           this,
           Invocation.method(
             #getEventContext,
@@ -8862,7 +8895,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
+            _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
           this,
           Invocation.method(
             #getEventContext,
@@ -8876,10 +8909,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.EventContext>);
+      ) as _i13.Future<_i4.EventContext>);
 
   @override
-  _i12.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i13.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8891,7 +8924,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8902,7 +8935,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8912,20 +8945,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.MatrixEvent>);
+      ) as _i13.Future<_i4.MatrixEvent>);
 
   @override
-  _i12.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i13.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> inviteBy3PID(
+  _i13.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -8937,12 +8970,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> inviteUser(
+  _i13.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8956,12 +8989,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> joinRoomById(
+  _i13.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -8975,7 +9008,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8987,7 +9020,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8998,23 +9031,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i13.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i12.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i13.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i12.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i12.Future<Map<String, _i4.RoomMember>?>);
+            _i13.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i13.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i12.Future<void> kick(
+  _i13.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9028,12 +9061,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> leaveRoom(
+  _i13.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9043,12 +9076,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i13.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9064,12 +9097,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i12.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i12.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i13.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i13.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i12.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i13.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9091,8 +9124,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_71(
+        returnValue: _i13.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_72(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9108,8 +9141,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_71(
+        returnValueForMissingStub: _i13.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_72(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9125,10 +9158,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomEventsResponse>);
+      ) as _i13.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i12.Future<void> setReadMarker(
+  _i13.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9144,12 +9177,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> postReceipt(
+  _i13.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9165,12 +9198,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEvent(
+  _i13.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9186,12 +9219,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> reportRoom(
+  _i13.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9203,12 +9236,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> reportEvent(
+  _i13.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9226,12 +9259,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> sendMessage(
+  _i13.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9247,7 +9280,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9260,7 +9293,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9272,23 +9305,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i13.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i12.Future<List<_i4.MatrixEvent>>);
+            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i13.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i13.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9305,13 +9338,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<String> setRoomStateWithKey(
+  _i13.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9327,7 +9360,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9340,7 +9373,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9352,10 +9385,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> unban(
+  _i13.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9369,12 +9402,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> upgradeRoom(
+  _i13.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9388,7 +9421,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9400,7 +9433,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9411,10 +9444,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.SearchResults> search(
+  _i13.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9424,7 +9457,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
+        returnValue: _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
           this,
           Invocation.method(
             #search,
@@ -9433,7 +9466,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
+            _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
           this,
           Invocation.method(
             #search,
@@ -9441,10 +9474,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i12.Future<_i4.SearchResults>);
+      ) as _i13.Future<_i4.SearchResults>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> sync({
+  _i13.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9465,7 +9498,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #sync,
@@ -9481,7 +9514,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #sync,
@@ -9496,22 +9529,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i13.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i12.Future<List<_i4.Location>>);
+            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i13.Future<List<_i4.Location>>);
 
   @override
-  _i12.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i13.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9521,21 +9554,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i12.Future<List<_i4.Location>>);
+            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i13.Future<List<_i4.Location>>);
 
   @override
-  _i12.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i13.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_73(
+        returnValue: _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_74(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9543,45 +9576,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_73(
+            _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_74(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i12.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i13.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i12.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i13.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9592,13 +9625,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getAccountData(
+  _i13.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9611,13 +9644,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> setAccountData(
+  _i13.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9631,12 +9664,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> defineFilter(
+  _i13.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9648,7 +9681,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9659,7 +9692,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9669,10 +9702,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.Filter> getFilter(
+  _i13.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9684,7 +9717,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
+        returnValue: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
           this,
           Invocation.method(
             #getFilter,
@@ -9694,7 +9727,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
+        returnValueForMissingStub: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
           this,
           Invocation.method(
             #getFilter,
@@ -9704,10 +9737,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.Filter>);
+      ) as _i13.Future<_i4.Filter>);
 
   @override
-  _i12.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i13.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9720,7 +9753,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
+            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9731,7 +9764,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
+            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9741,10 +9774,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.OpenIdCredentials>);
+      ) as _i13.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i12.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i13.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9759,13 +9792,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> setAccountDataPerRoom(
+  _i13.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9781,12 +9814,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i13.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9798,12 +9831,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i12.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i12.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i12.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i13.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i13.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i13.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i12.Future<void> deleteRoomTag(
+  _i13.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9817,12 +9850,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setRoomTag(
+  _i13.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9838,12 +9871,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i13.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9853,8 +9886,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i12.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_75(
+        returnValue: _i13.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_76(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9863,8 +9896,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_75(
+            _i13.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_76(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9872,10 +9905,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i12.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i13.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> reportUser(
+  _i13.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9888,40 +9921,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i13.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i12.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_76(
+        returnValue: _i13.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_77(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_76(
+        returnValueForMissingStub: _i13.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_77(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.CreateContentResponse>);
+      ) as _i13.Future<_i4.CreateContentResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> uploadContentToMXC(
+  _i13.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i22.Uint8List? body, {
+    _i23.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -9939,8 +9972,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 }

--- a/test/widgets/invite_tile_test.mocks.dart
+++ b/test/widgets/invite_tile_test.mocks.dart
@@ -3,17 +3,18 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i12;
-import 'dart:typed_data' as _i22;
-import 'dart:ui' as _i16;
+import 'dart:async' as _i13;
+import 'dart:typed_data' as _i23;
+import 'dart:ui' as _i17;
 
-import 'package:flutter/services.dart' as _i17;
-import 'package:flutter/widgets.dart' as _i18;
-import 'package:http/http.dart' as _i11;
-import 'package:kohera/core/services/matrix_service.dart' as _i14;
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
+import 'package:http/http.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
@@ -22,14 +23,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i21;
+import 'package:matrix/encryption.dart' as _i22;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i13;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i20;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i10;
-import 'package:matrix/src/utils/space_child.dart' as _i19;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i14;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i11;
+import 'package:matrix/src/utils/space_child.dart' as _i20;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -130,8 +131,8 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeRoomSummary_8 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_8(
+class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
+  _FakeOutboxService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -140,9 +141,8 @@ class _FakeRoomSummary_8 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_9<T> extends _i1.SmartFake
-    implements _i10.CachedStreamController<T> {
-  _FakeCachedStreamController_9(
+class _FakeRoomSummary_9 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -151,8 +151,9 @@ class _FakeCachedStreamController_9<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_10 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_10(
+class _FakeCachedStreamController_10<T> extends _i1.SmartFake
+    implements _i11.CachedStreamController<T> {
+  _FakeCachedStreamController_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -161,9 +162,19 @@ class _FakeDateTime_10 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_11 extends _i1.SmartFake
+class _FakeDateTime_11 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_11(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_12 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_11(
+  _FakeLatestReceiptState_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -172,8 +183,8 @@ class _FakeLatestReceiptState_11 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_12 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_12(
+class _FakeSyncUpdate_13 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -182,8 +193,8 @@ class _FakeSyncUpdate_12 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_13 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_13(
+class _FakeTimeline_14 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -192,8 +203,8 @@ class _FakeTimeline_13 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_14 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_14(
+class _FakeUser_15 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -202,8 +213,8 @@ class _FakeUser_14 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_15 extends _i1.SmartFake implements Uri {
-  _FakeUri_15(
+class _FakeUri_16 extends _i1.SmartFake implements Uri {
+  _FakeUri_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -212,8 +223,8 @@ class _FakeUri_15 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_16 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_16(
+class _FakeDatabaseApi_17 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -222,8 +233,8 @@ class _FakeDatabaseApi_16 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_17 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_17(
+class _FakeFilter_18 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -232,9 +243,9 @@ class _FakeFilter_17 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_18 extends _i1.SmartFake
+class _FakeNativeImplementations_19 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_18(
+  _FakeNativeImplementations_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -243,8 +254,8 @@ class _FakeNativeImplementations_18 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_19 extends _i1.SmartFake implements Duration {
-  _FakeDuration_19(
+class _FakeDuration_20 extends _i1.SmartFake implements Duration {
+  _FakeDuration_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -253,9 +264,9 @@ class _FakeDuration_19 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_20 extends _i1.SmartFake
+class _FakePushruleEvaluator_21 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_20(
+  _FakePushruleEvaluator_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -264,8 +275,8 @@ class _FakePushruleEvaluator_20 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_21 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_21(
+class _FakeProfile_22 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -274,8 +285,8 @@ class _FakeProfile_21 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_22 extends _i1.SmartFake implements _i11.Client {
-  _FakeClient_22(
+class _FakeClient_23 extends _i1.SmartFake implements _i12.Client {
+  _FakeClient_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -284,9 +295,9 @@ class _FakeClient_22 extends _i1.SmartFake implements _i11.Client {
         );
 }
 
-class _FakeDiscoveryInformation_23 extends _i1.SmartFake
+class _FakeDiscoveryInformation_24 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_23(
+  _FakeDiscoveryInformation_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -295,9 +306,9 @@ class _FakeDiscoveryInformation_23 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_24 extends _i1.SmartFake
+class _FakeGetVersionsResponse_25 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_24(
+  _FakeGetVersionsResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -306,9 +317,9 @@ class _FakeGetVersionsResponse_24 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_25 extends _i1.SmartFake
+class _FakeRegisterResponse_26 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_25(
+  _FakeRegisterResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -317,8 +328,8 @@ class _FakeRegisterResponse_25 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_26 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_26(
+class _FakeLoginResponse_27 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -327,9 +338,9 @@ class _FakeLoginResponse_26 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_27 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_28 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_27(
+  _FakeGetAuthMetadataResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -338,8 +349,8 @@ class _FakeGetAuthMetadataResponse_27 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_28<T1> extends _i1.SmartFake implements _i12.Future<T1> {
-  _FakeFuture_28(
+class _FakeFuture_29<T1> extends _i1.SmartFake implements _i13.Future<T1> {
+  _FakeFuture_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -348,9 +359,9 @@ class _FakeFuture_28<T1> extends _i1.SmartFake implements _i12.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_29 extends _i1.SmartFake
+class _FakeCachedProfileInformation_30 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_29(
+  _FakeCachedProfileInformation_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -359,8 +370,8 @@ class _FakeCachedProfileInformation_29 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_30(
+class _FakeMediaConfig_31 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -369,8 +380,8 @@ class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_31 extends _i1.SmartFake implements _i13.FileResponse {
-  _FakeFileResponse_31(
+class _FakeFileResponse_32 extends _i1.SmartFake implements _i14.FileResponse {
+  _FakeFileResponse_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -379,8 +390,8 @@ class _FakeFileResponse_31 extends _i1.SmartFake implements _i13.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_32(
+class _FakePreviewForUrl_33 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -389,9 +400,9 @@ class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_33 extends _i1.SmartFake
+class _FakeCachedPresence_34 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_33(
+  _FakeCachedPresence_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -400,9 +411,9 @@ class _FakeCachedPresence_33 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_34 extends _i1.SmartFake
+class _FakeTurnServerCredentials_35 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_34(
+  _FakeTurnServerCredentials_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -411,9 +422,9 @@ class _FakeTurnServerCredentials_34 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_35(
+  _FakeRoomKeysUpdateResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -422,8 +433,8 @@ class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_36(
+class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -432,9 +443,9 @@ class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_37(
+  _FakeGetWellknownSupportResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -443,9 +454,9 @@ class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_38(
+  _FakeGenerateLoginTokenResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -454,9 +465,9 @@ class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_39(
+  _FakeGetRoomSummaryResponse$3_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -465,9 +476,9 @@ class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_40(
+  _FakeGetSpaceHierarchyResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -476,9 +487,9 @@ class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_41(
+  _FakeGetRelatingEventsResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -487,9 +498,9 @@ class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_42(
+  _FakeGetRelatingEventsWithRelTypeResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -498,9 +509,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -509,9 +520,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_44(
+  _FakeGetThreadRootsResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -520,9 +531,9 @@ class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_45(
+  _FakeGetEventByTimestampResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -531,9 +542,9 @@ class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_46 extends _i1.SmartFake
+class _FakeRequestTokenResponse_47 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_46(
+  _FakeRequestTokenResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -542,9 +553,9 @@ class _FakeRequestTokenResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_47(
+  _FakeTokenOwnerInfo_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -553,8 +564,8 @@ class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_48(
+class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -563,8 +574,8 @@ class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_49(
+class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -573,8 +584,8 @@ class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_50(
+class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -583,9 +594,9 @@ class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_51(
+  _FakeGetRoomIdByAliasResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -594,9 +605,9 @@ class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_52 extends _i1.SmartFake
+class _FakeGetEventsResponse_53 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_52(
+  _FakeGetEventsResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -605,9 +616,9 @@ class _FakeGetEventsResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_53 extends _i1.SmartFake
+class _FakePeekEventsResponse_54 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_53(
+  _FakePeekEventsResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -616,8 +627,8 @@ class _FakePeekEventsResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_54(
+class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -626,9 +637,9 @@ class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_55(
+  _FakeGetKeysChangesResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -637,9 +648,9 @@ class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_56 extends _i1.SmartFake
+class _FakeClaimKeysResponse_57 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_56(
+  _FakeClaimKeysResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -648,9 +659,9 @@ class _FakeClaimKeysResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_57 extends _i1.SmartFake
+class _FakeQueryKeysResponse_58 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_57(
+  _FakeQueryKeysResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -659,9 +670,9 @@ class _FakeQueryKeysResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_58(
+  _FakeGetNotificationsResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -670,9 +681,9 @@ class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_59 extends _i1.SmartFake
+class _FakeGetPresenceResponse_60 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_59(
+  _FakeGetPresenceResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -681,9 +692,9 @@ class _FakeGetPresenceResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_60(
+  _FakeGetPublicRoomsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -692,9 +703,9 @@ class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_61(
+  _FakeQueryPublicRoomsResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -703,8 +714,8 @@ class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_62(
+class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -713,9 +724,9 @@ class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_63(
+  _FakeGetPushRulesGlobalResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -724,8 +735,8 @@ class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_64(
+class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -734,9 +745,9 @@ class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_65 extends _i1.SmartFake
+class _FakeRefreshResponse_66 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_65(
+  _FakeRefreshResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -745,8 +756,8 @@ class _FakeRefreshResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_66(
+class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -755,8 +766,8 @@ class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_67(
+class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -765,9 +776,9 @@ class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_68(
+  _FakeGetRoomKeysVersionCurrentResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -776,9 +787,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_69(
+  _FakeGetRoomKeysVersionResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -787,8 +798,8 @@ class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_70(
+class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -797,9 +808,9 @@ class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_71(
+  _FakeGetRoomEventsResponse_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,8 +819,8 @@ class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_72(
+class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -818,9 +829,9 @@ class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_73(
+  _FakeGetProtocolMetadataResponse$2_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,9 +840,9 @@ class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_74 extends _i1.SmartFake
+class _FakeOpenIdCredentials_75 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_74(
+  _FakeOpenIdCredentials_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -840,9 +851,9 @@ class _FakeOpenIdCredentials_74 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_75(
+  _FakeSearchUserDirectoryResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -851,9 +862,9 @@ class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_76 extends _i1.SmartFake
+class _FakeCreateContentResponse_77 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_76(
+  _FakeCreateContentResponse_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -865,7 +876,7 @@ class _FakeCreateContentResponse_76 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -895,11 +906,11 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -998,6 +1009,19 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as _i9.AuthService);
 
   @override
+  _i10.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i10.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -1077,6 +1101,15 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
+  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -1084,14 +1117,14 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as bool);
 
   @override
-  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1121,7 +1154,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i16.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1131,18 +1164,18 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<bool> login({
+  _i13.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1157,12 +1190,12 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> completeSsoLogin({
+  _i13.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1175,12 +1208,12 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> completeRegistration(
+  _i13.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1190,32 +1223,32 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1224,7 +1257,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1233,17 +1266,17 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i17.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1254,7 +1287,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i17.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1291,26 +1324,26 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> didPushRouteInformation(
-          _i18.RouteInformation? routeInformation) =>
+  _i13.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1340,7 +1373,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i16.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1349,7 +1382,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i16.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1358,16 +1391,16 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<_i16.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i13.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
+            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
-      ) as _i12.Future<_i16.AppExitResponse>);
+            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i13.Future<_i17.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1395,11 +1428,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1429,11 +1462,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_8(
+        returnValue: _FakeRoomSummary_9(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_8(
+        returnValueForMissingStub: _FakeRoomSummary_9(
           this,
           Invocation.getter(#summary),
         ),
@@ -1463,11 +1496,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i12.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i13.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i12.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i12.Completer<dynamic>>[],
-      ) as List<_i12.Completer<dynamic>>);
+        returnValue: <_i13.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i13.Completer<dynamic>>[],
+      ) as List<_i13.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1486,51 +1519,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i10.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i11.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i10.CachedStreamController<String> get onSessionKeyReceived =>
+  _i11.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1546,11 +1579,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1559,11 +1592,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1606,11 +1639,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1619,11 +1652,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_10(
+        returnValue: _FakeDateTime_11(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_10(
+        returnValueForMissingStub: _FakeDateTime_11(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1653,11 +1686,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_11(
+        returnValue: _FakeLatestReceiptState_12(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_11(
+        returnValueForMissingStub: _FakeLatestReceiptState_12(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1678,18 +1711,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i12.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i13.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -1869,18 +1902,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i19.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i19.SpaceParent>[],
-        returnValueForMissingStub: <_i19.SpaceParent>[],
-      ) as List<_i19.SpaceParent>);
+        returnValue: <_i20.SpaceParent>[],
+        returnValueForMissingStub: <_i20.SpaceParent>[],
+      ) as List<_i20.SpaceParent>);
 
   @override
-  List<_i19.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i19.SpaceChild>[],
-        returnValueForMissingStub: <_i19.SpaceChild>[],
-      ) as List<_i19.SpaceChild>);
+        returnValue: <_i20.SpaceChild>[],
+        returnValueForMissingStub: <_i20.SpaceChild>[],
+      ) as List<_i20.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -1993,14 +2026,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i12.Future<void> postLoad() => (super.noSuchMethod(
+  _i13.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2028,15 +2061,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i12.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i13.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i12.Future<List<_i4.User>>);
+            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i13.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2047,14 +2080,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2064,18 +2097,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i12.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i13.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Event?> refreshLastEvent(
+  _i13.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2083,9 +2116,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2097,12 +2130,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i12.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i13.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2110,22 +2143,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i13.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2133,17 +2166,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> addTag(
+  _i13.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2153,27 +2186,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i13.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i13.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2181,43 +2214,43 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i13.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i13.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i13.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2225,14 +2258,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2244,7 +2277,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i12.Future<String?> sendTextEvent(
+  _i13.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2276,12 +2309,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendReaction(
+  _i13.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2295,12 +2328,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendLocation(
+  _i13.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2314,12 +2347,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendFileEvent(
+  _i13.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2347,25 +2380,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i13.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i12.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i13.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i12.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i13.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i12.Future<_i4.EncryptionHealthState>);
+      ) as _i13.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i12.Future<String?> sendEvent(
+  _i13.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2389,73 +2422,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i13.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> leave() => (super.noSuchMethod(
+  _i13.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> forget() => (super.noSuchMethod(
+  _i13.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> setPower(
+  _i13.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2467,7 +2500,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2478,7 +2511,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2488,10 +2521,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> invite(
+  _i13.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2501,12 +2534,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<int> requestHistory({
+  _i13.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2523,32 +2556,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<int>.value(0),
-        returnValueForMissingStub: _i12.Future<int>.value(0),
-      ) as _i12.Future<int>);
+        returnValue: _i13.Future<int>.value(0),
+        returnValueForMissingStub: _i13.Future<int>.value(0),
+      ) as _i13.Future<int>);
 
   @override
-  _i12.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i13.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setReadMarker(
+  _i13.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2562,23 +2595,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i20.TimelineChunk?> getEventContext(String? eventId) =>
+  _i13.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i12.Future<_i20.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i12.Future<_i20.TimelineChunk?>.value(),
-      ) as _i12.Future<_i20.TimelineChunk?>);
+        returnValue: _i13.Future<_i21.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i13.Future<_i21.TimelineChunk?>.value(),
+      ) as _i13.Future<_i21.TimelineChunk?>);
 
   @override
-  _i12.Future<void> postReceipt(
+  _i13.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2588,12 +2621,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Timeline> getTimeline({
+  _i13.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2616,7 +2649,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
+        returnValue: _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
           this,
           Invocation.method(
             #getTimeline,
@@ -2633,7 +2666,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
+            _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
           this,
           Invocation.method(
             #getTimeline,
@@ -2649,7 +2682,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Timeline>);
+      ) as _i13.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2668,7 +2701,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i12.Future<List<_i4.User>> requestParticipants([
+  _i13.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2686,10 +2719,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i12.Future<List<_i4.User>>);
+            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i13.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2697,14 +2730,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_14(
+        returnValue: _FakeUser_15(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_14(
+        returnValueForMissingStub: _FakeUser_15(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2720,14 +2753,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_14(
+        returnValue: _FakeUser_15(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_14(
+        returnValueForMissingStub: _FakeUser_15(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2737,7 +2770,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i12.Future<_i4.User?> requestUser(
+  _i13.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2753,19 +2786,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i12.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.User?>.value(),
-      ) as _i12.Future<_i4.User?>);
+        returnValue: _i13.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.User?>.value(),
+      ) as _i13.Future<_i4.User?>);
 
   @override
-  _i12.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i13.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2778,12 +2811,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i12.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i13.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2791,14 +2824,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2821,14 +2854,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i12.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i13.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -2867,18 +2900,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i12.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i13.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEvent(
+  _i13.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -2892,12 +2925,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> setTyping(
+  _i13.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -2907,12 +2940,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setJoinRules(
+  _i13.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -2926,59 +2959,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i13.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setHistoryVisibility(
+  _i13.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i13.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i13.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i12.Future<List<_i4.DeviceKeys>>);
+            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i13.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i12.Future<void> requestSessionKey(
+  _i13.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -2990,12 +3023,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setSpaceChild(
+  _i13.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3011,44 +3044,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i13.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i12.Future<Uri>);
+      ) as _i13.Future<Uri>);
 
   @override
-  _i12.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i13.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<
+  _i13.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3075,21 +3108,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i12.Future<
+        returnValue: _i13.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i12.Future<
+        returnValueForMissingStub: _i13.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i12.Future<
+      ) as _i13.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3104,23 +3137,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_16(
+        returnValue: _FakeDatabaseApi_17(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_16(
+        returnValueForMissingStub: _FakeDatabaseApi_17(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i21.KeyVerificationMethod> get verificationMethods =>
+  Set<_i22.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i21.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i21.KeyVerificationMethod>{},
-      ) as Set<_i21.KeyVerificationMethod>);
+        returnValue: <_i22.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i22.KeyVerificationMethod>{},
+      ) as Set<_i22.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3181,11 +3214,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_17(
+        returnValue: _FakeFilter_18(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_17(
+        returnValueForMissingStub: _FakeFilter_18(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3194,11 +3227,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_18(
+        returnValue: _FakeNativeImplementations_19(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_18(
+        returnValueForMissingStub: _FakeNativeImplementations_19(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3214,11 +3247,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_19(
+        returnValue: _FakeDuration_20(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_19(
+        returnValueForMissingStub: _FakeDuration_20(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3227,11 +3260,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_19(
+        returnValue: _FakeDuration_20(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_19(
+        returnValueForMissingStub: _FakeDuration_20(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3240,11 +3273,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3281,11 +3314,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3315,11 +3348,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3328,11 +3361,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3355,11 +3388,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_20(
+        returnValue: _FakePushruleEvaluator_21(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_20(
+        returnValueForMissingStub: _FakePushruleEvaluator_21(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3380,332 +3413,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i12.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i13.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i10.CachedStreamController<String> get onUserProfileUpdate =>
+  _i11.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i12.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i13.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i12.Future<List<_i4.Room>>);
+            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i13.Future<List<_i4.Room>>);
 
   @override
-  _i10.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i11.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_10<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.EventUpdate>(
+            _FakeCachedStreamController_10<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.EventUpdate>);
+      ) as _i11.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i11.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i11.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onNotification =>
+  _i11.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i11.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i11.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i10.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i11.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i10.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i11.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i10.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i11.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_9<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_10<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.LoginState>(
+            _FakeCachedStreamController_10<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i10.CachedStreamController<_i4.LoginState>);
+      ) as _i11.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i10.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i11.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_9<bool>(
+        returnValue: _FakeCachedStreamController_10<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i10.CachedStreamController<bool>);
+      ) as _i11.CachedStreamController<bool>);
 
   @override
-  _i10.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i11.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_9<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_10<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i10.CachedStreamController<_i4.SdkError>);
+      ) as _i11.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i10.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i11.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_9<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_10<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.SyncUpdate>(
+            _FakeCachedStreamController_10<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i10.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i11.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i11.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i10.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i11.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.Presence> get onPresence =>
+  _i11.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_9<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_10<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i10.CachedStreamController<_i4.Presence>);
+      ) as _i11.CachedStreamController<_i4.Presence>);
 
   @override
-  _i10.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i11.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_9<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_10<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.CachedPresence>(
+            _FakeCachedStreamController_10<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i10.CachedStreamController<_i4.CachedPresence>);
+      ) as _i11.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i10.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i11.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_9<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_10<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.BasicEvent>(
+            _FakeCachedStreamController_10<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i10.CachedStreamController<_i4.BasicEvent>);
+      ) as _i11.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i10.CachedStreamController<_i21.RoomKeyRequest> get onRoomKeyRequest =>
+  _i11.CachedStreamController<_i22.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
+            _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i10.CachedStreamController<_i21.RoomKeyRequest>);
+      ) as _i11.CachedStreamController<_i22.RoomKeyRequest>);
 
   @override
-  _i10.CachedStreamController<_i21.KeyVerification>
+  _i11.CachedStreamController<_i22.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_9<_i21.KeyVerification>(
+            returnValue: _FakeCachedStreamController_10<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_9<_i21.KeyVerification>(
+                _FakeCachedStreamController_10<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i10.CachedStreamController<_i21.KeyVerification>);
+          ) as _i11.CachedStreamController<_i22.KeyVerification>);
 
   @override
-  _i10.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i11.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i10.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i11.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i11.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<String> get onCancelSendEvent =>
+  _i11.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i10.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i11.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_9<
+            returnValue: _FakeCachedStreamController_10<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_9<
+            returnValueForMissingStub: _FakeCachedStreamController_10<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i10.CachedStreamController<
+          ) as _i11.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3725,11 +3758,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_10(
+        returnValue: _FakeDateTime_11(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_10(
+        returnValueForMissingStub: _FakeDateTime_11(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3802,7 +3835,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i21.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i22.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3857,7 +3890,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i12.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i13.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3868,7 +3901,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i12.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i13.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -3979,7 +4012,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -3988,7 +4021,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -3997,7 +4030,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4024,20 +4057,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i11.Client get httpClient => (super.noSuchMethod(
+  _i12.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_22(
+        returnValue: _FakeClient_23(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_22(
+        returnValueForMissingStub: _FakeClient_23(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i11.Client);
+      ) as _i12.Client);
 
   @override
-  set httpClient(_i11.Client? value) => super.noSuchMethod(
+  set httpClient(_i12.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4064,7 +4097,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<void> refreshAccessToken(
+  _i13.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4072,9 +4105,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4092,14 +4125,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4136,33 +4169,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i12.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i13.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i12.Future<_i4.DiscoveryInformation>);
+      ) as _i13.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i12.Future<
+  _i13.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4184,7 +4217,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i12.Future<
+        returnValue: _i13.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4192,7 +4225,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_24(
+          _FakeGetVersionsResponse_25(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4207,7 +4240,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i12.Future<
+        returnValueForMissingStub: _i13.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4215,7 +4248,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_24(
+          _FakeGetVersionsResponse_25(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4230,7 +4263,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i12.Future<
+      ) as _i13.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4239,7 +4272,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i12.Future<_i4.DiscoveryInformation> getWellknown({
+  _i13.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4252,8 +4285,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getWellknown,
@@ -4264,8 +4297,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getWellknown,
@@ -4276,10 +4309,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.DiscoveryInformation>);
+      ) as _i13.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i12.Future<_i4.RegisterResponse> register({
+  _i13.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4307,7 +4340,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
+            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
           this,
           Invocation.method(
             #register,
@@ -4326,7 +4359,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
+            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
           this,
           Invocation.method(
             #register,
@@ -4344,10 +4377,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RegisterResponse>);
+      ) as _i13.Future<_i4.RegisterResponse>);
 
   @override
-  _i12.Future<_i4.LoginResponse> login(
+  _i13.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4377,7 +4410,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
+        returnValue: _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
           this,
           Invocation.method(
             #login,
@@ -4397,7 +4430,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
+            _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
           this,
           Invocation.method(
             #login,
@@ -4416,10 +4449,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.LoginResponse>);
+      ) as _i13.Future<_i4.LoginResponse>);
 
   @override
-  _i12.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i13.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4432,8 +4465,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_27(
+        returnValue: _i13.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_28(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4445,8 +4478,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_27(
+            _i13.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_28(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4457,74 +4490,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i13.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> logoutAll() => (super.noSuchMethod(
+  _i13.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<T> uiaRequestBackground<T>(
-          _i12.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i13.Future<T> uiaRequestBackground<T>(
+          _i13.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i12.Future<T>.value(v),
+              (T v) => _i13.Future<T>.value(v),
             ) ??
-            _FakeFuture_28<T>(
+            _FakeFuture_29<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i12.Future<T>.value(v),
+              (T v) => _i13.Future<T>.value(v),
             ) ??
-            _FakeFuture_28<T>(
+            _FakeFuture_29<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i12.Future<T>);
+      ) as _i13.Future<T>);
 
   @override
-  _i12.Future<String> startDirectChat(
+  _i13.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4546,7 +4579,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4562,7 +4595,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4577,10 +4610,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<String> createGroupChat({
+  _i13.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4611,7 +4644,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4632,7 +4665,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4652,10 +4685,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i13.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4671,7 +4704,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4684,7 +4717,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4696,21 +4729,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i13.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<String> createSpace({
+  _i13.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4735,7 +4768,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4753,7 +4786,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4770,10 +4803,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i13.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4781,7 +4814,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4790,7 +4823,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4798,10 +4831,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i12.Future<_i4.Profile> fetchOwnProfile({
+  _i13.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4814,7 +4847,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4826,7 +4859,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4837,10 +4870,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i12.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i13.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4854,8 +4887,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i12.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_29(
+        returnValue: _i13.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_30(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4867,8 +4900,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_29(
+            _i13.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_30(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4879,10 +4912,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.CachedProfileInformation>);
+      ) as _i13.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i12.Future<_i4.Profile> getProfileFromUserId(
+  _i13.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4900,7 +4933,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4914,7 +4947,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4927,7 +4960,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -4949,31 +4982,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i12.Future<List<_i4.Room>>);
+            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i13.Future<List<_i4.Room>>);
 
   @override
-  _i12.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i13.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i12.Future<List<_i4.ArchivedRoom>>);
+            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i13.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i12.Future<_i4.GetVersionsResponse> getVersions({
+  _i13.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4986,8 +5019,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_24(
+        returnValue: _i13.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_25(
           this,
           Invocation.method(
             #getVersions,
@@ -4998,8 +5031,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_24(
+        returnValueForMissingStub: _i13.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_25(
           this,
           Invocation.method(
             #getVersions,
@@ -5010,20 +5043,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetVersionsResponse>);
+      ) as _i13.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i12.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i13.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<_i4.MediaConfig> getConfig({
+  _i13.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5036,7 +5069,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfig,
@@ -5048,7 +5081,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfig,
@@ -5059,10 +5092,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.MediaConfig>);
+      ) as _i13.Future<_i4.MediaConfig>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContent(
+  _i13.Future<_i14.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5082,7 +5115,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContent,
@@ -5098,7 +5131,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContent,
@@ -5113,10 +5146,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentOverrideName(
+  _i13.Future<_i14.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5138,7 +5171,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5155,7 +5188,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5171,10 +5204,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentThumbnail(
+  _i13.Future<_i14.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5202,7 +5235,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5222,7 +5255,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5241,10 +5274,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i13.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5254,7 +5287,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5263,7 +5296,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5271,11 +5304,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i12.Future<_i4.PreviewForUrl>);
+      ) as _i13.Future<_i4.PreviewForUrl>);
 
   @override
-  _i12.Future<Uri> uploadContent(
-    _i22.Uint8List? file, {
+  _i13.Future<Uri> uploadContent(
+    _i23.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5288,7 +5321,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #uploadContent,
@@ -5299,7 +5332,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #uploadContent,
@@ -5310,10 +5343,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<Uri>);
+      ) as _i13.Future<Uri>);
 
   @override
-  _i12.Future<void> setTyping(
+  _i13.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5329,42 +5362,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> exportDump() => (super.noSuchMethod(
+  _i13.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i13.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i13.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Event?> getEventByPushNotification(
+  _i13.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5380,12 +5413,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
-  _i12.Future<void> init({
+  _i13.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5420,9 +5453,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5434,40 +5467,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<void> clear() => (super.noSuchMethod(
+  _i13.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i13.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ensureNotSoftLoggedOut(
+  _i13.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleSync(
+  _i13.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5477,9 +5510,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5492,29 +5525,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i12.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i13.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i13.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDevice(
+  _i13.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5528,12 +5561,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDevicesOfUserIds(
+  _i13.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5549,12 +5582,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDeviceEncrypted(
+  _i13.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5574,12 +5607,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDeviceEncryptedChunked(
+  _i13.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5593,23 +5626,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i13.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> joinRoom(
+  _i13.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5627,7 +5660,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5641,7 +5674,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5654,10 +5687,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> changePassword(
+  _i13.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5673,22 +5706,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> clearCache() => (super.noSuchMethod(
+  _i13.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ignoreUser(
+  _i13.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5698,22 +5731,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i13.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i13.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5724,7 +5757,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5733,7 +5766,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5741,32 +5774,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i12.Future<_i4.CachedPresence>);
+      ) as _i13.Future<_i4.CachedPresence>);
 
   @override
-  _i12.Future<void> abortSync() => (super.noSuchMethod(
+  _i13.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i13.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEventWithMetadata(
+  _i13.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5786,14 +5819,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i11.BaseResponse? response,
-    _i22.Uint8List? body,
+    _i12.BaseResponse? response,
+    _i23.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5825,7 +5858,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i12.Future<Map<String, Object?>> request(
+  _i13.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -5846,13 +5879,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> postPusher(
+  _i13.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -5862,57 +5895,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i13.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i13.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i13.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i12.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_34(
+        returnValue: _i13.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_35(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_34(
+        returnValueForMissingStub: _i13.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_35(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.TurnServerCredentials>);
+      ) as _i13.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5926,8 +5959,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5939,8 +5972,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5951,10 +5984,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5970,8 +6003,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5984,8 +6017,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5997,10 +6030,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i13.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6014,7 +6047,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6026,7 +6059,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6037,17 +6070,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.KeyBackupData>);
+      ) as _i13.Future<_i4.KeyBackupData>);
 
   @override
-  _i12.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i13.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i12.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_37(
+        returnValue: _i13.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_38(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6055,18 +6088,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_37(
+            _i13.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_38(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i13.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i12.Future<int> pingAppservice(
+  _i13.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6076,12 +6109,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i12.Future<int>.value(0),
-        returnValueForMissingStub: _i12.Future<int>.value(0),
-      ) as _i12.Future<int>);
+        returnValue: _i13.Future<int>.value(0),
+        returnValueForMissingStub: _i13.Future<int>.value(0),
+      ) as _i13.Future<int>);
 
   @override
-  _i12.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i13.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6089,8 +6122,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_38(
+        returnValue: _i13.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_39(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6099,8 +6132,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_38(
+            _i13.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_39(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6108,15 +6141,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i12.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i13.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i12.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i13.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6124,17 +6157,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.MediaConfig>);
+      ) as _i13.Future<_i4.MediaConfig>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentAuthed(
+  _i13.Future<_i14.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6148,7 +6181,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6160,7 +6193,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6171,10 +6204,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentOverrideNameAuthed(
+  _i13.Future<_i14.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6190,7 +6223,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6203,7 +6236,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6215,10 +6248,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i13.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6228,7 +6261,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6237,7 +6270,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6245,10 +6278,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i12.Future<_i4.PreviewForUrl>);
+      ) as _i13.Future<_i4.PreviewForUrl>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentThumbnailAuthed(
+  _i13.Future<_i14.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6272,7 +6305,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6290,7 +6323,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6307,21 +6340,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<bool> registrationTokenValidity(String? token) =>
+  _i13.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i13.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6331,8 +6364,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_39(
+        returnValue: _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_40(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6341,8 +6374,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_39(
+            _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_40(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6350,10 +6383,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i13.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i12.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i13.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6371,8 +6404,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_40(
+        returnValue: _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_41(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6386,8 +6419,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_40(
+            _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_41(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6400,10 +6433,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i13.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i13.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6427,8 +6460,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i12.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_41(
+        returnValue: _i13.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_42(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6446,8 +6479,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_41(
+            _i13.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_42(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6464,10 +6497,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i13.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6495,8 +6528,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_42(
+                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6515,8 +6548,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_42(
+                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6534,10 +6567,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i13.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6566,9 +6599,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i12.Future<
+            returnValue: _i13.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6587,9 +6620,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i12.Future<
+            returnValueForMissingStub: _i13.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6608,11 +6641,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i12
+          ) as _i13
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i12.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i13.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6628,8 +6661,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i12.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_44(
+        returnValue: _i13.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_45(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6642,8 +6675,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_44(
+            _i13.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_45(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6655,10 +6688,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetThreadRootsResponse>);
+      ) as _i13.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i12.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i13.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6672,8 +6705,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i12.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_45(
+        returnValue: _i13.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_46(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6685,8 +6718,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_45(
+            _i13.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_46(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6697,33 +6730,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i13.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i13.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i12.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i13.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i12.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i13.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i12.Future<Uri?>.value(),
-        returnValueForMissingStub: _i12.Future<Uri?>.value(),
-      ) as _i12.Future<Uri?>);
+        returnValue: _i13.Future<Uri?>.value(),
+        returnValueForMissingStub: _i13.Future<Uri?>.value(),
+      ) as _i13.Future<Uri?>);
 
   @override
-  _i12.Future<void> add3PID(
+  _i13.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6737,12 +6770,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> bind3PID(
+  _i13.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6758,12 +6791,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i13.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6777,14 +6810,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6806,8 +6839,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6823,8 +6856,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6840,10 +6873,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6867,8 +6900,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6885,8 +6918,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6903,10 +6936,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i13.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6920,14 +6953,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i13.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -6942,14 +6975,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6971,8 +7004,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -6988,8 +7021,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7005,10 +7038,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7032,8 +7065,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7050,8 +7083,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7068,16 +7101,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i13.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
+            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7085,22 +7118,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
+            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.TokenOwnerInfo>);
+      ) as _i13.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i12.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i13.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
+        returnValue: _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7108,22 +7141,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
+            _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i4.WhoIsInfo>);
+      ) as _i13.Future<_i4.WhoIsInfo>);
 
   @override
-  _i12.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i13.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
+        returnValue: _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7131,17 +7164,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
+            _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.Capabilities>);
+      ) as _i13.Future<_i4.Capabilities>);
 
   @override
-  _i12.Future<String> createRoom({
+  _i13.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7174,7 +7207,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7196,7 +7229,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7217,10 +7250,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> deleteDevices(
+  _i13.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7230,22 +7263,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.Device>?>.value(),
-      ) as _i12.Future<List<_i4.Device>?>);
+        returnValue: _i13.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.Device>?>.value(),
+      ) as _i13.Future<List<_i4.Device>?>);
 
   @override
-  _i12.Future<void> deleteDevice(
+  _i13.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7255,34 +7288,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i13.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i12.Future<_i4.Device>.value(_FakeDevice_50(
+        returnValue: _i13.Future<_i4.Device>.value(_FakeDevice_51(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.Device>.value(_FakeDevice_50(
+        returnValueForMissingStub: _i13.Future<_i4.Device>.value(_FakeDevice_51(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i12.Future<_i4.Device>);
+      ) as _i13.Future<_i4.Device>);
 
   @override
-  _i12.Future<void> updateDevice(
+  _i13.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7292,12 +7325,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i13.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7312,24 +7345,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i13.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i12.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Visibility?>.value(),
-      ) as _i12.Future<_i4.Visibility?>);
+        returnValue: _i13.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Visibility?>.value(),
+      ) as _i13.Future<_i4.Visibility?>);
 
   @override
-  _i12.Future<void> setRoomVisibilityOnDirectory(
+  _i13.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7339,30 +7372,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i13.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i13.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_51(
+        returnValue: _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_52(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7370,18 +7403,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_51(
+            _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_52(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i13.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i12.Future<void> setRoomAlias(
+  _i13.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7393,12 +7426,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetEventsResponse> getEvents({
+  _i13.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7412,7 +7445,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
+            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
           this,
           Invocation.method(
             #getEvents,
@@ -7424,7 +7457,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
+            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
           this,
           Invocation.method(
             #getEvents,
@@ -7435,10 +7468,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetEventsResponse>);
+      ) as _i13.Future<_i4.GetEventsResponse>);
 
   @override
-  _i12.Future<_i4.PeekEventsResponse> peekEvents({
+  _i13.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7453,8 +7486,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i12.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_53(
+        returnValue: _i13.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_54(
           this,
           Invocation.method(
             #peekEvents,
@@ -7466,8 +7499,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_53(
+        returnValueForMissingStub: _i13.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_54(
           this,
           Invocation.method(
             #peekEvents,
@@ -7479,16 +7512,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.PeekEventsResponse>);
+      ) as _i13.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i12.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i13.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7496,27 +7529,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i12.Future<_i4.MatrixEvent>);
+      ) as _i13.Future<_i4.MatrixEvent>);
 
   @override
-  _i12.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i13.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i12.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
-      ) as _i12.Future<List<String>>);
+        returnValue: _i13.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
+      ) as _i13.Future<List<String>>);
 
   @override
-  _i12.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i13.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7528,8 +7561,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i12.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_55(
+        returnValue: _i13.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_56(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7540,8 +7573,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_55(
+            _i13.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_56(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7551,10 +7584,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.GetKeysChangesResponse>);
+      ) as _i13.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i12.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i13.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7565,7 +7598,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
+            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
           this,
           Invocation.method(
             #claimKeys,
@@ -7574,7 +7607,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
+            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
           this,
           Invocation.method(
             #claimKeys,
@@ -7582,10 +7615,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i12.Future<_i4.ClaimKeysResponse>);
+      ) as _i13.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i12.Future<void> uploadCrossSigningKeys({
+  _i13.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7602,12 +7635,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.QueryKeysResponse> queryKeys(
+  _i13.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7618,7 +7651,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
+            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
           this,
           Invocation.method(
             #queryKeys,
@@ -7627,7 +7660,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
+            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
           this,
           Invocation.method(
             #queryKeys,
@@ -7635,10 +7668,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i12.Future<_i4.QueryKeysResponse>);
+      ) as _i13.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7646,14 +7679,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i12.Future<
+            returnValue: _i13.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i12.Future<
+            returnValueForMissingStub: _i13.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i12.Future<Map<String, int>> uploadKeys({
+  _i13.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7668,13 +7701,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i12.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i13.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i12.Future<Map<String, int>>);
+            _i13.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i13.Future<Map<String, int>>);
 
   @override
-  _i12.Future<String> knockRoom(
+  _i13.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7688,7 +7721,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7700,7 +7733,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7711,20 +7744,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i13.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i12.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i13.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i13.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i12.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i13.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7739,8 +7772,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i12.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_58(
+        returnValue: _i13.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_59(
           this,
           Invocation.method(
             #getNotifications,
@@ -7753,8 +7786,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_58(
+            _i13.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_59(
           this,
           Invocation.method(
             #getNotifications,
@@ -7766,35 +7799,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetNotificationsResponse>);
+      ) as _i13.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i12.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i13.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i12.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_59(
+        returnValue: _i13.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_60(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_59(
+        returnValueForMissingStub: _i13.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_60(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i4.GetPresenceResponse>);
+      ) as _i13.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i12.Future<void> setPresence(
+  _i13.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -7808,12 +7841,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, Object?>> deleteProfileField(
+  _i13.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7826,13 +7859,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getProfileField(
+  _i13.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7845,13 +7878,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<Map<String, Object?>> setProfileField(
+  _i13.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7866,13 +7899,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i13.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7887,8 +7920,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i12.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_60(
+        returnValue: _i13.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_61(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7901,8 +7934,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_60(
+            _i13.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_61(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7914,10 +7947,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i13.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i12.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i13.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -7938,8 +7971,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i12.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_61(
+        returnValue: _i13.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_62(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7955,8 +7988,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_61(
+            _i13.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_62(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7971,25 +8004,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i13.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i12.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.Pusher>?>.value(),
-      ) as _i12.Future<List<_i4.Pusher>?>);
+        returnValue: _i13.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.Pusher>?>.value(),
+      ) as _i13.Future<List<_i4.Pusher>?>);
 
   @override
-  _i12.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i13.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
+        returnValue: _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
           this,
           Invocation.method(
             #getPushRules,
@@ -7997,24 +8030,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
+            _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.PushRuleSet>);
+      ) as _i13.Future<_i4.PushRuleSet>);
 
   @override
-  _i12.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i13.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_63(
+        returnValue: _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_64(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8022,18 +8055,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_63(
+            _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_64(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i13.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i12.Future<void> deletePushRule(
+  _i13.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8045,12 +8078,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.PushRule> getPushRule(
+  _i13.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8062,7 +8095,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
+        returnValue: _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
           this,
           Invocation.method(
             #getPushRule,
@@ -8073,7 +8106,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
+            _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
           this,
           Invocation.method(
             #getPushRule,
@@ -8083,10 +8116,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.PushRule>);
+      ) as _i13.Future<_i4.PushRule>);
 
   @override
-  _i12.Future<void> setPushRule(
+  _i13.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8110,12 +8143,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<Object?>> getPushRuleActions(
+  _i13.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8127,13 +8160,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i13.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i12.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i12.Future<List<Object?>>);
+            _i13.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i13.Future<List<Object?>>);
 
   @override
-  _i12.Future<void> setPushRuleActions(
+  _i13.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8147,12 +8180,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<bool> isPushRuleEnabled(
+  _i13.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8164,12 +8197,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> setPushRuleEnabled(
+  _i13.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8183,19 +8216,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i13.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
+            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
           this,
           Invocation.method(
             #refresh,
@@ -8203,28 +8236,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
+            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i12.Future<_i4.RefreshResponse>);
+      ) as _i13.Future<_i4.RefreshResponse>);
 
   @override
-  _i12.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i13.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i12.Future<bool?>.value(),
-        returnValueForMissingStub: _i12.Future<bool?>.value(),
-      ) as _i12.Future<bool?>);
+        returnValue: _i13.Future<bool?>.value(),
+        returnValueForMissingStub: _i13.Future<bool?>.value(),
+      ) as _i13.Future<bool?>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8246,8 +8279,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8263,8 +8296,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8280,10 +8313,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8307,8 +8340,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8325,8 +8358,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8343,17 +8376,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8361,23 +8394,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i13.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
+        returnValue: _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8385,17 +8418,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
+            _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeys>);
+      ) as _i13.Future<_i4.RoomKeys>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8407,8 +8440,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8419,8 +8452,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8430,10 +8463,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8445,8 +8478,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8457,8 +8490,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8468,10 +8501,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8483,7 +8516,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
+        returnValue: _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8494,7 +8527,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
+            _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8504,10 +8537,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeyBackup>);
+      ) as _i13.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8521,8 +8554,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8534,8 +8567,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8546,10 +8579,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8563,8 +8596,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8576,8 +8609,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8588,10 +8621,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i13.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8605,7 +8638,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8617,7 +8650,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8628,10 +8661,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.KeyBackupData>);
+      ) as _i13.Future<_i4.KeyBackupData>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8647,8 +8680,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8661,8 +8694,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8674,18 +8707,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_68(
+                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_69(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8693,18 +8726,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_68(
+                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_69(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i12.Future<String> postRoomKeysVersion(
+  _i13.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8716,7 +8749,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8727,7 +8760,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8737,29 +8770,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i13.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i13.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_69(
+        returnValue: _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_70(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8767,18 +8800,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_69(
+            _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_70(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i13.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i13.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8793,24 +8826,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i13.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i12.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
-      ) as _i12.Future<List<String>>);
+        returnValue: _i13.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
+      ) as _i13.Future<List<String>>);
 
   @override
-  _i12.Future<void> ban(
+  _i13.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8824,12 +8857,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.EventContext> getEventContext(
+  _i13.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8847,7 +8880,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
+        returnValue: _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
           this,
           Invocation.method(
             #getEventContext,
@@ -8862,7 +8895,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
+            _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
           this,
           Invocation.method(
             #getEventContext,
@@ -8876,10 +8909,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.EventContext>);
+      ) as _i13.Future<_i4.EventContext>);
 
   @override
-  _i12.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i13.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8891,7 +8924,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8902,7 +8935,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8912,20 +8945,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.MatrixEvent>);
+      ) as _i13.Future<_i4.MatrixEvent>);
 
   @override
-  _i12.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i13.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> inviteBy3PID(
+  _i13.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -8937,12 +8970,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> inviteUser(
+  _i13.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8956,12 +8989,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> joinRoomById(
+  _i13.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -8975,7 +9008,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8987,7 +9020,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8998,23 +9031,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i13.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i12.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i13.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i12.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i12.Future<Map<String, _i4.RoomMember>?>);
+            _i13.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i13.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i12.Future<void> kick(
+  _i13.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9028,12 +9061,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> leaveRoom(
+  _i13.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9043,12 +9076,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i13.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9064,12 +9097,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i12.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i12.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i13.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i13.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i12.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i13.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9091,8 +9124,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_71(
+        returnValue: _i13.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_72(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9108,8 +9141,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_71(
+        returnValueForMissingStub: _i13.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_72(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9125,10 +9158,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomEventsResponse>);
+      ) as _i13.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i12.Future<void> setReadMarker(
+  _i13.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9144,12 +9177,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> postReceipt(
+  _i13.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9165,12 +9198,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEvent(
+  _i13.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9186,12 +9219,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> reportRoom(
+  _i13.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9203,12 +9236,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> reportEvent(
+  _i13.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9226,12 +9259,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> sendMessage(
+  _i13.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9247,7 +9280,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9260,7 +9293,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9272,23 +9305,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i13.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i12.Future<List<_i4.MatrixEvent>>);
+            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i13.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i13.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9305,13 +9338,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<String> setRoomStateWithKey(
+  _i13.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9327,7 +9360,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9340,7 +9373,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9352,10 +9385,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> unban(
+  _i13.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9369,12 +9402,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> upgradeRoom(
+  _i13.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9388,7 +9421,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9400,7 +9433,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9411,10 +9444,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.SearchResults> search(
+  _i13.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9424,7 +9457,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
+        returnValue: _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
           this,
           Invocation.method(
             #search,
@@ -9433,7 +9466,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
+            _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
           this,
           Invocation.method(
             #search,
@@ -9441,10 +9474,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i12.Future<_i4.SearchResults>);
+      ) as _i13.Future<_i4.SearchResults>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> sync({
+  _i13.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9465,7 +9498,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #sync,
@@ -9481,7 +9514,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #sync,
@@ -9496,22 +9529,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i13.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i12.Future<List<_i4.Location>>);
+            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i13.Future<List<_i4.Location>>);
 
   @override
-  _i12.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i13.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9521,21 +9554,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i12.Future<List<_i4.Location>>);
+            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i13.Future<List<_i4.Location>>);
 
   @override
-  _i12.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i13.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_73(
+        returnValue: _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_74(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9543,45 +9576,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_73(
+            _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_74(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i12.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i13.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i12.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i13.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9592,13 +9625,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getAccountData(
+  _i13.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9611,13 +9644,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> setAccountData(
+  _i13.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9631,12 +9664,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> defineFilter(
+  _i13.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9648,7 +9681,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9659,7 +9692,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9669,10 +9702,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.Filter> getFilter(
+  _i13.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9684,7 +9717,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
+        returnValue: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
           this,
           Invocation.method(
             #getFilter,
@@ -9694,7 +9727,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
+        returnValueForMissingStub: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
           this,
           Invocation.method(
             #getFilter,
@@ -9704,10 +9737,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.Filter>);
+      ) as _i13.Future<_i4.Filter>);
 
   @override
-  _i12.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i13.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9720,7 +9753,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
+            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9731,7 +9764,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
+            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9741,10 +9774,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.OpenIdCredentials>);
+      ) as _i13.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i12.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i13.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9759,13 +9792,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> setAccountDataPerRoom(
+  _i13.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9781,12 +9814,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i13.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9798,12 +9831,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i12.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i12.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i12.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i13.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i13.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i13.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i12.Future<void> deleteRoomTag(
+  _i13.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9817,12 +9850,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setRoomTag(
+  _i13.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9838,12 +9871,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i13.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9853,8 +9886,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i12.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_75(
+        returnValue: _i13.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_76(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9863,8 +9896,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_75(
+            _i13.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_76(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9872,10 +9905,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i12.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i13.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> reportUser(
+  _i13.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9888,40 +9921,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i13.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i12.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_76(
+        returnValue: _i13.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_77(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_76(
+        returnValueForMissingStub: _i13.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_77(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.CreateContentResponse>);
+      ) as _i13.Future<_i4.CreateContentResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> uploadContentToMXC(
+  _i13.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i22.Uint8List? body, {
+    _i23.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -9939,8 +9972,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 }

--- a/test/widgets/key_backup_banner_test.mocks.dart
+++ b/test/widgets/key_backup_banner_test.mocks.dart
@@ -62,6 +62,25 @@ class MockChatBackupService extends _i1.Mock implements _i2.ChatBackupService {
       ) as _i3.Future<void>);
 
   @override
+  _i3.Future<void> refreshOnResume() => (super.noSuchMethod(
+        Invocation.method(
+          #refreshOnResume,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i3.Future<void> disableChatBackup() => (super.noSuchMethod(
         Invocation.method(
           #disableChatBackup,
@@ -158,15 +177,6 @@ class MockChatBackupService extends _i1.Mock implements _i2.ChatBackupService {
         Invocation.method(
           #removeListener,
           [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
         ),
         returnValueForMissingStub: null,
       );

--- a/test/widgets/login_controller_test.mocks.dart
+++ b/test/widgets/login_controller_test.mocks.dart
@@ -3,19 +3,20 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i13;
-import 'dart:typed_data' as _i22;
-import 'dart:ui' as _i17;
+import 'dart:async' as _i14;
+import 'dart:typed_data' as _i23;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
-import 'package:http/http.dart' as _i12;
-import 'package:kohera/core/models/server_auth_capabilities.dart' as _i15;
-import 'package:kohera/core/services/client_manager.dart' as _i20;
-import 'package:kohera/core/services/matrix_service.dart' as _i10;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
+import 'package:http/http.dart' as _i13;
+import 'package:kohera/core/models/server_auth_capabilities.dart' as _i16;
+import 'package:kohera/core/services/client_manager.dart' as _i21;
+import 'package:kohera/core/services/matrix_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
@@ -24,12 +25,12 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i21;
+import 'package:matrix/encryption.dart' as _i22;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i14;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i11;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i15;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i12;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -130,8 +131,8 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeMatrixService_8 extends _i1.SmartFake implements _i10.MatrixService {
-  _FakeMatrixService_8(
+class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
+  _FakeOutboxService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -140,8 +141,8 @@ class _FakeMatrixService_8 extends _i1.SmartFake implements _i10.MatrixService {
         );
 }
 
-class _FakeDatabaseApi_9 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_9(
+class _FakeMatrixService_9 extends _i1.SmartFake implements _i11.MatrixService {
+  _FakeMatrixService_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -150,8 +151,8 @@ class _FakeDatabaseApi_9 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_10 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_10(
+class _FakeDatabaseApi_10 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -160,9 +161,19 @@ class _FakeFilter_10 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_11 extends _i1.SmartFake
+class _FakeFilter_11 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_11(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeNativeImplementations_12 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_11(
+  _FakeNativeImplementations_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -171,8 +182,8 @@ class _FakeNativeImplementations_11 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_12 extends _i1.SmartFake implements Duration {
-  _FakeDuration_12(
+class _FakeDuration_13 extends _i1.SmartFake implements Duration {
+  _FakeDuration_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -181,9 +192,9 @@ class _FakeDuration_12 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_13 extends _i1.SmartFake
+class _FakePushruleEvaluator_14 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_13(
+  _FakePushruleEvaluator_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -192,8 +203,8 @@ class _FakePushruleEvaluator_13 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_14 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_14(
+class _FakeProfile_15 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -202,9 +213,9 @@ class _FakeProfile_14 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeCachedStreamController_15<T> extends _i1.SmartFake
-    implements _i11.CachedStreamController<T> {
-  _FakeCachedStreamController_15(
+class _FakeCachedStreamController_16<T> extends _i1.SmartFake
+    implements _i12.CachedStreamController<T> {
+  _FakeCachedStreamController_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -213,8 +224,8 @@ class _FakeCachedStreamController_15<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_16 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_16(
+class _FakeDateTime_17 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -223,8 +234,8 @@ class _FakeDateTime_16 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_17 extends _i1.SmartFake implements _i12.Client {
-  _FakeClient_17(
+class _FakeClient_18 extends _i1.SmartFake implements _i13.Client {
+  _FakeClient_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -233,9 +244,9 @@ class _FakeClient_17 extends _i1.SmartFake implements _i12.Client {
         );
 }
 
-class _FakeDiscoveryInformation_18 extends _i1.SmartFake
+class _FakeDiscoveryInformation_19 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_18(
+  _FakeDiscoveryInformation_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -244,9 +255,9 @@ class _FakeDiscoveryInformation_18 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_19 extends _i1.SmartFake
+class _FakeGetVersionsResponse_20 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_19(
+  _FakeGetVersionsResponse_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -255,9 +266,9 @@ class _FakeGetVersionsResponse_19 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_20 extends _i1.SmartFake
+class _FakeRegisterResponse_21 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_20(
+  _FakeRegisterResponse_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -266,8 +277,8 @@ class _FakeRegisterResponse_20 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_21 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_21(
+class _FakeLoginResponse_22 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -276,9 +287,9 @@ class _FakeLoginResponse_21 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_22 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_23 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_22(
+  _FakeGetAuthMetadataResponse_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -287,8 +298,8 @@ class _FakeGetAuthMetadataResponse_22 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_23<T1> extends _i1.SmartFake implements _i13.Future<T1> {
-  _FakeFuture_23(
+class _FakeFuture_24<T1> extends _i1.SmartFake implements _i14.Future<T1> {
+  _FakeFuture_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -297,8 +308,8 @@ class _FakeFuture_23<T1> extends _i1.SmartFake implements _i13.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_24 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_24(
+class _FakeSyncUpdate_25 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -307,9 +318,9 @@ class _FakeSyncUpdate_24 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_25 extends _i1.SmartFake
+class _FakeCachedProfileInformation_26 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_25(
+  _FakeCachedProfileInformation_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -318,8 +329,8 @@ class _FakeCachedProfileInformation_25 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_26 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_26(
+class _FakeMediaConfig_27 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -328,8 +339,8 @@ class _FakeMediaConfig_26 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_27 extends _i1.SmartFake implements _i14.FileResponse {
-  _FakeFileResponse_27(
+class _FakeFileResponse_28 extends _i1.SmartFake implements _i15.FileResponse {
+  _FakeFileResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -338,8 +349,8 @@ class _FakeFileResponse_27 extends _i1.SmartFake implements _i14.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_28 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_28(
+class _FakePreviewForUrl_29 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -348,8 +359,8 @@ class _FakePreviewForUrl_28 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeUri_29 extends _i1.SmartFake implements Uri {
-  _FakeUri_29(
+class _FakeUri_30 extends _i1.SmartFake implements Uri {
+  _FakeUri_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -358,9 +369,9 @@ class _FakeUri_29 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_30 extends _i1.SmartFake
+class _FakeCachedPresence_31 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_30(
+  _FakeCachedPresence_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -369,9 +380,9 @@ class _FakeCachedPresence_30 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_31 extends _i1.SmartFake
+class _FakeTurnServerCredentials_32 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_31(
+  _FakeTurnServerCredentials_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -380,9 +391,9 @@ class _FakeTurnServerCredentials_31 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_32 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_33 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_32(
+  _FakeRoomKeysUpdateResponse_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -391,8 +402,8 @@ class _FakeRoomKeysUpdateResponse_32 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_33 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_33(
+class _FakeKeyBackupData_34 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -401,9 +412,9 @@ class _FakeKeyBackupData_33 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_34 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_35 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_34(
+  _FakeGetWellknownSupportResponse_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -412,9 +423,9 @@ class _FakeGetWellknownSupportResponse_34 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_35 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_36 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_35(
+  _FakeGenerateLoginTokenResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -423,9 +434,9 @@ class _FakeGenerateLoginTokenResponse_35 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_36 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_37 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_36(
+  _FakeGetRoomSummaryResponse$3_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -434,9 +445,9 @@ class _FakeGetRoomSummaryResponse$3_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_37 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_38 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_37(
+  _FakeGetSpaceHierarchyResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -445,9 +456,9 @@ class _FakeGetSpaceHierarchyResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_38 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_39 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_38(
+  _FakeGetRelatingEventsResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -456,9 +467,9 @@ class _FakeGetRelatingEventsResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_39 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_40 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_39(
+  _FakeGetRelatingEventsWithRelTypeResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -467,9 +478,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -478,9 +489,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_41 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_42 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_41(
+  _FakeGetThreadRootsResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -489,9 +500,9 @@ class _FakeGetThreadRootsResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_42 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_43 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_42(
+  _FakeGetEventByTimestampResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -500,9 +511,9 @@ class _FakeGetEventByTimestampResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_43 extends _i1.SmartFake
+class _FakeRequestTokenResponse_44 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_43(
+  _FakeRequestTokenResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -511,9 +522,9 @@ class _FakeRequestTokenResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_44 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_45 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_44(
+  _FakeTokenOwnerInfo_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -522,8 +533,8 @@ class _FakeTokenOwnerInfo_44 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_45 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_45(
+class _FakeWhoIsInfo_46 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -532,8 +543,8 @@ class _FakeWhoIsInfo_45 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_46 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_46(
+class _FakeCapabilities_47 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -542,8 +553,8 @@ class _FakeCapabilities_46 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_47 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_47(
+class _FakeDevice_48 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -552,9 +563,9 @@ class _FakeDevice_47 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_48 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_49 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_48(
+  _FakeGetRoomIdByAliasResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -563,9 +574,9 @@ class _FakeGetRoomIdByAliasResponse_48 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_49 extends _i1.SmartFake
+class _FakeGetEventsResponse_50 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_49(
+  _FakeGetEventsResponse_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -574,9 +585,9 @@ class _FakeGetEventsResponse_49 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_50 extends _i1.SmartFake
+class _FakePeekEventsResponse_51 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_50(
+  _FakePeekEventsResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -585,8 +596,8 @@ class _FakePeekEventsResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_51 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_51(
+class _FakeMatrixEvent_52 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -595,9 +606,9 @@ class _FakeMatrixEvent_51 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_52 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_53 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_52(
+  _FakeGetKeysChangesResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -606,9 +617,9 @@ class _FakeGetKeysChangesResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_53 extends _i1.SmartFake
+class _FakeClaimKeysResponse_54 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_53(
+  _FakeClaimKeysResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -617,9 +628,9 @@ class _FakeClaimKeysResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_54 extends _i1.SmartFake
+class _FakeQueryKeysResponse_55 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_54(
+  _FakeQueryKeysResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -628,9 +639,9 @@ class _FakeQueryKeysResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_55 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_56 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_55(
+  _FakeGetNotificationsResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -639,9 +650,9 @@ class _FakeGetNotificationsResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_56 extends _i1.SmartFake
+class _FakeGetPresenceResponse_57 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_56(
+  _FakeGetPresenceResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -650,9 +661,9 @@ class _FakeGetPresenceResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_57 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_58 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_57(
+  _FakeGetPublicRoomsResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -661,9 +672,9 @@ class _FakeGetPublicRoomsResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_58 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_59 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_58(
+  _FakeQueryPublicRoomsResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -672,8 +683,8 @@ class _FakeQueryPublicRoomsResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_59 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_59(
+class _FakePushRuleSet_60 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -682,9 +693,9 @@ class _FakePushRuleSet_59 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_60 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_61 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_60(
+  _FakeGetPushRulesGlobalResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -693,8 +704,8 @@ class _FakeGetPushRulesGlobalResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_61 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_61(
+class _FakePushRule_62 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -703,9 +714,9 @@ class _FakePushRule_61 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_62 extends _i1.SmartFake
+class _FakeRefreshResponse_63 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_62(
+  _FakeRefreshResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -714,8 +725,8 @@ class _FakeRefreshResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_63 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_63(
+class _FakeRoomKeys_64 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -724,8 +735,8 @@ class _FakeRoomKeys_63 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_64 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_64(
+class _FakeRoomKeyBackup_65 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -734,9 +745,9 @@ class _FakeRoomKeyBackup_64 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_65 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_66 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_65(
+  _FakeGetRoomKeysVersionCurrentResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -745,9 +756,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_66 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_67 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_66(
+  _FakeGetRoomKeysVersionResponse_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,8 +767,8 @@ class _FakeGetRoomKeysVersionResponse_66 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_67 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_67(
+class _FakeEventContext_68 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,9 +777,9 @@ class _FakeEventContext_67 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_68 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_69 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_68(
+  _FakeGetRoomEventsResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -777,8 +788,8 @@ class _FakeGetRoomEventsResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_69 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_69(
+class _FakeSearchResults_70 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -787,9 +798,9 @@ class _FakeSearchResults_69 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_70 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_71 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_70(
+  _FakeGetProtocolMetadataResponse$2_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,9 +809,9 @@ class _FakeGetProtocolMetadataResponse$2_70 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_71 extends _i1.SmartFake
+class _FakeOpenIdCredentials_72 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_71(
+  _FakeOpenIdCredentials_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -809,9 +820,9 @@ class _FakeOpenIdCredentials_71 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_72 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_73 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_72(
+  _FakeSearchUserDirectoryResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -820,9 +831,9 @@ class _FakeSearchUserDirectoryResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_73 extends _i1.SmartFake
+class _FakeCreateContentResponse_74 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_73(
+  _FakeCreateContentResponse_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -831,9 +842,9 @@ class _FakeCreateContentResponse_73 extends _i1.SmartFake
         );
 }
 
-class _FakeServerAuthCapabilities_74 extends _i1.SmartFake
-    implements _i15.ServerAuthCapabilities {
-  _FakeServerAuthCapabilities_74(
+class _FakeServerAuthCapabilities_75 extends _i1.SmartFake
+    implements _i16.ServerAuthCapabilities {
+  _FakeServerAuthCapabilities_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -845,7 +856,7 @@ class _FakeServerAuthCapabilities_74 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -875,11 +886,11 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -978,6 +989,19 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       ) as _i9.AuthService);
 
   @override
+  _i10.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i10.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -1057,6 +1081,15 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
+  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -1064,14 +1097,14 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       ) as bool);
 
   @override
-  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1101,7 +1134,7 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1111,18 +1144,18 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<bool> login({
+  _i14.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1137,12 +1170,12 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> completeSsoLogin({
+  _i14.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1155,12 +1188,12 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> completeRegistration(
+  _i14.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1170,32 +1203,32 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1204,7 +1237,7 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1213,17 +1246,17 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1234,7 +1267,7 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1271,26 +1304,26 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+  _i14.Future<bool> didPushRouteInformation(
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1320,7 +1353,7 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1329,7 +1362,7 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1338,16 +1371,16 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
       );
 
   @override
-  _i13.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i14.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i13.Future<_i17.AppExitResponse>);
+            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i14.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1371,13 +1404,13 @@ class MockMatrixService extends _i1.Mock implements _i10.MatrixService {
 /// A class which mocks [ClientManager].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockClientManager extends _i1.Mock implements _i20.ClientManager {
+class MockClientManager extends _i1.Mock implements _i21.ClientManager {
   @override
-  List<_i10.MatrixService> get services => (super.noSuchMethod(
+  List<_i11.MatrixService> get services => (super.noSuchMethod(
         Invocation.getter(#services),
-        returnValue: <_i10.MatrixService>[],
-        returnValueForMissingStub: <_i10.MatrixService>[],
-      ) as List<_i10.MatrixService>);
+        returnValue: <_i11.MatrixService>[],
+        returnValueForMissingStub: <_i11.MatrixService>[],
+      ) as List<_i11.MatrixService>);
 
   @override
   int get activeIndex => (super.noSuchMethod(
@@ -1387,17 +1420,17 @@ class MockClientManager extends _i1.Mock implements _i20.ClientManager {
       ) as int);
 
   @override
-  _i10.MatrixService get activeService => (super.noSuchMethod(
+  _i11.MatrixService get activeService => (super.noSuchMethod(
         Invocation.getter(#activeService),
-        returnValue: _FakeMatrixService_8(
+        returnValue: _FakeMatrixService_9(
           this,
           Invocation.getter(#activeService),
         ),
-        returnValueForMissingStub: _FakeMatrixService_8(
+        returnValueForMissingStub: _FakeMatrixService_9(
           this,
           Invocation.getter(#activeService),
         ),
-      ) as _i10.MatrixService);
+      ) as _i11.MatrixService);
 
   @override
   bool get hasMultipleAccounts => (super.noSuchMethod(
@@ -1414,14 +1447,14 @@ class MockClientManager extends _i1.Mock implements _i20.ClientManager {
       ) as bool);
 
   @override
-  _i13.Future<void> init() => (super.noSuchMethod(
+  _i14.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void setActiveAccount(int? index) => super.noSuchMethod(
@@ -1433,12 +1466,12 @@ class MockClientManager extends _i1.Mock implements _i20.ClientManager {
       );
 
   @override
-  _i13.Future<_i10.MatrixService> createLoginService() => (super.noSuchMethod(
+  _i14.Future<_i11.MatrixService> createLoginService() => (super.noSuchMethod(
         Invocation.method(
           #createLoginService,
           [],
         ),
-        returnValue: _i13.Future<_i10.MatrixService>.value(_FakeMatrixService_8(
+        returnValue: _i14.Future<_i11.MatrixService>.value(_FakeMatrixService_9(
           this,
           Invocation.method(
             #createLoginService,
@@ -1446,14 +1479,14 @@ class MockClientManager extends _i1.Mock implements _i20.ClientManager {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i10.MatrixService>.value(_FakeMatrixService_8(
+            _i14.Future<_i11.MatrixService>.value(_FakeMatrixService_9(
           this,
           Invocation.method(
             #createLoginService,
             [],
           ),
         )),
-      ) as _i13.Future<_i10.MatrixService>);
+      ) as _i14.Future<_i11.MatrixService>);
 
   @override
   void commitPendingService() => super.noSuchMethod(
@@ -1474,36 +1507,36 @@ class MockClientManager extends _i1.Mock implements _i20.ClientManager {
       );
 
   @override
-  _i13.Future<void> addService(_i10.MatrixService? service) =>
+  _i14.Future<void> addService(_i11.MatrixService? service) =>
       (super.noSuchMethod(
         Invocation.method(
           #addService,
           [service],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> signOut(_i10.MatrixService? service) => (super.noSuchMethod(
+  _i14.Future<void> signOut(_i11.MatrixService? service) => (super.noSuchMethod(
         Invocation.method(
           #signOut,
           [service],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> removeService(_i10.MatrixService? service) =>
+  _i14.Future<void> removeService(_i11.MatrixService? service) =>
       (super.noSuchMethod(
         Invocation.method(
           #removeService,
           [service],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -1515,7 +1548,7 @@ class MockClientManager extends _i1.Mock implements _i20.ClientManager {
       );
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1524,7 +1557,7 @@ class MockClientManager extends _i1.Mock implements _i20.ClientManager {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1549,23 +1582,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_9(
+        returnValue: _FakeDatabaseApi_10(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_9(
+        returnValueForMissingStub: _FakeDatabaseApi_10(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i21.KeyVerificationMethod> get verificationMethods =>
+  Set<_i22.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i21.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i21.KeyVerificationMethod>{},
-      ) as Set<_i21.KeyVerificationMethod>);
+        returnValue: <_i22.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i22.KeyVerificationMethod>{},
+      ) as Set<_i22.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1626,11 +1659,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_10(
+        returnValue: _FakeFilter_11(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_10(
+        returnValueForMissingStub: _FakeFilter_11(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -1639,11 +1672,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_11(
+        returnValue: _FakeNativeImplementations_12(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_11(
+        returnValueForMissingStub: _FakeNativeImplementations_12(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -1659,11 +1692,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_12(
+        returnValue: _FakeDuration_13(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_12(
+        returnValueForMissingStub: _FakeDuration_13(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -1672,11 +1705,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_12(
+        returnValue: _FakeDuration_13(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_12(
+        returnValueForMissingStub: _FakeDuration_13(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -1685,11 +1718,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1726,11 +1759,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1760,11 +1793,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1773,11 +1806,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1800,11 +1833,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_13(
+        returnValue: _FakePushruleEvaluator_14(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_13(
+        returnValueForMissingStub: _FakePushruleEvaluator_14(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -1825,332 +1858,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i13.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i14.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i11.CachedStreamController<String> get onUserProfileUpdate =>
+  _i12.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_15<String>(
+        returnValue: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i13.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i14.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i13.Future<List<_i4.Room>>);
+            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i14.Future<List<_i4.Room>>);
 
   @override
-  _i11.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i12.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_15<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_16<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.EventUpdate>(
+            _FakeCachedStreamController_16<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.EventUpdate>);
+      ) as _i12.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i12.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_15<_i4.Event>(
+        returnValue: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i12.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_15<_i4.Event>(
+        returnValue: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onNotification =>
+  _i12.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_15<_i4.Event>(
+        returnValue: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i12.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_15<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_16<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_16<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i12.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i11.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i12.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_15<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_16<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_15<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_16<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i11.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i12.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i11.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i12.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_15<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_16<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.LoginState>(
+            _FakeCachedStreamController_16<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i11.CachedStreamController<_i4.LoginState>);
+      ) as _i12.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i11.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i12.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_15<bool>(
+        returnValue: _FakeCachedStreamController_16<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i11.CachedStreamController<bool>);
+      ) as _i12.CachedStreamController<bool>);
 
   @override
-  _i11.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i12.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_15<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_16<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i11.CachedStreamController<_i4.SdkError>);
+      ) as _i12.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i11.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i12.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_15<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_16<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.SyncUpdate>(
+            _FakeCachedStreamController_16<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i11.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i12.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i12.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_15<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_16<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_16<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i11.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i12.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.Presence> get onPresence =>
+  _i12.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_15<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_16<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i11.CachedStreamController<_i4.Presence>);
+      ) as _i12.CachedStreamController<_i4.Presence>);
 
   @override
-  _i11.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i12.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_15<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_16<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.CachedPresence>(
+            _FakeCachedStreamController_16<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i11.CachedStreamController<_i4.CachedPresence>);
+      ) as _i12.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i11.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i12.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_15<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_16<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.BasicEvent>(
+            _FakeCachedStreamController_16<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i11.CachedStreamController<_i4.BasicEvent>);
+      ) as _i12.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i11.CachedStreamController<_i21.RoomKeyRequest> get onRoomKeyRequest =>
+  _i12.CachedStreamController<_i22.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_15<_i21.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_16<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i21.RoomKeyRequest>(
+            _FakeCachedStreamController_16<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i11.CachedStreamController<_i21.RoomKeyRequest>);
+      ) as _i12.CachedStreamController<_i22.RoomKeyRequest>);
 
   @override
-  _i11.CachedStreamController<_i21.KeyVerification>
+  _i12.CachedStreamController<_i22.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_15<_i21.KeyVerification>(
+            returnValue: _FakeCachedStreamController_16<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_15<_i21.KeyVerification>(
+                _FakeCachedStreamController_16<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i11.CachedStreamController<_i21.KeyVerification>);
+          ) as _i12.CachedStreamController<_i22.KeyVerification>);
 
   @override
-  _i11.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i12.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_15<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_16<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_16<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i11.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i12.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i12.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_15<_i4.Event>(
+        returnValue: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<String> get onCancelSendEvent =>
+  _i12.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_15<String>(
+        returnValue: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i11.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i12.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_15<
+            returnValue: _FakeCachedStreamController_16<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_15<
+            returnValueForMissingStub: _FakeCachedStreamController_16<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i11.CachedStreamController<
+          ) as _i12.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -2170,11 +2203,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_16(
+        returnValue: _FakeDateTime_17(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_16(
+        returnValueForMissingStub: _FakeDateTime_17(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2247,7 +2280,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i21.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i22.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2302,7 +2335,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i13.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i14.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2313,7 +2346,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i13.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i14.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -2424,7 +2457,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2433,7 +2466,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2442,7 +2475,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -2469,20 +2502,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Client get httpClient => (super.noSuchMethod(
+  _i13.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_17(
+        returnValue: _FakeClient_18(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_17(
+        returnValueForMissingStub: _FakeClient_18(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i12.Client);
+      ) as _i13.Client);
 
   @override
-  set httpClient(_i12.Client? value) => super.noSuchMethod(
+  set httpClient(_i13.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -2509,7 +2542,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<void> refreshAccessToken(
+  _i14.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2517,9 +2550,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -2537,14 +2570,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2581,33 +2614,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i13.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i14.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_18(
+        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_19(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_18(
+        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_19(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i13.Future<_i4.DiscoveryInformation>);
+      ) as _i14.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i13.Future<
+  _i14.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -2629,7 +2662,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i13.Future<
+        returnValue: _i14.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2637,7 +2670,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_19(
+          _FakeGetVersionsResponse_20(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2652,7 +2685,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i13.Future<
+        returnValueForMissingStub: _i14.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2660,7 +2693,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_19(
+          _FakeGetVersionsResponse_20(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2675,7 +2708,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i13.Future<
+      ) as _i14.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -2684,7 +2717,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i13.Future<_i4.DiscoveryInformation> getWellknown({
+  _i14.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2697,8 +2730,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_18(
+        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_19(
           this,
           Invocation.method(
             #getWellknown,
@@ -2709,8 +2742,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_18(
+        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_19(
           this,
           Invocation.method(
             #getWellknown,
@@ -2721,10 +2754,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.DiscoveryInformation>);
+      ) as _i14.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i13.Future<_i4.RegisterResponse> register({
+  _i14.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -2752,7 +2785,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_20(
+            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_21(
           this,
           Invocation.method(
             #register,
@@ -2771,7 +2804,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_20(
+            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_21(
           this,
           Invocation.method(
             #register,
@@ -2789,10 +2822,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RegisterResponse>);
+      ) as _i14.Future<_i4.RegisterResponse>);
 
   @override
-  _i13.Future<_i4.LoginResponse> login(
+  _i14.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -2822,7 +2855,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_21(
+        returnValue: _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_22(
           this,
           Invocation.method(
             #login,
@@ -2842,7 +2875,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_21(
+            _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_22(
           this,
           Invocation.method(
             #login,
@@ -2861,10 +2894,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.LoginResponse>);
+      ) as _i14.Future<_i4.LoginResponse>);
 
   @override
-  _i13.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i14.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2877,8 +2910,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_22(
+        returnValue: _i14.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_23(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2890,8 +2923,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_22(
+            _i14.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_23(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2902,74 +2935,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i14.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> logoutAll() => (super.noSuchMethod(
+  _i14.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<T> uiaRequestBackground<T>(
-          _i13.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i14.Future<T> uiaRequestBackground<T>(
+          _i14.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i13.Future<T>.value(v),
+              (T v) => _i14.Future<T>.value(v),
             ) ??
-            _FakeFuture_23<T>(
+            _FakeFuture_24<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i13.Future<T>.value(v),
+              (T v) => _i14.Future<T>.value(v),
             ) ??
-            _FakeFuture_23<T>(
+            _FakeFuture_24<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i13.Future<T>);
+      ) as _i14.Future<T>);
 
   @override
-  _i13.Future<String> startDirectChat(
+  _i14.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -2991,7 +3024,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3007,7 +3040,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3022,10 +3055,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<String> createGroupChat({
+  _i14.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -3056,7 +3089,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3077,7 +3110,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3097,10 +3130,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i14.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -3116,7 +3149,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3129,7 +3162,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3141,21 +3174,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i14.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<String> createSpace({
+  _i14.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -3180,7 +3213,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3198,7 +3231,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3215,10 +3248,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i14.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3226,7 +3259,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3235,7 +3268,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3243,10 +3276,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i13.Future<_i4.Profile> fetchOwnProfile({
+  _i14.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3259,7 +3292,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3271,7 +3304,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3282,10 +3315,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i13.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i14.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3299,8 +3332,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i13.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_25(
+        returnValue: _i14.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_26(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3312,8 +3345,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_25(
+            _i14.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_26(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3324,10 +3357,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.CachedProfileInformation>);
+      ) as _i14.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i13.Future<_i4.Profile> getProfileFromUserId(
+  _i14.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3345,7 +3378,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3359,7 +3392,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3372,7 +3405,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -3394,31 +3427,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i13.Future<List<_i4.Room>>);
+            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i14.Future<List<_i4.Room>>);
 
   @override
-  _i13.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i14.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i13.Future<List<_i4.ArchivedRoom>>);
+            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i14.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i13.Future<_i4.GetVersionsResponse> getVersions({
+  _i14.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3431,8 +3464,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_19(
+        returnValue: _i14.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_20(
           this,
           Invocation.method(
             #getVersions,
@@ -3443,8 +3476,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_19(
+        returnValueForMissingStub: _i14.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_20(
           this,
           Invocation.method(
             #getVersions,
@@ -3455,20 +3488,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetVersionsResponse>);
+      ) as _i14.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i13.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i14.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<_i4.MediaConfig> getConfig({
+  _i14.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3481,7 +3514,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
+        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
           this,
           Invocation.method(
             #getConfig,
@@ -3493,7 +3526,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
+            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
           this,
           Invocation.method(
             #getConfig,
@@ -3504,10 +3537,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.MediaConfig>);
+      ) as _i14.Future<_i4.MediaConfig>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContent(
+  _i14.Future<_i15.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -3527,7 +3560,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContent,
@@ -3543,7 +3576,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContent,
@@ -3558,10 +3591,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentOverrideName(
+  _i14.Future<_i15.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -3583,7 +3616,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3600,7 +3633,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3616,10 +3649,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentThumbnail(
+  _i14.Future<_i15.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -3647,7 +3680,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3667,7 +3700,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3686,10 +3719,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i14.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -3699,7 +3732,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
+        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3708,7 +3741,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
+            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3716,11 +3749,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i13.Future<_i4.PreviewForUrl>);
+      ) as _i14.Future<_i4.PreviewForUrl>);
 
   @override
-  _i13.Future<Uri> uploadContent(
-    _i22.Uint8List? file, {
+  _i14.Future<Uri> uploadContent(
+    _i23.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3733,7 +3766,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i13.Future<Uri>.value(_FakeUri_29(
+        returnValue: _i14.Future<Uri>.value(_FakeUri_30(
           this,
           Invocation.method(
             #uploadContent,
@@ -3744,7 +3777,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_29(
+        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_30(
           this,
           Invocation.method(
             #uploadContent,
@@ -3755,10 +3788,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<Uri>);
+      ) as _i14.Future<Uri>);
 
   @override
-  _i13.Future<void> setTyping(
+  _i14.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -3774,42 +3807,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> exportDump() => (super.noSuchMethod(
+  _i14.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i14.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i14.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Event?> getEventByPushNotification(
+  _i14.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -3825,12 +3858,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
-  _i13.Future<void> init({
+  _i14.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -3865,9 +3898,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -3879,40 +3912,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<void> clear() => (super.noSuchMethod(
+  _i14.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i14.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ensureNotSoftLoggedOut(
+  _i14.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleSync(
+  _i14.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -3922,9 +3955,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -3937,29 +3970,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i13.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i14.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i14.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDevice(
+  _i14.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -3973,12 +4006,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDevicesOfUserIds(
+  _i14.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -3994,12 +4027,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDeviceEncrypted(
+  _i14.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4019,12 +4052,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDeviceEncryptedChunked(
+  _i14.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -4038,23 +4071,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i14.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> joinRoom(
+  _i14.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -4072,7 +4105,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4086,7 +4119,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4099,10 +4132,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> changePassword(
+  _i14.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -4118,22 +4151,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> clearCache() => (super.noSuchMethod(
+  _i14.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ignoreUser(
+  _i14.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4143,22 +4176,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i14.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i14.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4169,7 +4202,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_30(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_31(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4178,7 +4211,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_30(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_31(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4186,32 +4219,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i13.Future<_i4.CachedPresence>);
+      ) as _i14.Future<_i4.CachedPresence>);
 
   @override
-  _i13.Future<void> abortSync() => (super.noSuchMethod(
+  _i14.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i14.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEventWithMetadata(
+  _i14.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4231,14 +4264,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i12.BaseResponse? response,
-    _i22.Uint8List? body,
+    _i13.BaseResponse? response,
+    _i23.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4270,7 +4303,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i13.Future<Map<String, Object?>> request(
+  _i14.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -4291,13 +4324,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> postPusher(
+  _i14.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -4307,57 +4340,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i14.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i14.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i14.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i13.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_31(
+        returnValue: _i14.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_32(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_31(
+        returnValueForMissingStub: _i14.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_32(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.TurnServerCredentials>);
+      ) as _i14.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4371,8 +4404,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4384,8 +4417,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4396,10 +4429,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4415,8 +4448,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4429,8 +4462,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4442,10 +4475,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i14.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4459,7 +4492,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
+        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4471,7 +4504,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
+            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4482,17 +4515,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.KeyBackupData>);
+      ) as _i14.Future<_i4.KeyBackupData>);
 
   @override
-  _i13.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i14.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i13.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_34(
+        returnValue: _i14.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_35(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -4500,18 +4533,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_34(
+            _i14.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_35(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i14.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i13.Future<int> pingAppservice(
+  _i14.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -4521,12 +4554,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i13.Future<int>.value(0),
-        returnValueForMissingStub: _i13.Future<int>.value(0),
-      ) as _i13.Future<int>);
+        returnValue: _i14.Future<int>.value(0),
+        returnValueForMissingStub: _i14.Future<int>.value(0),
+      ) as _i14.Future<int>);
 
   @override
-  _i13.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i14.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4534,8 +4567,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_35(
+        returnValue: _i14.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_36(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4544,8 +4577,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_35(
+            _i14.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_36(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4553,15 +4586,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i13.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i14.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i13.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i14.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
+        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -4569,17 +4602,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
+            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.MediaConfig>);
+      ) as _i14.Future<_i4.MediaConfig>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentAuthed(
+  _i14.Future<_i15.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -4593,7 +4626,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4605,7 +4638,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4616,10 +4649,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentOverrideNameAuthed(
+  _i14.Future<_i15.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4635,7 +4668,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4648,7 +4681,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4660,10 +4693,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i14.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -4673,7 +4706,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
+        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4682,7 +4715,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
+            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4690,10 +4723,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i13.Future<_i4.PreviewForUrl>);
+      ) as _i14.Future<_i4.PreviewForUrl>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentThumbnailAuthed(
+  _i14.Future<_i15.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -4717,7 +4750,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4735,7 +4768,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4752,21 +4785,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<bool> registrationTokenValidity(String? token) =>
+  _i14.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i14.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -4776,8 +4809,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_36(
+        returnValue: _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_37(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4786,8 +4819,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_36(
+            _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_37(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4795,10 +4828,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i14.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i13.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i14.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -4816,8 +4849,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_37(
+        returnValue: _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_38(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4831,8 +4864,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_37(
+            _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_38(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4845,10 +4878,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i14.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i14.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -4872,8 +4905,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i13.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_38(
+        returnValue: _i14.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_39(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4891,8 +4924,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_38(
+            _i14.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_39(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4909,10 +4942,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i14.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -4940,8 +4973,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_39(
+                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_40(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4960,8 +4993,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_39(
+                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_40(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4979,10 +5012,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i14.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -5011,9 +5044,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i13.Future<
+            returnValue: _i14.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5032,9 +5065,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i13.Future<
+            returnValueForMissingStub: _i14.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5053,11 +5086,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i13
+          ) as _i14
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i13.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i14.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -5073,8 +5106,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i13.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_41(
+        returnValue: _i14.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_42(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5087,8 +5120,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_41(
+            _i14.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_42(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5100,10 +5133,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetThreadRootsResponse>);
+      ) as _i14.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i13.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i14.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -5117,8 +5150,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i13.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_42(
+        returnValue: _i14.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_43(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5130,8 +5163,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_42(
+            _i14.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_43(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5142,33 +5175,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i14.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i14.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i13.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i14.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i13.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i14.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i13.Future<Uri?>.value(),
-        returnValueForMissingStub: _i13.Future<Uri?>.value(),
-      ) as _i13.Future<Uri?>);
+        returnValue: _i14.Future<Uri?>.value(),
+        returnValueForMissingStub: _i14.Future<Uri?>.value(),
+      ) as _i14.Future<Uri?>);
 
   @override
-  _i13.Future<void> add3PID(
+  _i14.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -5182,12 +5215,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> bind3PID(
+  _i14.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5203,12 +5236,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i14.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5222,14 +5255,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5251,8 +5284,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5268,8 +5301,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5285,10 +5318,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5312,8 +5345,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5330,8 +5363,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5348,10 +5381,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i14.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5365,14 +5398,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i14.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -5387,14 +5420,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5416,8 +5449,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5433,8 +5466,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5450,10 +5483,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5477,8 +5510,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5495,8 +5528,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5513,16 +5546,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i14.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_44(
+            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_45(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -5530,22 +5563,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_44(
+            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_45(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.TokenOwnerInfo>);
+      ) as _i14.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i13.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i14.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_45(
+        returnValue: _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_46(
           this,
           Invocation.method(
             #getWhoIs,
@@ -5553,22 +5586,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_45(
+            _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_46(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i13.Future<_i4.WhoIsInfo>);
+      ) as _i14.Future<_i4.WhoIsInfo>);
 
   @override
-  _i13.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i14.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_46(
+        returnValue: _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_47(
           this,
           Invocation.method(
             #getCapabilities,
@@ -5576,17 +5609,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_46(
+            _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_47(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.Capabilities>);
+      ) as _i14.Future<_i4.Capabilities>);
 
   @override
-  _i13.Future<String> createRoom({
+  _i14.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -5619,7 +5652,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5641,7 +5674,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5662,10 +5695,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> deleteDevices(
+  _i14.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5675,22 +5708,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.Device>?>.value(),
-      ) as _i13.Future<List<_i4.Device>?>);
+        returnValue: _i14.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.Device>?>.value(),
+      ) as _i14.Future<List<_i4.Device>?>);
 
   @override
-  _i13.Future<void> deleteDevice(
+  _i14.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5700,34 +5733,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i14.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i13.Future<_i4.Device>.value(_FakeDevice_47(
+        returnValue: _i14.Future<_i4.Device>.value(_FakeDevice_48(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.Device>.value(_FakeDevice_47(
+        returnValueForMissingStub: _i14.Future<_i4.Device>.value(_FakeDevice_48(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i13.Future<_i4.Device>);
+      ) as _i14.Future<_i4.Device>);
 
   @override
-  _i13.Future<void> updateDevice(
+  _i14.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -5737,12 +5770,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i14.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -5757,24 +5790,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i14.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i13.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Visibility?>.value(),
-      ) as _i13.Future<_i4.Visibility?>);
+        returnValue: _i14.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Visibility?>.value(),
+      ) as _i14.Future<_i4.Visibility?>);
 
   @override
-  _i13.Future<void> setRoomVisibilityOnDirectory(
+  _i14.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -5784,30 +5817,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i14.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i14.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_48(
+        returnValue: _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_49(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -5815,18 +5848,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_48(
+            _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_49(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i14.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i13.Future<void> setRoomAlias(
+  _i14.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -5838,12 +5871,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetEventsResponse> getEvents({
+  _i14.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -5857,7 +5890,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_49(
+            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_50(
           this,
           Invocation.method(
             #getEvents,
@@ -5869,7 +5902,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_49(
+            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_50(
           this,
           Invocation.method(
             #getEvents,
@@ -5880,10 +5913,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetEventsResponse>);
+      ) as _i14.Future<_i4.GetEventsResponse>);
 
   @override
-  _i13.Future<_i4.PeekEventsResponse> peekEvents({
+  _i14.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -5898,8 +5931,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i13.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_50(
+        returnValue: _i14.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_51(
           this,
           Invocation.method(
             #peekEvents,
@@ -5911,8 +5944,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_50(
+        returnValueForMissingStub: _i14.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_51(
           this,
           Invocation.method(
             #peekEvents,
@@ -5924,16 +5957,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.PeekEventsResponse>);
+      ) as _i14.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i13.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i14.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
+        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
           this,
           Invocation.method(
             #getOneEvent,
@@ -5941,27 +5974,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
+            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i13.Future<_i4.MatrixEvent>);
+      ) as _i14.Future<_i4.MatrixEvent>);
 
   @override
-  _i13.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i14.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i13.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
-      ) as _i13.Future<List<String>>);
+        returnValue: _i14.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
+      ) as _i14.Future<List<String>>);
 
   @override
-  _i13.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i14.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -5973,8 +6006,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i13.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_52(
+        returnValue: _i14.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_53(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5985,8 +6018,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_52(
+            _i14.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_53(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5996,10 +6029,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.GetKeysChangesResponse>);
+      ) as _i14.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i13.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i14.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -6010,7 +6043,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_53(
+            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_54(
           this,
           Invocation.method(
             #claimKeys,
@@ -6019,7 +6052,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_53(
+            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_54(
           this,
           Invocation.method(
             #claimKeys,
@@ -6027,10 +6060,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i13.Future<_i4.ClaimKeysResponse>);
+      ) as _i14.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i13.Future<void> uploadCrossSigningKeys({
+  _i14.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -6047,12 +6080,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.QueryKeysResponse> queryKeys(
+  _i14.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -6063,7 +6096,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_54(
+            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_55(
           this,
           Invocation.method(
             #queryKeys,
@@ -6072,7 +6105,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_54(
+            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_55(
           this,
           Invocation.method(
             #queryKeys,
@@ -6080,10 +6113,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i13.Future<_i4.QueryKeysResponse>);
+      ) as _i14.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -6091,14 +6124,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i13.Future<
+            returnValue: _i14.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i13.Future<
+            returnValueForMissingStub: _i14.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i13.Future<Map<String, int>> uploadKeys({
+  _i14.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -6113,13 +6146,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i13.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i14.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i13.Future<Map<String, int>>);
+            _i14.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i14.Future<Map<String, int>>);
 
   @override
-  _i13.Future<String> knockRoom(
+  _i14.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6133,7 +6166,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6145,7 +6178,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6156,20 +6189,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i14.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i13.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i14.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i14.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i13.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i14.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6184,8 +6217,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i13.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_55(
+        returnValue: _i14.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_56(
           this,
           Invocation.method(
             #getNotifications,
@@ -6198,8 +6231,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_55(
+            _i14.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_56(
           this,
           Invocation.method(
             #getNotifications,
@@ -6211,35 +6244,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetNotificationsResponse>);
+      ) as _i14.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i13.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i14.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i13.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_56(
+        returnValue: _i14.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_57(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_56(
+        returnValueForMissingStub: _i14.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_57(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i13.Future<_i4.GetPresenceResponse>);
+      ) as _i14.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i13.Future<void> setPresence(
+  _i14.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -6253,12 +6286,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, Object?>> deleteProfileField(
+  _i14.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6271,13 +6304,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getProfileField(
+  _i14.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6290,13 +6323,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<Map<String, Object?>> setProfileField(
+  _i14.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6311,13 +6344,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i14.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6332,8 +6365,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i13.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_57(
+        returnValue: _i14.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_58(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6346,8 +6379,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_57(
+            _i14.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_58(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6359,10 +6392,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i14.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i13.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i14.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -6383,8 +6416,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i13.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_58(
+        returnValue: _i14.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_59(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6400,8 +6433,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_58(
+            _i14.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_59(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6416,25 +6449,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i14.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i13.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.Pusher>?>.value(),
-      ) as _i13.Future<List<_i4.Pusher>?>);
+        returnValue: _i14.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.Pusher>?>.value(),
+      ) as _i14.Future<List<_i4.Pusher>?>);
 
   @override
-  _i13.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i14.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_59(
+        returnValue: _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_60(
           this,
           Invocation.method(
             #getPushRules,
@@ -6442,24 +6475,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_59(
+            _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_60(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.PushRuleSet>);
+      ) as _i14.Future<_i4.PushRuleSet>);
 
   @override
-  _i13.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i14.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_60(
+        returnValue: _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_61(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -6467,18 +6500,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_60(
+            _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_61(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i14.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i13.Future<void> deletePushRule(
+  _i14.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6490,12 +6523,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.PushRule> getPushRule(
+  _i14.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6507,7 +6540,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<_i4.PushRule>.value(_FakePushRule_61(
+        returnValue: _i14.Future<_i4.PushRule>.value(_FakePushRule_62(
           this,
           Invocation.method(
             #getPushRule,
@@ -6518,7 +6551,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PushRule>.value(_FakePushRule_61(
+            _i14.Future<_i4.PushRule>.value(_FakePushRule_62(
           this,
           Invocation.method(
             #getPushRule,
@@ -6528,10 +6561,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.PushRule>);
+      ) as _i14.Future<_i4.PushRule>);
 
   @override
-  _i13.Future<void> setPushRule(
+  _i14.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -6555,12 +6588,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<Object?>> getPushRuleActions(
+  _i14.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6572,13 +6605,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i14.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i13.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i13.Future<List<Object?>>);
+            _i14.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i14.Future<List<Object?>>);
 
   @override
-  _i13.Future<void> setPushRuleActions(
+  _i14.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -6592,12 +6625,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<bool> isPushRuleEnabled(
+  _i14.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6609,12 +6642,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> setPushRuleEnabled(
+  _i14.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -6628,19 +6661,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i14.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_62(
+            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_63(
           this,
           Invocation.method(
             #refresh,
@@ -6648,28 +6681,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_62(
+            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_63(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i13.Future<_i4.RefreshResponse>);
+      ) as _i14.Future<_i4.RefreshResponse>);
 
   @override
-  _i13.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i14.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i13.Future<bool?>.value(),
-        returnValueForMissingStub: _i13.Future<bool?>.value(),
-      ) as _i13.Future<bool?>);
+        returnValue: _i14.Future<bool?>.value(),
+        returnValueForMissingStub: _i14.Future<bool?>.value(),
+      ) as _i14.Future<bool?>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6691,8 +6724,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6708,8 +6741,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6725,10 +6758,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6752,8 +6785,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6770,8 +6803,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6788,17 +6821,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -6806,23 +6839,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i14.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_63(
+        returnValue: _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_64(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -6830,17 +6863,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_63(
+            _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_64(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeys>);
+      ) as _i14.Future<_i4.RoomKeys>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -6852,8 +6885,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6864,8 +6897,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6875,10 +6908,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6890,8 +6923,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6902,8 +6935,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6913,10 +6946,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6928,7 +6961,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_64(
+        returnValue: _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_65(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6939,7 +6972,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_64(
+            _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_65(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6949,10 +6982,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeyBackup>);
+      ) as _i14.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -6966,8 +6999,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6979,8 +7012,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6991,10 +7024,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7008,8 +7041,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7021,8 +7054,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7033,10 +7066,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i14.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7050,7 +7083,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
+        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7062,7 +7095,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
+            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7073,10 +7106,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.KeyBackupData>);
+      ) as _i14.Future<_i4.KeyBackupData>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7092,8 +7125,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7106,8 +7139,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7119,18 +7152,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_65(
+                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_66(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7138,18 +7171,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_65(
+                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_66(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i13.Future<String> postRoomKeysVersion(
+  _i14.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -7161,7 +7194,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7172,7 +7205,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7182,29 +7215,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i14.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i14.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_66(
+        returnValue: _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_67(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7212,18 +7245,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_66(
+            _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_67(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i14.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i14.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -7238,24 +7271,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i14.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i13.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
-      ) as _i13.Future<List<String>>);
+        returnValue: _i14.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
+      ) as _i14.Future<List<String>>);
 
   @override
-  _i13.Future<void> ban(
+  _i14.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7269,12 +7302,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.EventContext> getEventContext(
+  _i14.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7292,7 +7325,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<_i4.EventContext>.value(_FakeEventContext_67(
+        returnValue: _i14.Future<_i4.EventContext>.value(_FakeEventContext_68(
           this,
           Invocation.method(
             #getEventContext,
@@ -7307,7 +7340,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.EventContext>.value(_FakeEventContext_67(
+            _i14.Future<_i4.EventContext>.value(_FakeEventContext_68(
           this,
           Invocation.method(
             #getEventContext,
@@ -7321,10 +7354,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.EventContext>);
+      ) as _i14.Future<_i4.EventContext>);
 
   @override
-  _i13.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i14.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7336,7 +7369,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
+        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7347,7 +7380,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
+            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7357,20 +7390,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.MatrixEvent>);
+      ) as _i14.Future<_i4.MatrixEvent>);
 
   @override
-  _i13.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i14.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> inviteBy3PID(
+  _i14.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -7382,12 +7415,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> inviteUser(
+  _i14.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7401,12 +7434,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> joinRoomById(
+  _i14.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -7420,7 +7453,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7432,7 +7465,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7443,23 +7476,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i14.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i13.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i14.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i13.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i13.Future<Map<String, _i4.RoomMember>?>);
+            _i14.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i14.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i13.Future<void> kick(
+  _i14.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7473,12 +7506,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> leaveRoom(
+  _i14.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -7488,12 +7521,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i14.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -7509,12 +7542,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i13.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i13.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i14.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i14.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i13.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i14.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -7536,8 +7569,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_68(
+        returnValue: _i14.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_69(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7553,8 +7586,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_68(
+        returnValueForMissingStub: _i14.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_69(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7570,10 +7603,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomEventsResponse>);
+      ) as _i14.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i13.Future<void> setReadMarker(
+  _i14.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -7589,12 +7622,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> postReceipt(
+  _i14.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -7610,12 +7643,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEvent(
+  _i14.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -7631,12 +7664,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> reportRoom(
+  _i14.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -7648,12 +7681,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> reportEvent(
+  _i14.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -7671,12 +7704,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> sendMessage(
+  _i14.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -7692,7 +7725,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7705,7 +7738,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7717,23 +7750,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i14.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i13.Future<List<_i4.MatrixEvent>>);
+            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i14.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i14.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -7750,13 +7783,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<String> setRoomStateWithKey(
+  _i14.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -7772,7 +7805,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7785,7 +7818,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7797,10 +7830,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> unban(
+  _i14.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7814,12 +7847,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> upgradeRoom(
+  _i14.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -7833,7 +7866,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7845,7 +7878,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7856,10 +7889,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.SearchResults> search(
+  _i14.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -7869,7 +7902,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_69(
+        returnValue: _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_70(
           this,
           Invocation.method(
             #search,
@@ -7878,7 +7911,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_69(
+            _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_70(
           this,
           Invocation.method(
             #search,
@@ -7886,10 +7919,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i13.Future<_i4.SearchResults>);
+      ) as _i14.Future<_i4.SearchResults>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> sync({
+  _i14.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -7910,7 +7943,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.method(
             #sync,
@@ -7926,7 +7959,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.method(
             #sync,
@@ -7941,22 +7974,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i14.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i13.Future<List<_i4.Location>>);
+            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i14.Future<List<_i4.Location>>);
 
   @override
-  _i13.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i14.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -7966,21 +7999,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i13.Future<List<_i4.Location>>);
+            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i14.Future<List<_i4.Location>>);
 
   @override
-  _i13.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i14.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_70(
+        returnValue: _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_71(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -7988,45 +8021,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_70(
+            _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_71(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i13.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i14.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i13.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i14.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8037,13 +8070,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getAccountData(
+  _i14.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -8056,13 +8089,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> setAccountData(
+  _i14.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -8076,12 +8109,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> defineFilter(
+  _i14.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -8093,7 +8126,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8104,7 +8137,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8114,10 +8147,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.Filter> getFilter(
+  _i14.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8129,7 +8162,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i13.Future<_i4.Filter>.value(_FakeFilter_10(
+        returnValue: _i14.Future<_i4.Filter>.value(_FakeFilter_11(
           this,
           Invocation.method(
             #getFilter,
@@ -8139,7 +8172,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.Filter>.value(_FakeFilter_10(
+        returnValueForMissingStub: _i14.Future<_i4.Filter>.value(_FakeFilter_11(
           this,
           Invocation.method(
             #getFilter,
@@ -8149,10 +8182,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.Filter>);
+      ) as _i14.Future<_i4.Filter>);
 
   @override
-  _i13.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i14.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8165,7 +8198,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_71(
+            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_72(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8176,7 +8209,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_71(
+            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_72(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8186,10 +8219,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.OpenIdCredentials>);
+      ) as _i14.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i13.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i14.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8204,13 +8237,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> setAccountDataPerRoom(
+  _i14.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8226,12 +8259,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i14.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8243,12 +8276,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i13.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i13.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i13.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i14.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i14.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i14.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i13.Future<void> deleteRoomTag(
+  _i14.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8262,12 +8295,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setRoomTag(
+  _i14.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8283,12 +8316,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i14.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8298,8 +8331,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i13.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_72(
+        returnValue: _i14.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_73(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8308,8 +8341,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_72(
+            _i14.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_73(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8317,10 +8350,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i13.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i14.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> reportUser(
+  _i14.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8333,40 +8366,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i14.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i13.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_73(
+        returnValue: _i14.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_74(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_73(
+        returnValueForMissingStub: _i14.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_74(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.CreateContentResponse>);
+      ) as _i14.Future<_i4.CreateContentResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> uploadContentToMXC(
+  _i14.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i22.Uint8List? body, {
+    _i23.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8384,10 +8417,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [AuthService].
@@ -8427,7 +8460,7 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
       ) as bool);
 
   @override
-  _i13.Future<bool> login({
+  _i14.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -8442,12 +8475,12 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
             #password: password,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> completeSsoLogin({
+  _i14.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -8460,12 +8493,12 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> completeRegistration(
+  _i14.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -8475,9 +8508,9 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
           [response],
           {#password: password},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void activateRestoredSession() => super.noSuchMethod(
@@ -8489,37 +8522,37 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
       );
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleServerLogout() => (super.noSuchMethod(
+  _i14.Future<void> handleServerLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleServerLogout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> saveSessionBackup() => (super.noSuchMethod(
+  _i14.Future<void> saveSessionBackup() => (super.noSuchMethod(
         Invocation.method(
           #saveSessionBackup,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i15.ServerAuthCapabilities> getServerAuthCapabilities(
+  _i14.Future<_i16.ServerAuthCapabilities> getServerAuthCapabilities(
     String? homeserver, {
     required bool? isLoggedIn,
   }) =>
@@ -8529,8 +8562,8 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
           [homeserver],
           {#isLoggedIn: isLoggedIn},
         ),
-        returnValue: _i13.Future<_i15.ServerAuthCapabilities>.value(
-            _FakeServerAuthCapabilities_74(
+        returnValue: _i14.Future<_i16.ServerAuthCapabilities>.value(
+            _FakeServerAuthCapabilities_75(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8539,8 +8572,8 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i15.ServerAuthCapabilities>.value(
-                _FakeServerAuthCapabilities_74(
+            _i14.Future<_i16.ServerAuthCapabilities>.value(
+                _FakeServerAuthCapabilities_75(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8548,7 +8581,7 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
             {#isLoggedIn: isLoggedIn},
           ),
         )),
-      ) as _i13.Future<_i15.ServerAuthCapabilities>);
+      ) as _i14.Future<_i16.ServerAuthCapabilities>);
 
   @override
   bool isPermanentAuthFailure(Object? error) => (super.noSuchMethod(
@@ -8561,37 +8594,37 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
       ) as bool);
 
   @override
-  _i13.Future<void> clearSessionKeys() => (super.noSuchMethod(
+  _i14.Future<void> clearSessionKeys() => (super.noSuchMethod(
         Invocation.method(
           #clearSessionKeys,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> migrateStorageKeys() => (super.noSuchMethod(
+  _i14.Future<void> migrateStorageKeys() => (super.noSuchMethod(
         Invocation.method(
           #migrateStorageKeys,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> persistCredentials() => (super.noSuchMethod(
+  _i14.Future<void> persistCredentials() => (super.noSuchMethod(
         Invocation.method(
           #persistCredentials,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8600,7 +8633,7 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/test/widgets/message_reply_test.mocks.dart
+++ b/test/widgets/message_reply_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i17;
-import 'dart:ui' as _i19;
+import 'dart:typed_data' as _i18;
+import 'dart:ui' as _i20;
 
-import 'package:flutter/services.dart' as _i20;
-import 'package:flutter/widgets.dart' as _i21;
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,14 +23,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i15;
+import 'package:matrix/encryption.dart' as _i16;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i14;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i15;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i22;
+import 'package:matrix/src/utils/space_child.dart' as _i23;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -821,8 +822,9 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_73(
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -831,9 +833,19 @@ class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_74 extends _i1.SmartFake
+class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_74(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_75 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_74(
+  _FakeLatestReceiptState_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,8 +854,8 @@ class _FakeLatestReceiptState_74 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_75(
+class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,8 +864,8 @@ class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_76(
+class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -862,8 +874,8 @@ class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_77 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_77(
+class _FakeRoom_78 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -872,9 +884,9 @@ class _FakeRoom_77 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_78 extends _i1.SmartFake
-    implements _i14.TimelineChunk {
-  _FakeTimelineChunk_78(
+class _FakeTimelineChunk_79 extends _i1.SmartFake
+    implements _i15.TimelineChunk {
+  _FakeTimelineChunk_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -883,8 +895,8 @@ class _FakeTimelineChunk_78 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixFile_79 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_79(
+class _FakeMatrixFile_80 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -893,8 +905,8 @@ class _FakeMatrixFile_79 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_80 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_80(
+class _FakeEvent_81 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -921,12 +933,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i15.KeyVerificationMethod> get verificationMethods =>
+  Set<_i16.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i15.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
-      ) as Set<_i15.KeyVerificationMethod>);
+        returnValue: <_i16.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
+      ) as Set<_i16.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1046,11 +1058,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1087,11 +1099,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1121,11 +1133,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1134,11 +1146,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1424,34 +1436,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i15.KeyVerification>
+  _i3.CachedStreamController<_i16.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i15.KeyVerification>(
+                _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i15.KeyVerification>);
+          ) as _i3.CachedStreamController<_i16.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1607,7 +1619,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1896,14 +1908,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2291,8 +2303,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2308,8 +2320,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2350,7 +2362,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2366,7 +2378,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2415,7 +2427,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2436,7 +2448,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2539,7 +2551,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2557,7 +2569,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3076,7 +3088,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i17.Uint8List? file, {
+    _i18.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3428,7 +3440,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3442,7 +3454,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3593,7 +3605,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i17.Uint8List? body,
+    _i18.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4971,7 +4983,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4993,7 +5005,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5487,7 +5499,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5499,7 +5511,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6507,7 +6519,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6518,7 +6530,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6766,7 +6778,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6778,7 +6790,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7038,7 +7050,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7051,7 +7063,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7118,7 +7130,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7131,7 +7143,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7179,7 +7191,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7191,7 +7203,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7439,7 +7451,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7450,7 +7462,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7712,7 +7724,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i17.Uint8List? body, {
+    _i18.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7739,7 +7751,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7769,11 +7781,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7872,6 +7884,19 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7951,6 +7976,15 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7995,7 +8029,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8089,7 +8123,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8098,7 +8132,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8117,7 +8151,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8128,7 +8162,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8176,7 +8210,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8214,7 +8248,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8223,7 +8257,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8232,16 +8266,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i5.Future<_i19.AppExitResponse>);
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i5.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8269,11 +8303,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8303,11 +8337,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_73(
+        returnValue: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_73(
+        returnValueForMissingStub: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
@@ -8360,11 +8394,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8400,11 +8434,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8420,11 +8454,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8433,11 +8467,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8480,11 +8514,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8527,11 +8561,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_74(
+        returnValue: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_74(
+        returnValueForMissingStub: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8743,18 +8777,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i22.SpaceParent>[],
-        returnValueForMissingStub: <_i22.SpaceParent>[],
-      ) as List<_i22.SpaceParent>);
+        returnValue: <_i23.SpaceParent>[],
+        returnValueForMissingStub: <_i23.SpaceParent>[],
+      ) as List<_i23.SpaceParent>);
 
   @override
-  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i22.SpaceChild>[],
-        returnValueForMissingStub: <_i22.SpaceChild>[],
-      ) as List<_i22.SpaceChild>);
+        returnValue: <_i23.SpaceChild>[],
+        returnValueForMissingStub: <_i23.SpaceChild>[],
+      ) as List<_i23.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8921,14 +8955,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8976,7 +9010,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8984,7 +9018,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8999,7 +9033,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9007,7 +9041,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9091,7 +9125,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9099,7 +9133,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9341,7 +9375,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9352,7 +9386,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9441,15 +9475,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i14.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i15.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i14.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i14.TimelineChunk?>.value(),
-      ) as _i5.Future<_i14.TimelineChunk?>);
+        returnValue: _i5.Future<_i15.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i15.TimelineChunk?>.value(),
+      ) as _i5.Future<_i15.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9490,7 +9524,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9507,7 +9541,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9571,14 +9605,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9594,14 +9628,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9657,7 +9691,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9665,7 +9699,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9977,11 +10011,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_77(
+        returnValue: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_77(
+        returnValueForMissingStub: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
@@ -10031,17 +10065,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i14.TimelineChunk get chunk => (super.noSuchMethod(
+  _i15.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_78(
+        returnValue: _FakeTimelineChunk_79(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_78(
+        returnValueForMissingStub: _FakeTimelineChunk_79(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i14.TimelineChunk);
+      ) as _i15.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10144,7 +10178,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i14.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i15.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -10343,11 +10377,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.getter(#sender),
         ),
@@ -10356,11 +10390,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10369,11 +10403,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_77(
+        returnValue: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_77(
+        returnValueForMissingStub: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
@@ -10396,11 +10430,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10409,11 +10443,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10422,11 +10456,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10435,11 +10469,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10448,11 +10482,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10461,11 +10495,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10530,11 +10564,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10543,11 +10577,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10600,11 +10634,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10689,11 +10723,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10711,11 +10745,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10926,7 +10960,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i17.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i18.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10941,7 +10975,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_79(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_80(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10955,7 +10989,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_79(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_80(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10991,7 +11025,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11006,7 +11040,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11043,7 +11077,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11057,7 +11091,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11094,7 +11128,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11108,7 +11142,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11142,7 +11176,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11155,7 +11189,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11231,14 +11265,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_80(
+        returnValue: _FakeEvent_81(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_80(
+        returnValueForMissingStub: _FakeEvent_81(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -11255,11 +11289,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_77(
+        returnValue: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_77(
+        returnValueForMissingStub: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
@@ -11268,11 +11302,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -11338,11 +11372,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11367,11 +11401,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11389,11 +11423,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11440,7 +11474,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11452,7 +11486,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11522,7 +11556,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11535,7 +11569,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/new_dm_dialog_test.mocks.dart
+++ b/test/widgets/new_dm_dialog_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,14 +23,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/src/utils/space_child.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -821,8 +822,9 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_73(
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -831,9 +833,19 @@ class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_74 extends _i1.SmartFake
+class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_74(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_75 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_74(
+  _FakeLatestReceiptState_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,8 +854,8 @@ class _FakeLatestReceiptState_74 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_75(
+class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,8 +864,8 @@ class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_76(
+class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -880,12 +892,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1005,11 +1017,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1046,11 +1058,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1080,11 +1092,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1093,11 +1105,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1383,34 +1395,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1566,7 +1578,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1855,14 +1867,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2250,8 +2262,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2267,8 +2279,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2309,7 +2321,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2325,7 +2337,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2374,7 +2386,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2395,7 +2407,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2498,7 +2510,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2516,7 +2528,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3035,7 +3047,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3387,7 +3399,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3401,7 +3413,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3552,7 +3564,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4930,7 +4942,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4952,7 +4964,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5446,7 +5458,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5458,7 +5470,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6466,7 +6478,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6477,7 +6489,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6725,7 +6737,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6737,7 +6749,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6997,7 +7009,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7010,7 +7022,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7077,7 +7089,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7090,7 +7102,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7138,7 +7150,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7150,7 +7162,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7398,7 +7410,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7409,7 +7421,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7671,7 +7683,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7698,7 +7710,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7728,11 +7740,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7831,6 +7843,19 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7910,6 +7935,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7954,7 +7988,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8048,7 +8082,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8057,7 +8091,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8076,7 +8110,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8087,7 +8121,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8135,7 +8169,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8173,7 +8207,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8182,7 +8216,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8191,16 +8225,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8228,11 +8262,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8262,11 +8296,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_73(
+        returnValue: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_73(
+        returnValueForMissingStub: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
@@ -8319,11 +8353,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8359,11 +8393,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8379,11 +8413,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8392,11 +8426,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8439,11 +8473,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8486,11 +8520,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_74(
+        returnValue: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_74(
+        returnValueForMissingStub: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8702,18 +8736,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i22.SpaceParent>[],
+        returnValueForMissingStub: <_i22.SpaceParent>[],
+      ) as List<_i22.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i22.SpaceChild>[],
+        returnValueForMissingStub: <_i22.SpaceChild>[],
+      ) as List<_i22.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8880,14 +8914,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8935,7 +8969,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8943,7 +8977,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8958,7 +8992,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8966,7 +9000,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9050,7 +9084,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9058,7 +9092,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9300,7 +9334,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9311,7 +9345,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9400,15 +9434,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i22.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i22.TimelineChunk?>.value(),
-      ) as _i5.Future<_i22.TimelineChunk?>);
+        returnValue: _i5.Future<_i23.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i23.TimelineChunk?>.value(),
+      ) as _i5.Future<_i23.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9449,7 +9483,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9466,7 +9500,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9530,14 +9564,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9553,14 +9587,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9616,7 +9650,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9624,7 +9658,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/new_room_dialog_test.mocks.dart
+++ b/test/widgets/new_room_dialog_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,12 +23,12 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -819,6 +820,17 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -837,12 +849,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -962,11 +974,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1003,11 +1015,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1037,11 +1049,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1050,11 +1062,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1340,34 +1352,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1523,7 +1535,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1812,14 +1824,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2207,8 +2219,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2224,8 +2236,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2266,7 +2278,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2282,7 +2294,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2331,7 +2343,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2352,7 +2364,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2455,7 +2467,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2473,7 +2485,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2992,7 +3004,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3344,7 +3356,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3358,7 +3370,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3509,7 +3521,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4887,7 +4899,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4909,7 +4921,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5403,7 +5415,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5415,7 +5427,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6423,7 +6435,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6434,7 +6446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6682,7 +6694,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6694,7 +6706,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6954,7 +6966,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6967,7 +6979,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7034,7 +7046,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7047,7 +7059,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7095,7 +7107,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7107,7 +7119,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7355,7 +7367,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7366,7 +7378,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7628,7 +7640,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7655,7 +7667,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7685,11 +7697,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7788,6 +7800,19 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7867,6 +7892,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7911,7 +7945,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8005,7 +8039,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8014,7 +8048,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8033,7 +8067,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8044,7 +8078,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8092,7 +8126,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8130,7 +8164,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8139,7 +8173,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8148,16 +8182,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/recovery_key_handler_test.mocks.dart
+++ b/test/widgets/recovery_key_handler_test.mocks.dart
@@ -3,17 +3,18 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i13;
-import 'dart:typed_data' as _i23;
-import 'dart:ui' as _i20;
+import 'dart:async' as _i14;
+import 'dart:typed_data' as _i24;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
-import 'package:http/http.dart' as _i12;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
+import 'package:http/http.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
@@ -22,15 +23,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i10;
-import 'package:matrix/encryption/cross_signing.dart' as _i17;
-import 'package:matrix/encryption/key_verification_manager.dart' as _i16;
-import 'package:matrix/encryption/olm_manager.dart' as _i15;
+import 'package:matrix/encryption.dart' as _i11;
+import 'package:matrix/encryption/cross_signing.dart' as _i18;
+import 'package:matrix/encryption/key_verification_manager.dart' as _i17;
+import 'package:matrix/encryption/olm_manager.dart' as _i16;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i14;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i11;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i15;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i12;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -131,8 +132,8 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeEncryption_8 extends _i1.SmartFake implements _i10.Encryption {
-  _FakeEncryption_8(
+class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
+  _FakeOutboxService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -141,8 +142,8 @@ class _FakeEncryption_8 extends _i1.SmartFake implements _i10.Encryption {
         );
 }
 
-class _FakeSSSS_9 extends _i1.SmartFake implements _i10.SSSS {
-  _FakeSSSS_9(
+class _FakeEncryption_9 extends _i1.SmartFake implements _i11.Encryption {
+  _FakeEncryption_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -151,9 +152,19 @@ class _FakeSSSS_9 extends _i1.SmartFake implements _i10.SSSS {
         );
 }
 
-class _FakeSecretStorageKeyContent_10 extends _i1.SmartFake
+class _FakeSSSS_10 extends _i1.SmartFake implements _i11.SSSS {
+  _FakeSSSS_10(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeSecretStorageKeyContent_11 extends _i1.SmartFake
     implements _i4.SecretStorageKeyContent {
-  _FakeSecretStorageKeyContent_10(
+  _FakeSecretStorageKeyContent_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -162,8 +173,8 @@ class _FakeSecretStorageKeyContent_10 extends _i1.SmartFake
         );
 }
 
-class _FakeDatabaseApi_11 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_11(
+class _FakeDatabaseApi_12 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -172,8 +183,8 @@ class _FakeDatabaseApi_11 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_12 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_12(
+class _FakeFilter_13 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -182,9 +193,9 @@ class _FakeFilter_12 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_13 extends _i1.SmartFake
+class _FakeNativeImplementations_14 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_13(
+  _FakeNativeImplementations_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -193,8 +204,8 @@ class _FakeNativeImplementations_13 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_14 extends _i1.SmartFake implements Duration {
-  _FakeDuration_14(
+class _FakeDuration_15 extends _i1.SmartFake implements Duration {
+  _FakeDuration_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -203,9 +214,9 @@ class _FakeDuration_14 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_15 extends _i1.SmartFake
+class _FakePushruleEvaluator_16 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_15(
+  _FakePushruleEvaluator_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -214,8 +225,8 @@ class _FakePushruleEvaluator_15 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_16 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_16(
+class _FakeProfile_17 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -224,9 +235,9 @@ class _FakeProfile_16 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeCachedStreamController_17<T> extends _i1.SmartFake
-    implements _i11.CachedStreamController<T> {
-  _FakeCachedStreamController_17(
+class _FakeCachedStreamController_18<T> extends _i1.SmartFake
+    implements _i12.CachedStreamController<T> {
+  _FakeCachedStreamController_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -235,8 +246,8 @@ class _FakeCachedStreamController_17<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_18 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_18(
+class _FakeDateTime_19 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -245,8 +256,8 @@ class _FakeDateTime_18 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_19 extends _i1.SmartFake implements _i12.Client {
-  _FakeClient_19(
+class _FakeClient_20 extends _i1.SmartFake implements _i13.Client {
+  _FakeClient_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -255,9 +266,9 @@ class _FakeClient_19 extends _i1.SmartFake implements _i12.Client {
         );
 }
 
-class _FakeDiscoveryInformation_20 extends _i1.SmartFake
+class _FakeDiscoveryInformation_21 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_20(
+  _FakeDiscoveryInformation_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -266,9 +277,9 @@ class _FakeDiscoveryInformation_20 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_21 extends _i1.SmartFake
+class _FakeGetVersionsResponse_22 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_21(
+  _FakeGetVersionsResponse_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -277,9 +288,9 @@ class _FakeGetVersionsResponse_21 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_22 extends _i1.SmartFake
+class _FakeRegisterResponse_23 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_22(
+  _FakeRegisterResponse_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -288,8 +299,8 @@ class _FakeRegisterResponse_22 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_23 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_23(
+class _FakeLoginResponse_24 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -298,9 +309,9 @@ class _FakeLoginResponse_23 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_24 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_25 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_24(
+  _FakeGetAuthMetadataResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -309,8 +320,8 @@ class _FakeGetAuthMetadataResponse_24 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_25<T1> extends _i1.SmartFake implements _i13.Future<T1> {
-  _FakeFuture_25(
+class _FakeFuture_26<T1> extends _i1.SmartFake implements _i14.Future<T1> {
+  _FakeFuture_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -319,8 +330,8 @@ class _FakeFuture_25<T1> extends _i1.SmartFake implements _i13.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_26 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_26(
+class _FakeSyncUpdate_27 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -329,9 +340,9 @@ class _FakeSyncUpdate_26 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_27 extends _i1.SmartFake
+class _FakeCachedProfileInformation_28 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_27(
+  _FakeCachedProfileInformation_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -340,8 +351,8 @@ class _FakeCachedProfileInformation_27 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_28 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_28(
+class _FakeMediaConfig_29 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -350,8 +361,8 @@ class _FakeMediaConfig_28 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_29 extends _i1.SmartFake implements _i14.FileResponse {
-  _FakeFileResponse_29(
+class _FakeFileResponse_30 extends _i1.SmartFake implements _i15.FileResponse {
+  _FakeFileResponse_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -360,8 +371,8 @@ class _FakeFileResponse_29 extends _i1.SmartFake implements _i14.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_30 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_30(
+class _FakePreviewForUrl_31 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -370,8 +381,8 @@ class _FakePreviewForUrl_30 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeUri_31 extends _i1.SmartFake implements Uri {
-  _FakeUri_31(
+class _FakeUri_32 extends _i1.SmartFake implements Uri {
+  _FakeUri_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -380,9 +391,9 @@ class _FakeUri_31 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_32 extends _i1.SmartFake
+class _FakeCachedPresence_33 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_32(
+  _FakeCachedPresence_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -391,9 +402,9 @@ class _FakeCachedPresence_32 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_33 extends _i1.SmartFake
+class _FakeTurnServerCredentials_34 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_33(
+  _FakeTurnServerCredentials_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -402,9 +413,9 @@ class _FakeTurnServerCredentials_33 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_34(
+  _FakeRoomKeysUpdateResponse_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -413,8 +424,8 @@ class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_35(
+class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -423,9 +434,9 @@ class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_36(
+  _FakeGetWellknownSupportResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -434,9 +445,9 @@ class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_37(
+  _FakeGenerateLoginTokenResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -445,9 +456,9 @@ class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_38(
+  _FakeGetRoomSummaryResponse$3_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -456,9 +467,9 @@ class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_39(
+  _FakeGetSpaceHierarchyResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -467,9 +478,9 @@ class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_40(
+  _FakeGetRelatingEventsResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -478,9 +489,9 @@ class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_41(
+  _FakeGetRelatingEventsWithRelTypeResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -489,9 +500,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -500,9 +511,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_43(
+  _FakeGetThreadRootsResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -511,9 +522,9 @@ class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_44(
+  _FakeGetEventByTimestampResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -522,9 +533,9 @@ class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_45 extends _i1.SmartFake
+class _FakeRequestTokenResponse_46 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_45(
+  _FakeRequestTokenResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -533,9 +544,9 @@ class _FakeRequestTokenResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_46(
+  _FakeTokenOwnerInfo_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -544,8 +555,8 @@ class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_47(
+class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -554,8 +565,8 @@ class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_48 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_48(
+class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -564,8 +575,8 @@ class _FakeCapabilities_48 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_49 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_49(
+class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -574,9 +585,9 @@ class _FakeDevice_49 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_50(
+  _FakeGetRoomIdByAliasResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -585,9 +596,9 @@ class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_51 extends _i1.SmartFake
+class _FakeGetEventsResponse_52 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_51(
+  _FakeGetEventsResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -596,9 +607,9 @@ class _FakeGetEventsResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_52 extends _i1.SmartFake
+class _FakePeekEventsResponse_53 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_52(
+  _FakePeekEventsResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -607,8 +618,8 @@ class _FakePeekEventsResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_53(
+class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -617,9 +628,9 @@ class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_54(
+  _FakeGetKeysChangesResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -628,9 +639,9 @@ class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_55 extends _i1.SmartFake
+class _FakeClaimKeysResponse_56 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_55(
+  _FakeClaimKeysResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -639,9 +650,9 @@ class _FakeClaimKeysResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_56 extends _i1.SmartFake
+class _FakeQueryKeysResponse_57 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_56(
+  _FakeQueryKeysResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -650,9 +661,9 @@ class _FakeQueryKeysResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_57(
+  _FakeGetNotificationsResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -661,9 +672,9 @@ class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_58 extends _i1.SmartFake
+class _FakeGetPresenceResponse_59 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_58(
+  _FakeGetPresenceResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -672,9 +683,9 @@ class _FakeGetPresenceResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_59(
+  _FakeGetPublicRoomsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -683,9 +694,9 @@ class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_60(
+  _FakeQueryPublicRoomsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -694,8 +705,8 @@ class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_61 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_61(
+class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -704,9 +715,9 @@ class _FakePushRuleSet_61 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_62(
+  _FakeGetPushRulesGlobalResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -715,8 +726,8 @@ class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_63 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_63(
+class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -725,9 +736,9 @@ class _FakePushRule_63 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_64 extends _i1.SmartFake
+class _FakeRefreshResponse_65 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_64(
+  _FakeRefreshResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -736,8 +747,8 @@ class _FakeRefreshResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_65 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_65(
+class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -746,8 +757,8 @@ class _FakeRoomKeys_65 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_66(
+class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,9 +767,9 @@ class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_67(
+  _FakeGetRoomKeysVersionCurrentResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -767,9 +778,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_68(
+  _FakeGetRoomKeysVersionResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -778,8 +789,8 @@ class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_69 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_69(
+class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -788,9 +799,9 @@ class _FakeEventContext_69 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_70(
+  _FakeGetRoomEventsResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -799,8 +810,8 @@ class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_71 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_71(
+class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -809,9 +820,9 @@ class _FakeSearchResults_71 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_72(
+  _FakeGetProtocolMetadataResponse$2_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -820,9 +831,9 @@ class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_73 extends _i1.SmartFake
+class _FakeOpenIdCredentials_74 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_73(
+  _FakeOpenIdCredentials_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -831,9 +842,9 @@ class _FakeOpenIdCredentials_73 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_74(
+  _FakeSearchUserDirectoryResponse_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,9 +853,9 @@ class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_75 extends _i1.SmartFake
+class _FakeCreateContentResponse_76 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_75(
+  _FakeCreateContentResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -853,8 +864,8 @@ class _FakeCreateContentResponse_75 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyManager_76 extends _i1.SmartFake implements _i10.KeyManager {
-  _FakeKeyManager_76(
+class _FakeKeyManager_77 extends _i1.SmartFake implements _i11.KeyManager {
+  _FakeKeyManager_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -863,8 +874,8 @@ class _FakeKeyManager_76 extends _i1.SmartFake implements _i10.KeyManager {
         );
 }
 
-class _FakeOlmManager_77 extends _i1.SmartFake implements _i15.OlmManager {
-  _FakeOlmManager_77(
+class _FakeOlmManager_78 extends _i1.SmartFake implements _i16.OlmManager {
+  _FakeOlmManager_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -873,9 +884,9 @@ class _FakeOlmManager_77 extends _i1.SmartFake implements _i15.OlmManager {
         );
 }
 
-class _FakeKeyVerificationManager_78 extends _i1.SmartFake
-    implements _i16.KeyVerificationManager {
-  _FakeKeyVerificationManager_78(
+class _FakeKeyVerificationManager_79 extends _i1.SmartFake
+    implements _i17.KeyVerificationManager {
+  _FakeKeyVerificationManager_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -884,8 +895,8 @@ class _FakeKeyVerificationManager_78 extends _i1.SmartFake
         );
 }
 
-class _FakeCrossSigning_79 extends _i1.SmartFake implements _i17.CrossSigning {
-  _FakeCrossSigning_79(
+class _FakeCrossSigning_80 extends _i1.SmartFake implements _i18.CrossSigning {
+  _FakeCrossSigning_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -894,8 +905,8 @@ class _FakeCrossSigning_79 extends _i1.SmartFake implements _i17.CrossSigning {
         );
 }
 
-class _FakeBootstrap_80 extends _i1.SmartFake implements _i10.Bootstrap {
-  _FakeBootstrap_80(
+class _FakeBootstrap_81 extends _i1.SmartFake implements _i11.Bootstrap {
+  _FakeBootstrap_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -904,8 +915,8 @@ class _FakeBootstrap_80 extends _i1.SmartFake implements _i10.Bootstrap {
         );
 }
 
-class _FakeToDeviceEvent_81 extends _i1.SmartFake implements _i4.ToDeviceEvent {
-  _FakeToDeviceEvent_81(
+class _FakeToDeviceEvent_82 extends _i1.SmartFake implements _i4.ToDeviceEvent {
+  _FakeToDeviceEvent_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -914,8 +925,8 @@ class _FakeToDeviceEvent_81 extends _i1.SmartFake implements _i4.ToDeviceEvent {
         );
 }
 
-class _FakeEvent_82 extends _i1.SmartFake implements _i4.Event {
-  _FakeEvent_82(
+class _FakeEvent_83 extends _i1.SmartFake implements _i4.Event {
+  _FakeEvent_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -927,7 +938,7 @@ class _FakeEvent_82 extends _i1.SmartFake implements _i4.Event {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -957,11 +968,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1060,6 +1071,19 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i9.AuthService);
 
   @override
+  _i10.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i10.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -1139,6 +1163,15 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
+  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -1146,14 +1179,14 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1183,7 +1216,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1193,18 +1226,18 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<bool> login({
+  _i14.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1219,12 +1252,12 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> completeSsoLogin({
+  _i14.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1237,12 +1270,12 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> completeRegistration(
+  _i14.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1252,32 +1285,32 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1286,7 +1319,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1295,17 +1328,17 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1316,7 +1349,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1353,26 +1386,26 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+  _i14.Future<bool> didPushRouteInformation(
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1402,7 +1435,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1411,7 +1444,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1420,16 +1453,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i13.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i14.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i13.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i14.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i13.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i13.Future<_i20.AppExitResponse>);
+            _i14.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i14.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1476,24 +1509,43 @@ class MockChatBackupService extends _i1.Mock implements _i6.ChatBackupService {
       ) as bool);
 
   @override
-  _i13.Future<void> checkChatBackupStatus() => (super.noSuchMethod(
+  _i14.Future<void> checkChatBackupStatus() => (super.noSuchMethod(
         Invocation.method(
           #checkChatBackupStatus,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> disableChatBackup() => (super.noSuchMethod(
+  _i14.Future<void> refreshOnResume() => (super.noSuchMethod(
+        Invocation.method(
+          #refreshOnResume,
+          [],
+        ),
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
+
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i14.Future<void> disableChatBackup() => (super.noSuchMethod(
         Invocation.method(
           #disableChatBackup,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void resetChatBackupState() => super.noSuchMethod(
@@ -1505,71 +1557,71 @@ class MockChatBackupService extends _i1.Mock implements _i6.ChatBackupService {
       );
 
   @override
-  _i13.Future<void> tryAutoUnlockBackup() => (super.noSuchMethod(
+  _i14.Future<void> tryAutoUnlockBackup() => (super.noSuchMethod(
         Invocation.method(
           #tryAutoUnlockBackup,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> runKeyRecovery({_i10.OpenSSSS? ssssKey}) =>
+  _i14.Future<void> runKeyRecovery({_i11.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
           [],
           {#ssssKey: ssssKey},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> requestMissingRoomKeys({bool? force = false}) =>
+  _i14.Future<void> requestMissingRoomKeys({bool? force = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #requestMissingRoomKeys,
           [],
           {#force: force},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> getStoredRecoveryKey() => (super.noSuchMethod(
+  _i14.Future<String?> getStoredRecoveryKey() => (super.noSuchMethod(
         Invocation.method(
           #getStoredRecoveryKey,
           [],
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> storeRecoveryKey(String? key) => (super.noSuchMethod(
+  _i14.Future<void> storeRecoveryKey(String? key) => (super.noSuchMethod(
         Invocation.method(
           #storeRecoveryKey,
           [key],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deleteStoredRecoveryKey() => (super.noSuchMethod(
+  _i14.Future<void> deleteStoredRecoveryKey() => (super.noSuchMethod(
         Invocation.method(
           #deleteStoredRecoveryKey,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1578,19 +1630,10 @@ class MockChatBackupService extends _i1.Mock implements _i6.ChatBackupService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
         ),
         returnValueForMissingStub: null,
       );
@@ -1608,19 +1651,19 @@ class MockChatBackupService extends _i1.Mock implements _i6.ChatBackupService {
 /// A class which mocks [Bootstrap].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBootstrap extends _i1.Mock implements _i10.Bootstrap {
+class MockBootstrap extends _i1.Mock implements _i11.Bootstrap {
   @override
-  _i10.Encryption get encryption => (super.noSuchMethod(
+  _i11.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_8(
+        returnValue: _FakeEncryption_9(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_8(
+        returnValueForMissingStub: _FakeEncryption_9(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i10.Encryption);
+      ) as _i11.Encryption);
 
   @override
   _i4.Client get client => (super.noSuchMethod(
@@ -1636,14 +1679,14 @@ class MockBootstrap extends _i1.Mock implements _i10.Bootstrap {
       ) as _i4.Client);
 
   @override
-  _i10.BootstrapState get state => (super.noSuchMethod(
+  _i11.BootstrapState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i10.BootstrapState.loading,
-        returnValueForMissingStub: _i10.BootstrapState.loading,
-      ) as _i10.BootstrapState);
+        returnValue: _i11.BootstrapState.loading,
+        returnValueForMissingStub: _i11.BootstrapState.loading,
+      ) as _i11.BootstrapState);
 
   @override
-  set onUpdate(void Function(_i10.Bootstrap)? value) => super.noSuchMethod(
+  set onUpdate(void Function(_i11.Bootstrap)? value) => super.noSuchMethod(
         Invocation.setter(
           #onUpdate,
           value,
@@ -1652,7 +1695,7 @@ class MockBootstrap extends _i1.Mock implements _i10.Bootstrap {
       );
 
   @override
-  set oldSsssKeys(Map<String, _i10.OpenSSSS>? value) => super.noSuchMethod(
+  set oldSsssKeys(Map<String, _i11.OpenSSSS>? value) => super.noSuchMethod(
         Invocation.setter(
           #oldSsssKeys,
           value,
@@ -1661,7 +1704,7 @@ class MockBootstrap extends _i1.Mock implements _i10.Bootstrap {
       );
 
   @override
-  set newSsssKey(_i10.OpenSSSS? value) => super.noSuchMethod(
+  set newSsssKey(_i11.OpenSSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #newSsssKey,
           value,
@@ -1679,7 +1722,7 @@ class MockBootstrap extends _i1.Mock implements _i10.Bootstrap {
       );
 
   @override
-  set state(_i10.BootstrapState? newState) => super.noSuchMethod(
+  set state(_i11.BootstrapState? newState) => super.noSuchMethod(
         Invocation.setter(
           #state,
           newState,
@@ -1713,14 +1756,14 @@ class MockBootstrap extends _i1.Mock implements _i10.Bootstrap {
           #mostUsedKey,
           [secrets],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
             [secrets],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
@@ -1790,7 +1833,7 @@ class MockBootstrap extends _i1.Mock implements _i10.Bootstrap {
       );
 
   @override
-  _i13.Future<void> newSsss([
+  _i14.Future<void> newSsss([
     String? passphrase,
     String? name,
   ]) =>
@@ -1802,19 +1845,19 @@ class MockBootstrap extends _i1.Mock implements _i10.Bootstrap {
             name,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> openExistingSsss() => (super.noSuchMethod(
+  _i14.Future<void> openExistingSsss() => (super.noSuchMethod(
         Invocation.method(
           #openExistingSsss,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void checkCrossSigning() => super.noSuchMethod(
@@ -1826,17 +1869,17 @@ class MockBootstrap extends _i1.Mock implements _i10.Bootstrap {
       );
 
   @override
-  _i13.Future<void> wipeCrossSigning(bool? wipe) => (super.noSuchMethod(
+  _i14.Future<void> wipeCrossSigning(bool? wipe) => (super.noSuchMethod(
         Invocation.method(
           #wipeCrossSigning,
           [wipe],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> askSetupCrossSigning({
+  _i14.Future<void> askSetupCrossSigning({
     bool? setupMasterKey = false,
     bool? setupSelfSigningKey = false,
     bool? setupUserSigningKey = false,
@@ -1851,9 +1894,9 @@ class MockBootstrap extends _i1.Mock implements _i10.Bootstrap {
             #setupUserSigningKey: setupUserSigningKey,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void checkOnlineKeyBackup() => super.noSuchMethod(
@@ -1874,41 +1917,41 @@ class MockBootstrap extends _i1.Mock implements _i10.Bootstrap {
       );
 
   @override
-  _i13.Future<void> askSetupOnlineKeyBackup(bool? setup) => (super.noSuchMethod(
+  _i14.Future<void> askSetupOnlineKeyBackup(bool? setup) => (super.noSuchMethod(
         Invocation.method(
           #askSetupOnlineKeyBackup,
           [setup],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 }
 
 /// A class which mocks [OpenSSSS].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockOpenSSSS extends _i1.Mock implements _i10.OpenSSSS {
+class MockOpenSSSS extends _i1.Mock implements _i11.OpenSSSS {
   @override
-  _i10.SSSS get ssss => (super.noSuchMethod(
+  _i11.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_9(
+        returnValue: _FakeSSSS_10(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_9(
+        returnValueForMissingStub: _FakeSSSS_10(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i10.SSSS);
+      ) as _i11.SSSS);
 
   @override
   String get keyId => (super.noSuchMethod(
         Invocation.getter(#keyId),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
@@ -1917,11 +1960,11 @@ class MockOpenSSSS extends _i1.Mock implements _i10.OpenSSSS {
   @override
   _i4.SecretStorageKeyContent get keyData => (super.noSuchMethod(
         Invocation.getter(#keyData),
-        returnValue: _FakeSecretStorageKeyContent_10(
+        returnValue: _FakeSecretStorageKeyContent_11(
           this,
           Invocation.getter(#keyData),
         ),
-        returnValueForMissingStub: _FakeSecretStorageKeyContent_10(
+        returnValueForMissingStub: _FakeSecretStorageKeyContent_11(
           this,
           Invocation.getter(#keyData),
         ),
@@ -1942,7 +1985,7 @@ class MockOpenSSSS extends _i1.Mock implements _i10.OpenSSSS {
       ) as bool);
 
   @override
-  set privateKey(_i23.Uint8List? value) => super.noSuchMethod(
+  set privateKey(_i24.Uint8List? value) => super.noSuchMethod(
         Invocation.setter(
           #privateKey,
           value,
@@ -1951,7 +1994,7 @@ class MockOpenSSSS extends _i1.Mock implements _i10.OpenSSSS {
       );
 
   @override
-  _i13.Future<void> unlock({
+  _i14.Future<void> unlock({
     String? passphrase,
     String? recoveryKey,
     String? keyOrPassphrase,
@@ -1968,27 +2011,27 @@ class MockOpenSSSS extends _i1.Mock implements _i10.OpenSSSS {
             #postUnlock: postUnlock,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setPrivateKey(_i23.Uint8List? key) => (super.noSuchMethod(
+  _i14.Future<void> setPrivateKey(_i24.Uint8List? key) => (super.noSuchMethod(
         Invocation.method(
           #setPrivateKey,
           [key],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> getStored(String? type) => (super.noSuchMethod(
+  _i14.Future<String> getStored(String? type) => (super.noSuchMethod(
         Invocation.method(
           #getStored,
           [type],
         ),
-        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,
@@ -1996,17 +2039,17 @@ class MockOpenSSSS extends _i1.Mock implements _i10.OpenSSSS {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i19.dummyValue<String>(
+            _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,
             [type],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> store(
+  _i14.Future<void> store(
     String? type,
     String? secret, {
     bool? add = false,
@@ -2020,12 +2063,12 @@ class MockOpenSSSS extends _i1.Mock implements _i10.OpenSSSS {
           ],
           {#add: add},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> validateAndStripOtherKeys(
+  _i14.Future<void> validateAndStripOtherKeys(
     String? type,
     String? secret,
   ) =>
@@ -2037,19 +2080,19 @@ class MockOpenSSSS extends _i1.Mock implements _i10.OpenSSSS {
             secret,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> maybeCacheAll() => (super.noSuchMethod(
+  _i14.Future<void> maybeCacheAll() => (super.noSuchMethod(
         Invocation.method(
           #maybeCacheAll,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 }
 
 /// A class which mocks [Client].
@@ -2059,23 +2102,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_11(
+        returnValue: _FakeDatabaseApi_12(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_11(
+        returnValueForMissingStub: _FakeDatabaseApi_12(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i10.KeyVerificationMethod> get verificationMethods =>
+  Set<_i11.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i10.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i10.KeyVerificationMethod>{},
-      ) as Set<_i10.KeyVerificationMethod>);
+        returnValue: <_i11.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i11.KeyVerificationMethod>{},
+      ) as Set<_i11.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -2136,11 +2179,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_12(
+        returnValue: _FakeFilter_13(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_12(
+        returnValueForMissingStub: _FakeFilter_13(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -2149,11 +2192,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_13(
+        returnValue: _FakeNativeImplementations_14(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_13(
+        returnValueForMissingStub: _FakeNativeImplementations_14(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -2169,11 +2212,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_14(
+        returnValue: _FakeDuration_15(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_14(
+        returnValueForMissingStub: _FakeDuration_15(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -2182,11 +2225,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_14(
+        returnValue: _FakeDuration_15(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_14(
+        returnValueForMissingStub: _FakeDuration_15(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -2195,11 +2238,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -2236,11 +2279,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -2270,11 +2313,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -2283,11 +2326,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -2310,11 +2353,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_15(
+        returnValue: _FakePushruleEvaluator_16(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_15(
+        returnValueForMissingStub: _FakePushruleEvaluator_16(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -2335,332 +2378,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i13.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i14.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_16(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_16(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i11.CachedStreamController<String> get onUserProfileUpdate =>
+  _i12.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_17<String>(
+        returnValue: _FakeCachedStreamController_18<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i13.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i14.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i13.Future<List<_i4.Room>>);
+            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i14.Future<List<_i4.Room>>);
 
   @override
-  _i11.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i12.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_17<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_18<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.EventUpdate>(
+            _FakeCachedStreamController_18<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.EventUpdate>);
+      ) as _i12.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i12.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_17<_i4.Event>(
+        returnValue: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i12.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_17<_i4.Event>(
+        returnValue: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onNotification =>
+  _i12.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_17<_i4.Event>(
+        returnValue: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i12.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_17<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_18<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_18<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i12.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i11.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i12.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_17<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_18<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_17<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_18<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i11.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i12.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i11.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i12.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_17<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_18<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.LoginState>(
+            _FakeCachedStreamController_18<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i11.CachedStreamController<_i4.LoginState>);
+      ) as _i12.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i11.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i12.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_17<bool>(
+        returnValue: _FakeCachedStreamController_18<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i11.CachedStreamController<bool>);
+      ) as _i12.CachedStreamController<bool>);
 
   @override
-  _i11.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i12.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_17<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_18<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i11.CachedStreamController<_i4.SdkError>);
+      ) as _i12.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i11.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i12.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_17<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_18<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.SyncUpdate>(
+            _FakeCachedStreamController_18<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i11.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i12.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i12.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_17<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_18<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_18<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i11.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i12.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.Presence> get onPresence =>
+  _i12.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_17<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_18<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i11.CachedStreamController<_i4.Presence>);
+      ) as _i12.CachedStreamController<_i4.Presence>);
 
   @override
-  _i11.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i12.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_17<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_18<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.CachedPresence>(
+            _FakeCachedStreamController_18<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i11.CachedStreamController<_i4.CachedPresence>);
+      ) as _i12.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i11.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i12.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_17<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_18<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.BasicEvent>(
+            _FakeCachedStreamController_18<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i11.CachedStreamController<_i4.BasicEvent>);
+      ) as _i12.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i11.CachedStreamController<_i10.RoomKeyRequest> get onRoomKeyRequest =>
+  _i12.CachedStreamController<_i11.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_17<_i10.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_18<_i11.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i10.RoomKeyRequest>(
+            _FakeCachedStreamController_18<_i11.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i11.CachedStreamController<_i10.RoomKeyRequest>);
+      ) as _i12.CachedStreamController<_i11.RoomKeyRequest>);
 
   @override
-  _i11.CachedStreamController<_i10.KeyVerification>
+  _i12.CachedStreamController<_i11.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_17<_i10.KeyVerification>(
+            returnValue: _FakeCachedStreamController_18<_i11.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_17<_i10.KeyVerification>(
+                _FakeCachedStreamController_18<_i11.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i11.CachedStreamController<_i10.KeyVerification>);
+          ) as _i12.CachedStreamController<_i11.KeyVerification>);
 
   @override
-  _i11.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i12.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_17<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_18<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_18<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i11.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i12.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i12.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_17<_i4.Event>(
+        returnValue: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<String> get onCancelSendEvent =>
+  _i12.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_17<String>(
+        returnValue: _FakeCachedStreamController_18<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i11.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i12.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_17<
+            returnValue: _FakeCachedStreamController_18<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_17<
+            returnValueForMissingStub: _FakeCachedStreamController_18<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i11.CachedStreamController<
+          ) as _i12.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -2680,11 +2723,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_18(
+        returnValue: _FakeDateTime_19(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_18(
+        returnValueForMissingStub: _FakeDateTime_19(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2757,7 +2800,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i10.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i11.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2812,7 +2855,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i13.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i14.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2823,7 +2866,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i13.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i14.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -2934,7 +2977,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2943,7 +2986,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2952,7 +2995,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -2979,20 +3022,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Client get httpClient => (super.noSuchMethod(
+  _i13.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_19(
+        returnValue: _FakeClient_20(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_19(
+        returnValueForMissingStub: _FakeClient_20(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i12.Client);
+      ) as _i13.Client);
 
   @override
-  set httpClient(_i12.Client? value) => super.noSuchMethod(
+  set httpClient(_i13.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -3019,7 +3062,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<void> refreshAccessToken(
+  _i14.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3027,9 +3070,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -3047,14 +3090,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -3091,33 +3134,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i13.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i14.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_20(
+        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_21(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_20(
+        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_21(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i13.Future<_i4.DiscoveryInformation>);
+      ) as _i14.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i13.Future<
+  _i14.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -3139,7 +3182,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i13.Future<
+        returnValue: _i14.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -3147,7 +3190,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_21(
+          _FakeGetVersionsResponse_22(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -3162,7 +3205,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i13.Future<
+        returnValueForMissingStub: _i14.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -3170,7 +3213,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_21(
+          _FakeGetVersionsResponse_22(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -3185,7 +3228,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i13.Future<
+      ) as _i14.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -3194,7 +3237,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i13.Future<_i4.DiscoveryInformation> getWellknown({
+  _i14.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3207,8 +3250,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_20(
+        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_21(
           this,
           Invocation.method(
             #getWellknown,
@@ -3219,8 +3262,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_20(
+        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_21(
           this,
           Invocation.method(
             #getWellknown,
@@ -3231,10 +3274,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.DiscoveryInformation>);
+      ) as _i14.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i13.Future<_i4.RegisterResponse> register({
+  _i14.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -3262,7 +3305,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_22(
+            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_23(
           this,
           Invocation.method(
             #register,
@@ -3281,7 +3324,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_22(
+            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_23(
           this,
           Invocation.method(
             #register,
@@ -3299,10 +3342,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RegisterResponse>);
+      ) as _i14.Future<_i4.RegisterResponse>);
 
   @override
-  _i13.Future<_i4.LoginResponse> login(
+  _i14.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -3332,7 +3375,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_23(
+        returnValue: _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_24(
           this,
           Invocation.method(
             #login,
@@ -3352,7 +3395,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_23(
+            _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_24(
           this,
           Invocation.method(
             #login,
@@ -3371,10 +3414,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.LoginResponse>);
+      ) as _i14.Future<_i4.LoginResponse>);
 
   @override
-  _i13.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i14.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3387,8 +3430,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_24(
+        returnValue: _i14.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_25(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -3400,8 +3443,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_24(
+            _i14.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_25(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -3412,74 +3455,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i14.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> logoutAll() => (super.noSuchMethod(
+  _i14.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<T> uiaRequestBackground<T>(
-          _i13.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i14.Future<T> uiaRequestBackground<T>(
+          _i14.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i13.Future<T>.value(v),
+              (T v) => _i14.Future<T>.value(v),
             ) ??
-            _FakeFuture_25<T>(
+            _FakeFuture_26<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i13.Future<T>.value(v),
+              (T v) => _i14.Future<T>.value(v),
             ) ??
-            _FakeFuture_25<T>(
+            _FakeFuture_26<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i13.Future<T>);
+      ) as _i14.Future<T>);
 
   @override
-  _i13.Future<String> startDirectChat(
+  _i14.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -3501,7 +3544,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3517,7 +3560,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i19.dummyValue<String>(
+            _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3532,10 +3575,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<String> createGroupChat({
+  _i14.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -3566,7 +3609,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3587,7 +3630,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i19.dummyValue<String>(
+            _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3607,10 +3650,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i14.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -3626,7 +3669,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3639,7 +3682,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3651,21 +3694,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i14.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<String> createSpace({
+  _i14.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -3690,7 +3733,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3708,7 +3751,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i19.dummyValue<String>(
+            _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3725,10 +3768,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i14.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3736,7 +3779,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_16(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3745,7 +3788,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_16(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3753,10 +3796,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i13.Future<_i4.Profile> fetchOwnProfile({
+  _i14.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3769,7 +3812,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_16(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3781,7 +3824,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_16(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3792,10 +3835,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i13.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i14.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3809,8 +3852,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i13.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_27(
+        returnValue: _i14.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_28(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3822,8 +3865,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_27(
+            _i14.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_28(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3834,10 +3877,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.CachedProfileInformation>);
+      ) as _i14.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i13.Future<_i4.Profile> getProfileFromUserId(
+  _i14.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3855,7 +3898,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_16(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3869,7 +3912,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_16(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3882,7 +3925,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -3904,31 +3947,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i13.Future<List<_i4.Room>>);
+            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i14.Future<List<_i4.Room>>);
 
   @override
-  _i13.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i14.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i13.Future<List<_i4.ArchivedRoom>>);
+            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i14.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i13.Future<_i4.GetVersionsResponse> getVersions({
+  _i14.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3941,8 +3984,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_21(
+        returnValue: _i14.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_22(
           this,
           Invocation.method(
             #getVersions,
@@ -3953,8 +3996,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_21(
+        returnValueForMissingStub: _i14.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_22(
           this,
           Invocation.method(
             #getVersions,
@@ -3965,20 +4008,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetVersionsResponse>);
+      ) as _i14.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i13.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i14.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<_i4.MediaConfig> getConfig({
+  _i14.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3991,7 +4034,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
+        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
           this,
           Invocation.method(
             #getConfig,
@@ -4003,7 +4046,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
+            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
           this,
           Invocation.method(
             #getConfig,
@@ -4014,10 +4057,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.MediaConfig>);
+      ) as _i14.Future<_i4.MediaConfig>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContent(
+  _i14.Future<_i15.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -4037,7 +4080,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContent,
@@ -4053,7 +4096,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContent,
@@ -4068,10 +4111,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentOverrideName(
+  _i14.Future<_i15.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4093,7 +4136,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -4110,7 +4153,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -4126,10 +4169,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentThumbnail(
+  _i14.Future<_i15.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -4157,7 +4200,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -4177,7 +4220,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -4196,10 +4239,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i14.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -4209,7 +4252,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
+        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -4218,7 +4261,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
+            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -4226,11 +4269,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i13.Future<_i4.PreviewForUrl>);
+      ) as _i14.Future<_i4.PreviewForUrl>);
 
   @override
-  _i13.Future<Uri> uploadContent(
-    _i23.Uint8List? file, {
+  _i14.Future<Uri> uploadContent(
+    _i24.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -4243,7 +4286,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i13.Future<Uri>.value(_FakeUri_31(
+        returnValue: _i14.Future<Uri>.value(_FakeUri_32(
           this,
           Invocation.method(
             #uploadContent,
@@ -4254,7 +4297,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_31(
+        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_32(
           this,
           Invocation.method(
             #uploadContent,
@@ -4265,10 +4308,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<Uri>);
+      ) as _i14.Future<Uri>);
 
   @override
-  _i13.Future<void> setTyping(
+  _i14.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -4284,42 +4327,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> exportDump() => (super.noSuchMethod(
+  _i14.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i14.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i14.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Event?> getEventByPushNotification(
+  _i14.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -4335,12 +4378,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
-  _i13.Future<void> init({
+  _i14.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -4375,9 +4418,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -4389,40 +4432,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<void> clear() => (super.noSuchMethod(
+  _i14.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i14.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ensureNotSoftLoggedOut(
+  _i14.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleSync(
+  _i14.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -4432,9 +4475,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -4447,29 +4490,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i13.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i14.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i14.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDevice(
+  _i14.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -4483,12 +4526,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDevicesOfUserIds(
+  _i14.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4504,12 +4547,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDeviceEncrypted(
+  _i14.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4529,12 +4572,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDeviceEncryptedChunked(
+  _i14.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -4548,23 +4591,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i14.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> joinRoom(
+  _i14.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -4582,7 +4625,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4596,7 +4639,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i19.dummyValue<String>(
+            _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4609,10 +4652,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> changePassword(
+  _i14.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -4628,22 +4671,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> clearCache() => (super.noSuchMethod(
+  _i14.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ignoreUser(
+  _i14.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4653,22 +4696,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i14.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i14.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4679,7 +4722,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_32(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4688,7 +4731,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_32(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4696,32 +4739,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i13.Future<_i4.CachedPresence>);
+      ) as _i14.Future<_i4.CachedPresence>);
 
   @override
-  _i13.Future<void> abortSync() => (super.noSuchMethod(
+  _i14.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i14.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEventWithMetadata(
+  _i14.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4741,14 +4784,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i12.BaseResponse? response,
-    _i23.Uint8List? body,
+    _i13.BaseResponse? response,
+    _i24.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4780,7 +4823,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i13.Future<Map<String, Object?>> request(
+  _i14.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -4801,13 +4844,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> postPusher(
+  _i14.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -4817,57 +4860,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i14.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i14.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i14.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i13.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_33(
+        returnValue: _i14.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_34(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_33(
+        returnValueForMissingStub: _i14.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_34(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.TurnServerCredentials>);
+      ) as _i14.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4881,8 +4924,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4894,8 +4937,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4906,10 +4949,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4925,8 +4968,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4939,8 +4982,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4952,10 +4995,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i14.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4969,7 +5012,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
+        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4981,7 +5024,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
+            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4992,17 +5035,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.KeyBackupData>);
+      ) as _i14.Future<_i4.KeyBackupData>);
 
   @override
-  _i13.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i14.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i13.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_36(
+        returnValue: _i14.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_37(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -5010,18 +5053,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_36(
+            _i14.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_37(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i14.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i13.Future<int> pingAppservice(
+  _i14.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -5031,12 +5074,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i13.Future<int>.value(0),
-        returnValueForMissingStub: _i13.Future<int>.value(0),
-      ) as _i13.Future<int>);
+        returnValue: _i14.Future<int>.value(0),
+        returnValueForMissingStub: _i14.Future<int>.value(0),
+      ) as _i14.Future<int>);
 
   @override
-  _i13.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i14.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5044,8 +5087,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_37(
+        returnValue: _i14.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_38(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -5054,8 +5097,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_37(
+            _i14.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_38(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -5063,15 +5106,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i13.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i14.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i13.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i14.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
+        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -5079,17 +5122,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
+            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.MediaConfig>);
+      ) as _i14.Future<_i4.MediaConfig>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentAuthed(
+  _i14.Future<_i15.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -5103,7 +5146,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -5115,7 +5158,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -5126,10 +5169,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentOverrideNameAuthed(
+  _i14.Future<_i15.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5145,7 +5188,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -5158,7 +5201,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -5170,10 +5213,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i14.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -5183,7 +5226,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
+        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -5192,7 +5235,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
+            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -5200,10 +5243,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i13.Future<_i4.PreviewForUrl>);
+      ) as _i14.Future<_i4.PreviewForUrl>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentThumbnailAuthed(
+  _i14.Future<_i15.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5227,7 +5270,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -5245,7 +5288,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_29(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -5262,21 +5305,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<bool> registrationTokenValidity(String? token) =>
+  _i14.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i14.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -5286,8 +5329,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_38(
+        returnValue: _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_39(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -5296,8 +5339,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_38(
+            _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_39(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -5305,10 +5348,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i14.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i13.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i14.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -5326,8 +5369,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_39(
+        returnValue: _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_40(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -5341,8 +5384,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_39(
+            _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_40(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -5355,10 +5398,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i14.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i14.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -5382,8 +5425,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i13.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_40(
+        returnValue: _i14.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_41(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -5401,8 +5444,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_40(
+            _i14.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_41(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -5419,10 +5462,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i14.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -5450,8 +5493,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_41(
+                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5470,8 +5513,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_41(
+                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5489,10 +5532,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i14.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -5521,9 +5564,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i13.Future<
+            returnValue: _i14.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5542,9 +5585,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i13.Future<
+            returnValueForMissingStub: _i14.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5563,11 +5606,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i13
+          ) as _i14
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i13.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i14.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -5583,8 +5626,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i13.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_43(
+        returnValue: _i14.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_44(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5597,8 +5640,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_43(
+            _i14.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_44(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5610,10 +5653,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetThreadRootsResponse>);
+      ) as _i14.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i13.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i14.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -5627,8 +5670,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i13.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_44(
+        returnValue: _i14.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_45(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5640,8 +5683,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_44(
+            _i14.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_45(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5652,33 +5695,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i14.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i14.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i13.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i14.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i13.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i14.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i13.Future<Uri?>.value(),
-        returnValueForMissingStub: _i13.Future<Uri?>.value(),
-      ) as _i13.Future<Uri?>);
+        returnValue: _i14.Future<Uri?>.value(),
+        returnValueForMissingStub: _i14.Future<Uri?>.value(),
+      ) as _i14.Future<Uri?>);
 
   @override
-  _i13.Future<void> add3PID(
+  _i14.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -5692,12 +5735,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> bind3PID(
+  _i14.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5713,12 +5756,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i14.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5732,14 +5775,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5761,8 +5804,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5778,8 +5821,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5795,10 +5838,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5822,8 +5865,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5840,8 +5883,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5858,10 +5901,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i14.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5875,14 +5918,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i14.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -5897,14 +5940,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5926,8 +5969,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5943,8 +5986,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5960,10 +6003,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5987,8 +6030,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -6005,8 +6048,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -6023,16 +6066,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i14.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
+            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -6040,22 +6083,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
+            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.TokenOwnerInfo>);
+      ) as _i14.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i13.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i14.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_47(
+        returnValue: _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
           this,
           Invocation.method(
             #getWhoIs,
@@ -6063,22 +6106,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_47(
+            _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i13.Future<_i4.WhoIsInfo>);
+      ) as _i14.Future<_i4.WhoIsInfo>);
 
   @override
-  _i13.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i14.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_48(
+        returnValue: _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
           this,
           Invocation.method(
             #getCapabilities,
@@ -6086,17 +6129,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_48(
+            _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.Capabilities>);
+      ) as _i14.Future<_i4.Capabilities>);
 
   @override
-  _i13.Future<String> createRoom({
+  _i14.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -6129,7 +6172,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -6151,7 +6194,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i19.dummyValue<String>(
+            _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -6172,10 +6215,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> deleteDevices(
+  _i14.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -6185,22 +6228,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.Device>?>.value(),
-      ) as _i13.Future<List<_i4.Device>?>);
+        returnValue: _i14.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.Device>?>.value(),
+      ) as _i14.Future<List<_i4.Device>?>);
 
   @override
-  _i13.Future<void> deleteDevice(
+  _i14.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -6210,34 +6253,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i14.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i13.Future<_i4.Device>.value(_FakeDevice_49(
+        returnValue: _i14.Future<_i4.Device>.value(_FakeDevice_50(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.Device>.value(_FakeDevice_49(
+        returnValueForMissingStub: _i14.Future<_i4.Device>.value(_FakeDevice_50(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i13.Future<_i4.Device>);
+      ) as _i14.Future<_i4.Device>);
 
   @override
-  _i13.Future<void> updateDevice(
+  _i14.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -6247,12 +6290,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i14.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -6267,24 +6310,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i14.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i13.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Visibility?>.value(),
-      ) as _i13.Future<_i4.Visibility?>);
+        returnValue: _i14.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Visibility?>.value(),
+      ) as _i14.Future<_i4.Visibility?>);
 
   @override
-  _i13.Future<void> setRoomVisibilityOnDirectory(
+  _i14.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -6294,30 +6337,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i14.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i14.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_50(
+        returnValue: _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_51(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -6325,18 +6368,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_50(
+            _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_51(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i14.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i13.Future<void> setRoomAlias(
+  _i14.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -6348,12 +6391,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetEventsResponse> getEvents({
+  _i14.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -6367,7 +6410,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_51(
+            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
           this,
           Invocation.method(
             #getEvents,
@@ -6379,7 +6422,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_51(
+            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
           this,
           Invocation.method(
             #getEvents,
@@ -6390,10 +6433,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetEventsResponse>);
+      ) as _i14.Future<_i4.GetEventsResponse>);
 
   @override
-  _i13.Future<_i4.PeekEventsResponse> peekEvents({
+  _i14.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -6408,8 +6451,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i13.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_52(
+        returnValue: _i14.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_53(
           this,
           Invocation.method(
             #peekEvents,
@@ -6421,8 +6464,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_52(
+        returnValueForMissingStub: _i14.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_53(
           this,
           Invocation.method(
             #peekEvents,
@@ -6434,16 +6477,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.PeekEventsResponse>);
+      ) as _i14.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i13.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i14.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
+        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneEvent,
@@ -6451,27 +6494,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
+            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i13.Future<_i4.MatrixEvent>);
+      ) as _i14.Future<_i4.MatrixEvent>);
 
   @override
-  _i13.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i14.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i13.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
-      ) as _i13.Future<List<String>>);
+        returnValue: _i14.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
+      ) as _i14.Future<List<String>>);
 
   @override
-  _i13.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i14.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -6483,8 +6526,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i13.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_54(
+        returnValue: _i14.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_55(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6495,8 +6538,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_54(
+            _i14.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_55(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6506,10 +6549,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.GetKeysChangesResponse>);
+      ) as _i14.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i13.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i14.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -6520,7 +6563,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
+            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
           this,
           Invocation.method(
             #claimKeys,
@@ -6529,7 +6572,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
+            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
           this,
           Invocation.method(
             #claimKeys,
@@ -6537,10 +6580,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i13.Future<_i4.ClaimKeysResponse>);
+      ) as _i14.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i13.Future<void> uploadCrossSigningKeys({
+  _i14.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -6557,12 +6600,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.QueryKeysResponse> queryKeys(
+  _i14.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -6573,7 +6616,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
+            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
           this,
           Invocation.method(
             #queryKeys,
@@ -6582,7 +6625,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
+            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
           this,
           Invocation.method(
             #queryKeys,
@@ -6590,10 +6633,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i13.Future<_i4.QueryKeysResponse>);
+      ) as _i14.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -6601,14 +6644,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i13.Future<
+            returnValue: _i14.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i13.Future<
+            returnValueForMissingStub: _i14.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i13.Future<Map<String, int>> uploadKeys({
+  _i14.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -6623,13 +6666,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i13.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i14.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i13.Future<Map<String, int>>);
+            _i14.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i14.Future<Map<String, int>>);
 
   @override
-  _i13.Future<String> knockRoom(
+  _i14.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6643,7 +6686,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6655,7 +6698,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i19.dummyValue<String>(
+            _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6666,20 +6709,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i14.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i13.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i14.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i14.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i13.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i14.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6694,8 +6737,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i13.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_57(
+        returnValue: _i14.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_58(
           this,
           Invocation.method(
             #getNotifications,
@@ -6708,8 +6751,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_57(
+            _i14.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_58(
           this,
           Invocation.method(
             #getNotifications,
@@ -6721,35 +6764,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetNotificationsResponse>);
+      ) as _i14.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i13.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i14.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i13.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_58(
+        returnValue: _i14.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_59(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_58(
+        returnValueForMissingStub: _i14.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_59(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i13.Future<_i4.GetPresenceResponse>);
+      ) as _i14.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i13.Future<void> setPresence(
+  _i14.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -6763,12 +6806,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, Object?>> deleteProfileField(
+  _i14.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6781,13 +6824,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getProfileField(
+  _i14.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6800,13 +6843,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<Map<String, Object?>> setProfileField(
+  _i14.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6821,13 +6864,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i14.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6842,8 +6885,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i13.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_59(
+        returnValue: _i14.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_60(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6856,8 +6899,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_59(
+            _i14.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_60(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6869,10 +6912,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i14.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i13.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i14.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -6893,8 +6936,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i13.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_60(
+        returnValue: _i14.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_61(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6910,8 +6953,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_60(
+            _i14.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_61(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6926,25 +6969,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i14.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i13.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.Pusher>?>.value(),
-      ) as _i13.Future<List<_i4.Pusher>?>);
+        returnValue: _i14.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.Pusher>?>.value(),
+      ) as _i14.Future<List<_i4.Pusher>?>);
 
   @override
-  _i13.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i14.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_61(
+        returnValue: _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
           this,
           Invocation.method(
             #getPushRules,
@@ -6952,24 +6995,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_61(
+            _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.PushRuleSet>);
+      ) as _i14.Future<_i4.PushRuleSet>);
 
   @override
-  _i13.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i14.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_62(
+        returnValue: _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_63(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -6977,18 +7020,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_62(
+            _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_63(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i14.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i13.Future<void> deletePushRule(
+  _i14.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -7000,12 +7043,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.PushRule> getPushRule(
+  _i14.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -7017,7 +7060,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<_i4.PushRule>.value(_FakePushRule_63(
+        returnValue: _i14.Future<_i4.PushRule>.value(_FakePushRule_64(
           this,
           Invocation.method(
             #getPushRule,
@@ -7028,7 +7071,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PushRule>.value(_FakePushRule_63(
+            _i14.Future<_i4.PushRule>.value(_FakePushRule_64(
           this,
           Invocation.method(
             #getPushRule,
@@ -7038,10 +7081,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.PushRule>);
+      ) as _i14.Future<_i4.PushRule>);
 
   @override
-  _i13.Future<void> setPushRule(
+  _i14.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -7065,12 +7108,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<Object?>> getPushRuleActions(
+  _i14.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -7082,13 +7125,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i14.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i13.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i13.Future<List<Object?>>);
+            _i14.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i14.Future<List<Object?>>);
 
   @override
-  _i13.Future<void> setPushRuleActions(
+  _i14.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -7102,12 +7145,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<bool> isPushRuleEnabled(
+  _i14.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -7119,12 +7162,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> setPushRuleEnabled(
+  _i14.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -7138,19 +7181,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i14.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_64(
+            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
           this,
           Invocation.method(
             #refresh,
@@ -7158,28 +7201,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_64(
+            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i13.Future<_i4.RefreshResponse>);
+      ) as _i14.Future<_i4.RefreshResponse>);
 
   @override
-  _i13.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i14.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i13.Future<bool?>.value(),
-        returnValueForMissingStub: _i13.Future<bool?>.value(),
-      ) as _i13.Future<bool?>);
+        returnValue: _i14.Future<bool?>.value(),
+        returnValueForMissingStub: _i14.Future<bool?>.value(),
+      ) as _i14.Future<bool?>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7201,8 +7244,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -7218,8 +7261,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -7235,10 +7278,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7262,8 +7305,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -7280,8 +7323,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -7298,17 +7341,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -7316,23 +7359,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i14.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_65(
+        returnValue: _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -7340,17 +7383,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_65(
+            _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeys>);
+      ) as _i14.Future<_i4.RoomKeys>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -7362,8 +7405,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -7374,8 +7417,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -7385,10 +7428,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -7400,8 +7443,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -7412,8 +7455,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -7423,10 +7466,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -7438,7 +7481,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
+        returnValue: _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -7449,7 +7492,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
+            _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -7459,10 +7502,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeyBackup>);
+      ) as _i14.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -7476,8 +7519,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7489,8 +7532,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7501,10 +7544,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7518,8 +7561,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7531,8 +7574,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7543,10 +7586,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i14.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7560,7 +7603,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
+        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7572,7 +7615,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
+            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7583,10 +7626,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.KeyBackupData>);
+      ) as _i14.Future<_i4.KeyBackupData>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7602,8 +7645,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7616,8 +7659,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7629,18 +7672,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_67(
+                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_68(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7648,18 +7691,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_67(
+                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_68(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i13.Future<String> postRoomKeysVersion(
+  _i14.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -7671,7 +7714,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7682,7 +7725,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i19.dummyValue<String>(
+            _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7692,29 +7735,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i14.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i14.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_68(
+        returnValue: _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_69(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7722,18 +7765,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_68(
+            _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_69(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i14.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i14.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -7748,24 +7791,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i14.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i13.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
-      ) as _i13.Future<List<String>>);
+        returnValue: _i14.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
+      ) as _i14.Future<List<String>>);
 
   @override
-  _i13.Future<void> ban(
+  _i14.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7779,12 +7822,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.EventContext> getEventContext(
+  _i14.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7802,7 +7845,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<_i4.EventContext>.value(_FakeEventContext_69(
+        returnValue: _i14.Future<_i4.EventContext>.value(_FakeEventContext_70(
           this,
           Invocation.method(
             #getEventContext,
@@ -7817,7 +7860,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.EventContext>.value(_FakeEventContext_69(
+            _i14.Future<_i4.EventContext>.value(_FakeEventContext_70(
           this,
           Invocation.method(
             #getEventContext,
@@ -7831,10 +7874,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.EventContext>);
+      ) as _i14.Future<_i4.EventContext>);
 
   @override
-  _i13.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i14.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7846,7 +7889,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
+        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7857,7 +7900,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
+            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7867,20 +7910,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.MatrixEvent>);
+      ) as _i14.Future<_i4.MatrixEvent>);
 
   @override
-  _i13.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i14.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> inviteBy3PID(
+  _i14.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -7892,12 +7935,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> inviteUser(
+  _i14.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7911,12 +7954,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> joinRoomById(
+  _i14.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -7930,7 +7973,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7942,7 +7985,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i19.dummyValue<String>(
+            _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7953,23 +7996,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i14.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i13.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i14.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i13.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i13.Future<Map<String, _i4.RoomMember>?>);
+            _i14.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i14.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i13.Future<void> kick(
+  _i14.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7983,12 +8026,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> leaveRoom(
+  _i14.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -7998,12 +8041,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i14.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -8019,12 +8062,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i13.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i13.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i14.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i14.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i13.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i14.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -8046,8 +8089,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_70(
+        returnValue: _i14.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_71(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -8063,8 +8106,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_70(
+        returnValueForMissingStub: _i14.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_71(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -8080,10 +8123,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomEventsResponse>);
+      ) as _i14.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i13.Future<void> setReadMarker(
+  _i14.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -8099,12 +8142,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> postReceipt(
+  _i14.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -8120,12 +8163,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEvent(
+  _i14.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -8141,12 +8184,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> reportRoom(
+  _i14.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -8158,12 +8201,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> reportEvent(
+  _i14.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -8181,12 +8224,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> sendMessage(
+  _i14.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -8202,7 +8245,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -8215,7 +8258,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i19.dummyValue<String>(
+            _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -8227,23 +8270,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i14.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i13.Future<List<_i4.MatrixEvent>>);
+            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i14.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i14.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -8260,13 +8303,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<String> setRoomStateWithKey(
+  _i14.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -8282,7 +8325,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -8295,7 +8338,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i19.dummyValue<String>(
+            _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -8307,10 +8350,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> unban(
+  _i14.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8324,12 +8367,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> upgradeRoom(
+  _i14.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -8343,7 +8386,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -8355,7 +8398,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i19.dummyValue<String>(
+            _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -8366,10 +8409,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.SearchResults> search(
+  _i14.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -8379,7 +8422,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_71(
+        returnValue: _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
           this,
           Invocation.method(
             #search,
@@ -8388,7 +8431,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_71(
+            _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
           this,
           Invocation.method(
             #search,
@@ -8396,10 +8439,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i13.Future<_i4.SearchResults>);
+      ) as _i14.Future<_i4.SearchResults>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> sync({
+  _i14.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -8420,7 +8463,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
           this,
           Invocation.method(
             #sync,
@@ -8436,7 +8479,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
           this,
           Invocation.method(
             #sync,
@@ -8451,22 +8494,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i14.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i13.Future<List<_i4.Location>>);
+            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i14.Future<List<_i4.Location>>);
 
   @override
-  _i13.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i14.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8476,21 +8519,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i13.Future<List<_i4.Location>>);
+            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i14.Future<List<_i4.Location>>);
 
   @override
-  _i13.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i14.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_72(
+        returnValue: _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_73(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -8498,45 +8541,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_72(
+            _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_73(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i13.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i14.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i13.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i14.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8547,13 +8590,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getAccountData(
+  _i14.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -8566,13 +8609,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> setAccountData(
+  _i14.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -8586,12 +8629,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> defineFilter(
+  _i14.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -8603,7 +8646,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8614,7 +8657,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i19.dummyValue<String>(
+            _i14.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8624,10 +8667,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.Filter> getFilter(
+  _i14.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8639,7 +8682,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i13.Future<_i4.Filter>.value(_FakeFilter_12(
+        returnValue: _i14.Future<_i4.Filter>.value(_FakeFilter_13(
           this,
           Invocation.method(
             #getFilter,
@@ -8649,7 +8692,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.Filter>.value(_FakeFilter_12(
+        returnValueForMissingStub: _i14.Future<_i4.Filter>.value(_FakeFilter_13(
           this,
           Invocation.method(
             #getFilter,
@@ -8659,10 +8702,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.Filter>);
+      ) as _i14.Future<_i4.Filter>);
 
   @override
-  _i13.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i14.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8675,7 +8718,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
+            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8686,7 +8729,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
+            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8696,10 +8739,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.OpenIdCredentials>);
+      ) as _i14.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i13.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i14.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8714,13 +8757,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> setAccountDataPerRoom(
+  _i14.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8736,12 +8779,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i14.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8753,12 +8796,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i13.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i13.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i13.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i14.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i14.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i14.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i13.Future<void> deleteRoomTag(
+  _i14.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8772,12 +8815,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setRoomTag(
+  _i14.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8793,12 +8836,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i14.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8808,8 +8851,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i13.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_74(
+        returnValue: _i14.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_75(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8818,8 +8861,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_74(
+            _i14.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_75(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8827,10 +8870,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i13.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i14.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> reportUser(
+  _i14.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8843,40 +8886,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i14.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i13.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_75(
+        returnValue: _i14.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_76(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_75(
+        returnValueForMissingStub: _i14.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_76(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.CreateContentResponse>);
+      ) as _i14.Future<_i4.CreateContentResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> uploadContentToMXC(
+  _i14.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i23.Uint8List? body, {
+    _i24.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8894,16 +8937,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [Encryption].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEncryption extends _i1.Mock implements _i10.Encryption {
+class MockEncryption extends _i1.Mock implements _i11.Encryption {
   @override
   _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -8932,85 +8975,85 @@ class MockEncryption extends _i1.Mock implements _i10.Encryption {
       ) as bool);
 
   @override
-  _i10.KeyManager get keyManager => (super.noSuchMethod(
+  _i11.KeyManager get keyManager => (super.noSuchMethod(
         Invocation.getter(#keyManager),
-        returnValue: _FakeKeyManager_76(
+        returnValue: _FakeKeyManager_77(
           this,
           Invocation.getter(#keyManager),
         ),
-        returnValueForMissingStub: _FakeKeyManager_76(
+        returnValueForMissingStub: _FakeKeyManager_77(
           this,
           Invocation.getter(#keyManager),
         ),
-      ) as _i10.KeyManager);
+      ) as _i11.KeyManager);
 
   @override
-  _i15.OlmManager get olmManager => (super.noSuchMethod(
+  _i16.OlmManager get olmManager => (super.noSuchMethod(
         Invocation.getter(#olmManager),
-        returnValue: _FakeOlmManager_77(
+        returnValue: _FakeOlmManager_78(
           this,
           Invocation.getter(#olmManager),
         ),
-        returnValueForMissingStub: _FakeOlmManager_77(
+        returnValueForMissingStub: _FakeOlmManager_78(
           this,
           Invocation.getter(#olmManager),
         ),
-      ) as _i15.OlmManager);
+      ) as _i16.OlmManager);
 
   @override
-  _i16.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
+  _i17.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
         Invocation.getter(#keyVerificationManager),
-        returnValue: _FakeKeyVerificationManager_78(
+        returnValue: _FakeKeyVerificationManager_79(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-        returnValueForMissingStub: _FakeKeyVerificationManager_78(
+        returnValueForMissingStub: _FakeKeyVerificationManager_79(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-      ) as _i16.KeyVerificationManager);
+      ) as _i17.KeyVerificationManager);
 
   @override
-  _i17.CrossSigning get crossSigning => (super.noSuchMethod(
+  _i18.CrossSigning get crossSigning => (super.noSuchMethod(
         Invocation.getter(#crossSigning),
-        returnValue: _FakeCrossSigning_79(
+        returnValue: _FakeCrossSigning_80(
           this,
           Invocation.getter(#crossSigning),
         ),
-        returnValueForMissingStub: _FakeCrossSigning_79(
+        returnValueForMissingStub: _FakeCrossSigning_80(
           this,
           Invocation.getter(#crossSigning),
         ),
-      ) as _i17.CrossSigning);
+      ) as _i18.CrossSigning);
 
   @override
-  _i10.SSSS get ssss => (super.noSuchMethod(
+  _i11.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_9(
+        returnValue: _FakeSSSS_10(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_9(
+        returnValueForMissingStub: _FakeSSSS_10(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i10.SSSS);
+      ) as _i11.SSSS);
 
   @override
   String get ourDeviceId => (super.noSuchMethod(
         Invocation.getter(#ourDeviceId),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
       ) as String);
 
   @override
-  set keyManager(_i10.KeyManager? value) => super.noSuchMethod(
+  set keyManager(_i11.KeyManager? value) => super.noSuchMethod(
         Invocation.setter(
           #keyManager,
           value,
@@ -9019,7 +9062,7 @@ class MockEncryption extends _i1.Mock implements _i10.Encryption {
       );
 
   @override
-  set olmManager(_i15.OlmManager? value) => super.noSuchMethod(
+  set olmManager(_i16.OlmManager? value) => super.noSuchMethod(
         Invocation.setter(
           #olmManager,
           value,
@@ -9028,7 +9071,7 @@ class MockEncryption extends _i1.Mock implements _i10.Encryption {
       );
 
   @override
-  set keyVerificationManager(_i16.KeyVerificationManager? value) =>
+  set keyVerificationManager(_i17.KeyVerificationManager? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #keyVerificationManager,
@@ -9038,7 +9081,7 @@ class MockEncryption extends _i1.Mock implements _i10.Encryption {
       );
 
   @override
-  set crossSigning(_i17.CrossSigning? value) => super.noSuchMethod(
+  set crossSigning(_i18.CrossSigning? value) => super.noSuchMethod(
         Invocation.setter(
           #crossSigning,
           value,
@@ -9047,7 +9090,7 @@ class MockEncryption extends _i1.Mock implements _i10.Encryption {
       );
 
   @override
-  set ssss(_i10.SSSS? value) => super.noSuchMethod(
+  set ssss(_i11.SSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #ssss,
           value,
@@ -9065,7 +9108,7 @@ class MockEncryption extends _i1.Mock implements _i10.Encryption {
       );
 
   @override
-  _i13.Future<void> init(
+  _i14.Future<void> init(
     String? olmAccount, {
     String? deviceId,
     String? pickleKey,
@@ -9081,19 +9124,19 @@ class MockEncryption extends _i1.Mock implements _i10.Encryption {
             #dehydratedDeviceAlgorithm: dehydratedDeviceAlgorithm,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i10.Bootstrap bootstrap({void Function(_i10.Bootstrap)? onUpdate}) =>
+  _i11.Bootstrap bootstrap({void Function(_i11.Bootstrap)? onUpdate}) =>
       (super.noSuchMethod(
         Invocation.method(
           #bootstrap,
           [],
           {#onUpdate: onUpdate},
         ),
-        returnValue: _FakeBootstrap_80(
+        returnValue: _FakeBootstrap_81(
           this,
           Invocation.method(
             #bootstrap,
@@ -9101,7 +9144,7 @@ class MockEncryption extends _i1.Mock implements _i10.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-        returnValueForMissingStub: _FakeBootstrap_80(
+        returnValueForMissingStub: _FakeBootstrap_81(
           this,
           Invocation.method(
             #bootstrap,
@@ -9109,7 +9152,7 @@ class MockEncryption extends _i1.Mock implements _i10.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-      ) as _i10.Bootstrap);
+      ) as _i11.Bootstrap);
 
   @override
   void handleDeviceOneTimeKeysCount(
@@ -9137,18 +9180,18 @@ class MockEncryption extends _i1.Mock implements _i10.Encryption {
       );
 
   @override
-  _i13.Future<void> handleToDeviceEvent(_i4.ToDeviceEvent? event) =>
+  _i14.Future<void> handleToDeviceEvent(_i4.ToDeviceEvent? event) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleToDeviceEvent,
           [event],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleEventUpdate(
+  _i14.Future<void> handleEventUpdate(
     _i4.Event? event,
     _i4.EventUpdateType? type,
   ) =>
@@ -9160,19 +9203,19 @@ class MockEncryption extends _i1.Mock implements _i10.Encryption {
             type,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.ToDeviceEvent> decryptToDeviceEvent(
+  _i14.Future<_i4.ToDeviceEvent> decryptToDeviceEvent(
           _i4.ToDeviceEvent? event) =>
       (super.noSuchMethod(
         Invocation.method(
           #decryptToDeviceEvent,
           [event],
         ),
-        returnValue: _i13.Future<_i4.ToDeviceEvent>.value(_FakeToDeviceEvent_81(
+        returnValue: _i14.Future<_i4.ToDeviceEvent>.value(_FakeToDeviceEvent_82(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -9180,14 +9223,14 @@ class MockEncryption extends _i1.Mock implements _i10.Encryption {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.ToDeviceEvent>.value(_FakeToDeviceEvent_81(
+            _i14.Future<_i4.ToDeviceEvent>.value(_FakeToDeviceEvent_82(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
             [event],
           ),
         )),
-      ) as _i13.Future<_i4.ToDeviceEvent>);
+      ) as _i14.Future<_i4.ToDeviceEvent>);
 
   @override
   _i4.Event decryptRoomEventSync(_i4.Event? event) => (super.noSuchMethod(
@@ -9195,14 +9238,14 @@ class MockEncryption extends _i1.Mock implements _i10.Encryption {
           #decryptRoomEventSync,
           [event],
         ),
-        returnValue: _FakeEvent_82(
+        returnValue: _FakeEvent_83(
           this,
           Invocation.method(
             #decryptRoomEventSync,
             [event],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_82(
+        returnValueForMissingStub: _FakeEvent_83(
           this,
           Invocation.method(
             #decryptRoomEventSync,
@@ -9212,7 +9255,7 @@ class MockEncryption extends _i1.Mock implements _i10.Encryption {
       ) as _i4.Event);
 
   @override
-  _i13.Future<_i4.Event> decryptRoomEvent(
+  _i14.Future<_i4.Event> decryptRoomEvent(
     _i4.Event? event, {
     bool? store = false,
     _i4.EventUpdateType? updateType = _i4.EventUpdateType.timeline,
@@ -9226,7 +9269,7 @@ class MockEncryption extends _i1.Mock implements _i10.Encryption {
             #updateType: updateType,
           },
         ),
-        returnValue: _i13.Future<_i4.Event>.value(_FakeEvent_82(
+        returnValue: _i14.Future<_i4.Event>.value(_FakeEvent_83(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -9237,7 +9280,7 @@ class MockEncryption extends _i1.Mock implements _i10.Encryption {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.Event>.value(_FakeEvent_82(
+        returnValueForMissingStub: _i14.Future<_i4.Event>.value(_FakeEvent_83(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -9248,10 +9291,10 @@ class MockEncryption extends _i1.Mock implements _i10.Encryption {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Event>);
+      ) as _i14.Future<_i4.Event>);
 
   @override
-  _i13.Future<Map<String, dynamic>> encryptGroupMessagePayload(
+  _i14.Future<Map<String, dynamic>> encryptGroupMessagePayload(
     String? roomId,
     Map<String, dynamic>? payload, {
     String? type = 'm.room.message',
@@ -9266,13 +9309,13 @@ class MockEncryption extends _i1.Mock implements _i10.Encryption {
           {#type: type},
         ),
         returnValue:
-            _i13.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
+            _i14.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
-      ) as _i13.Future<Map<String, dynamic>>);
+            _i14.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
+      ) as _i14.Future<Map<String, dynamic>>);
 
   @override
-  _i13.Future<
+  _i14.Future<
       Map<String, Map<String, Map<String, dynamic>>>> encryptToDeviceMessage(
     List<_i4.DeviceKeys>? deviceKeys,
     String? type,
@@ -9288,50 +9331,50 @@ class MockEncryption extends _i1.Mock implements _i10.Encryption {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
+            _i14.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
                 <String, Map<String, Map<String, dynamic>>>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
+            _i14.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
                 <String, Map<String, Map<String, dynamic>>>{}),
-      ) as _i13.Future<Map<String, Map<String, Map<String, dynamic>>>>);
+      ) as _i14.Future<Map<String, Map<String, Map<String, dynamic>>>>);
 
   @override
-  _i13.Future<void> autovalidateMasterOwnKey() => (super.noSuchMethod(
+  _i14.Future<void> autovalidateMasterOwnKey() => (super.noSuchMethod(
         Invocation.method(
           #autovalidateMasterOwnKey,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> dispose() => (super.noSuchMethod(
+  _i14.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 }
 
 /// A class which mocks [CrossSigning].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCrossSigning extends _i1.Mock implements _i17.CrossSigning {
+class MockCrossSigning extends _i1.Mock implements _i18.CrossSigning {
   @override
-  _i10.Encryption get encryption => (super.noSuchMethod(
+  _i11.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_8(
+        returnValue: _FakeEncryption_9(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_8(
+        returnValueForMissingStub: _FakeEncryption_9(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i10.Encryption);
+      ) as _i11.Encryption);
 
   @override
   _i4.Client get client => (super.noSuchMethod(
@@ -9354,21 +9397,21 @@ class MockCrossSigning extends _i1.Mock implements _i17.CrossSigning {
       ) as bool);
 
   @override
-  _i13.Future<bool> isCached() => (super.noSuchMethod(
+  _i14.Future<bool> isCached() => (super.noSuchMethod(
         Invocation.method(
           #isCached,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> selfSign({
+  _i14.Future<void> selfSign({
     String? passphrase,
     String? recoveryKey,
     String? keyOrPassphrase,
-    _i10.OpenSSSS? openSsss,
+    _i11.OpenSSSS? openSsss,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9381,9 +9424,9 @@ class MockCrossSigning extends _i1.Mock implements _i17.CrossSigning {
             #openSsss: openSsss,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   bool signable(List<_i4.SignableKey>? keys) => (super.noSuchMethod(
@@ -9396,12 +9439,12 @@ class MockCrossSigning extends _i1.Mock implements _i17.CrossSigning {
       ) as bool);
 
   @override
-  _i13.Future<void> sign(List<_i4.SignableKey>? keys) => (super.noSuchMethod(
+  _i14.Future<void> sign(List<_i4.SignableKey>? keys) => (super.noSuchMethod(
         Invocation.method(
           #sign,
           [keys],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 }

--- a/test/widgets/registration_controller_test.mocks.dart
+++ b/test/widgets/registration_controller_test.mocks.dart
@@ -4,17 +4,18 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i17;
-import 'dart:ui' as _i19;
+import 'dart:typed_data' as _i18;
+import 'dart:ui' as _i20;
 
-import 'package:flutter/services.dart' as _i20;
-import 'package:flutter/widgets.dart' as _i21;
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/models/server_auth_capabilities.dart' as _i14;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
+import 'package:kohera/core/models/server_auth_capabilities.dart' as _i15;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -23,12 +24,12 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i15;
+import 'package:matrix/encryption.dart' as _i16;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -820,9 +821,20 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeServerAuthCapabilities_73 extends _i1.SmartFake
-    implements _i14.ServerAuthCapabilities {
-  _FakeServerAuthCapabilities_73(
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeServerAuthCapabilities_74 extends _i1.SmartFake
+    implements _i15.ServerAuthCapabilities {
+  _FakeServerAuthCapabilities_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -849,12 +861,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i15.KeyVerificationMethod> get verificationMethods =>
+  Set<_i16.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i15.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
-      ) as Set<_i15.KeyVerificationMethod>);
+        returnValue: <_i16.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
+      ) as Set<_i16.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -974,11 +986,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1015,11 +1027,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1049,11 +1061,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1062,11 +1074,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1352,34 +1364,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i15.KeyVerification>
+  _i3.CachedStreamController<_i16.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i15.KeyVerification>(
+                _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i15.KeyVerification>);
+          ) as _i3.CachedStreamController<_i16.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1535,7 +1547,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1824,14 +1836,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2219,8 +2231,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2236,8 +2248,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2278,7 +2290,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2294,7 +2306,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2343,7 +2355,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2364,7 +2376,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2467,7 +2479,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2485,7 +2497,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3004,7 +3016,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i17.Uint8List? file, {
+    _i18.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3356,7 +3368,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3370,7 +3382,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3521,7 +3533,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i17.Uint8List? body,
+    _i18.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4899,7 +4911,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4921,7 +4933,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5415,7 +5427,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5427,7 +5439,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6435,7 +6447,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6446,7 +6458,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6694,7 +6706,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6706,7 +6718,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6966,7 +6978,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6979,7 +6991,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7046,7 +7058,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7059,7 +7071,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7107,7 +7119,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7119,7 +7131,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7367,7 +7379,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7378,7 +7390,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7640,7 +7652,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i17.Uint8List? body, {
+    _i18.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7667,7 +7679,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7697,11 +7709,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7800,6 +7812,19 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7879,6 +7904,15 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7923,7 +7957,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8017,7 +8051,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8026,7 +8060,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8045,7 +8079,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8056,7 +8090,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8104,7 +8138,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8142,7 +8176,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8151,7 +8185,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8160,16 +8194,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i5.Future<_i19.AppExitResponse>);
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i5.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8319,7 +8353,7 @@ class MockAuthService extends _i1.Mock implements _i13.AuthService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i14.ServerAuthCapabilities> getServerAuthCapabilities(
+  _i5.Future<_i15.ServerAuthCapabilities> getServerAuthCapabilities(
     String? homeserver, {
     required bool? isLoggedIn,
   }) =>
@@ -8329,8 +8363,8 @@ class MockAuthService extends _i1.Mock implements _i13.AuthService {
           [homeserver],
           {#isLoggedIn: isLoggedIn},
         ),
-        returnValue: _i5.Future<_i14.ServerAuthCapabilities>.value(
-            _FakeServerAuthCapabilities_73(
+        returnValue: _i5.Future<_i15.ServerAuthCapabilities>.value(
+            _FakeServerAuthCapabilities_74(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8339,8 +8373,8 @@ class MockAuthService extends _i1.Mock implements _i13.AuthService {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i14.ServerAuthCapabilities>.value(
-                _FakeServerAuthCapabilities_73(
+            _i5.Future<_i15.ServerAuthCapabilities>.value(
+                _FakeServerAuthCapabilities_74(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8348,7 +8382,7 @@ class MockAuthService extends _i1.Mock implements _i13.AuthService {
             {#isLoggedIn: isLoggedIn},
           ),
         )),
-      ) as _i5.Future<_i14.ServerAuthCapabilities>);
+      ) as _i5.Future<_i15.ServerAuthCapabilities>);
 
   @override
   bool isPermanentAuthFailure(Object? error) => (super.noSuchMethod(
@@ -8391,7 +8425,7 @@ class MockAuthService extends _i1.Mock implements _i13.AuthService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8400,7 +8434,7 @@ class MockAuthService extends _i1.Mock implements _i13.AuthService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/test/widgets/room_context_menu_test.mocks.dart
+++ b/test/widgets/room_context_menu_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,14 +23,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/src/utils/space_child.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -821,8 +822,9 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_73(
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -831,9 +833,19 @@ class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_74 extends _i1.SmartFake
+class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_74(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_75 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_74(
+  _FakeLatestReceiptState_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,8 +854,8 @@ class _FakeLatestReceiptState_74 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_75(
+class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,8 +864,8 @@ class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_76(
+class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -880,12 +892,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1005,11 +1017,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1046,11 +1058,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1080,11 +1092,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1093,11 +1105,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1383,34 +1395,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1566,7 +1578,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1855,14 +1867,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2250,8 +2262,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2267,8 +2279,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2309,7 +2321,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2325,7 +2337,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2374,7 +2386,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2395,7 +2407,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2498,7 +2510,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2516,7 +2528,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3035,7 +3047,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3387,7 +3399,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3401,7 +3413,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3552,7 +3564,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4930,7 +4942,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4952,7 +4964,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5446,7 +5458,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5458,7 +5470,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6466,7 +6478,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6477,7 +6489,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6725,7 +6737,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6737,7 +6749,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6997,7 +7009,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7010,7 +7022,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7077,7 +7089,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7090,7 +7102,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7138,7 +7150,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7150,7 +7162,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7398,7 +7410,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7409,7 +7421,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7671,7 +7683,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7698,7 +7710,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7728,11 +7740,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7831,6 +7843,19 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7910,6 +7935,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7954,7 +7988,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8048,7 +8082,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8057,7 +8091,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8076,7 +8110,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8087,7 +8121,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8135,7 +8169,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8173,7 +8207,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8182,7 +8216,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8191,16 +8225,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8228,11 +8262,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8262,11 +8296,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_73(
+        returnValue: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_73(
+        returnValueForMissingStub: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
@@ -8319,11 +8353,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8359,11 +8393,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8379,11 +8413,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8392,11 +8426,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8439,11 +8473,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8486,11 +8520,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_74(
+        returnValue: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_74(
+        returnValueForMissingStub: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8702,18 +8736,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i22.SpaceParent>[],
+        returnValueForMissingStub: <_i22.SpaceParent>[],
+      ) as List<_i22.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i22.SpaceChild>[],
+        returnValueForMissingStub: <_i22.SpaceChild>[],
+      ) as List<_i22.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8880,14 +8914,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8935,7 +8969,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8943,7 +8977,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8958,7 +8992,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8966,7 +9000,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9050,7 +9084,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9058,7 +9092,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9300,7 +9334,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9311,7 +9345,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9400,15 +9434,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i22.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i22.TimelineChunk?>.value(),
-      ) as _i5.Future<_i22.TimelineChunk?>);
+        returnValue: _i5.Future<_i23.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i23.TimelineChunk?>.value(),
+      ) as _i5.Future<_i23.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9449,7 +9483,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9466,7 +9500,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9530,14 +9564,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9553,14 +9587,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9616,7 +9650,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9624,7 +9658,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/room_details_panel_test.mocks.dart
+++ b/test/widgets/room_details_panel_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,14 +23,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/src/utils/space_child.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -821,8 +822,9 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_73(
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -831,9 +833,19 @@ class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_74 extends _i1.SmartFake
+class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_74(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_75 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_74(
+  _FakeLatestReceiptState_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,8 +854,8 @@ class _FakeLatestReceiptState_74 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_75(
+class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,8 +864,8 @@ class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_76(
+class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -880,12 +892,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1005,11 +1017,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1046,11 +1058,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1080,11 +1092,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1093,11 +1105,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1383,34 +1395,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1566,7 +1578,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1855,14 +1867,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2250,8 +2262,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2267,8 +2279,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2309,7 +2321,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2325,7 +2337,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2374,7 +2386,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2395,7 +2407,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2498,7 +2510,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2516,7 +2528,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3035,7 +3047,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3387,7 +3399,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3401,7 +3413,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3552,7 +3564,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4930,7 +4942,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4952,7 +4964,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5446,7 +5458,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5458,7 +5470,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6466,7 +6478,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6477,7 +6489,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6725,7 +6737,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6737,7 +6749,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6997,7 +7009,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7010,7 +7022,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7077,7 +7089,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7090,7 +7102,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7138,7 +7150,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7150,7 +7162,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7398,7 +7410,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7409,7 +7421,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7671,7 +7683,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7698,7 +7710,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7728,11 +7740,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7831,6 +7843,19 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7910,6 +7935,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7954,7 +7988,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8048,7 +8082,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8057,7 +8091,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8076,7 +8110,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8087,7 +8121,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8135,7 +8169,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8173,7 +8207,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8182,7 +8216,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8191,16 +8225,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8228,11 +8262,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8262,11 +8296,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_73(
+        returnValue: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_73(
+        returnValueForMissingStub: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
@@ -8319,11 +8353,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8359,11 +8393,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8379,11 +8413,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8392,11 +8426,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8439,11 +8473,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8486,11 +8520,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_74(
+        returnValue: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_74(
+        returnValueForMissingStub: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8702,18 +8736,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i22.SpaceParent>[],
+        returnValueForMissingStub: <_i22.SpaceParent>[],
+      ) as List<_i22.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i22.SpaceChild>[],
+        returnValueForMissingStub: <_i22.SpaceChild>[],
+      ) as List<_i22.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8880,14 +8914,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8935,7 +8969,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8943,7 +8977,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8958,7 +8992,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8966,7 +9000,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9050,7 +9084,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9058,7 +9092,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9300,7 +9334,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9311,7 +9345,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9400,15 +9434,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i22.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i22.TimelineChunk?>.value(),
-      ) as _i5.Future<_i22.TimelineChunk?>);
+        returnValue: _i5.Future<_i23.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i23.TimelineChunk?>.value(),
+      ) as _i5.Future<_i23.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9449,7 +9483,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9466,7 +9500,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9530,14 +9564,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9553,14 +9587,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9616,7 +9650,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9624,7 +9658,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/room_members_section_test.mocks.dart
+++ b/test/widgets/room_members_section_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,14 +23,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/src/utils/space_child.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -821,8 +822,9 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_73(
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -831,9 +833,19 @@ class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_74 extends _i1.SmartFake
+class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_74(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_75 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_74(
+  _FakeLatestReceiptState_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,8 +854,8 @@ class _FakeLatestReceiptState_74 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_75(
+class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,8 +864,8 @@ class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_76(
+class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -862,8 +874,8 @@ class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_77 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_77(
+class _FakeRoom_78 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -890,12 +902,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1015,11 +1027,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1056,11 +1068,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1090,11 +1102,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1103,11 +1115,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1393,34 +1405,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1576,7 +1588,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1865,14 +1877,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2260,8 +2272,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2277,8 +2289,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2319,7 +2331,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2335,7 +2347,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2384,7 +2396,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2405,7 +2417,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2508,7 +2520,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2526,7 +2538,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3045,7 +3057,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3397,7 +3409,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3411,7 +3423,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3562,7 +3574,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4940,7 +4952,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4962,7 +4974,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5456,7 +5468,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5468,7 +5480,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6476,7 +6488,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6487,7 +6499,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6735,7 +6747,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6747,7 +6759,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7007,7 +7019,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7020,7 +7032,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7087,7 +7099,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7100,7 +7112,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7148,7 +7160,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7160,7 +7172,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7408,7 +7420,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7419,7 +7431,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7681,7 +7693,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7708,7 +7720,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7738,11 +7750,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7841,6 +7853,19 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7920,6 +7945,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7964,7 +7998,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8058,7 +8092,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8067,7 +8101,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8086,7 +8120,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8097,7 +8131,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8145,7 +8179,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8183,7 +8217,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8192,7 +8226,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8201,16 +8235,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8238,11 +8272,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8272,11 +8306,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_73(
+        returnValue: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_73(
+        returnValueForMissingStub: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
@@ -8329,11 +8363,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8369,11 +8403,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8389,11 +8423,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8402,11 +8436,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8449,11 +8483,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8496,11 +8530,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_74(
+        returnValue: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_74(
+        returnValueForMissingStub: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8712,18 +8746,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i22.SpaceParent>[],
+        returnValueForMissingStub: <_i22.SpaceParent>[],
+      ) as List<_i22.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i22.SpaceChild>[],
+        returnValueForMissingStub: <_i22.SpaceChild>[],
+      ) as List<_i22.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8890,14 +8924,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8945,7 +8979,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8953,7 +8987,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8968,7 +9002,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8976,7 +9010,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9060,7 +9094,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9068,7 +9102,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9310,7 +9344,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9321,7 +9355,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9410,15 +9444,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i22.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i22.TimelineChunk?>.value(),
-      ) as _i5.Future<_i22.TimelineChunk?>);
+        returnValue: _i5.Future<_i23.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i23.TimelineChunk?>.value(),
+      ) as _i5.Future<_i23.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9459,7 +9493,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9476,7 +9510,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9540,14 +9574,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9563,14 +9597,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9626,7 +9660,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9634,7 +9668,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9946,11 +9980,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_77(
+        returnValue: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_77(
+        returnValueForMissingStub: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
@@ -9959,11 +9993,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -10029,11 +10063,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -10058,11 +10092,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10080,11 +10114,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10131,7 +10165,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -10143,7 +10177,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -10213,7 +10247,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -10226,7 +10260,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/room_section_header_test.mocks.dart
+++ b/test/widgets/room_section_header_test.mocks.dart
@@ -4,35 +4,36 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i17;
-import 'dart:ui' as _i19;
+import 'dart:typed_data' as _i18;
+import 'dart:ui' as _i20;
 
-import 'package:flutter/material.dart' as _i23;
-import 'package:flutter/services.dart' as _i20;
-import 'package:flutter/widgets.dart' as _i21;
+import 'package:flutter/material.dart' as _i24;
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
-import 'package:kohera/core/services/preferences_service.dart' as _i22;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/preferences_service.dart' as _i23;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
-import 'package:kohera/core/theme/custom_theme.dart' as _i14;
+import 'package:kohera/core/theme/custom_theme.dart' as _i15;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i15;
+import 'package:matrix/encryption.dart' as _i16;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i25;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i26;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i24;
+import 'package:matrix/src/utils/space_child.dart' as _i25;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -824,8 +825,9 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeCustomTheme_73 extends _i1.SmartFake implements _i14.CustomTheme {
-  _FakeCustomTheme_73(
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -834,8 +836,8 @@ class _FakeCustomTheme_73 extends _i1.SmartFake implements _i14.CustomTheme {
         );
 }
 
-class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_74(
+class _FakeCustomTheme_74 extends _i1.SmartFake implements _i15.CustomTheme {
+  _FakeCustomTheme_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -844,9 +846,19 @@ class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_75 extends _i1.SmartFake
+class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_76 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_75(
+  _FakeLatestReceiptState_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -855,8 +867,8 @@ class _FakeLatestReceiptState_75 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_76(
+class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -865,8 +877,8 @@ class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_77(
+class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -893,12 +905,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i15.KeyVerificationMethod> get verificationMethods =>
+  Set<_i16.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i15.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
-      ) as Set<_i15.KeyVerificationMethod>);
+        returnValue: <_i16.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
+      ) as Set<_i16.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1018,11 +1030,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1059,11 +1071,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1093,11 +1105,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1106,11 +1118,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1396,34 +1408,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i15.KeyVerification>
+  _i3.CachedStreamController<_i16.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i15.KeyVerification>(
+                _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i15.KeyVerification>);
+          ) as _i3.CachedStreamController<_i16.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1579,7 +1591,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1868,14 +1880,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2263,8 +2275,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2280,8 +2292,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2322,7 +2334,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2338,7 +2350,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2387,7 +2399,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2408,7 +2420,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2511,7 +2523,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2529,7 +2541,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3048,7 +3060,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i17.Uint8List? file, {
+    _i18.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3400,7 +3412,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3414,7 +3426,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3565,7 +3577,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i17.Uint8List? body,
+    _i18.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4943,7 +4955,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4965,7 +4977,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5459,7 +5471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5471,7 +5483,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6479,7 +6491,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6490,7 +6502,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6738,7 +6750,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6750,7 +6762,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7010,7 +7022,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7023,7 +7035,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7090,7 +7102,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7103,7 +7115,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7151,7 +7163,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7163,7 +7175,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7411,7 +7423,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7422,7 +7434,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7684,7 +7696,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i17.Uint8List? body, {
+    _i18.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7711,7 +7723,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7741,11 +7753,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7844,6 +7856,19 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7923,6 +7948,15 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7967,7 +8001,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8061,7 +8095,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8070,7 +8104,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8089,7 +8123,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8100,7 +8134,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8148,7 +8182,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8186,7 +8220,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8195,7 +8229,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8204,16 +8238,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i5.Future<_i19.AppExitResponse>);
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i5.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8238,60 +8272,60 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockPreferencesService extends _i1.Mock
-    implements _i22.PreferencesService {
+    implements _i23.PreferencesService {
   @override
-  _i22.MessageDensity get messageDensity => (super.noSuchMethod(
+  _i23.MessageDensity get messageDensity => (super.noSuchMethod(
         Invocation.getter(#messageDensity),
-        returnValue: _i22.MessageDensity.compact,
-        returnValueForMissingStub: _i22.MessageDensity.compact,
-      ) as _i22.MessageDensity);
+        returnValue: _i23.MessageDensity.compact,
+        returnValueForMissingStub: _i23.MessageDensity.compact,
+      ) as _i23.MessageDensity);
 
   @override
-  _i22.MobileTab get lastMobileTab => (super.noSuchMethod(
+  _i23.MobileTab get lastMobileTab => (super.noSuchMethod(
         Invocation.getter(#lastMobileTab),
-        returnValue: _i22.MobileTab.inbox,
-        returnValueForMissingStub: _i22.MobileTab.inbox,
-      ) as _i22.MobileTab);
+        returnValue: _i23.MobileTab.inbox,
+        returnValueForMissingStub: _i23.MobileTab.inbox,
+      ) as _i23.MobileTab);
 
   @override
-  _i23.ThemeMode get themeMode => (super.noSuchMethod(
+  _i24.ThemeMode get themeMode => (super.noSuchMethod(
         Invocation.getter(#themeMode),
-        returnValue: _i23.ThemeMode.system,
-        returnValueForMissingStub: _i23.ThemeMode.system,
-      ) as _i23.ThemeMode);
+        returnValue: _i24.ThemeMode.system,
+        returnValueForMissingStub: _i24.ThemeMode.system,
+      ) as _i24.ThemeMode);
 
   @override
   String get themeModeLabel => (super.noSuchMethod(
         Invocation.getter(#themeModeLabel),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#themeModeLabel),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#themeModeLabel),
         ),
       ) as String);
 
   @override
-  _i14.CustomTheme get customTheme => (super.noSuchMethod(
+  _i15.CustomTheme get customTheme => (super.noSuchMethod(
         Invocation.getter(#customTheme),
-        returnValue: _FakeCustomTheme_73(
+        returnValue: _FakeCustomTheme_74(
           this,
           Invocation.getter(#customTheme),
         ),
-        returnValueForMissingStub: _FakeCustomTheme_73(
+        returnValueForMissingStub: _FakeCustomTheme_74(
           this,
           Invocation.getter(#customTheme),
         ),
-      ) as _i14.CustomTheme);
+      ) as _i15.CustomTheme);
 
   @override
-  _i23.ThemeMode get customThemeMode => (super.noSuchMethod(
+  _i24.ThemeMode get customThemeMode => (super.noSuchMethod(
         Invocation.getter(#customThemeMode),
-        returnValue: _i23.ThemeMode.system,
-        returnValueForMissingStub: _i23.ThemeMode.system,
-      ) as _i23.ThemeMode);
+        returnValue: _i24.ThemeMode.system,
+        returnValueForMissingStub: _i24.ThemeMode.system,
+      ) as _i24.ThemeMode);
 
   @override
   Set<String> get collapsedSpaceSections => (super.noSuchMethod(
@@ -8322,20 +8356,20 @@ class MockPreferencesService extends _i1.Mock
       ) as double);
 
   @override
-  _i22.NotificationLevel get notificationLevel => (super.noSuchMethod(
+  _i23.NotificationLevel get notificationLevel => (super.noSuchMethod(
         Invocation.getter(#notificationLevel),
-        returnValue: _i22.NotificationLevel.all,
-        returnValueForMissingStub: _i22.NotificationLevel.all,
-      ) as _i22.NotificationLevel);
+        returnValue: _i23.NotificationLevel.all,
+        returnValueForMissingStub: _i23.NotificationLevel.all,
+      ) as _i23.NotificationLevel);
 
   @override
   String get notificationLevelLabel => (super.noSuchMethod(
         Invocation.getter(#notificationLevelLabel),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#notificationLevelLabel),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#notificationLevelLabel),
         ),
@@ -8489,11 +8523,11 @@ class MockPreferencesService extends _i1.Mock
       ) as bool);
 
   @override
-  _i22.AudioQuality get audioQuality => (super.noSuchMethod(
+  _i23.AudioQuality get audioQuality => (super.noSuchMethod(
         Invocation.getter(#audioQuality),
-        returnValue: _i22.AudioQuality.speech,
-        returnValueForMissingStub: _i22.AudioQuality.speech,
-      ) as _i22.AudioQuality);
+        returnValue: _i23.AudioQuality.speech,
+        returnValueForMissingStub: _i23.AudioQuality.speech,
+      ) as _i23.AudioQuality);
 
   @override
   bool get highPassFilter => (super.noSuchMethod(
@@ -8544,7 +8578,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setMessageDensity(_i22.MessageDensity? density) =>
+  _i5.Future<void> setMessageDensity(_i23.MessageDensity? density) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMessageDensity,
@@ -8555,7 +8589,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setLastMobileTab(_i22.MobileTab? tab) => (super.noSuchMethod(
+  _i5.Future<void> setLastMobileTab(_i23.MobileTab? tab) => (super.noSuchMethod(
         Invocation.method(
           #setLastMobileTab,
           [tab],
@@ -8565,7 +8599,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setThemeMode(_i23.ThemeMode? mode) => (super.noSuchMethod(
+  _i5.Future<void> setThemeMode(_i24.ThemeMode? mode) => (super.noSuchMethod(
         Invocation.method(
           #setThemeMode,
           [mode],
@@ -8585,7 +8619,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setCustomTheme(_i14.CustomTheme? theme) =>
+  _i5.Future<void> setCustomTheme(_i15.CustomTheme? theme) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCustomTheme,
@@ -8596,7 +8630,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setCustomThemeMode(_i23.ThemeMode? mode) =>
+  _i5.Future<void> setCustomThemeMode(_i24.ThemeMode? mode) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCustomThemeMode,
@@ -8648,7 +8682,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setNotificationLevel(_i22.NotificationLevel? level) =>
+  _i5.Future<void> setNotificationLevel(_i23.NotificationLevel? level) =>
       (super.noSuchMethod(
         Invocation.method(
           #setNotificationLevel,
@@ -8927,7 +8961,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setAudioQuality(_i22.AudioQuality? quality) =>
+  _i5.Future<void> setAudioQuality(_i23.AudioQuality? quality) =>
       (super.noSuchMethod(
         Invocation.method(
           #setAudioQuality,
@@ -8968,7 +9002,27 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  _i5.Future<void> markUpdateDismissed(String? tag) => (super.noSuchMethod(
+        Invocation.method(
+          #markUpdateDismissed,
+          [tag],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  bool isUpdateAvailable(String? latestTag) => (super.noSuchMethod(
+        Invocation.method(
+          #isUpdateAvailable,
+          [latestTag],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8977,7 +9031,7 @@ class MockPreferencesService extends _i1.Mock
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -9011,11 +9065,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -9045,11 +9099,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_74(
+        returnValue: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_74(
+        returnValueForMissingStub: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
@@ -9102,11 +9156,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -9142,11 +9196,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -9162,11 +9216,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -9175,11 +9229,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -9222,11 +9276,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -9269,11 +9323,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_75(
+        returnValue: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_75(
+        returnValueForMissingStub: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -9485,18 +9539,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i24.SpaceParent>[],
-        returnValueForMissingStub: <_i24.SpaceParent>[],
-      ) as List<_i24.SpaceParent>);
+        returnValue: <_i25.SpaceParent>[],
+        returnValueForMissingStub: <_i25.SpaceParent>[],
+      ) as List<_i25.SpaceParent>);
 
   @override
-  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i24.SpaceChild>[],
-        returnValueForMissingStub: <_i24.SpaceChild>[],
-      ) as List<_i24.SpaceChild>);
+        returnValue: <_i25.SpaceChild>[],
+        returnValueForMissingStub: <_i25.SpaceChild>[],
+      ) as List<_i25.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9663,14 +9717,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9718,7 +9772,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9726,7 +9780,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9741,7 +9795,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9749,7 +9803,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9833,7 +9887,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9841,7 +9895,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -10083,7 +10137,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10094,7 +10148,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10183,15 +10237,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i25.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i26.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i25.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i25.TimelineChunk?>.value(),
-      ) as _i5.Future<_i25.TimelineChunk?>);
+        returnValue: _i5.Future<_i26.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i26.TimelineChunk?>.value(),
+      ) as _i5.Future<_i26.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -10232,7 +10286,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -10249,7 +10303,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -10313,14 +10367,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -10336,14 +10390,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -10399,7 +10453,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10407,7 +10461,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/room_tile_test.mocks.dart
+++ b/test/widgets/room_tile_test.mocks.dart
@@ -3,41 +3,42 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i12;
-import 'dart:typed_data' as _i22;
-import 'dart:ui' as _i16;
+import 'dart:async' as _i13;
+import 'dart:typed_data' as _i23;
+import 'dart:ui' as _i17;
 
-import 'package:flutter/services.dart' as _i17;
-import 'package:flutter/widgets.dart' as _i18;
-import 'package:http/http.dart' as _i11;
-import 'package:kohera/core/services/call_service.dart' as _i23;
-import 'package:kohera/core/services/matrix_service.dart' as _i14;
-import 'package:kohera/core/services/preferences_service.dart' as _i29;
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
+import 'package:http/http.dart' as _i12;
+import 'package:kohera/core/services/call_service.dart' as _i24;
+import 'package:kohera/core/services/matrix_service.dart' as _i15;
+import 'package:kohera/core/services/preferences_service.dart' as _i30;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
-import 'package:kohera/features/calling/models/call_participant.dart' as _i26;
-import 'package:kohera/features/calling/models/call_state.dart' as _i28;
-import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i27;
-import 'package:kohera/features/calling/services/livekit_service.dart' as _i24;
-import 'package:kohera/features/calling/services/ringtone_service.dart' as _i30;
+import 'package:kohera/features/calling/models/call_participant.dart' as _i27;
+import 'package:kohera/features/calling/models/call_state.dart' as _i29;
+import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i28;
+import 'package:kohera/features/calling/services/livekit_service.dart' as _i25;
+import 'package:kohera/features/calling/services/ringtone_service.dart' as _i31;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:livekit_client/livekit_client.dart' as _i25;
-import 'package:matrix/encryption.dart' as _i21;
+import 'package:livekit_client/livekit_client.dart' as _i26;
+import 'package:matrix/encryption.dart' as _i22;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i13;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i20;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i10;
-import 'package:matrix/src/utils/space_child.dart' as _i19;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i14;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i11;
+import 'package:matrix/src/utils/space_child.dart' as _i20;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -138,8 +139,8 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeRoomSummary_8 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_8(
+class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
+  _FakeOutboxService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -148,9 +149,8 @@ class _FakeRoomSummary_8 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_9<T> extends _i1.SmartFake
-    implements _i10.CachedStreamController<T> {
-  _FakeCachedStreamController_9(
+class _FakeRoomSummary_9 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -159,8 +159,9 @@ class _FakeCachedStreamController_9<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_10 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_10(
+class _FakeCachedStreamController_10<T> extends _i1.SmartFake
+    implements _i11.CachedStreamController<T> {
+  _FakeCachedStreamController_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -169,9 +170,19 @@ class _FakeDateTime_10 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_11 extends _i1.SmartFake
+class _FakeDateTime_11 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_11(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_12 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_11(
+  _FakeLatestReceiptState_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -180,8 +191,8 @@ class _FakeLatestReceiptState_11 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_12 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_12(
+class _FakeSyncUpdate_13 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -190,8 +201,8 @@ class _FakeSyncUpdate_12 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_13 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_13(
+class _FakeTimeline_14 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -200,8 +211,8 @@ class _FakeTimeline_13 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_14 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_14(
+class _FakeUser_15 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -210,8 +221,8 @@ class _FakeUser_14 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_15 extends _i1.SmartFake implements Uri {
-  _FakeUri_15(
+class _FakeUri_16 extends _i1.SmartFake implements Uri {
+  _FakeUri_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -220,8 +231,8 @@ class _FakeUri_15 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_16 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_16(
+class _FakeDatabaseApi_17 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -230,8 +241,8 @@ class _FakeDatabaseApi_16 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_17 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_17(
+class _FakeFilter_18 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -240,9 +251,9 @@ class _FakeFilter_17 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_18 extends _i1.SmartFake
+class _FakeNativeImplementations_19 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_18(
+  _FakeNativeImplementations_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -251,8 +262,8 @@ class _FakeNativeImplementations_18 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_19 extends _i1.SmartFake implements Duration {
-  _FakeDuration_19(
+class _FakeDuration_20 extends _i1.SmartFake implements Duration {
+  _FakeDuration_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -261,9 +272,9 @@ class _FakeDuration_19 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_20 extends _i1.SmartFake
+class _FakePushruleEvaluator_21 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_20(
+  _FakePushruleEvaluator_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -272,8 +283,8 @@ class _FakePushruleEvaluator_20 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_21 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_21(
+class _FakeProfile_22 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -282,8 +293,8 @@ class _FakeProfile_21 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_22 extends _i1.SmartFake implements _i11.Client {
-  _FakeClient_22(
+class _FakeClient_23 extends _i1.SmartFake implements _i12.Client {
+  _FakeClient_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -292,9 +303,9 @@ class _FakeClient_22 extends _i1.SmartFake implements _i11.Client {
         );
 }
 
-class _FakeDiscoveryInformation_23 extends _i1.SmartFake
+class _FakeDiscoveryInformation_24 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_23(
+  _FakeDiscoveryInformation_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -303,9 +314,9 @@ class _FakeDiscoveryInformation_23 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_24 extends _i1.SmartFake
+class _FakeGetVersionsResponse_25 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_24(
+  _FakeGetVersionsResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -314,9 +325,9 @@ class _FakeGetVersionsResponse_24 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_25 extends _i1.SmartFake
+class _FakeRegisterResponse_26 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_25(
+  _FakeRegisterResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -325,8 +336,8 @@ class _FakeRegisterResponse_25 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_26 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_26(
+class _FakeLoginResponse_27 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -335,9 +346,9 @@ class _FakeLoginResponse_26 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_27 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_28 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_27(
+  _FakeGetAuthMetadataResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -346,8 +357,8 @@ class _FakeGetAuthMetadataResponse_27 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_28<T1> extends _i1.SmartFake implements _i12.Future<T1> {
-  _FakeFuture_28(
+class _FakeFuture_29<T1> extends _i1.SmartFake implements _i13.Future<T1> {
+  _FakeFuture_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -356,9 +367,9 @@ class _FakeFuture_28<T1> extends _i1.SmartFake implements _i12.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_29 extends _i1.SmartFake
+class _FakeCachedProfileInformation_30 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_29(
+  _FakeCachedProfileInformation_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -367,8 +378,8 @@ class _FakeCachedProfileInformation_29 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_30(
+class _FakeMediaConfig_31 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -377,8 +388,8 @@ class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_31 extends _i1.SmartFake implements _i13.FileResponse {
-  _FakeFileResponse_31(
+class _FakeFileResponse_32 extends _i1.SmartFake implements _i14.FileResponse {
+  _FakeFileResponse_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -387,8 +398,8 @@ class _FakeFileResponse_31 extends _i1.SmartFake implements _i13.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_32(
+class _FakePreviewForUrl_33 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -397,9 +408,9 @@ class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_33 extends _i1.SmartFake
+class _FakeCachedPresence_34 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_33(
+  _FakeCachedPresence_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -408,9 +419,9 @@ class _FakeCachedPresence_33 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_34 extends _i1.SmartFake
+class _FakeTurnServerCredentials_35 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_34(
+  _FakeTurnServerCredentials_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -419,9 +430,9 @@ class _FakeTurnServerCredentials_34 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_35(
+  _FakeRoomKeysUpdateResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -430,8 +441,8 @@ class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_36(
+class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -440,9 +451,9 @@ class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_37(
+  _FakeGetWellknownSupportResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -451,9 +462,9 @@ class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_38(
+  _FakeGenerateLoginTokenResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -462,9 +473,9 @@ class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_39(
+  _FakeGetRoomSummaryResponse$3_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -473,9 +484,9 @@ class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_40(
+  _FakeGetSpaceHierarchyResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -484,9 +495,9 @@ class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_41(
+  _FakeGetRelatingEventsResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -495,9 +506,9 @@ class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_42(
+  _FakeGetRelatingEventsWithRelTypeResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -506,9 +517,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -517,9 +528,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_44(
+  _FakeGetThreadRootsResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -528,9 +539,9 @@ class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_45(
+  _FakeGetEventByTimestampResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -539,9 +550,9 @@ class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_46 extends _i1.SmartFake
+class _FakeRequestTokenResponse_47 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_46(
+  _FakeRequestTokenResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -550,9 +561,9 @@ class _FakeRequestTokenResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_47(
+  _FakeTokenOwnerInfo_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -561,8 +572,8 @@ class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_48(
+class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -571,8 +582,8 @@ class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_49(
+class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -581,8 +592,8 @@ class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_50(
+class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -591,9 +602,9 @@ class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_51(
+  _FakeGetRoomIdByAliasResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -602,9 +613,9 @@ class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_52 extends _i1.SmartFake
+class _FakeGetEventsResponse_53 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_52(
+  _FakeGetEventsResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -613,9 +624,9 @@ class _FakeGetEventsResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_53 extends _i1.SmartFake
+class _FakePeekEventsResponse_54 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_53(
+  _FakePeekEventsResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -624,8 +635,8 @@ class _FakePeekEventsResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_54(
+class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -634,9 +645,9 @@ class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_55(
+  _FakeGetKeysChangesResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -645,9 +656,9 @@ class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_56 extends _i1.SmartFake
+class _FakeClaimKeysResponse_57 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_56(
+  _FakeClaimKeysResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -656,9 +667,9 @@ class _FakeClaimKeysResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_57 extends _i1.SmartFake
+class _FakeQueryKeysResponse_58 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_57(
+  _FakeQueryKeysResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -667,9 +678,9 @@ class _FakeQueryKeysResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_58(
+  _FakeGetNotificationsResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -678,9 +689,9 @@ class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_59 extends _i1.SmartFake
+class _FakeGetPresenceResponse_60 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_59(
+  _FakeGetPresenceResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -689,9 +700,9 @@ class _FakeGetPresenceResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_60(
+  _FakeGetPublicRoomsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -700,9 +711,9 @@ class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_61(
+  _FakeQueryPublicRoomsResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -711,8 +722,8 @@ class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_62(
+class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -721,9 +732,9 @@ class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_63(
+  _FakeGetPushRulesGlobalResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -732,8 +743,8 @@ class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_64(
+class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -742,9 +753,9 @@ class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_65 extends _i1.SmartFake
+class _FakeRefreshResponse_66 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_65(
+  _FakeRefreshResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -753,8 +764,8 @@ class _FakeRefreshResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_66(
+class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -763,8 +774,8 @@ class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_67(
+class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -773,9 +784,9 @@ class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_68(
+  _FakeGetRoomKeysVersionCurrentResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -784,9 +795,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_69(
+  _FakeGetRoomKeysVersionResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -795,8 +806,8 @@ class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_70(
+class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -805,9 +816,9 @@ class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_71(
+  _FakeGetRoomEventsResponse_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -816,8 +827,8 @@ class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_72(
+class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -826,9 +837,9 @@ class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_73(
+  _FakeGetProtocolMetadataResponse$2_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -837,9 +848,9 @@ class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_74 extends _i1.SmartFake
+class _FakeOpenIdCredentials_75 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_74(
+  _FakeOpenIdCredentials_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -848,9 +859,9 @@ class _FakeOpenIdCredentials_74 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_75(
+  _FakeSearchUserDirectoryResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -859,9 +870,9 @@ class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_76 extends _i1.SmartFake
+class _FakeCreateContentResponse_77 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_76(
+  _FakeCreateContentResponse_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -870,8 +881,8 @@ class _FakeCreateContentResponse_76 extends _i1.SmartFake
         );
 }
 
-class _FakeRoom_77 extends _i1.SmartFake implements _i4.Room {
-  _FakeRoom_77(
+class _FakeRoom_78 extends _i1.SmartFake implements _i4.Room {
+  _FakeRoom_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -880,8 +891,8 @@ class _FakeRoom_77 extends _i1.SmartFake implements _i4.Room {
         );
 }
 
-class _FakeMatrixFile_78 extends _i1.SmartFake implements _i4.MatrixFile {
-  _FakeMatrixFile_78(
+class _FakeMatrixFile_79 extends _i1.SmartFake implements _i4.MatrixFile {
+  _FakeMatrixFile_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -890,8 +901,8 @@ class _FakeMatrixFile_78 extends _i1.SmartFake implements _i4.MatrixFile {
         );
 }
 
-class _FakeEvent_79 extends _i1.SmartFake implements _i4.Event {
-  _FakeEvent_79(
+class _FakeEvent_80 extends _i1.SmartFake implements _i4.Event {
+  _FakeEvent_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -900,8 +911,8 @@ class _FakeEvent_79 extends _i1.SmartFake implements _i4.Event {
         );
 }
 
-class _FakeResponse_80 extends _i1.SmartFake implements _i11.Response {
-  _FakeResponse_80(
+class _FakeResponse_81 extends _i1.SmartFake implements _i12.Response {
+  _FakeResponse_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -913,7 +924,7 @@ class _FakeResponse_80 extends _i1.SmartFake implements _i11.Response {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -943,11 +954,11 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1046,6 +1057,19 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as _i9.AuthService);
 
   @override
+  _i10.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_8(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i10.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -1125,6 +1149,15 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
+  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -1132,14 +1165,14 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as bool);
 
   @override
-  _i12.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1169,7 +1202,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i16.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1179,18 +1212,18 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<bool> login({
+  _i13.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1205,12 +1238,12 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> completeSsoLogin({
+  _i13.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1223,12 +1256,12 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> completeRegistration(
+  _i13.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1238,32 +1271,32 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1272,7 +1305,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1281,17 +1314,17 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i17.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1302,7 +1335,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i17.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1339,26 +1372,26 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> didPushRouteInformation(
-          _i18.RouteInformation? routeInformation) =>
+  _i13.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1388,7 +1421,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i16.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1397,7 +1430,7 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i16.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1406,16 +1439,16 @@ class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
       );
 
   @override
-  _i12.Future<_i16.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i13.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
+            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
-      ) as _i12.Future<_i16.AppExitResponse>);
+            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i13.Future<_i17.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1443,11 +1476,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1477,11 +1510,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_8(
+        returnValue: _FakeRoomSummary_9(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_8(
+        returnValueForMissingStub: _FakeRoomSummary_9(
           this,
           Invocation.getter(#summary),
         ),
@@ -1511,11 +1544,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i12.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i13.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i12.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i12.Completer<dynamic>>[],
-      ) as List<_i12.Completer<dynamic>>);
+        returnValue: <_i13.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i13.Completer<dynamic>>[],
+      ) as List<_i13.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1534,51 +1567,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i10.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i11.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i10.CachedStreamController<String> get onSessionKeyReceived =>
+  _i11.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1594,11 +1627,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1607,11 +1640,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1654,11 +1687,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1667,11 +1700,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_10(
+        returnValue: _FakeDateTime_11(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_10(
+        returnValueForMissingStub: _FakeDateTime_11(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1701,11 +1734,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_11(
+        returnValue: _FakeLatestReceiptState_12(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_11(
+        returnValueForMissingStub: _FakeLatestReceiptState_12(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1726,18 +1759,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i12.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i13.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -1917,18 +1950,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i19.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i19.SpaceParent>[],
-        returnValueForMissingStub: <_i19.SpaceParent>[],
-      ) as List<_i19.SpaceParent>);
+        returnValue: <_i20.SpaceParent>[],
+        returnValueForMissingStub: <_i20.SpaceParent>[],
+      ) as List<_i20.SpaceParent>);
 
   @override
-  List<_i19.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i19.SpaceChild>[],
-        returnValueForMissingStub: <_i19.SpaceChild>[],
-      ) as List<_i19.SpaceChild>);
+        returnValue: <_i20.SpaceChild>[],
+        returnValueForMissingStub: <_i20.SpaceChild>[],
+      ) as List<_i20.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -2041,14 +2074,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i12.Future<void> postLoad() => (super.noSuchMethod(
+  _i13.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2076,15 +2109,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i12.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i13.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i12.Future<List<_i4.User>>);
+            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i13.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2095,14 +2128,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2112,18 +2145,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i12.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i13.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Event?> refreshLastEvent(
+  _i13.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2131,9 +2164,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2145,12 +2178,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i12.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i13.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2158,22 +2191,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i13.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2181,17 +2214,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> addTag(
+  _i13.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2201,27 +2234,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i13.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i13.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2229,43 +2262,43 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i13.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i13.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i13.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2273,14 +2306,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2292,7 +2325,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i12.Future<String?> sendTextEvent(
+  _i13.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2324,12 +2357,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendReaction(
+  _i13.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2343,12 +2376,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendLocation(
+  _i13.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2362,12 +2395,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> sendFileEvent(
+  _i13.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2395,25 +2428,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i13.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i12.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i13.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i12.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i13.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i12.Future<_i4.EncryptionHealthState>);
+      ) as _i13.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i12.Future<String?> sendEvent(
+  _i13.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2437,73 +2470,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i13.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> leave() => (super.noSuchMethod(
+  _i13.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> forget() => (super.noSuchMethod(
+  _i13.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> setPower(
+  _i13.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2515,7 +2548,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2526,7 +2559,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2536,10 +2569,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> invite(
+  _i13.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2549,12 +2582,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<int> requestHistory({
+  _i13.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2571,32 +2604,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<int>.value(0),
-        returnValueForMissingStub: _i12.Future<int>.value(0),
-      ) as _i12.Future<int>);
+        returnValue: _i13.Future<int>.value(0),
+        returnValueForMissingStub: _i13.Future<int>.value(0),
+      ) as _i13.Future<int>);
 
   @override
-  _i12.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i13.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i13.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setReadMarker(
+  _i13.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2610,23 +2643,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i20.TimelineChunk?> getEventContext(String? eventId) =>
+  _i13.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i12.Future<_i20.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i12.Future<_i20.TimelineChunk?>.value(),
-      ) as _i12.Future<_i20.TimelineChunk?>);
+        returnValue: _i13.Future<_i21.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i13.Future<_i21.TimelineChunk?>.value(),
+      ) as _i13.Future<_i21.TimelineChunk?>);
 
   @override
-  _i12.Future<void> postReceipt(
+  _i13.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2636,12 +2669,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Timeline> getTimeline({
+  _i13.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2664,7 +2697,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
+        returnValue: _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
           this,
           Invocation.method(
             #getTimeline,
@@ -2681,7 +2714,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Timeline>.value(_FakeTimeline_13(
+            _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
           this,
           Invocation.method(
             #getTimeline,
@@ -2697,7 +2730,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Timeline>);
+      ) as _i13.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2716,7 +2749,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i12.Future<List<_i4.User>> requestParticipants([
+  _i13.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2734,10 +2767,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i12.Future<List<_i4.User>>);
+            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i13.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2745,14 +2778,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_14(
+        returnValue: _FakeUser_15(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_14(
+        returnValueForMissingStub: _FakeUser_15(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2768,14 +2801,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_14(
+        returnValue: _FakeUser_15(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_14(
+        returnValueForMissingStub: _FakeUser_15(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2785,7 +2818,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i12.Future<_i4.User?> requestUser(
+  _i13.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2801,19 +2834,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i12.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.User?>.value(),
-      ) as _i12.Future<_i4.User?>);
+        returnValue: _i13.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.User?>.value(),
+      ) as _i13.Future<_i4.User?>);
 
   @override
-  _i12.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i13.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2826,12 +2859,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i12.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i13.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2839,14 +2872,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2869,14 +2902,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i12.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i13.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -2915,18 +2948,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i12.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i13.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEvent(
+  _i13.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -2940,12 +2973,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> setTyping(
+  _i13.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -2955,12 +2988,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setJoinRules(
+  _i13.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -2974,59 +3007,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i13.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setHistoryVisibility(
+  _i13.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i13.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i13.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i12.Future<List<_i4.DeviceKeys>>);
+            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i13.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i12.Future<void> requestSessionKey(
+  _i13.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -3038,12 +3071,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setSpaceChild(
+  _i13.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3059,44 +3092,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i13.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i12.Future<Uri>);
+      ) as _i13.Future<Uri>);
 
   @override
-  _i12.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i13.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<
+  _i13.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3123,21 +3156,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i12.Future<
+        returnValue: _i13.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i12.Future<
+        returnValueForMissingStub: _i13.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i12.Future<
+      ) as _i13.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3152,23 +3185,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_16(
+        returnValue: _FakeDatabaseApi_17(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_16(
+        returnValueForMissingStub: _FakeDatabaseApi_17(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i21.KeyVerificationMethod> get verificationMethods =>
+  Set<_i22.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i21.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i21.KeyVerificationMethod>{},
-      ) as Set<_i21.KeyVerificationMethod>);
+        returnValue: <_i22.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i22.KeyVerificationMethod>{},
+      ) as Set<_i22.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3229,11 +3262,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_17(
+        returnValue: _FakeFilter_18(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_17(
+        returnValueForMissingStub: _FakeFilter_18(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3242,11 +3275,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_18(
+        returnValue: _FakeNativeImplementations_19(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_18(
+        returnValueForMissingStub: _FakeNativeImplementations_19(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3262,11 +3295,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_19(
+        returnValue: _FakeDuration_20(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_19(
+        returnValueForMissingStub: _FakeDuration_20(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3275,11 +3308,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_19(
+        returnValue: _FakeDuration_20(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_19(
+        returnValueForMissingStub: _FakeDuration_20(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3288,11 +3321,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3329,11 +3362,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3363,11 +3396,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3376,11 +3409,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3403,11 +3436,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_20(
+        returnValue: _FakePushruleEvaluator_21(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_20(
+        returnValueForMissingStub: _FakePushruleEvaluator_21(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3428,332 +3461,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i12.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i13.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i10.CachedStreamController<String> get onUserProfileUpdate =>
+  _i11.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i12.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i13.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i12.Future<List<_i4.Room>>);
+            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i13.Future<List<_i4.Room>>);
 
   @override
-  _i10.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i11.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_10<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.EventUpdate>(
+            _FakeCachedStreamController_10<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.EventUpdate>);
+      ) as _i11.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i11.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i11.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onNotification =>
+  _i11.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i11.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i10.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i11.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i10.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i11.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_9<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i10.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i11.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i10.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i11.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_9<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_10<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.LoginState>(
+            _FakeCachedStreamController_10<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i10.CachedStreamController<_i4.LoginState>);
+      ) as _i11.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i10.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i11.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_9<bool>(
+        returnValue: _FakeCachedStreamController_10<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i10.CachedStreamController<bool>);
+      ) as _i11.CachedStreamController<bool>);
 
   @override
-  _i10.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i11.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_9<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_10<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i10.CachedStreamController<_i4.SdkError>);
+      ) as _i11.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i10.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i11.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_9<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_10<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.SyncUpdate>(
+            _FakeCachedStreamController_10<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i10.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i11.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i11.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i10.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i11.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i10.CachedStreamController<_i4.Presence> get onPresence =>
+  _i11.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_9<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_10<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i10.CachedStreamController<_i4.Presence>);
+      ) as _i11.CachedStreamController<_i4.Presence>);
 
   @override
-  _i10.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i11.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_9<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_10<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.CachedPresence>(
+            _FakeCachedStreamController_10<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i10.CachedStreamController<_i4.CachedPresence>);
+      ) as _i11.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i10.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i11.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_9<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_10<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.BasicEvent>(
+            _FakeCachedStreamController_10<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i10.CachedStreamController<_i4.BasicEvent>);
+      ) as _i11.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i10.CachedStreamController<_i21.RoomKeyRequest> get onRoomKeyRequest =>
+  _i11.CachedStreamController<_i22.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i21.RoomKeyRequest>(
+            _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i10.CachedStreamController<_i21.RoomKeyRequest>);
+      ) as _i11.CachedStreamController<_i22.RoomKeyRequest>);
 
   @override
-  _i10.CachedStreamController<_i21.KeyVerification>
+  _i11.CachedStreamController<_i22.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_9<_i21.KeyVerification>(
+            returnValue: _FakeCachedStreamController_10<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_9<_i21.KeyVerification>(
+                _FakeCachedStreamController_10<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i10.CachedStreamController<_i21.KeyVerification>);
+          ) as _i11.CachedStreamController<_i22.KeyVerification>);
 
   @override
-  _i10.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i11.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_9<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i10.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i11.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i10.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i11.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_9<_i4.Event>(
+        returnValue: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i10.CachedStreamController<_i4.Event>);
+      ) as _i11.CachedStreamController<_i4.Event>);
 
   @override
-  _i10.CachedStreamController<String> get onCancelSendEvent =>
+  _i11.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_9<String>(
+        returnValue: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_9<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i10.CachedStreamController<String>);
+      ) as _i11.CachedStreamController<String>);
 
   @override
-  _i10.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i11.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_9<
+            returnValue: _FakeCachedStreamController_10<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_9<
+            returnValueForMissingStub: _FakeCachedStreamController_10<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i10.CachedStreamController<
+          ) as _i11.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3773,11 +3806,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_10(
+        returnValue: _FakeDateTime_11(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_10(
+        returnValueForMissingStub: _FakeDateTime_11(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3850,7 +3883,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i21.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i22.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3905,7 +3938,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i12.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i13.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3916,7 +3949,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i12.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i13.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -4027,7 +4060,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -4036,7 +4069,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -4045,7 +4078,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i12.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i13.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4072,20 +4105,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i11.Client get httpClient => (super.noSuchMethod(
+  _i12.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_22(
+        returnValue: _FakeClient_23(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_22(
+        returnValueForMissingStub: _FakeClient_23(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i11.Client);
+      ) as _i12.Client);
 
   @override
-  set httpClient(_i11.Client? value) => super.noSuchMethod(
+  set httpClient(_i12.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4112,7 +4145,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<void> refreshAccessToken(
+  _i13.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4120,9 +4153,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4140,14 +4173,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4184,33 +4217,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i12.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i13.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i12.Future<_i4.DiscoveryInformation>);
+      ) as _i13.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i12.Future<
+  _i13.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4232,7 +4265,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i12.Future<
+        returnValue: _i13.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4240,7 +4273,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_24(
+          _FakeGetVersionsResponse_25(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4255,7 +4288,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i12.Future<
+        returnValueForMissingStub: _i13.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4263,7 +4296,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_24(
+          _FakeGetVersionsResponse_25(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4278,7 +4311,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i12.Future<
+      ) as _i13.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4287,7 +4320,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i12.Future<_i4.DiscoveryInformation> getWellknown({
+  _i13.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4300,8 +4333,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getWellknown,
@@ -4312,8 +4345,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_23(
+        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_24(
           this,
           Invocation.method(
             #getWellknown,
@@ -4324,10 +4357,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.DiscoveryInformation>);
+      ) as _i13.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i12.Future<_i4.RegisterResponse> register({
+  _i13.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4355,7 +4388,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
+            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
           this,
           Invocation.method(
             #register,
@@ -4374,7 +4407,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
+            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
           this,
           Invocation.method(
             #register,
@@ -4392,10 +4425,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RegisterResponse>);
+      ) as _i13.Future<_i4.RegisterResponse>);
 
   @override
-  _i12.Future<_i4.LoginResponse> login(
+  _i13.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4425,7 +4458,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
+        returnValue: _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
           this,
           Invocation.method(
             #login,
@@ -4445,7 +4478,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
+            _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
           this,
           Invocation.method(
             #login,
@@ -4464,10 +4497,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.LoginResponse>);
+      ) as _i13.Future<_i4.LoginResponse>);
 
   @override
-  _i12.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i13.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4480,8 +4513,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_27(
+        returnValue: _i13.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_28(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4493,8 +4526,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_27(
+            _i13.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_28(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4505,74 +4538,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i13.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i12.Future<void> logout() => (super.noSuchMethod(
+  _i13.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> logoutAll() => (super.noSuchMethod(
+  _i13.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<T> uiaRequestBackground<T>(
-          _i12.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i13.Future<T> uiaRequestBackground<T>(
+          _i13.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i12.Future<T>.value(v),
+              (T v) => _i13.Future<T>.value(v),
             ) ??
-            _FakeFuture_28<T>(
+            _FakeFuture_29<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i12.Future<T>.value(v),
+              (T v) => _i13.Future<T>.value(v),
             ) ??
-            _FakeFuture_28<T>(
+            _FakeFuture_29<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i12.Future<T>);
+      ) as _i13.Future<T>);
 
   @override
-  _i12.Future<String> startDirectChat(
+  _i13.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4594,7 +4627,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4610,7 +4643,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4625,10 +4658,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<String> createGroupChat({
+  _i13.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4659,7 +4692,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4680,7 +4713,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4700,10 +4733,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i13.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4719,7 +4752,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4732,7 +4765,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4744,21 +4777,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i13.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<String> createSpace({
+  _i13.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4783,7 +4816,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4801,7 +4834,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4818,10 +4851,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i13.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4829,7 +4862,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4838,7 +4871,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4846,10 +4879,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i12.Future<_i4.Profile> fetchOwnProfile({
+  _i13.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4862,7 +4895,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4874,7 +4907,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4885,10 +4918,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
-  _i12.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i13.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4902,8 +4935,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i12.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_29(
+        returnValue: _i13.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_30(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4915,8 +4948,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_29(
+            _i13.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_30(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4927,10 +4960,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.CachedProfileInformation>);
+      ) as _i13.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i12.Future<_i4.Profile> getProfileFromUserId(
+  _i13.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4948,7 +4981,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4962,7 +4995,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Profile>.value(_FakeProfile_21(
+            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4975,7 +5008,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.Profile>);
+      ) as _i13.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -4997,31 +5030,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i12.Future<List<_i4.Room>>);
+            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i13.Future<List<_i4.Room>>);
 
   @override
-  _i12.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i13.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i12.Future<List<_i4.ArchivedRoom>>);
+            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i13.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i12.Future<_i4.GetVersionsResponse> getVersions({
+  _i13.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5034,8 +5067,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_24(
+        returnValue: _i13.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_25(
           this,
           Invocation.method(
             #getVersions,
@@ -5046,8 +5079,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_24(
+        returnValueForMissingStub: _i13.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_25(
           this,
           Invocation.method(
             #getVersions,
@@ -5058,20 +5091,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetVersionsResponse>);
+      ) as _i13.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i12.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i13.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<_i4.MediaConfig> getConfig({
+  _i13.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5084,7 +5117,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfig,
@@ -5096,7 +5129,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfig,
@@ -5107,10 +5140,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.MediaConfig>);
+      ) as _i13.Future<_i4.MediaConfig>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContent(
+  _i13.Future<_i14.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5130,7 +5163,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContent,
@@ -5146,7 +5179,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContent,
@@ -5161,10 +5194,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentOverrideName(
+  _i13.Future<_i14.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5186,7 +5219,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5203,7 +5236,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5219,10 +5252,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentThumbnail(
+  _i13.Future<_i14.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5250,7 +5283,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5270,7 +5303,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5289,10 +5322,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i13.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5302,7 +5335,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5311,7 +5344,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5319,11 +5352,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i12.Future<_i4.PreviewForUrl>);
+      ) as _i13.Future<_i4.PreviewForUrl>);
 
   @override
-  _i12.Future<Uri> uploadContent(
-    _i22.Uint8List? file, {
+  _i13.Future<Uri> uploadContent(
+    _i23.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5336,7 +5369,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #uploadContent,
@@ -5347,7 +5380,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<Uri>.value(_FakeUri_15(
+        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
           this,
           Invocation.method(
             #uploadContent,
@@ -5358,10 +5391,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<Uri>);
+      ) as _i13.Future<Uri>);
 
   @override
-  _i12.Future<void> setTyping(
+  _i13.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5377,42 +5410,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> exportDump() => (super.noSuchMethod(
+  _i13.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i13.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i13.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Event?> getEventByPushNotification(
+  _i13.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5428,12 +5461,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
-  _i12.Future<void> init({
+  _i13.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5468,9 +5501,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5482,40 +5515,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Future<void> clear() => (super.noSuchMethod(
+  _i13.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i13.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ensureNotSoftLoggedOut(
+  _i13.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> handleSync(
+  _i13.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5525,9 +5558,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5540,29 +5573,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i12.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i13.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i13.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDevice(
+  _i13.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5576,12 +5609,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDevicesOfUserIds(
+  _i13.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5597,12 +5630,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDeviceEncrypted(
+  _i13.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5622,12 +5655,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> sendToDeviceEncryptedChunked(
+  _i13.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5641,23 +5674,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i13.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> joinRoom(
+  _i13.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5675,7 +5708,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5689,7 +5722,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5702,10 +5735,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> changePassword(
+  _i13.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5721,22 +5754,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> clearCache() => (super.noSuchMethod(
+  _i13.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ignoreUser(
+  _i13.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5746,22 +5779,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i13.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i13.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5772,7 +5805,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5781,7 +5814,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5789,32 +5822,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i12.Future<_i4.CachedPresence>);
+      ) as _i13.Future<_i4.CachedPresence>);
 
   @override
-  _i12.Future<void> abortSync() => (super.noSuchMethod(
+  _i13.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i13.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEventWithMetadata(
+  _i13.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5834,14 +5867,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i11.BaseResponse? response,
-    _i22.Uint8List? body,
+    _i12.BaseResponse? response,
+    _i23.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5873,7 +5906,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i12.Future<Map<String, Object?>> request(
+  _i13.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -5894,13 +5927,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> postPusher(
+  _i13.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -5910,57 +5943,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i13.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i13.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i13.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i12.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_34(
+        returnValue: _i13.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_35(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_34(
+        returnValueForMissingStub: _i13.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_35(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.TurnServerCredentials>);
+      ) as _i13.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5974,8 +6007,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5987,8 +6020,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5999,10 +6032,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6018,8 +6051,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6032,8 +6065,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6045,10 +6078,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i13.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6062,7 +6095,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6074,7 +6107,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6085,17 +6118,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.KeyBackupData>);
+      ) as _i13.Future<_i4.KeyBackupData>);
 
   @override
-  _i12.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i13.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i12.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_37(
+        returnValue: _i13.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_38(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6103,18 +6136,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_37(
+            _i13.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_38(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i13.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i12.Future<int> pingAppservice(
+  _i13.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6124,12 +6157,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i12.Future<int>.value(0),
-        returnValueForMissingStub: _i12.Future<int>.value(0),
-      ) as _i12.Future<int>);
+        returnValue: _i13.Future<int>.value(0),
+        returnValueForMissingStub: _i13.Future<int>.value(0),
+      ) as _i13.Future<int>);
 
   @override
-  _i12.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i13.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6137,8 +6170,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_38(
+        returnValue: _i13.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_39(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6147,8 +6180,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_38(
+            _i13.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_39(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6156,15 +6189,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i12.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i13.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i12.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i13.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6172,17 +6205,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.MediaConfig>);
+      ) as _i13.Future<_i4.MediaConfig>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentAuthed(
+  _i13.Future<_i14.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6196,7 +6229,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6208,7 +6241,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6219,10 +6252,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentOverrideNameAuthed(
+  _i13.Future<_i14.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6238,7 +6271,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6251,7 +6284,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6263,10 +6296,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i13.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6276,7 +6309,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6285,7 +6318,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6293,10 +6326,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i12.Future<_i4.PreviewForUrl>);
+      ) as _i13.Future<_i4.PreviewForUrl>);
 
   @override
-  _i12.Future<_i13.FileResponse> getContentThumbnailAuthed(
+  _i13.Future<_i14.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6320,7 +6353,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6338,7 +6371,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i13.FileResponse>.value(_FakeFileResponse_31(
+            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6355,21 +6388,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i13.FileResponse>);
+      ) as _i13.Future<_i14.FileResponse>);
 
   @override
-  _i12.Future<bool> registrationTokenValidity(String? token) =>
+  _i13.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i13.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6379,8 +6412,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_39(
+        returnValue: _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_40(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6389,8 +6422,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_39(
+            _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_40(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6398,10 +6431,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i13.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i12.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i13.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6419,8 +6452,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_40(
+        returnValue: _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_41(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6434,8 +6467,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_40(
+            _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_41(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6448,10 +6481,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i13.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i13.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6475,8 +6508,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i12.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_41(
+        returnValue: _i13.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_42(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6494,8 +6527,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_41(
+            _i13.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_42(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6512,10 +6545,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i13.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6543,8 +6576,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_42(
+                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6563,8 +6596,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_42(
+                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6582,10 +6615,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i12.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i12.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i13.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6614,9 +6647,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i12.Future<
+            returnValue: _i13.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6635,9 +6668,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i12.Future<
+            returnValueForMissingStub: _i13.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6656,11 +6689,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i12
+          ) as _i13
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i12.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i13.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6676,8 +6709,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i12.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_44(
+        returnValue: _i13.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_45(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6690,8 +6723,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_44(
+            _i13.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_45(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6703,10 +6736,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetThreadRootsResponse>);
+      ) as _i13.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i12.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i13.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6720,8 +6753,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i12.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_45(
+        returnValue: _i13.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_46(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6733,8 +6766,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_45(
+            _i13.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_46(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6745,33 +6778,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i13.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i13.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i12.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i13.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i12.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i13.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i12.Future<Uri?>.value(),
-        returnValueForMissingStub: _i12.Future<Uri?>.value(),
-      ) as _i12.Future<Uri?>);
+        returnValue: _i13.Future<Uri?>.value(),
+        returnValueForMissingStub: _i13.Future<Uri?>.value(),
+      ) as _i13.Future<Uri?>);
 
   @override
-  _i12.Future<void> add3PID(
+  _i13.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6785,12 +6818,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> bind3PID(
+  _i13.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6806,12 +6839,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i13.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6825,14 +6858,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6854,8 +6887,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6871,8 +6904,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6888,10 +6921,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6915,8 +6948,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6933,8 +6966,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6951,10 +6984,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i13.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6968,14 +7001,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i13.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -6990,14 +7023,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i12.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i12.Future<_i4.IdServerUnbindResult>);
+      ) as _i13.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7019,8 +7052,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7036,8 +7069,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7053,10 +7086,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7080,8 +7113,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7098,8 +7131,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7116,16 +7149,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i13.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
+            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7133,22 +7166,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
+            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.TokenOwnerInfo>);
+      ) as _i13.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i12.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i13.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
+        returnValue: _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7156,22 +7189,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
+            _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i4.WhoIsInfo>);
+      ) as _i13.Future<_i4.WhoIsInfo>);
 
   @override
-  _i12.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i13.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
+        returnValue: _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7179,17 +7212,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
+            _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.Capabilities>);
+      ) as _i13.Future<_i4.Capabilities>);
 
   @override
-  _i12.Future<String> createRoom({
+  _i13.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7222,7 +7255,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7244,7 +7277,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7265,10 +7298,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> deleteDevices(
+  _i13.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7278,22 +7311,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.Device>?>.value(),
-      ) as _i12.Future<List<_i4.Device>?>);
+        returnValue: _i13.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.Device>?>.value(),
+      ) as _i13.Future<List<_i4.Device>?>);
 
   @override
-  _i12.Future<void> deleteDevice(
+  _i13.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7303,34 +7336,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i13.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i12.Future<_i4.Device>.value(_FakeDevice_50(
+        returnValue: _i13.Future<_i4.Device>.value(_FakeDevice_51(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.Device>.value(_FakeDevice_50(
+        returnValueForMissingStub: _i13.Future<_i4.Device>.value(_FakeDevice_51(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i12.Future<_i4.Device>);
+      ) as _i13.Future<_i4.Device>);
 
   @override
-  _i12.Future<void> updateDevice(
+  _i13.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7340,12 +7373,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i13.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7360,24 +7393,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i13.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i12.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Visibility?>.value(),
-      ) as _i12.Future<_i4.Visibility?>);
+        returnValue: _i13.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Visibility?>.value(),
+      ) as _i13.Future<_i4.Visibility?>);
 
   @override
-  _i12.Future<void> setRoomVisibilityOnDirectory(
+  _i13.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7387,30 +7420,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i13.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i13.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_51(
+        returnValue: _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_52(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7418,18 +7451,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_51(
+            _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_52(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i13.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i12.Future<void> setRoomAlias(
+  _i13.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7441,12 +7474,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetEventsResponse> getEvents({
+  _i13.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7460,7 +7493,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
+            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
           this,
           Invocation.method(
             #getEvents,
@@ -7472,7 +7505,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
+            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
           this,
           Invocation.method(
             #getEvents,
@@ -7483,10 +7516,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetEventsResponse>);
+      ) as _i13.Future<_i4.GetEventsResponse>);
 
   @override
-  _i12.Future<_i4.PeekEventsResponse> peekEvents({
+  _i13.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7501,8 +7534,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i12.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_53(
+        returnValue: _i13.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_54(
           this,
           Invocation.method(
             #peekEvents,
@@ -7514,8 +7547,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_53(
+        returnValueForMissingStub: _i13.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_54(
           this,
           Invocation.method(
             #peekEvents,
@@ -7527,16 +7560,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.PeekEventsResponse>);
+      ) as _i13.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i12.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i13.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7544,27 +7577,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i12.Future<_i4.MatrixEvent>);
+      ) as _i13.Future<_i4.MatrixEvent>);
 
   @override
-  _i12.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i13.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i12.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
-      ) as _i12.Future<List<String>>);
+        returnValue: _i13.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
+      ) as _i13.Future<List<String>>);
 
   @override
-  _i12.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i13.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7576,8 +7609,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i12.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_55(
+        returnValue: _i13.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_56(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7588,8 +7621,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_55(
+            _i13.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_56(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7599,10 +7632,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.GetKeysChangesResponse>);
+      ) as _i13.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i12.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i13.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7613,7 +7646,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
+            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
           this,
           Invocation.method(
             #claimKeys,
@@ -7622,7 +7655,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
+            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
           this,
           Invocation.method(
             #claimKeys,
@@ -7630,10 +7663,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i12.Future<_i4.ClaimKeysResponse>);
+      ) as _i13.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i12.Future<void> uploadCrossSigningKeys({
+  _i13.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7650,12 +7683,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.QueryKeysResponse> queryKeys(
+  _i13.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7666,7 +7699,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
+            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
           this,
           Invocation.method(
             #queryKeys,
@@ -7675,7 +7708,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
+            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
           this,
           Invocation.method(
             #queryKeys,
@@ -7683,10 +7716,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i12.Future<_i4.QueryKeysResponse>);
+      ) as _i13.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7694,14 +7727,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i12.Future<
+            returnValue: _i13.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i12.Future<
+            returnValueForMissingStub: _i13.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i12.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i12.Future<Map<String, int>> uploadKeys({
+  _i13.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7716,13 +7749,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i12.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i13.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i12.Future<Map<String, int>>);
+            _i13.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i13.Future<Map<String, int>>);
 
   @override
-  _i12.Future<String> knockRoom(
+  _i13.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7736,7 +7769,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7748,7 +7781,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7759,20 +7792,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i13.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i12.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i13.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i13.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i12.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i13.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7787,8 +7820,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i12.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_58(
+        returnValue: _i13.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_59(
           this,
           Invocation.method(
             #getNotifications,
@@ -7801,8 +7834,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_58(
+            _i13.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_59(
           this,
           Invocation.method(
             #getNotifications,
@@ -7814,35 +7847,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetNotificationsResponse>);
+      ) as _i13.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i12.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i13.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i12.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_59(
+        returnValue: _i13.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_60(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_59(
+        returnValueForMissingStub: _i13.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_60(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i12.Future<_i4.GetPresenceResponse>);
+      ) as _i13.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i12.Future<void> setPresence(
+  _i13.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -7856,12 +7889,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, Object?>> deleteProfileField(
+  _i13.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7874,13 +7907,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getProfileField(
+  _i13.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7893,13 +7926,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<Map<String, Object?>> setProfileField(
+  _i13.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7914,13 +7947,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i13.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7935,8 +7968,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i12.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_60(
+        returnValue: _i13.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_61(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7949,8 +7982,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_60(
+            _i13.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_61(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7962,10 +7995,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i13.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i12.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i13.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -7986,8 +8019,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i12.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_61(
+        returnValue: _i13.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_62(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8003,8 +8036,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_61(
+            _i13.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_62(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8019,25 +8052,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i13.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i12.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i13.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i12.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.Pusher>?>.value(),
-      ) as _i12.Future<List<_i4.Pusher>?>);
+        returnValue: _i13.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.Pusher>?>.value(),
+      ) as _i13.Future<List<_i4.Pusher>?>);
 
   @override
-  _i12.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i13.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
+        returnValue: _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
           this,
           Invocation.method(
             #getPushRules,
@@ -8045,24 +8078,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
+            _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.PushRuleSet>);
+      ) as _i13.Future<_i4.PushRuleSet>);
 
   @override
-  _i12.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i13.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_63(
+        returnValue: _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_64(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8070,18 +8103,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_63(
+            _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_64(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i13.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i12.Future<void> deletePushRule(
+  _i13.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8093,12 +8126,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.PushRule> getPushRule(
+  _i13.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8110,7 +8143,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
+        returnValue: _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
           this,
           Invocation.method(
             #getPushRule,
@@ -8121,7 +8154,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.PushRule>.value(_FakePushRule_64(
+            _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
           this,
           Invocation.method(
             #getPushRule,
@@ -8131,10 +8164,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.PushRule>);
+      ) as _i13.Future<_i4.PushRule>);
 
   @override
-  _i12.Future<void> setPushRule(
+  _i13.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8158,12 +8191,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<Object?>> getPushRuleActions(
+  _i13.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8175,13 +8208,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i13.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i12.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i12.Future<List<Object?>>);
+            _i13.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i13.Future<List<Object?>>);
 
   @override
-  _i12.Future<void> setPushRuleActions(
+  _i13.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8195,12 +8228,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<bool> isPushRuleEnabled(
+  _i13.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8212,12 +8245,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> setPushRuleEnabled(
+  _i13.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8231,19 +8264,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i13.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
+            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
           this,
           Invocation.method(
             #refresh,
@@ -8251,28 +8284,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
+            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i12.Future<_i4.RefreshResponse>);
+      ) as _i13.Future<_i4.RefreshResponse>);
 
   @override
-  _i12.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i13.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i12.Future<bool?>.value(),
-        returnValueForMissingStub: _i12.Future<bool?>.value(),
-      ) as _i12.Future<bool?>);
+        returnValue: _i13.Future<bool?>.value(),
+        returnValueForMissingStub: _i13.Future<bool?>.value(),
+      ) as _i13.Future<bool?>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8294,8 +8327,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8311,8 +8344,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8328,10 +8361,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8355,8 +8388,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8373,8 +8406,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8391,17 +8424,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.RequestTokenResponse>);
+      ) as _i13.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8409,23 +8442,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i13.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
+        returnValue: _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8433,17 +8466,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
+            _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeys>);
+      ) as _i13.Future<_i4.RoomKeys>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8455,8 +8488,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8467,8 +8500,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8478,10 +8511,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8493,8 +8526,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8505,8 +8538,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8516,10 +8549,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8531,7 +8564,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
+        returnValue: _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8542,7 +8575,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
+            _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8552,10 +8585,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeyBackup>);
+      ) as _i13.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8569,8 +8602,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8582,8 +8615,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8594,10 +8627,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8611,8 +8644,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8624,8 +8657,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8636,10 +8669,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i13.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8653,7 +8686,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8665,7 +8698,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8676,10 +8709,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.KeyBackupData>);
+      ) as _i13.Future<_i4.KeyBackupData>);
 
   @override
-  _i12.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8695,8 +8728,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8709,8 +8742,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8722,18 +8755,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_68(
+                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_69(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8741,18 +8774,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_68(
+                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_69(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i12.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i12.Future<String> postRoomKeysVersion(
+  _i13.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8764,7 +8797,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8775,7 +8808,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8785,29 +8818,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i13.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i13.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_69(
+        returnValue: _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_70(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8815,18 +8848,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_69(
+            _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_70(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i13.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i13.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8841,24 +8874,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i13.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i12.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i12.Future<List<String>>.value(<String>[]),
-      ) as _i12.Future<List<String>>);
+        returnValue: _i13.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
+      ) as _i13.Future<List<String>>);
 
   @override
-  _i12.Future<void> ban(
+  _i13.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8872,12 +8905,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.EventContext> getEventContext(
+  _i13.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8895,7 +8928,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
+        returnValue: _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
           this,
           Invocation.method(
             #getEventContext,
@@ -8910,7 +8943,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.EventContext>.value(_FakeEventContext_70(
+            _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
           this,
           Invocation.method(
             #getEventContext,
@@ -8924,10 +8957,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.EventContext>);
+      ) as _i13.Future<_i4.EventContext>);
 
   @override
-  _i12.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i13.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8939,7 +8972,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8950,7 +8983,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8960,20 +8993,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.MatrixEvent>);
+      ) as _i13.Future<_i4.MatrixEvent>);
 
   @override
-  _i12.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i13.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> inviteBy3PID(
+  _i13.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -8985,12 +9018,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> inviteUser(
+  _i13.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9004,12 +9037,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> joinRoomById(
+  _i13.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -9023,7 +9056,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9035,7 +9068,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9046,23 +9079,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i13.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i12.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i13.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i12.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i12.Future<Map<String, _i4.RoomMember>?>);
+            _i13.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i13.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i12.Future<void> kick(
+  _i13.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9076,12 +9109,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> leaveRoom(
+  _i13.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9091,12 +9124,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i13.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9112,12 +9145,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i12.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i12.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i12.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i13.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i13.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i13.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i12.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i13.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9139,8 +9172,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i12.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_71(
+        returnValue: _i13.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_72(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9156,8 +9189,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_71(
+        returnValueForMissingStub: _i13.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_72(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9173,10 +9206,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.GetRoomEventsResponse>);
+      ) as _i13.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i12.Future<void> setReadMarker(
+  _i13.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9192,12 +9225,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> postReceipt(
+  _i13.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9213,12 +9246,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> redactEvent(
+  _i13.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9234,12 +9267,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<void> reportRoom(
+  _i13.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9251,12 +9284,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> reportEvent(
+  _i13.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9274,12 +9307,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> sendMessage(
+  _i13.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9295,7 +9328,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9308,7 +9341,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9320,23 +9353,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i13.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i12.Future<List<_i4.MatrixEvent>>);
+            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i13.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i13.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9353,13 +9386,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<String> setRoomStateWithKey(
+  _i13.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9375,7 +9408,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9388,7 +9421,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9400,10 +9433,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<void> unban(
+  _i13.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9417,12 +9450,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> upgradeRoom(
+  _i13.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9436,7 +9469,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9448,7 +9481,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9459,10 +9492,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.SearchResults> search(
+  _i13.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9472,7 +9505,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
+        returnValue: _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
           this,
           Invocation.method(
             #search,
@@ -9481,7 +9514,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
+            _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
           this,
           Invocation.method(
             #search,
@@ -9489,10 +9522,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i12.Future<_i4.SearchResults>);
+      ) as _i13.Future<_i4.SearchResults>);
 
   @override
-  _i12.Future<_i4.SyncUpdate> sync({
+  _i13.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9513,7 +9546,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #sync,
@@ -9529,7 +9562,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_12(
+            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
           this,
           Invocation.method(
             #sync,
@@ -9544,22 +9577,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i12.Future<_i4.SyncUpdate>);
+      ) as _i13.Future<_i4.SyncUpdate>);
 
   @override
-  _i12.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i13.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i12.Future<List<_i4.Location>>);
+            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i13.Future<List<_i4.Location>>);
 
   @override
-  _i12.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i13.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9569,21 +9602,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i12.Future<List<_i4.Location>>);
+            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i13.Future<List<_i4.Location>>);
 
   @override
-  _i12.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i13.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_73(
+        returnValue: _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_74(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9591,45 +9624,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_73(
+            _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_74(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i12.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i13.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i12.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i13.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i12.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i12.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9640,13 +9673,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i12.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i12.Future<List<_i4.ThirdPartyUser>>);
+            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i12.Future<Map<String, Object?>> getAccountData(
+  _i13.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9659,13 +9692,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> setAccountData(
+  _i13.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9679,12 +9712,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> defineFilter(
+  _i13.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9696,7 +9729,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9707,7 +9740,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9717,10 +9750,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.Filter> getFilter(
+  _i13.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9732,7 +9765,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
+        returnValue: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
           this,
           Invocation.method(
             #getFilter,
@@ -9742,7 +9775,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.Filter>.value(_FakeFilter_17(
+        returnValueForMissingStub: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
           this,
           Invocation.method(
             #getFilter,
@@ -9752,10 +9785,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.Filter>);
+      ) as _i13.Future<_i4.Filter>);
 
   @override
-  _i12.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i13.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9768,7 +9801,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
+            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9779,7 +9812,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
+            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9789,10 +9822,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i12.Future<_i4.OpenIdCredentials>);
+      ) as _i13.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i12.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i13.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9807,13 +9840,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<void> setAccountDataPerRoom(
+  _i13.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9829,12 +9862,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i13.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9846,12 +9879,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i12.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i12.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i12.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i13.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i13.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i13.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i12.Future<void> deleteRoomTag(
+  _i13.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9865,12 +9898,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setRoomTag(
+  _i13.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9886,12 +9919,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i13.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9901,8 +9934,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i12.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_75(
+        returnValue: _i13.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_76(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9911,8 +9944,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_75(
+            _i13.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_76(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9920,10 +9953,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i12.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i13.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> reportUser(
+  _i13.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9936,40 +9969,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 
   @override
-  _i12.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i13.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i12.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_76(
+        returnValue: _i13.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_77(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i12.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_76(
+        returnValueForMissingStub: _i13.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_77(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.CreateContentResponse>);
+      ) as _i13.Future<_i4.CreateContentResponse>);
 
   @override
-  _i12.Future<Map<String, Object?>> uploadContentToMXC(
+  _i13.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i22.Uint8List? body, {
+    _i23.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -9987,10 +10020,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i12.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i12.Future<Map<String, Object?>>);
+            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i13.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [Event].
@@ -10000,11 +10033,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   _i4.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_14(
+        returnValue: _FakeUser_15(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_14(
+        returnValueForMissingStub: _FakeUser_15(
           this,
           Invocation.getter(#sender),
         ),
@@ -10013,11 +10046,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   _i4.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_14(
+        returnValue: _FakeUser_15(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_14(
+        returnValueForMissingStub: _FakeUser_15(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10026,11 +10059,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   _i4.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_77(
+        returnValue: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_77(
+        returnValueForMissingStub: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
@@ -10053,11 +10086,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   _i4.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_14(
+        returnValue: _FakeUser_15(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_14(
+        returnValueForMissingStub: _FakeUser_15(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10066,11 +10099,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10079,11 +10112,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10092,11 +10125,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10105,11 +10138,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10118,11 +10151,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10187,11 +10220,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10200,11 +10233,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10257,11 +10290,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10270,11 +10303,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   DateTime get originServerTs => (super.noSuchMethod(
         Invocation.getter(#originServerTs),
-        returnValue: _FakeDateTime_10(
+        returnValue: _FakeDateTime_11(
           this,
           Invocation.getter(#originServerTs),
         ),
-        returnValueForMissingStub: _FakeDateTime_10(
+        returnValueForMissingStub: _FakeDateTime_11(
           this,
           Invocation.getter(#originServerTs),
         ),
@@ -10346,11 +10379,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10368,11 +10401,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10404,14 +10437,14 @@ class MockEvent extends _i1.Mock implements _i4.Event {
       );
 
   @override
-  _i12.Future<_i4.User?> fetchSenderUser() => (super.noSuchMethod(
+  _i13.Future<_i4.User?> fetchSenderUser() => (super.noSuchMethod(
         Invocation.method(
           #fetchSenderUser,
           [],
         ),
-        returnValue: _i12.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.User?>.value(),
-      ) as _i12.Future<_i4.User?>);
+        returnValue: _i13.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.User?>.value(),
+      ) as _i13.Future<_i4.User?>);
 
   @override
   Map<String, dynamic> toJson() => (super.noSuchMethod(
@@ -10433,38 +10466,38 @@ class MockEvent extends _i1.Mock implements _i4.Event {
       );
 
   @override
-  _i12.Future<bool> remove() => (super.noSuchMethod(
+  _i13.Future<bool> remove() => (super.noSuchMethod(
         Invocation.method(
           #remove,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<void> cancelSend() => (super.noSuchMethod(
+  _i13.Future<void> cancelSend() => (super.noSuchMethod(
         Invocation.method(
           #cancelSend,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String?> sendAgain({String? txid}) => (super.noSuchMethod(
+  _i13.Future<String?> sendAgain({String? txid}) => (super.noSuchMethod(
         Invocation.method(
           #sendAgain,
           [],
           {#txid: txid},
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<String?> redactEvent({
+  _i13.Future<String?> redactEvent({
     String? reason,
     String? txid,
   }) =>
@@ -10477,30 +10510,30 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #txid: txid,
           },
         ),
-        returnValue: _i12.Future<String?>.value(),
-        returnValueForMissingStub: _i12.Future<String?>.value(),
-      ) as _i12.Future<String?>);
+        returnValue: _i13.Future<String?>.value(),
+        returnValueForMissingStub: _i13.Future<String?>.value(),
+      ) as _i13.Future<String?>);
 
   @override
-  _i12.Future<_i4.Event?> getReplyEvent(_i4.Timeline? timeline) =>
+  _i13.Future<_i4.Event?> getReplyEvent(_i4.Timeline? timeline) =>
       (super.noSuchMethod(
         Invocation.method(
           #getReplyEvent,
           [timeline],
         ),
-        returnValue: _i12.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i12.Future<_i4.Event?>.value(),
-      ) as _i12.Future<_i4.Event?>);
+        returnValue: _i13.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
+      ) as _i13.Future<_i4.Event?>);
 
   @override
-  _i12.Future<void> requestKey() => (super.noSuchMethod(
+  _i13.Future<void> requestKey() => (super.noSuchMethod(
         Invocation.method(
           #requestKey,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   Uri? attachmentOrThumbnailMxcUrl({bool? getThumbnail = false}) =>
@@ -10514,7 +10547,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
       ) as Uri?);
 
   @override
-  _i12.Future<Uri?> getAttachmentUri({
+  _i13.Future<Uri?> getAttachmentUri({
     bool? getThumbnail = false,
     bool? useThumbnailMxcUrl = false,
     double? width = 800.0,
@@ -10537,9 +10570,9 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #animated: animated,
           },
         ),
-        returnValue: _i12.Future<Uri?>.value(),
-        returnValueForMissingStub: _i12.Future<Uri?>.value(),
-      ) as _i12.Future<Uri?>);
+        returnValue: _i13.Future<Uri?>.value(),
+        returnValueForMissingStub: _i13.Future<Uri?>.value(),
+      ) as _i13.Future<Uri?>);
 
   @override
   Uri? getAttachmentUrl({
@@ -10569,21 +10602,21 @@ class MockEvent extends _i1.Mock implements _i4.Event {
       ) as Uri?);
 
   @override
-  _i12.Future<bool> isAttachmentInLocalStore({bool? getThumbnail = false}) =>
+  _i13.Future<bool> isAttachmentInLocalStore({bool? getThumbnail = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #isAttachmentInLocalStore,
           [],
           {#getThumbnail: getThumbnail},
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<_i4.MatrixFile> downloadAndDecryptAttachment({
+  _i13.Future<_i4.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i12.Future<_i22.Uint8List> Function(Uri)? downloadCallback,
+    _i13.Future<_i23.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10598,7 +10631,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i12.Future<_i4.MatrixFile>.value(_FakeMatrixFile_78(
+        returnValue: _i13.Future<_i4.MatrixFile>.value(_FakeMatrixFile_79(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10612,7 +10645,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.MatrixFile>.value(_FakeMatrixFile_78(
+            _i13.Future<_i4.MatrixFile>.value(_FakeMatrixFile_79(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10625,10 +10658,10 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         )),
-      ) as _i12.Future<_i4.MatrixFile>);
+      ) as _i13.Future<_i4.MatrixFile>);
 
   @override
-  _i12.Future<String> calcLocalizedBody(
+  _i13.Future<String> calcLocalizedBody(
     _i4.MatrixLocalizations? i18n, {
     bool? withSenderNamePrefix = false,
     bool? hideReply = false,
@@ -10648,7 +10681,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10663,7 +10696,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10677,7 +10710,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
   String getLocalizedBody(
@@ -10700,7 +10733,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10714,7 +10747,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10751,7 +10784,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10765,7 +10798,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10799,7 +10832,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10812,7 +10845,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10888,14 +10921,14 @@ class MockEvent extends _i1.Mock implements _i4.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_79(
+        returnValue: _FakeEvent_80(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_79(
+        returnValueForMissingStub: _FakeEvent_80(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -10912,11 +10945,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   _i4.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_77(
+        returnValue: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_77(
+        returnValueForMissingStub: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
@@ -10925,11 +10958,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -10950,19 +10983,19 @@ class MockUser extends _i1.Mock implements _i4.User {
       ) as _i4.Membership);
 
   @override
-  _i12.Future<_i4.CachedPresence> get currentPresence => (super.noSuchMethod(
+  _i13.Future<_i4.CachedPresence> get currentPresence => (super.noSuchMethod(
         Invocation.getter(#currentPresence),
         returnValue:
-            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.getter(#currentPresence),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.getter(#currentPresence),
         )),
-      ) as _i12.Future<_i4.CachedPresence>);
+      ) as _i13.Future<_i4.CachedPresence>);
 
   @override
   bool get canBan => (super.noSuchMethod(
@@ -10995,11 +11028,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11024,11 +11057,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11046,11 +11079,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11097,7 +11130,7 @@ class MockUser extends _i1.Mock implements _i4.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11109,7 +11142,7 @@ class MockUser extends _i1.Mock implements _i4.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11124,47 +11157,47 @@ class MockUser extends _i1.Mock implements _i4.User {
       ) as String);
 
   @override
-  _i12.Future<void> kick() => (super.noSuchMethod(
+  _i13.Future<void> kick() => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> ban() => (super.noSuchMethod(
+  _i13.Future<void> ban() => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> unban() => (super.noSuchMethod(
+  _i13.Future<void> unban() => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setPower(int? power) => (super.noSuchMethod(
+  _i13.Future<void> setPower(int? power) => (super.noSuchMethod(
         Invocation.method(
           #setPower,
           [power],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<String> startDirectChat({
+  _i13.Future<String> startDirectChat({
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
     bool? waitForSync = true,
@@ -11179,7 +11212,7 @@ class MockUser extends _i1.Mock implements _i4.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i12.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11192,7 +11225,7 @@ class MockUser extends _i1.Mock implements _i4.User {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<String>.value(_i15.dummyValue<String>(
+            _i13.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11204,16 +11237,16 @@ class MockUser extends _i1.Mock implements _i4.User {
             },
           ),
         )),
-      ) as _i12.Future<String>);
+      ) as _i13.Future<String>);
 
   @override
-  _i12.Future<_i4.CachedPresence> fetchCurrentPresence() => (super.noSuchMethod(
+  _i13.Future<_i4.CachedPresence> fetchCurrentPresence() => (super.noSuchMethod(
         Invocation.method(
           #fetchCurrentPresence,
           [],
         ),
         returnValue:
-            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -11221,14 +11254,14 @@ class MockUser extends _i1.Mock implements _i4.User {
           ),
         )),
         returnValueForMissingStub:
-            _i12.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.method(
             #fetchCurrentPresence,
             [],
           ),
         )),
-      ) as _i12.Future<_i4.CachedPresence>);
+      ) as _i13.Future<_i4.CachedPresence>);
 
   @override
   Map<String, Object?> toJson() => (super.noSuchMethod(
@@ -11244,7 +11277,7 @@ class MockUser extends _i1.Mock implements _i4.User {
 /// A class which mocks [CallService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCallService extends _i1.Mock implements _i23.CallService {
+class MockCallService extends _i1.Mock implements _i24.CallService {
   @override
   _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -11266,36 +11299,36 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       ) as bool);
 
   @override
-  _i24.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
+  _i25.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
         Invocation.getter(#httpPostForTest),
         returnValue: (
-          _i11.Client httpClient,
+          _i12.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i12.Future<_i11.Response>.value(_FakeResponse_80(
+            _i13.Future<_i12.Response>.value(_FakeResponse_81(
           this,
           Invocation.getter(#httpPostForTest),
         )),
         returnValueForMissingStub: (
-          _i11.Client httpClient,
+          _i12.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i12.Future<_i11.Response>.value(_FakeResponse_80(
+            _i13.Future<_i12.Response>.value(_FakeResponse_81(
           this,
           Invocation.getter(#httpPostForTest),
         )),
-      ) as _i24.HttpPostFunction);
+      ) as _i25.HttpPostFunction);
 
   @override
-  List<_i25.RemoteParticipant> get participants => (super.noSuchMethod(
+  List<_i26.RemoteParticipant> get participants => (super.noSuchMethod(
         Invocation.getter(#participants),
-        returnValue: <_i25.RemoteParticipant>[],
-        returnValueForMissingStub: <_i25.RemoteParticipant>[],
-      ) as List<_i25.RemoteParticipant>);
+        returnValue: <_i26.RemoteParticipant>[],
+        returnValueForMissingStub: <_i26.RemoteParticipant>[],
+      ) as List<_i26.RemoteParticipant>);
 
   @override
   bool get isMicEnabled => (super.noSuchMethod(
@@ -11326,14 +11359,14 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       ) as bool);
 
   @override
-  List<_i25.Participant<_i25.TrackPublication<_i25.Track>>>
+  List<_i26.Participant<_i26.TrackPublication<_i26.Track>>>
       get activeSpeakers => (super.noSuchMethod(
             Invocation.getter(#activeSpeakers),
-            returnValue: <_i25
-                .Participant<_i25.TrackPublication<_i25.Track>>>[],
-            returnValueForMissingStub: <_i25
-                .Participant<_i25.TrackPublication<_i25.Track>>>[],
-          ) as List<_i25.Participant<_i25.TrackPublication<_i25.Track>>>);
+            returnValue: <_i26
+                .Participant<_i26.TrackPublication<_i26.Track>>>[],
+            returnValueForMissingStub: <_i26
+                .Participant<_i26.TrackPublication<_i26.Track>>>[],
+          ) as List<_i26.Participant<_i26.TrackPublication<_i26.Track>>>);
 
   @override
   bool get isCallingAvailable => (super.noSuchMethod(
@@ -11343,11 +11376,11 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       ) as bool);
 
   @override
-  List<_i26.CallParticipant> get allParticipants => (super.noSuchMethod(
+  List<_i27.CallParticipant> get allParticipants => (super.noSuchMethod(
         Invocation.getter(#allParticipants),
-        returnValue: <_i26.CallParticipant>[],
-        returnValueForMissingStub: <_i26.CallParticipant>[],
-      ) as List<_i26.CallParticipant>);
+        returnValue: <_i27.CallParticipant>[],
+        returnValueForMissingStub: <_i27.CallParticipant>[],
+      ) as List<_i27.CallParticipant>);
 
   @override
   bool get isSpeakerOn => (super.noSuchMethod(
@@ -11357,29 +11390,29 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       ) as bool);
 
   @override
-  _i12.Stream<_i27.IncomingCallInfo> get incomingCallStream =>
+  _i13.Stream<_i28.IncomingCallInfo> get incomingCallStream =>
       (super.noSuchMethod(
         Invocation.getter(#incomingCallStream),
-        returnValue: _i12.Stream<_i27.IncomingCallInfo>.empty(),
-        returnValueForMissingStub: _i12.Stream<_i27.IncomingCallInfo>.empty(),
-      ) as _i12.Stream<_i27.IncomingCallInfo>);
+        returnValue: _i13.Stream<_i28.IncomingCallInfo>.empty(),
+        returnValueForMissingStub: _i13.Stream<_i28.IncomingCallInfo>.empty(),
+      ) as _i13.Stream<_i28.IncomingCallInfo>);
 
   @override
-  _i12.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
+  _i13.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
         Invocation.getter(#nativeAcceptedCallStream),
-        returnValue: _i12.Stream<String>.empty(),
-        returnValueForMissingStub: _i12.Stream<String>.empty(),
-      ) as _i12.Stream<String>);
+        returnValue: _i13.Stream<String>.empty(),
+        returnValueForMissingStub: _i13.Stream<String>.empty(),
+      ) as _i13.Stream<String>);
 
   @override
-  _i28.KoheraCallState get callState => (super.noSuchMethod(
+  _i29.KoheraCallState get callState => (super.noSuchMethod(
         Invocation.getter(#callState),
-        returnValue: _i28.KoheraCallState.idle,
-        returnValueForMissingStub: _i28.KoheraCallState.idle,
-      ) as _i28.KoheraCallState);
+        returnValue: _i29.KoheraCallState.idle,
+        returnValueForMissingStub: _i29.KoheraCallState.idle,
+      ) as _i29.KoheraCallState);
 
   @override
-  set preferencesService(_i29.PreferencesService? prefs) => super.noSuchMethod(
+  set preferencesService(_i30.PreferencesService? prefs) => super.noSuchMethod(
         Invocation.setter(
           #preferencesService,
           prefs,
@@ -11388,7 +11421,7 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  set ringtoneService(_i30.RingtoneService? service) => super.noSuchMethod(
+  set ringtoneService(_i31.RingtoneService? service) => super.noSuchMethod(
         Invocation.setter(
           #ringtoneService,
           service,
@@ -11397,7 +11430,7 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  set roomFactoryForTest(_i24.LiveKitRoomFactory? factory) =>
+  set roomFactoryForTest(_i25.LiveKitRoomFactory? factory) =>
       super.noSuchMethod(
         Invocation.setter(
           #roomFactoryForTest,
@@ -11407,7 +11440,7 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  set httpPostForTest(_i24.HttpPostFunction? fn) => super.noSuchMethod(
+  set httpPostForTest(_i25.HttpPostFunction? fn) => super.noSuchMethod(
         Invocation.setter(
           #httpPostForTest,
           fn,
@@ -11441,27 +11474,27 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  _i12.Future<void> toggleMicrophone() => (super.noSuchMethod(
+  _i13.Future<void> toggleMicrophone() => (super.noSuchMethod(
         Invocation.method(
           #toggleMicrophone,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> toggleCamera() => (super.noSuchMethod(
+  _i13.Future<void> toggleCamera() => (super.noSuchMethod(
         Invocation.method(
           #toggleCamera,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> toggleScreenShare({
+  _i13.Future<void> toggleScreenShare({
     String? sourceId,
     bool? captureScreenAudio = false,
   }) =>
@@ -11474,39 +11507,39 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
             #captureScreenAudio: captureScreenAudio,
           },
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> toggleScreenAudio() => (super.noSuchMethod(
+  _i13.Future<void> toggleScreenAudio() => (super.noSuchMethod(
         Invocation.method(
           #toggleScreenAudio,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
+  _i13.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
         Invocation.method(
           #setOutputVolume,
           [volume],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> toggleSpeaker() => (super.noSuchMethod(
+  _i13.Future<void> toggleSpeaker() => (super.noSuchMethod(
         Invocation.method(
           #toggleSpeaker,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void setVoipPushHandlesCallKit(bool? value) => super.noSuchMethod(
@@ -11536,7 +11569,7 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i16.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -11564,36 +11597,36 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  _i12.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
+  _i13.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #joinCall,
           [roomId],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> leaveCall() => (super.noSuchMethod(
+  _i13.Future<void> leaveCall() => (super.noSuchMethod(
         Invocation.method(
           #leaveCall,
           [],
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
-  _i12.Future<void> acceptCall({bool? withVideo = false}) =>
+  _i13.Future<void> acceptCall({bool? withVideo = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #acceptCall,
           [],
           {#withVideo: withVideo},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   void declineCall() => super.noSuchMethod(
@@ -11615,9 +11648,9 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  _i12.Future<void> initiateCall(
+  _i13.Future<void> initiateCall(
     String? roomId, {
-    _i27.CallType? type = _i27.CallType.voice,
+    _i28.CallType? type = _i28.CallType.voice,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -11625,9 +11658,9 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
           [roomId],
           {#type: type},
         ),
-        returnValue: _i12.Future<void>.value(),
-        returnValueForMissingStub: _i12.Future<void>.value(),
-      ) as _i12.Future<void>);
+        returnValue: _i13.Future<void>.value(),
+        returnValueForMissingStub: _i13.Future<void>.value(),
+      ) as _i13.Future<void>);
 
   @override
   bool roomHasActiveCall(String? roomId) => (super.noSuchMethod(
@@ -11720,7 +11753,7 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -11729,7 +11762,7 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -11738,17 +11771,17 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  _i12.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i17.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -11759,7 +11792,7 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i17.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -11796,26 +11829,26 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  _i12.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
-  _i12.Future<bool> didPushRouteInformation(
-          _i18.RouteInformation? routeInformation) =>
+  _i13.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i12.Future<bool>.value(false),
-        returnValueForMissingStub: _i12.Future<bool>.value(false),
-      ) as _i12.Future<bool>);
+        returnValue: _i13.Future<bool>.value(false),
+        returnValueForMissingStub: _i13.Future<bool>.value(false),
+      ) as _i13.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -11845,7 +11878,7 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  void didChangeLocales(List<_i16.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -11854,7 +11887,7 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  void didChangeViewFocus(_i16.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -11863,16 +11896,16 @@ class MockCallService extends _i1.Mock implements _i23.CallService {
       );
 
   @override
-  _i12.Future<_i16.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i13.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
+            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i12.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
-      ) as _i12.Future<_i16.AppExitResponse>);
+            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i13.Future<_i17.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/space_action_dialog_test.mocks.dart
+++ b/test/widgets/space_action_dialog_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,14 +23,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/src/utils/space_child.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -821,8 +822,9 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_73(
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -831,9 +833,19 @@ class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_74 extends _i1.SmartFake
+class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_74(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_75 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_74(
+  _FakeLatestReceiptState_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,8 +854,8 @@ class _FakeLatestReceiptState_74 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_75(
+class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,8 +864,8 @@ class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_76(
+class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -880,12 +892,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1005,11 +1017,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1046,11 +1058,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1080,11 +1092,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1093,11 +1105,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1383,34 +1395,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1566,7 +1578,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1855,14 +1867,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2250,8 +2262,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2267,8 +2279,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2309,7 +2321,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2325,7 +2337,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2374,7 +2386,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2395,7 +2407,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2498,7 +2510,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2516,7 +2528,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3035,7 +3047,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3387,7 +3399,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3401,7 +3413,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3552,7 +3564,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4930,7 +4942,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4952,7 +4964,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5446,7 +5458,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5458,7 +5470,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6466,7 +6478,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6477,7 +6489,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6725,7 +6737,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6737,7 +6749,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6997,7 +7009,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7010,7 +7022,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7077,7 +7089,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7090,7 +7102,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7138,7 +7150,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7150,7 +7162,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7398,7 +7410,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7409,7 +7421,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7671,7 +7683,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7698,7 +7710,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7728,11 +7740,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7831,6 +7843,19 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7910,6 +7935,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7954,7 +7988,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8048,7 +8082,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8057,7 +8091,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8076,7 +8110,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8087,7 +8121,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8135,7 +8169,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8173,7 +8207,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8182,7 +8216,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8191,16 +8225,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8228,11 +8262,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8262,11 +8296,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_73(
+        returnValue: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_73(
+        returnValueForMissingStub: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
@@ -8319,11 +8353,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8359,11 +8393,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8379,11 +8413,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8392,11 +8426,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8439,11 +8473,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8486,11 +8520,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_74(
+        returnValue: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_74(
+        returnValueForMissingStub: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8702,18 +8736,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i22.SpaceParent>[],
+        returnValueForMissingStub: <_i22.SpaceParent>[],
+      ) as List<_i22.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i22.SpaceChild>[],
+        returnValueForMissingStub: <_i22.SpaceChild>[],
+      ) as List<_i22.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8880,14 +8914,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8935,7 +8969,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8943,7 +8977,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8958,7 +8992,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8966,7 +9000,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9050,7 +9084,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9058,7 +9092,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9300,7 +9334,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9311,7 +9345,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9400,15 +9434,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i22.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i22.TimelineChunk?>.value(),
-      ) as _i5.Future<_i22.TimelineChunk?>);
+        returnValue: _i5.Future<_i23.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i23.TimelineChunk?>.value(),
+      ) as _i5.Future<_i23.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9449,7 +9483,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9466,7 +9500,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9530,14 +9564,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9553,14 +9587,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9616,7 +9650,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9624,7 +9658,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/space_context_menu_test.mocks.dart
+++ b/test/widgets/space_context_menu_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,14 +23,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/src/utils/space_child.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -821,8 +822,9 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_73(
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -831,9 +833,19 @@ class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_74 extends _i1.SmartFake
+class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_74(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_75 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_74(
+  _FakeLatestReceiptState_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,8 +854,8 @@ class _FakeLatestReceiptState_74 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_75(
+class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,8 +864,8 @@ class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_76(
+class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -862,8 +874,8 @@ class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_77 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_77(
+class _FakeRoom_78 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -872,8 +884,8 @@ class _FakeRoom_77 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeMatrixFile_78 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_78(
+class _FakeMatrixFile_79 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -882,8 +894,8 @@ class _FakeMatrixFile_78 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_79 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_79(
+class _FakeEvent_80 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -910,12 +922,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1035,11 +1047,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1076,11 +1088,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1110,11 +1122,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1123,11 +1135,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1413,34 +1425,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1596,7 +1608,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1885,14 +1897,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2280,8 +2292,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2297,8 +2309,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2339,7 +2351,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2355,7 +2367,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2404,7 +2416,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2425,7 +2437,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2528,7 +2540,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2546,7 +2558,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3065,7 +3077,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3417,7 +3429,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3431,7 +3443,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3582,7 +3594,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4960,7 +4972,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4982,7 +4994,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5476,7 +5488,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5488,7 +5500,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6496,7 +6508,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6507,7 +6519,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6755,7 +6767,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6767,7 +6779,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7027,7 +7039,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7040,7 +7052,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7107,7 +7119,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7120,7 +7132,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7168,7 +7180,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7180,7 +7192,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7428,7 +7440,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7439,7 +7451,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7701,7 +7713,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7728,7 +7740,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7758,11 +7770,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7861,6 +7873,19 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7940,6 +7965,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7984,7 +8018,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8078,7 +8112,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8087,7 +8121,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8106,7 +8140,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8117,7 +8151,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8165,7 +8199,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8203,7 +8237,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8212,7 +8246,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8221,16 +8255,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8258,11 +8292,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8292,11 +8326,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_73(
+        returnValue: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_73(
+        returnValueForMissingStub: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
@@ -8349,11 +8383,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8389,11 +8423,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8409,11 +8443,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8422,11 +8456,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8469,11 +8503,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8516,11 +8550,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_74(
+        returnValue: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_74(
+        returnValueForMissingStub: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8732,18 +8766,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i22.SpaceParent>[],
+        returnValueForMissingStub: <_i22.SpaceParent>[],
+      ) as List<_i22.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i22.SpaceChild>[],
+        returnValueForMissingStub: <_i22.SpaceChild>[],
+      ) as List<_i22.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8910,14 +8944,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8965,7 +8999,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8973,7 +9007,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8988,7 +9022,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8996,7 +9030,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9080,7 +9114,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9088,7 +9122,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9330,7 +9364,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9341,7 +9375,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9430,15 +9464,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i22.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i22.TimelineChunk?>.value(),
-      ) as _i5.Future<_i22.TimelineChunk?>);
+        returnValue: _i5.Future<_i23.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i23.TimelineChunk?>.value(),
+      ) as _i5.Future<_i23.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9479,7 +9513,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9496,7 +9530,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9560,14 +9594,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9583,14 +9617,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9646,7 +9680,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9654,7 +9688,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9966,11 +10000,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.getter(#sender),
         ),
@@ -9979,11 +10013,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -9992,11 +10026,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_77(
+        returnValue: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_77(
+        returnValueForMissingStub: _FakeRoom_78(
           this,
           Invocation.getter(#room),
         ),
@@ -10019,11 +10053,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10032,11 +10066,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10045,11 +10079,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10058,11 +10092,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10071,11 +10105,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10084,11 +10118,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10153,11 +10187,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10166,11 +10200,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10223,11 +10257,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10312,11 +10346,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10334,11 +10368,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10549,7 +10583,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i16.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i17.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10564,7 +10598,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_78(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_79(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10578,7 +10612,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_78(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_79(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10614,7 +10648,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10629,7 +10663,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10666,7 +10700,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10680,7 +10714,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10717,7 +10751,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10731,7 +10765,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10765,7 +10799,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10778,7 +10812,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10854,14 +10888,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_79(
+        returnValue: _FakeEvent_80(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_79(
+        returnValueForMissingStub: _FakeEvent_80(
           this,
           Invocation.method(
             #getDisplayEvent,

--- a/test/widgets/space_details_panel_test.mocks.dart
+++ b/test/widgets/space_details_panel_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,14 +23,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/src/utils/space_child.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -821,8 +822,9 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_73(
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -831,9 +833,19 @@ class _FakeRoomSummary_73 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_74 extends _i1.SmartFake
+class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_74(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_75 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_74(
+  _FakeLatestReceiptState_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,8 +854,8 @@ class _FakeLatestReceiptState_74 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_75(
+class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,8 +864,8 @@ class _FakeTimeline_75 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_76 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_76(
+class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -880,12 +892,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1005,11 +1017,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1046,11 +1058,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1080,11 +1092,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1093,11 +1105,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1383,34 +1395,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1566,7 +1578,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1855,14 +1867,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2250,8 +2262,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2267,8 +2279,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2309,7 +2321,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2325,7 +2337,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2374,7 +2386,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2395,7 +2407,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2498,7 +2510,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2516,7 +2528,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3035,7 +3047,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3387,7 +3399,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3401,7 +3413,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3552,7 +3564,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4930,7 +4942,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4952,7 +4964,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5446,7 +5458,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5458,7 +5470,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6466,7 +6478,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6477,7 +6489,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6725,7 +6737,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6737,7 +6749,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6997,7 +7009,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7010,7 +7022,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7077,7 +7089,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7090,7 +7102,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7138,7 +7150,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7150,7 +7162,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7398,7 +7410,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7409,7 +7421,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7671,7 +7683,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7698,7 +7710,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7728,11 +7740,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7831,6 +7843,19 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7910,6 +7935,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7954,7 +7988,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8048,7 +8082,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8057,7 +8091,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8076,7 +8110,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8087,7 +8121,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8135,7 +8169,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8173,7 +8207,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8182,7 +8216,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8191,16 +8225,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8228,11 +8262,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8262,11 +8296,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_73(
+        returnValue: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_73(
+        returnValueForMissingStub: _FakeRoomSummary_74(
           this,
           Invocation.getter(#summary),
         ),
@@ -8319,11 +8353,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8359,11 +8393,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8379,11 +8413,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8392,11 +8426,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8439,11 +8473,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8486,11 +8520,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_74(
+        returnValue: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_74(
+        returnValueForMissingStub: _FakeLatestReceiptState_75(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8702,18 +8736,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i22.SpaceParent>[],
+        returnValueForMissingStub: <_i22.SpaceParent>[],
+      ) as List<_i22.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i22.SpaceChild>[],
+        returnValueForMissingStub: <_i22.SpaceChild>[],
+      ) as List<_i22.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8880,14 +8914,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8935,7 +8969,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8943,7 +8977,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8958,7 +8992,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -8966,7 +9000,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9050,7 +9084,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9058,7 +9092,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9300,7 +9334,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9311,7 +9345,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9400,15 +9434,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i22.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i22.TimelineChunk?>.value(),
-      ) as _i5.Future<_i22.TimelineChunk?>);
+        returnValue: _i5.Future<_i23.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i23.TimelineChunk?>.value(),
+      ) as _i5.Future<_i23.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9449,7 +9483,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9466,7 +9500,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_75(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
           this,
           Invocation.method(
             #getTimeline,
@@ -9530,14 +9564,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9553,14 +9587,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_76(
+        returnValue: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_76(
+        returnValueForMissingStub: _FakeUser_77(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9616,7 +9650,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9624,7 +9658,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/space_discovery_search_test.mocks.dart
+++ b/test/widgets/space_discovery_search_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,12 +23,12 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -819,6 +820,17 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -837,12 +849,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -962,11 +974,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1003,11 +1015,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1037,11 +1049,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1050,11 +1062,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1340,34 +1352,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1523,7 +1535,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1812,14 +1824,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2207,8 +2219,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2224,8 +2236,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2266,7 +2278,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2282,7 +2294,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2331,7 +2343,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2352,7 +2364,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2455,7 +2467,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2473,7 +2485,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2992,7 +3004,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3344,7 +3356,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3358,7 +3370,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3509,7 +3521,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4887,7 +4899,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4909,7 +4921,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5403,7 +5415,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5415,7 +5427,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6423,7 +6435,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6434,7 +6446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6682,7 +6694,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6694,7 +6706,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6954,7 +6966,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6967,7 +6979,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7034,7 +7046,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7047,7 +7059,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7095,7 +7107,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7107,7 +7119,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7355,7 +7367,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7366,7 +7378,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7628,7 +7640,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7655,7 +7667,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7685,11 +7697,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7788,6 +7800,19 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7867,6 +7892,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7911,7 +7945,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8005,7 +8039,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8014,7 +8048,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8033,7 +8067,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8044,7 +8078,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8092,7 +8126,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8130,7 +8164,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8139,7 +8173,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8148,16 +8182,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/space_discovery_server_test.mocks.dart
+++ b/test/widgets/space_discovery_server_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,12 +23,12 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -819,6 +820,17 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -837,12 +849,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -962,11 +974,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1003,11 +1015,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1037,11 +1049,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1050,11 +1062,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1340,34 +1352,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1523,7 +1535,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1812,14 +1824,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2207,8 +2219,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2224,8 +2236,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2266,7 +2278,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2282,7 +2294,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2331,7 +2343,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2352,7 +2364,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2455,7 +2467,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2473,7 +2485,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2992,7 +3004,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3344,7 +3356,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3358,7 +3370,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3509,7 +3521,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4887,7 +4899,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4909,7 +4921,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5403,7 +5415,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5415,7 +5427,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6423,7 +6435,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6434,7 +6446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6682,7 +6694,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6694,7 +6706,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6954,7 +6966,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6967,7 +6979,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7034,7 +7046,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7047,7 +7059,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7095,7 +7107,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7107,7 +7119,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7355,7 +7367,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7366,7 +7378,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7628,7 +7640,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7655,7 +7667,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7685,11 +7697,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7788,6 +7800,19 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7867,6 +7892,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7911,7 +7945,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8005,7 +8039,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8014,7 +8048,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8033,7 +8067,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8044,7 +8078,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8092,7 +8126,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8130,7 +8164,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8139,7 +8173,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8148,16 +8182,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/space_discovery_servers_edit_test.mocks.dart
+++ b/test/widgets/space_discovery_servers_edit_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,12 +23,12 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -819,6 +820,17 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -837,12 +849,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -962,11 +974,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1003,11 +1015,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1037,11 +1049,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1050,11 +1062,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1340,34 +1352,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1523,7 +1535,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1812,14 +1824,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2207,8 +2219,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2224,8 +2236,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2266,7 +2278,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2282,7 +2294,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2331,7 +2343,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2352,7 +2364,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2455,7 +2467,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2473,7 +2485,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2992,7 +3004,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3344,7 +3356,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3358,7 +3370,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3509,7 +3521,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4887,7 +4899,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4909,7 +4921,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5403,7 +5415,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5415,7 +5427,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6423,7 +6435,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6434,7 +6446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6682,7 +6694,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6694,7 +6706,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6954,7 +6966,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6967,7 +6979,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7034,7 +7046,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7047,7 +7059,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7095,7 +7107,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7107,7 +7119,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7355,7 +7367,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7366,7 +7378,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7628,7 +7640,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7655,7 +7667,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7685,11 +7697,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7788,6 +7800,19 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7867,6 +7892,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7911,7 +7945,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8005,7 +8039,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8014,7 +8048,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8033,7 +8067,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8044,7 +8078,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8092,7 +8126,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8130,7 +8164,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8139,7 +8173,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8148,16 +8182,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/verification_request_listener_test.mocks.dart
+++ b/test/widgets/verification_request_listener_test.mocks.dart
@@ -4,16 +4,17 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i16;
-import 'dart:ui' as _i18;
+import 'dart:typed_data' as _i17;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i18;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
@@ -22,12 +23,12 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i14;
+import 'package:matrix/encryption.dart' as _i15;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i15;
+import 'package:mockito/src/dummies.dart' as _i16;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -819,6 +820,17 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
+class _FakeOutboxService_73 extends _i1.SmartFake
+    implements _i14.OutboxService {
+  _FakeOutboxService_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -837,12 +849,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i14.KeyVerificationMethod> get verificationMethods =>
+  Set<_i15.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i14.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i14.KeyVerificationMethod>{},
-      ) as Set<_i14.KeyVerificationMethod>);
+        returnValue: <_i15.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
+      ) as Set<_i15.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -962,11 +974,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1003,11 +1015,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1037,11 +1049,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1050,11 +1062,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1340,34 +1352,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i14.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i14.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i14.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i14.KeyVerification>
+  _i3.CachedStreamController<_i15.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i14.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i14.KeyVerification>(
+                _FakeCachedStreamController_6<_i15.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i14.KeyVerification>);
+          ) as _i3.CachedStreamController<_i15.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1523,7 +1535,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i14.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1812,14 +1824,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2207,8 +2219,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValue: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2224,8 +2236,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i15.ifNotNull(
-              _i15.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i16.ifNotNull(
+              _i16.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2266,7 +2278,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2282,7 +2294,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2331,7 +2343,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2352,7 +2364,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2455,7 +2467,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2473,7 +2485,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2992,7 +3004,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i16.Uint8List? file, {
+    _i17.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3344,7 +3356,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3358,7 +3370,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3509,7 +3521,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i16.Uint8List? body,
+    _i17.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4887,7 +4899,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4909,7 +4921,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5403,7 +5415,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5415,7 +5427,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6423,7 +6435,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6434,7 +6446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6682,7 +6694,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6694,7 +6706,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6954,7 +6966,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6967,7 +6979,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7034,7 +7046,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7047,7 +7059,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7095,7 +7107,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7107,7 +7119,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7355,7 +7367,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i15.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7366,7 +7378,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i15.dummyValue<String>(
+            _i5.Future<String>.value(_i16.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7628,7 +7640,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i16.Uint8List? body, {
+    _i17.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7655,7 +7667,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7685,11 +7697,11 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i15.dummyValue<String>(
+        returnValue: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i15.dummyValue<String>(
+        returnValueForMissingStub: _i16.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7788,6 +7800,19 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i13.AuthService);
 
   @override
+  _i14.OutboxService get outbox => (super.noSuchMethod(
+        Invocation.getter(#outbox),
+        returnValue: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+        returnValueForMissingStub: _FakeOutboxService_73(
+          this,
+          Invocation.getter(#outbox),
+        ),
+      ) as _i14.OutboxService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7867,6 +7892,15 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
+  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #outbox,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7911,7 +7945,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8005,7 +8039,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8014,7 +8048,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8033,7 +8067,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8044,7 +8078,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8092,7 +8126,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8130,7 +8164,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8139,7 +8173,7 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8148,16 +8182,16 @@ class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
       );
 
   @override
-  _i5.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i5.Future<_i18.AppExitResponse>);
+            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i5.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8214,6 +8248,25 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> refreshOnResume() => (super.noSuchMethod(
+        Invocation.method(
+          #refreshOnResume,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   _i5.Future<void> disableChatBackup() => (super.noSuchMethod(
         Invocation.method(
           #disableChatBackup,
@@ -8243,7 +8296,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> runKeyRecovery({_i14.OpenSSSS? ssssKey}) =>
+  _i5.Future<void> runKeyRecovery({_i15.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
@@ -8297,7 +8350,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8306,19 +8359,10 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
-        ),
-        returnValueForMissingStub: null,
-      );
-
-  @override
-  void dispose() => super.noSuchMethod(
-        Invocation.method(
-          #dispose,
-          [],
         ),
         returnValueForMissingStub: null,
       );


### PR DESCRIPTION
Closes #432.

## Summary
- **Stop false positives.** `BackupVersionManager.hasVersion()` returns `bool?` — `null` for "lookup failed" (not cached) instead of collapsing every error to `false`. `ChatBackupService.checkChatBackupStatus()` leaves the previous value in place on transient errors / `null` results instead of asserting "backup needed".
- **Refresh on real state changes.** `ChatBackupService` subscribes to `client.onSync` and re-checks when a sync delivers backup-relevant account-data (`m.megolm_backup.v1`, `m.cross_signing.*`), invalidating the `hasVersion` cache first.
- **Refresh on app resume.** New `ChatBackupService.refreshOnResume()` wired from `MatrixService.didChangeAppLifecycleState` resumed branch, throttled to once per 30s.

UI disambiguation (separate banner for "device not verified" vs "no backup") is deferred to a follow-up.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test test/services/backup_version_manager_test.dart` — extended with null-return + no-cache-on-null cases
- [x] `flutter test test/services/chat_backup_service_test.dart` — added account-data refresh + `refreshOnResume` throttle coverage; reframed prior "force-true on error" expectations to "stay unchanged"
- [x] `flutter test test/services/matrix_service_test.dart` — updated two tests that asserted the old force-true behavior
- [x] `flutter test` — all 1668 pass
- [ ] Manual: finish backup setup on a second device; banner clears within one sync cycle without restart
- [ ] Manual: kill network ~30s and restore; banner does not transiently appear

## Notes
The PR includes regenerated `*.mocks.dart` files because `hasVersion()`'s signature changed from `Future<bool>` to `Future<bool?>` and `build_runner` rewrites the shared mock file referenced by all suites.