### PR TITLE
fix(invite): prevent crash and reduce open lag in invite dialog

### DIFF
--- a/lib/features/rooms/widgets/invite_user_dialog.dart
+++ b/lib/features/rooms/widgets/invite_user_dialog.dart
@@ -38,11 +38,19 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
   int _searchGeneration = 0;
   List<Profile>? _cachedContacts;
   Set<String>? _cachedExistingMembers;
+  bool _suggestionsReady = false;
 
   @override
   void initState() {
     super.initState();
     _focusNode.addListener(_onFocusChanged);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _existingMembers();
+      _knownContacts();
+      if (!mounted) return;
+      setState(() => _suggestionsReady = true);
+    });
   }
 
   @override
@@ -147,6 +155,7 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
   }
 
   List<Widget> _buildSuggestions(ColorScheme cs) {
+    if (!_suggestionsReady) return [];
     final query = _controller.text.trim();
     final existing = _existingMembers();
     final source = query.isEmpty ? _knownContacts() : _searchResults;
@@ -201,18 +210,20 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
     final suggestions = _buildSuggestions(cs);
 
-    return SimpleDialog(
-      title: const Text('Invite user'),
-      contentPadding: const EdgeInsets.fromLTRB(24, 20, 24, 16),
-      children: [
-        ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 400),
+    return Dialog(
+      child: SizedBox(
+        width: 400,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(24, 20, 24, 16),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
+              Text('Invite user', style: tt.titleLarge),
+              const SizedBox(height: 16),
               TextField(
                 controller: _controller,
                 focusNode: _focusNode,
@@ -231,7 +242,18 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
                   padding: EdgeInsets.only(top: 4),
                   child: LinearProgressIndicator(),
                 ),
-              if (suggestions.isNotEmpty)
+              if (!_suggestionsReady)
+                const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 24),
+                  child: Center(
+                    child: SizedBox(
+                      height: 24,
+                      width: 24,
+                      child: CircularProgressIndicator(strokeWidth: 2.5),
+                    ),
+                  ),
+                )
+              else if (suggestions.isNotEmpty)
                 ConstrainedBox(
                   constraints: const BoxConstraints(maxHeight: 220),
                   child: ListView(
@@ -258,7 +280,7 @@ class _InviteUserDialogState extends State<InviteUserDialog> {
             ],
           ),
         ),
-      ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- Replace `SimpleDialog` with `Dialog` + `SizedBox(width: 400)` in `InviteUserDialog`. `SimpleDialog` wraps its children in `IntrinsicWidth`, which probes descendants for intrinsic width; the suggestions `ListView` (a `RenderShrinkWrappingViewport`) does not support intrinsic dimensions and threw whenever the user had at least one DM. The unit tests passed because the mocked client had no rooms, so the `ListView` was never built.
- Defer the synchronous warm-up work — `room.getParticipants()` and `knownContacts(client)` (which calls `getLocalizedDisplayname` for every DM) — to a `WidgetsBinding.addPostFrameCallback`. While the caches are still cold, the suggestions slot renders a small `CircularProgressIndicator` so the dialog itself paints on the first frame.

## Test plan
- [x] `flutter analyze lib/features/rooms/widgets/invite_user_dialog.dart` clean
- [x] `flutter test test/widgets/invite_user_dialog_test.dart` (all 8 cases pass)
- [ ] Manual: open the invite dialog from the room details panel on an account with several DMs and confirm (a) no crash, (b) dialog paints immediately with a spinner, (c) recent contacts replace the spinner on the next frame
- [ ] Manual: same flow from the space context menu and space details panel