### PR TITLE
feat(rooms,spaces): SpaceAccessService + JoinMode enum (read-only)

### DIFF
--- a/lib/core/models/join_mode.dart
+++ b/lib/core/models/join_mode.dart
@@ -1,0 +1,22 @@
+enum JoinMode {
+  invite,
+  restricted,
+  knockRestricted,
+  public,
+  knock;
+
+  String get displayLabel {
+    switch (this) {
+      case JoinMode.invite:
+        return 'Invite-only';
+      case JoinMode.restricted:
+        return 'Space members';
+      case JoinMode.knockRestricted:
+        return 'Space members + knock';
+      case JoinMode.public:
+        return 'Public';
+      case JoinMode.knock:
+        return 'Knock';
+    }
+  }
+}

--- a/lib/core/services/matrix_service.dart
+++ b/lib/core/services/matrix_service.dart
@@ -8,6 +8,7 @@ import 'package:kohera/core/services/sub_services/chat_backup_service.dart';
 import 'package:kohera/core/services/sub_services/outbox_connectivity.dart';
 import 'package:kohera/core/services/sub_services/outbox_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
+import 'package:kohera/core/services/sub_services/space_access_service.dart';
 import 'package:kohera/core/services/sub_services/sync_service.dart';
 import 'package:kohera/core/services/sub_services/uia_service.dart';
 import 'package:kohera/core/utils/network_error.dart';
@@ -50,6 +51,7 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
       storage: _storage,
     );
     selection = SelectionService(client: _client);
+    spaceAccess = SpaceAccessService(client: _client);
     sync = SyncService(
       client: _client,
       onPostSyncBackup: () async {
@@ -107,6 +109,7 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
   late final UiaService uia;
   late final ChatBackupService chatBackup;
   late final SelectionService selection;
+  late final SpaceAccessService spaceAccess;
   late final SyncService sync;
   late final AuthService auth;
   late final OutboxService outbox;

--- a/lib/core/services/sub_services/space_access_service.dart
+++ b/lib/core/services/sub_services/space_access_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:kohera/core/models/join_mode.dart';
 import 'package:matrix/matrix.dart';
 
@@ -57,7 +58,8 @@ class SpaceAccessService {
           const <String>[];
       return _supportedVersionsCache = List.unmodifiable(keys);
     } catch (e) {
-      return _supportedVersionsCache = const <String>[];
+      debugPrint('[Kohera] SpaceAccessService.serverSupportedRoomVersions failed: $e');
+      return const <String>[];
     }
   }
 }

--- a/lib/core/services/sub_services/space_access_service.dart
+++ b/lib/core/services/sub_services/space_access_service.dart
@@ -1,0 +1,63 @@
+import 'package:kohera/core/models/join_mode.dart';
+import 'package:matrix/matrix.dart';
+
+class SpaceAccessService {
+  SpaceAccessService({required Client client}) : _client = client;
+
+  final Client _client;
+  List<String>? _supportedVersionsCache;
+
+  JoinMode getJoinMode(Room room) {
+    final raw = room
+        .getState(EventTypes.RoomJoinRules)
+        ?.content
+        .tryGet<String>('join_rule');
+    switch (raw) {
+      case 'public':
+        return JoinMode.public;
+      case 'knock':
+        return JoinMode.knock;
+      case 'restricted':
+        return JoinMode.restricted;
+      case 'knock_restricted':
+        return JoinMode.knockRestricted;
+      case 'invite':
+      default:
+        return JoinMode.invite;
+    }
+  }
+
+  List<String> allowedSpaceIds(Room room) {
+    final allow = room
+        .getState(EventTypes.RoomJoinRules)
+        ?.content
+        .tryGetList<Map<String, Object?>>('allow');
+    if (allow == null) return const [];
+    final ids = <String>[];
+    for (final entry in allow) {
+      if (entry['type'] != 'm.room_membership') continue;
+      final roomId = entry['room_id'];
+      if (roomId is String) ids.add(roomId);
+    }
+    return List.unmodifiable(ids);
+  }
+
+  bool needsUpgradeForRestricted(Room room, {required bool wantKnock}) {
+    final version = int.tryParse(room.roomVersion ?? '1') ?? 0;
+    final threshold = wantKnock ? 10 : 8;
+    return version < threshold;
+  }
+
+  Future<List<String>> serverSupportedRoomVersions() async {
+    final cached = _supportedVersionsCache;
+    if (cached != null) return cached;
+    try {
+      final caps = await _client.getCapabilities();
+      final keys = caps.mRoomVersions?.available.keys.toList(growable: false) ??
+          const <String>[];
+      return _supportedVersionsCache = List.unmodifiable(keys);
+    } catch (e) {
+      return _supportedVersionsCache = const <String>[];
+    }
+  }
+}

