### PR TITLE
feat(rooms): search/filter members list

### DIFF
--- a/lib/features/rooms/widgets/room_members_section.dart
+++ b/lib/features/rooms/widgets/room_members_section.dart
@@ -26,11 +26,36 @@ class _RoomMembersSectionState extends State<RoomMembersSection> {
   bool _expanded = false;
   int? _lastMemberCount;
   int _loadGeneration = 0;
+  final TextEditingController _searchController = TextEditingController();
+  String _query = '';
 
   @override
   void initState() {
     super.initState();
     unawaited(_loadMembers());
+    _searchController.addListener(_onSearchChanged);
+  }
+
+  @override
+  void dispose() {
+    _searchController.removeListener(_onSearchChanged);
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  void _onSearchChanged() {
+    final next = _searchController.text.trim().toLowerCase();
+    if (next == _query) return;
+    setState(() => _query = next);
+  }
+
+  List<User> _filtered() {
+    if (_query.isEmpty) return _members;
+    return _members.where((u) {
+      final name = (u.displayName ?? '').toLowerCase();
+      final id = u.id.toLowerCase();
+      return name.contains(_query) || id.contains(_query);
+    }).toList();
   }
 
   @override
@@ -97,19 +122,54 @@ class _RoomMembersSectionState extends State<RoomMembersSection> {
             child: Center(child: CircularProgressIndicator()),
           )
         else ...[
-          for (final member in _expanded ? _members : _members.take(5))
-            _MemberTile(
-              user: member,
-              room: widget.room,
-            ),
-          if (_members.length > 5 && !_expanded)
-            TextButton(
-              onPressed: () => setState(() => _expanded = true),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Text('Show all ${_members.length} members'),
+          if (_members.length > 5)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
+              child: TextField(
+                controller: _searchController,
+                decoration: InputDecoration(
+                  isDense: true,
+                  prefixIcon: const Icon(Icons.search, size: 20),
+                  hintText: 'Search members',
+                  border: const OutlineInputBorder(),
+                  suffixIcon: _query.isEmpty
+                      ? null
+                      : IconButton(
+                          icon: const Icon(Icons.close, size: 20),
+                          onPressed: _searchController.clear,
+                        ),
+                ),
               ),
             ),
+          Builder(builder: (_) {
+            final filtered = _filtered();
+            if (filtered.isEmpty) {
+              return Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text(
+                  'No members match "${_searchController.text}"',
+                  style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
+                ),
+              );
+            }
+            final showAll = _expanded || _query.isNotEmpty;
+            final visible = showAll ? filtered : filtered.take(5);
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                for (final member in visible)
+                  _MemberTile(user: member, room: widget.room),
+                if (!showAll && filtered.length > 5)
+                  TextButton(
+                    onPressed: () => setState(() => _expanded = true),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: Text('Show all ${filtered.length} members'),
+                    ),
+                  ),
+              ],
+            );
+          },),
         ],
       ],
     );