--- a/lib/features/rooms/widgets/room_details_panel.dart
+++ b/lib/features/rooms/widgets/room_details_panel.dart
@@ -206,6 +206,8 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
             child: Text(_error!, style: TextStyle(color: cs.error, fontSize: 13)),
           ),
         const Divider(),
+        _buildJoinAccessRow(room, matrix, tt),
+        const Divider(),
         RoomMembersSection(room: room),
         const Divider(),
         _buildEncryptionSection(room, cs, tt),
@@ -291,6 +293,18 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
           ),
         ],
       ),
+    );
+  }
+
+  // ── Join access row ────────────────────────────────────────
+
+  Widget _buildJoinAccessRow(Room room, MatrixService matrix, TextTheme tt) {
+    final mode = matrix.spaceAccess.getJoinMode(room);
+    return ListTile(
+      dense: true,
+      leading: const Icon(Icons.lock_outline),
+      title: const Text('Join'),
+      trailing: Text(mode.displayLabel, style: tt.bodyMedium),
     );
   }
 

--- a/lib/features/spaces/widgets/space_details_panel.dart
+++ b/lib/features/spaces/widgets/space_details_panel.dart
@@ -121,6 +121,8 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
             child: Text(_error!, style: TextStyle(color: cs.error, fontSize: 13)),
           ),
         const Divider(),
+        _buildJoinAccessRow(space, tt),
+        const Divider(),
         RoomMembersSection(room: space),
         const Divider(),
         _buildNotificationSection(space, cs, tt),
@@ -135,6 +137,16 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
   }
 
   // ── Notification settings ──────────────────────────────────
+
+  Widget _buildJoinAccessRow(Room space, TextTheme tt) {
+    final mode = context.read<MatrixService>().spaceAccess.getJoinMode(space);
+    return ListTile(
+      dense: true,
+      leading: const Icon(Icons.lock_outline),
+      title: const Text('Join'),
+      trailing: Text(mode.displayLabel, style: tt.bodyMedium),
+    );
+  }
 
   Widget _buildNotificationSection(Room space, ColorScheme cs, TextTheme tt) {
     return Column(

--- a/test/services/space_access_service_test.dart
+++ b/test/services/space_access_service_test.dart
@@ -197,5 +197,24 @@ void main() {
       when(client.getCapabilities()).thenThrow(Exception('network'));
       expect(await service.serverSupportedRoomVersions(), isEmpty);
     });
+
+    test('retries after error and caches success', () async {
+      var calls = 0;
+      when(client.getCapabilities()).thenAnswer((_) async {
+        calls++;
+        if (calls == 1) throw Exception('network');
+        return Capabilities.fromJson({
+          'm.room_versions': {
+            'default': '10',
+            'available': {'10': 'stable'},
+          },
+        });
+      });
+
+      expect(await service.serverSupportedRoomVersions(), isEmpty);
+      expect(await service.serverSupportedRoomVersions(), ['10']);
+      await service.serverSupportedRoomVersions();
+      verify(client.getCapabilities()).called(2);
+    });
   });
 }

--- a/test/services/space_access_service_test.dart
+++ b/test/services/space_access_service_test.dart
@@ -1,0 +1,201 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/models/join_mode.dart';
+import 'package:kohera/core/services/sub_services/space_access_service.dart';
+import 'package:matrix/matrix.dart';
+import 'package:mockito/mockito.dart';
+
+import 'matrix_service_test.mocks.dart';
+
+StrippedStateEvent _joinRulesEvent({
+  required String joinRule,
+  List<Map<String, Object?>>? allow,
+}) {
+  return StrippedStateEvent(
+    type: EventTypes.RoomJoinRules,
+    stateKey: '',
+    senderId: '@admin:example.com',
+    content: {
+      'join_rule': joinRule,
+      if (allow != null) 'allow': allow,
+    },
+  );
+}
+
+void _stubJoinRules(MockRoom room, StrippedStateEvent? event) {
+  when(room.getState(EventTypes.RoomJoinRules)).thenReturn(event);
+}
+
+void _stubRoomVersion(MockRoom room, String? version) {
+  when(room.roomVersion).thenReturn(version);
+}
+
+void main() {
+  late MockClient client;
+  late SpaceAccessService service;
+
+  setUp(() {
+    client = MockClient();
+    service = SpaceAccessService(client: client);
+  });
+
+  group('getJoinMode', () {
+    test('maps each join_rule string to JoinMode', () {
+      final cases = {
+        'public': JoinMode.public,
+        'knock': JoinMode.knock,
+        'invite': JoinMode.invite,
+        'restricted': JoinMode.restricted,
+        'knock_restricted': JoinMode.knockRestricted,
+      };
+      for (final entry in cases.entries) {
+        final room = MockRoom();
+        _stubJoinRules(room, _joinRulesEvent(joinRule: entry.key));
+        expect(service.getJoinMode(room), entry.value,
+            reason: 'join_rule=${entry.key}',);
+      }
+    });
+
+    test('falls back to invite when state event missing', () {
+      final room = MockRoom();
+      _stubJoinRules(room, null);
+      expect(service.getJoinMode(room), JoinMode.invite);
+    });
+
+    test('falls back to invite for unknown join_rule string', () {
+      final room = MockRoom();
+      _stubJoinRules(room, _joinRulesEvent(joinRule: 'private'));
+      expect(service.getJoinMode(room), JoinMode.invite);
+    });
+  });
+
+  group('allowedSpaceIds', () {
+    test('returns room_ids from m.room_membership entries', () {
+      final room = MockRoom();
+      _stubJoinRules(
+        room,
+        _joinRulesEvent(joinRule: 'restricted', allow: [
+          {'type': 'm.room_membership', 'room_id': '!a:example.com'},
+          {'type': 'm.room_membership', 'room_id': '!b:example.com'},
+        ],),
+      );
+      expect(
+          service.allowedSpaceIds(room), ['!a:example.com', '!b:example.com'],);
+    });
+
+    test('filters out non-m.room_membership entries', () {
+      final room = MockRoom();
+      _stubJoinRules(
+        room,
+        _joinRulesEvent(joinRule: 'restricted', allow: [
+          {'type': 'm.room_membership', 'room_id': '!a:example.com'},
+          {'type': 'org.example.future', 'room_id': '!skip:example.com'},
+        ],),
+      );
+      expect(service.allowedSpaceIds(room), ['!a:example.com']);
+    });
+
+    test('returns empty when state missing', () {
+      final room = MockRoom();
+      _stubJoinRules(room, null);
+      expect(service.allowedSpaceIds(room), isEmpty);
+    });
+
+    test('returns empty when allow list missing', () {
+      final room = MockRoom();
+      _stubJoinRules(room, _joinRulesEvent(joinRule: 'invite'));
+      expect(service.allowedSpaceIds(room), isEmpty);
+    });
+
+    test('skips entries with missing or non-string room_id', () {
+      final room = MockRoom();
+      _stubJoinRules(
+        room,
+        _joinRulesEvent(joinRule: 'restricted', allow: [
+          {'type': 'm.room_membership'},
+          {'type': 'm.room_membership', 'room_id': 42},
+          {'type': 'm.room_membership', 'room_id': '!ok:example.com'},
+        ],),
+      );
+      expect(service.allowedSpaceIds(room), ['!ok:example.com']);
+    });
+  });
+
+  group('needsUpgradeForRestricted', () {
+    test('v7 needs upgrade for restricted', () {
+      final room = MockRoom();
+      _stubRoomVersion(room, '7');
+      expect(service.needsUpgradeForRestricted(room, wantKnock: false), isTrue);
+    });
+
+    test('v8 ok for restricted', () {
+      final room = MockRoom();
+      _stubRoomVersion(room, '8');
+      expect(
+          service.needsUpgradeForRestricted(room, wantKnock: false), isFalse,);
+    });
+
+    test('v9 needs upgrade for knock_restricted', () {
+      final room = MockRoom();
+      _stubRoomVersion(room, '9');
+      expect(service.needsUpgradeForRestricted(room, wantKnock: true), isTrue);
+    });
+
+    test('v10 ok for knock_restricted', () {
+      final room = MockRoom();
+      _stubRoomVersion(room, '10');
+      expect(service.needsUpgradeForRestricted(room, wantKnock: true), isFalse);
+    });
+
+    test('missing create event defaults to v1 (needs upgrade)', () {
+      final room = MockRoom();
+      _stubRoomVersion(room, null);
+      expect(service.needsUpgradeForRestricted(room, wantKnock: false), isTrue);
+    });
+
+    test('non-numeric version treated as needs upgrade', () {
+      final room = MockRoom();
+      _stubRoomVersion(room, 'org.matrix.msc-future');
+      expect(service.needsUpgradeForRestricted(room, wantKnock: false), isTrue);
+    });
+  });
+
+  group('serverSupportedRoomVersions', () {
+    test('returns available versions from capabilities', () async {
+      when(client.getCapabilities()).thenAnswer(
+        (_) async => Capabilities.fromJson({
+          'm.room_versions': {
+            'default': '10',
+            'available': {
+              '1': 'stable',
+              '9': 'stable',
+              '10': 'stable',
+            },
+          },
+        }),
+      );
+
+      final versions = await service.serverSupportedRoomVersions();
+      expect(versions, containsAll(<String>['1', '9', '10']));
+    });
+
+    test('caches subsequent calls', () async {
+      when(client.getCapabilities()).thenAnswer(
+        (_) async => Capabilities.fromJson({
+          'm.room_versions': {
+            'default': '10',
+            'available': {'10': 'stable'},
+          },
+        }),
+      );
+
+      await service.serverSupportedRoomVersions();
+      await service.serverSupportedRoomVersions();
+      verify(client.getCapabilities()).called(1);
+    });
+
+    test('returns empty on error', () async {
+      when(client.getCapabilities()).thenThrow(Exception('network'));
+      expect(await service.serverSupportedRoomVersions(), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
First slice of the restricted-join milestone.

## Summary
- New `lib/core/models/join_mode.dart` — `JoinMode` enum with `displayLabel` getter.
- New `lib/core/services/sub_services/space_access_service.dart` (read-only):
  - `getJoinMode(Room)` — reads `m.room.join_rules`; falls back to invite.
  - `allowedSpaceIds(Room)` — filters to `m.room_membership` entries.
  - `needsUpgradeForRestricted(Room, {wantKnock})` — version threshold check.
  - `serverSupportedRoomVersions()` — cached `client.getCapabilities()` wrapper.
- Wired onto `MatrixService.spaceAccess`.
- Read-only "Join: <mode>" row added above Members in `room_details_panel.dart` and `space_details_panel.dart`.

Closes #460.

## Test plan
- [x] `flutter test test/services/space_access_service_test.dart` — unit tests for mode mapping, allow filter, version thresholds.
- [x] `flutter analyze` clean.

## Stack
- This → #461 → #462 → #463 → #464