--- a/test/widgets/room_details_panel_test.dart
+++ b/test/widgets/room_details_panel_test.dart
@@ -182,6 +182,12 @@ void main() {
       await tester.pumpWidget(buildTestWidget());
       await tester.pumpAndSettle();
 
+      await tester.scrollUntilVisible(
+        find.text('All messages'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+
       expect(find.text('All messages'), findsOneWidget);
       expect(find.text('Mentions only'), findsOneWidget);
       expect(find.text('Muted'), findsOneWidget);

--- a/test/widgets/room_members_section_test.dart
+++ b/test/widgets/room_members_section_test.dart
@@ -53,7 +53,9 @@ void main() {
       home: ChangeNotifierProvider<MatrixService>.value(
         value: mockMatrixService,
         child: Scaffold(
-          body: RoomMembersSection(room: mockRoom),
+          body: SingleChildScrollView(
+            child: RoomMembersSection(room: mockRoom),
+          ),
         ),
       ),
     );
@@ -155,6 +157,76 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Mod'), findsOneWidget);
+    });
+
+    testWidgets('search filters members by display name and MXID',
+        (tester) async {
+      final users = [
+        _makeUser('@alice:example.com', 'Alice', room: mockRoom),
+        _makeUser('@bob:example.com', 'Bob', room: mockRoom),
+        _makeUser('@charlie:example.com', 'Charlie', room: mockRoom),
+        _makeUser('@dave:example.com', 'Dave', room: mockRoom),
+        _makeUser('@eve:example.com', 'Eve', room: mockRoom),
+        _makeUser('@frank:example.com', 'Frank', room: mockRoom),
+      ];
+      when(mockRoom.requestParticipants(any)).thenAnswer((_) async => users);
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TextField), findsOneWidget);
+
+      await tester.enterText(find.byType(TextField), 'ali');
+      await tester.pumpAndSettle();
+      expect(find.text('Alice'), findsOneWidget);
+      expect(find.text('Bob'), findsNothing);
+
+      await tester.enterText(find.byType(TextField), '@bob');
+      await tester.pumpAndSettle();
+      expect(find.text('Bob'), findsOneWidget);
+      expect(find.text('Alice'), findsNothing);
+
+      await tester.enterText(find.byType(TextField), 'zzzz');
+      await tester.pumpAndSettle();
+      expect(find.textContaining('No members match'), findsOneWidget);
+    });
+
+    testWidgets('search field hidden when 5 or fewer members', (tester) async {
+      final users = List.generate(
+        5,
+        (i) => _makeUser('@user$i:example.com', 'User $i', room: mockRoom),
+      );
+      when(mockRoom.requestParticipants(any)).thenAnswer((_) async => users);
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(TextField, 'Search members'), findsNothing);
+      expect(find.byIcon(Icons.search), findsNothing);
+    });
+
+    testWidgets('search clear button restores full list', (tester) async {
+      final users = List.generate(
+        6,
+        (i) => _makeUser('@user$i:example.com', 'User $i', room: mockRoom),
+      );
+      when(mockRoom.requestParticipants(any)).thenAnswer((_) async => users);
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), 'user0');
+      await tester.pumpAndSettle();
+      expect(find.text('User 0'), findsOneWidget);
+      expect(find.text('User 1'), findsNothing);
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+
+      for (var i = 0; i < 5; i++) {
+        expect(find.text('User $i'), findsOneWidget);
+      }
+      expect(find.text('Show all 6 members'), findsOneWidget);
     });
 
     testWidgets('tapping member opens SimpleDialog with member info',

--- a/test/widgets/space_details_panel_test.dart
+++ b/test/widgets/space_details_panel_test.dart
@@ -123,6 +123,12 @@ void main() {
       await tester.pumpWidget(buildTestWidget());
       await tester.pumpAndSettle();
 
+      await tester.scrollUntilVisible(
+        find.text('ADMIN SETTINGS'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+
       expect(find.text('ADMIN SETTINGS'), findsOneWidget);
     });
 


### PR DESCRIPTION
## Summary
- Adds a search `TextField` above `RoomMembersSection` (only when there are more than five members) with a clear button.
- Filters the in-memory list case-insensitively by display name or MXID, client-side — no SDK round-trip.
- When a query is active, the five-member cap is bypassed so all matches are visible.
- Empty-state copy renders when no members match.
- Picked up automatically by `SpaceDetailsPanel` since it embeds the same widget.

Closes #445. Part of #106.

## Test plan
- [x] Unit test: search filters by display name (`ali` → Alice only)
- [x] Unit test: search filters by MXID (`@bob` → Bob only)
- [x] Unit test: empty state shown when query has no matches
- [x] All existing `RoomMembersSection` tests still pass
- [ ] Manual: open a room with >5 members, type to filter, clear via the X button
- [ ] Manual: open a space's member list, confirm same behavior